### PR TITLE
fix: improve keyword color visibility in dark theme

### DIFF
--- a/media/styles/components.css
+++ b/media/styles/components.css
@@ -137,7 +137,7 @@
 .hljs-built_in,
 .hljs-name,
 .hljs-tag {
-    color: #569cd6;
+    color: #7dcfff;
 }
 
 .hljs-string,
@@ -167,7 +167,7 @@
 }
 
 .hljs-function .hljs-keyword {
-    color: #569cd6;
+    color: #7dcfff;
 }
 
 .hljs-class .hljs-title,


### PR DESCRIPTION
## Summary
- Updated highlight.js keyword color from `#569cd6` to `#7dcfff` for better visibility in dark theme
- The previous blue was too muted and difficult to read on dark backgrounds
- The new cyan-tinted blue provides better contrast while maintaining the blue color family

## Test plan
- [ ] Open the Review Editor View with a markdown file containing code blocks
- [ ] Verify keywords (e.g., `function`, `const`, `if`, `return`) are more visible in dark theme
- [ ] Confirm the color still looks appropriate and doesn't clash with other syntax colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)