### PR TITLE
feat: add zoom and pan controls to Mermaid diagrams

### DIFF
--- a/media/styles/components.css
+++ b/media/styles/components.css
@@ -19,7 +19,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 6px 12px;
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     border-bottom: 1px solid var(--border-color);
 }
 
@@ -50,7 +50,7 @@
 
 .code-action-btn:hover {
     opacity: 1;
-    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
 }
 
 .code-block-content {
@@ -76,7 +76,7 @@
 }
 
 .code-line:hover {
-    background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.05));
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.05));
 }
 
 .code-line::selection,
@@ -173,6 +173,7 @@
 
 /* Light theme overrides */
 @media (prefers-color-scheme: light) {
+
     .hljs-keyword,
     .hljs-selector-tag,
     .hljs-built_in,
@@ -180,7 +181,7 @@
     .hljs-tag {
         color: #0000ff;
     }
-    
+
     .hljs-string,
     .hljs-title,
     .hljs-section,
@@ -190,27 +191,27 @@
     .hljs-template-variable {
         color: #a31515;
     }
-    
+
     .hljs-number,
     .hljs-symbol,
     .hljs-bullet,
     .hljs-link {
         color: #098658;
     }
-    
+
     .hljs-comment,
     .hljs-quote,
     .hljs-deletion,
     .hljs-meta {
         color: #008000;
     }
-    
+
     .hljs-class .hljs-title,
     .hljs-function .hljs-title,
     .hljs-title.function_ {
         color: #795e26;
     }
-    
+
     .hljs-variable,
     .hljs-template-variable,
     .hljs-attr,
@@ -218,7 +219,7 @@
     .hljs-property {
         color: #001080;
     }
-    
+
     .hljs-type,
     .hljs-title.class_ {
         color: #267f99;
@@ -226,13 +227,33 @@
 }
 
 /* VSCode theme detection */
-body.vscode-light .hljs-keyword { color: #0000ff; }
-body.vscode-light .hljs-string { color: #a31515; }
-body.vscode-light .hljs-number { color: #098658; }
-body.vscode-light .hljs-comment { color: #008000; }
-body.vscode-light .hljs-title.function_ { color: #795e26; }
-body.vscode-light .hljs-variable { color: #001080; }
-body.vscode-light .hljs-type { color: #267f99; }
+body.vscode-light .hljs-keyword {
+    color: #0000ff;
+}
+
+body.vscode-light .hljs-string {
+    color: #a31515;
+}
+
+body.vscode-light .hljs-number {
+    color: #098658;
+}
+
+body.vscode-light .hljs-comment {
+    color: #008000;
+}
+
+body.vscode-light .hljs-title.function_ {
+    color: #795e26;
+}
+
+body.vscode-light .hljs-variable {
+    color: #001080;
+}
+
+body.vscode-light .hljs-type {
+    color: #267f99;
+}
 
 /* ==============================
  * Mermaid Diagram Styles
@@ -254,8 +275,9 @@ body.vscode-light .hljs-type { color: #267f99; }
     justify-content: space-between;
     align-items: center;
     padding: 8px 12px;
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     border-bottom: 1px solid var(--border-color);
+    gap: 8px;
 }
 
 .mermaid-label {
@@ -272,6 +294,51 @@ body.vscode-light .hljs-type { color: #267f99; }
     gap: 4px;
 }
 
+/* Zoom Controls */
+.mermaid-zoom-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    margin-right: 8px;
+}
+
+.mermaid-zoom-btn {
+    background: var(--vscode-button-secondaryBackground, rgba(255, 255, 255, 0.1));
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.2;
+    transition: background-color 0.2s, border-color 0.2s;
+    color: var(--text-color);
+    min-width: 28px;
+}
+
+.mermaid-zoom-btn:hover {
+    background: var(--vscode-button-secondaryHoverBackground, rgba(255, 255, 255, 0.2));
+    border-color: var(--vscode-focusBorder, #007acc);
+}
+
+.mermaid-zoom-btn:active {
+    transform: scale(0.95);
+}
+
+.mermaid-zoom-level {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--vscode-descriptionForeground, #888);
+    min-width: 42px;
+    text-align: center;
+    padding: 0 4px;
+}
+
+.mermaid-zoom-reset {
+    font-size: 12px;
+}
+
 .mermaid-action-btn {
     background: none;
     border: none;
@@ -286,7 +353,7 @@ body.vscode-light .hljs-type { color: #267f99; }
 
 .mermaid-action-btn:hover {
     opacity: 1;
-    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
 }
 
 .mermaid-preview {
@@ -295,11 +362,29 @@ body.vscode-light .hljs-type { color: #267f99; }
     justify-content: center;
     align-items: center;
     min-height: 100px;
-    overflow-x: auto;
+    overflow: hidden;
+    position: relative;
+    cursor: grab;
+}
+
+.mermaid-preview.mermaid-dragging {
+    cursor: grabbing;
+}
+
+.mermaid-svg-wrapper {
+    transform-origin: center center;
+    transition: transform 0.1s ease-out;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.mermaid-preview.mermaid-dragging .mermaid-svg-wrapper {
+    transition: none;
 }
 
 .mermaid-preview svg {
-    max-width: 100%;
+    max-width: none;
     height: auto;
 }
 
@@ -376,7 +461,9 @@ body.vscode-light .hljs-type { color: #267f99; }
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* ==============================
@@ -406,17 +493,17 @@ body.vscode-light .hljs-type { color: #267f99; }
 }
 
 .md-table th {
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     font-weight: 600;
     white-space: nowrap;
 }
 
 .md-table tr:nth-child(even) {
-    background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.02));
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.02));
 }
 
 .md-table tr:hover {
-    background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.08));
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.08));
 }
 
 .md-table td.align-center,
@@ -433,7 +520,7 @@ body.vscode-light .hljs-type { color: #267f99; }
     display: flex;
     justify-content: flex-end;
     padding: 6px 10px;
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     border-top: 1px solid var(--border-color);
 }
 
@@ -450,7 +537,7 @@ body.vscode-light .hljs-type { color: #267f99; }
 
 .md-table-action-btn:hover {
     opacity: 1;
-    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
 }
 
 /* Table row being parsed (separator row) */
@@ -458,4 +545,3 @@ body.vscode-light .hljs-type { color: #267f99; }
     color: var(--md-blockquote-color);
     opacity: 0.5;
 }
-

--- a/src/shortcuts/markdown-comments/styles/components.css
+++ b/src/shortcuts/markdown-comments/styles/components.css
@@ -19,7 +19,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 6px 12px;
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     border-bottom: 1px solid var(--border-color);
 }
 
@@ -50,7 +50,7 @@
 
 .code-action-btn:hover {
     opacity: 1;
-    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
 }
 
 .code-block-content {
@@ -76,7 +76,7 @@
 }
 
 .code-line:hover {
-    background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.05));
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.05));
 }
 
 .code-line::selection,
@@ -173,6 +173,7 @@
 
 /* Light theme overrides */
 @media (prefers-color-scheme: light) {
+
     .hljs-keyword,
     .hljs-selector-tag,
     .hljs-built_in,
@@ -180,7 +181,7 @@
     .hljs-tag {
         color: #0000ff;
     }
-    
+
     .hljs-string,
     .hljs-title,
     .hljs-section,
@@ -190,27 +191,27 @@
     .hljs-template-variable {
         color: #a31515;
     }
-    
+
     .hljs-number,
     .hljs-symbol,
     .hljs-bullet,
     .hljs-link {
         color: #098658;
     }
-    
+
     .hljs-comment,
     .hljs-quote,
     .hljs-deletion,
     .hljs-meta {
         color: #008000;
     }
-    
+
     .hljs-class .hljs-title,
     .hljs-function .hljs-title,
     .hljs-title.function_ {
         color: #795e26;
     }
-    
+
     .hljs-variable,
     .hljs-template-variable,
     .hljs-attr,
@@ -218,7 +219,7 @@
     .hljs-property {
         color: #001080;
     }
-    
+
     .hljs-type,
     .hljs-title.class_ {
         color: #267f99;
@@ -226,13 +227,33 @@
 }
 
 /* VSCode theme detection */
-body.vscode-light .hljs-keyword { color: #0000ff; }
-body.vscode-light .hljs-string { color: #a31515; }
-body.vscode-light .hljs-number { color: #098658; }
-body.vscode-light .hljs-comment { color: #008000; }
-body.vscode-light .hljs-title.function_ { color: #795e26; }
-body.vscode-light .hljs-variable { color: #001080; }
-body.vscode-light .hljs-type { color: #267f99; }
+body.vscode-light .hljs-keyword {
+    color: #0000ff;
+}
+
+body.vscode-light .hljs-string {
+    color: #a31515;
+}
+
+body.vscode-light .hljs-number {
+    color: #098658;
+}
+
+body.vscode-light .hljs-comment {
+    color: #008000;
+}
+
+body.vscode-light .hljs-title.function_ {
+    color: #795e26;
+}
+
+body.vscode-light .hljs-variable {
+    color: #001080;
+}
+
+body.vscode-light .hljs-type {
+    color: #267f99;
+}
 
 /* ==============================
  * Mermaid Diagram Styles
@@ -254,8 +275,9 @@ body.vscode-light .hljs-type { color: #267f99; }
     justify-content: space-between;
     align-items: center;
     padding: 8px 12px;
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     border-bottom: 1px solid var(--border-color);
+    gap: 8px;
 }
 
 .mermaid-label {
@@ -272,6 +294,51 @@ body.vscode-light .hljs-type { color: #267f99; }
     gap: 4px;
 }
 
+/* Zoom Controls */
+.mermaid-zoom-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    margin-right: 8px;
+}
+
+.mermaid-zoom-btn {
+    background: var(--vscode-button-secondaryBackground, rgba(255, 255, 255, 0.1));
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.2;
+    transition: background-color 0.2s, border-color 0.2s;
+    color: var(--text-color);
+    min-width: 28px;
+}
+
+.mermaid-zoom-btn:hover {
+    background: var(--vscode-button-secondaryHoverBackground, rgba(255, 255, 255, 0.2));
+    border-color: var(--vscode-focusBorder, #007acc);
+}
+
+.mermaid-zoom-btn:active {
+    transform: scale(0.95);
+}
+
+.mermaid-zoom-level {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--vscode-descriptionForeground, #888);
+    min-width: 42px;
+    text-align: center;
+    padding: 0 4px;
+}
+
+.mermaid-zoom-reset {
+    font-size: 12px;
+}
+
 .mermaid-action-btn {
     background: none;
     border: none;
@@ -286,7 +353,7 @@ body.vscode-light .hljs-type { color: #267f99; }
 
 .mermaid-action-btn:hover {
     opacity: 1;
-    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
 }
 
 .mermaid-preview {
@@ -295,11 +362,29 @@ body.vscode-light .hljs-type { color: #267f99; }
     justify-content: center;
     align-items: center;
     min-height: 100px;
-    overflow-x: auto;
+    overflow: hidden;
+    position: relative;
+    cursor: grab;
+}
+
+.mermaid-preview.mermaid-dragging {
+    cursor: grabbing;
+}
+
+.mermaid-svg-wrapper {
+    transform-origin: center center;
+    transition: transform 0.1s ease-out;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.mermaid-preview.mermaid-dragging .mermaid-svg-wrapper {
+    transition: none;
 }
 
 .mermaid-preview svg {
-    max-width: 100%;
+    max-width: none;
     height: auto;
 }
 
@@ -376,7 +461,9 @@ body.vscode-light .hljs-type { color: #267f99; }
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* ==============================
@@ -406,17 +493,17 @@ body.vscode-light .hljs-type { color: #267f99; }
 }
 
 .md-table th {
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     font-weight: 600;
     white-space: nowrap;
 }
 
 .md-table tr:nth-child(even) {
-    background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.02));
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.02));
 }
 
 .md-table tr:hover {
-    background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.08));
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.08));
 }
 
 .md-table td.align-center,
@@ -433,7 +520,7 @@ body.vscode-light .hljs-type { color: #267f99; }
     display: flex;
     justify-content: flex-end;
     padding: 6px 10px;
-    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0,0,0,0.2));
+    background: var(--vscode-editorGroupHeader-tabsBackground, rgba(0, 0, 0, 0.2));
     border-top: 1px solid var(--border-color);
 }
 
@@ -450,7 +537,7 @@ body.vscode-light .hljs-type { color: #267f99; }
 
 .md-table-action-btn:hover {
     opacity: 1;
-    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
 }
 
 /* Table row being parsed (separator row) */
@@ -458,4 +545,3 @@ body.vscode-light .hljs-type { color: #267f99; }
     color: var(--md-blockquote-color);
     opacity: 0.5;
 }
-

--- a/src/shortcuts/markdown-comments/webview-scripts/mermaid-handlers.ts
+++ b/src/shortcuts/markdown-comments/webview-scripts/mermaid-handlers.ts
@@ -2,13 +2,67 @@
  * Mermaid diagram handling for the webview
  */
 
-import { state } from './state';
-import { showFloatingPanel } from './panel-manager';
-import { escapeHtml } from '../webview-logic/markdown-renderer';
-import { checkBlockHasComments } from './code-block-handlers';
-import { parseCodeBlocks } from './code-block-handlers';
 import { MarkdownComment } from '../types';
+import { escapeHtml } from '../webview-logic/markdown-renderer';
+import { checkBlockHasComments, parseCodeBlocks } from './code-block-handlers';
+import { showFloatingPanel } from './panel-manager';
+import { state } from './state';
 import { CodeBlock } from './types';
+
+/**
+ * Zoom/pan state for each mermaid diagram
+ */
+interface MermaidViewState {
+    scale: number;
+    translateX: number;
+    translateY: number;
+    isDragging: boolean;
+    dragStartX: number;
+    dragStartY: number;
+    lastTranslateX: number;
+    lastTranslateY: number;
+}
+
+const mermaidViewStates: Map<string, MermaidViewState> = new Map();
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 4;
+const ZOOM_STEP = 0.25;
+
+/**
+ * Get or create view state for a mermaid diagram
+ */
+function getViewState(diagramId: string): MermaidViewState {
+    if (!mermaidViewStates.has(diagramId)) {
+        mermaidViewStates.set(diagramId, {
+            scale: 1,
+            translateX: 0,
+            translateY: 0,
+            isDragging: false,
+            dragStartX: 0,
+            dragStartY: 0,
+            lastTranslateX: 0,
+            lastTranslateY: 0
+        });
+    }
+    return mermaidViewStates.get(diagramId)!;
+}
+
+/**
+ * Apply transform to mermaid diagram
+ */
+function applyTransform(container: HTMLElement, viewState: MermaidViewState): void {
+    const svgWrapper = container.querySelector('.mermaid-svg-wrapper') as HTMLElement;
+    if (svgWrapper) {
+        svgWrapper.style.transform = `translate(${viewState.translateX}px, ${viewState.translateY}px) scale(${viewState.scale})`;
+    }
+
+    // Update zoom level display
+    const zoomDisplay = container.querySelector('.mermaid-zoom-level') as HTMLElement;
+    if (zoomDisplay) {
+        zoomDisplay.textContent = Math.round(viewState.scale * 100) + '%';
+    }
+}
 
 /**
  * Load mermaid.js lazily
@@ -18,31 +72,31 @@ export function loadMermaid(callback: () => void): void {
         callback();
         return;
     }
-    
+
     if (state.mermaidLoading) {
         state.addPendingMermaidBlock(callback);
         return;
     }
-    
+
     state.setMermaidLoading(true);
-    
+
     const script = document.createElement('script');
     script.src = 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js';
     script.onload = () => {
         state.setMermaidLoaded(true);
         state.setMermaidLoading(false);
-        
+
         // Initialize mermaid with theme based on VSCode theme
-        const isDark = document.body.classList.contains('vscode-dark') || 
-                       document.body.classList.contains('vscode-high-contrast');
+        const isDark = document.body.classList.contains('vscode-dark') ||
+            document.body.classList.contains('vscode-high-contrast');
         window.mermaid.initialize({
             startOnLoad: false,
             theme: isDark ? 'dark' : 'default',
             securityLevel: 'loose'
         });
-        
+
         callback();
-        
+
         // Process pending callbacks
         state.pendingMermaidBlocks.forEach(cb => cb());
         state.clearPendingMermaidBlocks();
@@ -61,20 +115,25 @@ async function renderMermaidDiagram(block: CodeBlock, container: HTMLElement): P
     try {
         const id = 'mermaid-' + block.startLine + '-' + Date.now();
         const { svg } = await window.mermaid.render(id, block.code);
-        
+
         const previewDiv = container.querySelector('.mermaid-preview');
         if (previewDiv) {
-            previewDiv.innerHTML = svg;
+            // Wrap SVG in a wrapper for zoom/pan transformations
+            previewDiv.innerHTML = '<div class="mermaid-svg-wrapper">' + svg + '</div>';
             previewDiv.classList.remove('mermaid-loading');
-            
+
             // Setup node click handlers for commenting
             setupMermaidNodeHandlers(previewDiv as HTMLElement, block);
+
+            // Setup zoom/pan handlers for this diagram
+            const diagramId = container.dataset.mermaidId || block.id;
+            setupMermaidZoomPan(container, diagramId);
         }
     } catch (error) {
         const previewDiv = container.querySelector('.mermaid-preview');
         if (previewDiv) {
             previewDiv.classList.remove('mermaid-loading');
-            previewDiv.innerHTML = '<div class="mermaid-error-message">Diagram Error: ' + 
+            previewDiv.innerHTML = '<div class="mermaid-error-message">Diagram Error: ' +
                 escapeHtml((error as Error).message || 'Unknown error') + '</div>';
         }
         container.classList.add('mermaid-error');
@@ -93,7 +152,7 @@ function setupMermaidNodeHandlers(previewDiv: HTMLElement, block: CodeBlock): vo
             const nodeEl = node as HTMLElement;
             const nodeId = nodeEl.id || nodeEl.getAttribute('data-id') || 'unknown';
             const nodeLabel = node.textContent?.trim() || nodeId;
-            
+
             // Open comment panel for this node
             openMermaidNodeComment(block, nodeId, nodeLabel, nodeEl);
         });
@@ -104,9 +163,9 @@ function setupMermaidNodeHandlers(previewDiv: HTMLElement, block: CodeBlock): vo
  * Open comment panel for a mermaid node
  */
 function openMermaidNodeComment(
-    block: CodeBlock, 
-    nodeId: string, 
-    nodeLabel: string, 
+    block: CodeBlock,
+    nodeId: string,
+    nodeLabel: string,
     element: HTMLElement
 ): void {
     state.setPendingSelection({
@@ -122,7 +181,7 @@ function openMermaidNodeComment(
             diagramType: block.language
         }
     });
-    
+
     const rect = element.getBoundingClientRect();
     showFloatingPanel(rect, 'Mermaid Node: ' + nodeLabel);
 }
@@ -131,24 +190,30 @@ function openMermaidNodeComment(
  * Render a mermaid block container
  */
 export function renderMermaidContainer(
-    block: CodeBlock, 
+    block: CodeBlock,
     commentsMap: Map<number, MarkdownComment[]>
 ): string {
     const hasBlockComments = checkBlockHasComments(block.startLine, block.endLine, commentsMap);
     const containerClass = 'mermaid-container' + (hasBlockComments ? ' has-comments' : '');
-    
-    return '<div class="' + containerClass + '" data-start-line="' + block.startLine + 
-           '" data-end-line="' + block.endLine + '" data-mermaid-id="' + block.id + '">' +
+
+    return '<div class="' + containerClass + '" data-start-line="' + block.startLine +
+        '" data-end-line="' + block.endLine + '" data-mermaid-id="' + block.id + '">' +
         '<div class="mermaid-header">' +
-            '<span class="mermaid-label">📊 Mermaid Diagram</span>' +
-            '<div class="mermaid-actions">' +
-                '<button class="mermaid-action-btn mermaid-toggle-btn" title="Toggle source/preview">🔄 Toggle</button>' +
-                '<button class="mermaid-action-btn mermaid-comment-btn" title="Add comment to diagram">💬</button>' +
-            '</div>' +
+        '<span class="mermaid-label">📊 Mermaid Diagram</span>' +
+        '<div class="mermaid-zoom-controls">' +
+        '<button class="mermaid-zoom-btn mermaid-zoom-out" title="Zoom out (−)">−</button>' +
+        '<span class="mermaid-zoom-level">100%</span>' +
+        '<button class="mermaid-zoom-btn mermaid-zoom-in" title="Zoom in (+)">+</button>' +
+        '<button class="mermaid-zoom-btn mermaid-zoom-reset" title="Reset view">⟲</button>' +
+        '</div>' +
+        '<div class="mermaid-actions">' +
+        '<button class="mermaid-action-btn mermaid-toggle-btn" title="Toggle source/preview">🔄 Toggle</button>' +
+        '<button class="mermaid-action-btn mermaid-comment-btn" title="Add comment to diagram">💬</button>' +
+        '</div>' +
         '</div>' +
         '<div class="mermaid-preview mermaid-loading">Loading diagram...</div>' +
         '<div class="mermaid-source" style="display: none;"><code>' + escapeHtml(block.code) + '</code></div>' +
-    '</div>';
+        '</div>';
 }
 
 /**
@@ -157,10 +222,10 @@ export function renderMermaidContainer(
 export function renderMermaidDiagrams(): void {
     const mermaidContainers = document.querySelectorAll('.mermaid-container');
     if (mermaidContainers.length === 0) return;
-    
+
     const codeBlocks = parseCodeBlocks(state.currentContent);
     const mermaidBlocks = codeBlocks.filter(b => b.isMermaid);
-    
+
     loadMermaid(() => {
         mermaidContainers.forEach((container, index) => {
             const block = mermaidBlocks[index];
@@ -169,9 +234,125 @@ export function renderMermaidDiagrams(): void {
             }
         });
     });
-    
+
     // Setup mermaid action handlers
     setupMermaidHandlers();
+}
+
+/**
+ * Setup zoom and pan handlers for a mermaid diagram
+ */
+function setupMermaidZoomPan(container: HTMLElement, diagramId: string): void {
+    const viewState = getViewState(diagramId);
+    const previewDiv = container.querySelector('.mermaid-preview') as HTMLElement;
+    const svgWrapper = container.querySelector('.mermaid-svg-wrapper') as HTMLElement;
+
+    if (!previewDiv || !svgWrapper) return;
+
+    // Zoom in button
+    const zoomInBtn = container.querySelector('.mermaid-zoom-in');
+    if (zoomInBtn) {
+        zoomInBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            viewState.scale = Math.min(MAX_ZOOM, viewState.scale + ZOOM_STEP);
+            applyTransform(container, viewState);
+        });
+    }
+
+    // Zoom out button
+    const zoomOutBtn = container.querySelector('.mermaid-zoom-out');
+    if (zoomOutBtn) {
+        zoomOutBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            viewState.scale = Math.max(MIN_ZOOM, viewState.scale - ZOOM_STEP);
+            applyTransform(container, viewState);
+        });
+    }
+
+    // Reset button
+    const resetBtn = container.querySelector('.mermaid-zoom-reset');
+    if (resetBtn) {
+        resetBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            viewState.scale = 1;
+            viewState.translateX = 0;
+            viewState.translateY = 0;
+            applyTransform(container, viewState);
+        });
+    }
+
+    // Mouse wheel zoom
+    previewDiv.addEventListener('wheel', (e) => {
+        // Only zoom if Ctrl/Cmd is held
+        if (!e.ctrlKey && !e.metaKey) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
+        const newScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, viewState.scale + delta));
+
+        // Zoom towards mouse position
+        if (newScale !== viewState.scale) {
+            const rect = previewDiv.getBoundingClientRect();
+            const mouseX = e.clientX - rect.left;
+            const mouseY = e.clientY - rect.top;
+
+            // Calculate the point under the mouse in diagram coordinates
+            const pointX = (mouseX - viewState.translateX) / viewState.scale;
+            const pointY = (mouseY - viewState.translateY) / viewState.scale;
+
+            viewState.scale = newScale;
+
+            // Adjust translation to keep the point under the mouse
+            viewState.translateX = mouseX - pointX * viewState.scale;
+            viewState.translateY = mouseY - pointY * viewState.scale;
+
+            applyTransform(container, viewState);
+        }
+    }, { passive: false });
+
+    // Mouse drag for panning
+    previewDiv.addEventListener('mousedown', (e) => {
+        // Only pan with middle mouse button or when holding space
+        // Or with left click when not clicking on a node
+        const target = e.target as HTMLElement;
+        const isNode = target.closest('.node, .cluster, .label');
+
+        if (e.button === 1 || (e.button === 0 && !isNode)) {
+            if (e.button === 0 && isNode) return; // Let node click handler handle it
+
+            viewState.isDragging = true;
+            viewState.dragStartX = e.clientX;
+            viewState.dragStartY = e.clientY;
+            viewState.lastTranslateX = viewState.translateX;
+            viewState.lastTranslateY = viewState.translateY;
+            previewDiv.classList.add('mermaid-dragging');
+            e.preventDefault();
+        }
+    });
+
+    previewDiv.addEventListener('mousemove', (e) => {
+        if (!viewState.isDragging) return;
+
+        const deltaX = e.clientX - viewState.dragStartX;
+        const deltaY = e.clientY - viewState.dragStartY;
+
+        viewState.translateX = viewState.lastTranslateX + deltaX;
+        viewState.translateY = viewState.lastTranslateY + deltaY;
+
+        applyTransform(container, viewState);
+    });
+
+    const stopDragging = () => {
+        if (viewState.isDragging) {
+            viewState.isDragging = false;
+            previewDiv.classList.remove('mermaid-dragging');
+        }
+    };
+
+    previewDiv.addEventListener('mouseup', stopDragging);
+    previewDiv.addEventListener('mouseleave', stopDragging);
 }
 
 /**
@@ -185,7 +366,7 @@ export function setupMermaidHandlers(): void {
             const container = (btn as HTMLElement).closest('.mermaid-container') as HTMLElement;
             const preview = container.querySelector('.mermaid-preview') as HTMLElement;
             const source = container.querySelector('.mermaid-source') as HTMLElement;
-            
+
             if (preview.style.display === 'none') {
                 preview.style.display = 'flex';
                 source.style.display = 'none';
@@ -197,7 +378,7 @@ export function setupMermaidHandlers(): void {
             }
         });
     });
-    
+
     // Comment button handlers for diagrams
     document.querySelectorAll('.mermaid-comment-btn').forEach(btn => {
         btn.addEventListener('click', (e) => {
@@ -206,7 +387,7 @@ export function setupMermaidHandlers(): void {
             const startLine = parseInt(container.dataset.startLine || '');
             const endLine = parseInt(container.dataset.endLine || '');
             const diagramId = container.dataset.mermaidId;
-            
+
             state.setPendingSelection({
                 startLine,
                 startColumn: 1,
@@ -218,7 +399,7 @@ export function setupMermaidHandlers(): void {
                     diagramType: 'mermaid'
                 }
             });
-            
+
             showFloatingPanel(btn.getBoundingClientRect(), 'Mermaid Diagram');
         });
     });


### PR DESCRIPTION
## Summary

- Add zoom in/out/reset buttons to mermaid diagram header for precise control
- Implement mouse wheel zoom with Ctrl/Cmd modifier for quick scaling
- Add click-and-drag panning for navigating large diagrams
- Show current zoom level percentage in the toolbar
- Store zoom/pan state per diagram for consistency during toggle operations

## Changes

**New Features:**
- Zoom controls (+, −, reset) in the mermaid header bar
- Mouse wheel zoom (Ctrl+wheel or Cmd+wheel)
- Click-and-drag panning on the diagram preview area
- Visual feedback with grab/grabbing cursors during pan operations

**Files Modified:**
- `media/styles/components.css` - Zoom control styles and pan cursor states
- `src/shortcuts/markdown-comments/styles/components.css` - Same styles (kept in sync)
- `src/shortcuts/markdown-comments/webview-scripts/mermaid-handlers.ts` - Zoom/pan logic

## Test plan

- [ ] Open a markdown file with a mermaid diagram
- [ ] Verify zoom buttons (+, −, reset) appear in the diagram header
- [ ] Test zoom in/out buttons change scale and display percentage
- [ ] Test reset button returns to 100% scale
- [ ] Test Ctrl+wheel (or Cmd+wheel on Mac) zooms toward mouse position
- [ ] Test click-and-drag pans the diagram
- [ ] Verify node click handlers still work for commenting
- [ ] Verify toggle between source/preview preserves zoom state

🤖 Generated with [Claude Code](https://claude.com/claude-code)