### PR TITLE
fix: add bottom padding to chat inputs to clear MobileTabBar on mobile

### DIFF
--- a/packages/coc/src/server/spa/client/react/repos/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/FollowUpInputArea.tsx
@@ -100,7 +100,7 @@ export function FollowUpInputArea({
     }, [followUpInput]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
-        <div className="border-t border-[#e0e0e0] dark:border-[#3c3c3c] p-3 space-y-2">
+        <div className="border-t border-[#e0e0e0] dark:border-[#3c3c3c] p-3 pb-14 md:pb-3 space-y-2">
             {(sending || task?.status === 'running') && (
                 <div className="flex items-center gap-2 text-xs text-[#848484] dark:text-[#999]" data-testid="agent-responding-indicator">
                     <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#0078d4] animate-pulse" />

--- a/packages/coc/src/server/spa/client/react/repos/NewChatArea.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/NewChatArea.tsx
@@ -89,7 +89,7 @@ export function NewChatArea({ workspaceId }: NewChatAreaProps) {
             </div>
 
             {/* Input area */}
-            <div className="border-t border-[#e0e0e0] dark:border-[#3c3c3c] p-3 space-y-2">
+            <div className="border-t border-[#e0e0e0] dark:border-[#3c3c3c] p-3 pb-14 md:pb-3 space-y-2">
                 {error && <div className="text-xs text-[#f14c4c]" data-testid="new-chat-error">{error}</div>}
                 <div className="flex flex-row items-center gap-2" data-testid="chat-input-bar">
                     <div className="flex-1 min-w-0">


### PR DESCRIPTION
Add pb-14 (56px) on mobile and md:pb-3 on tablet+ to FollowUpInputArea and NewChatArea so the input box is not obscured by the fixed-position MobileTabBar (h-12 / 48px) on small screens.