### PR TITLE
fix: Stop button stuck after task completion (SSE/WebSocket race)

### DIFF
--- a/packages/coc/src/server/spa/client/react/hooks/useChatSSE.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useChatSSE.ts
@@ -214,19 +214,57 @@ export function useChatSSE({
         });
 
         es.onerror = () => {
-            if (finished) return; // finish() already handled completion
-            finished = true;
-            closeSSE();
-            // Unblock any sendFollowUp awaiting completion so sending/Stop-button resets.
-            onSendComplete();
-            // Refresh task status from queue so task.status doesn't remain 'running'.
-            fetch(`${getApiBase()}/queue/${encodeURIComponent(taskId)}`)
-                .then(r => r.ok ? r.json() : null)
-                .then((data: any) => {
-                    if (data?.task) setTask((prev: any) => prev ? { ...prev, ...data.task } : data.task);
-                })
-                .catch(() => {});
-            void refreshConversation(processId);
+            // Defer to let the browser drain any buffered SSE events (e.g. 'done',
+            // 'status') that arrived before the connection closed.  Without this,
+            // es.close() inside the guard below would discard those events, causing
+            // task.status to remain 'running' permanently.
+            setTimeout(() => {
+                if (finished) return; // finish() already handled completion
+                finished = true;
+                closeSSE();
+                setBackgroundTasks(null);
+                // Optimistically mark the task as completed so the Stop button
+                // transitions to Send immediately instead of waiting for the
+                // async fetch below.
+                setTask(prev => prev && prev.status === 'running' ? { ...prev, status: 'completed' } : prev);
+                if (queueDispatch && workspaceId) {
+                    queueDispatch({ type: 'REPO_TASK_COMPLETED_OPTIMISTIC', repoId: workspaceId, taskId, status: 'completed' });
+                }
+                setPendingQueue(prev => prev.filter(m => m.status !== 'steering'));
+                // Unblock any sendFollowUp awaiting completion so sending/Stop-button resets.
+                onSendComplete();
+                // Fetch authoritative task status from queue with retry to handle
+                // the window where the server hasn't updated the process record yet.
+                const fetchTaskStatus = (attempt: number) => {
+                    fetch(`${getApiBase()}/queue/${encodeURIComponent(taskId)}`)
+                        .then(r => r.ok ? r.json() : null)
+                        .then((data: any) => {
+                            if (data?.task) {
+                                const serverStatus = data.task.status;
+                                if (serverStatus === 'running' && attempt < 3) {
+                                    // Server hasn't updated yet — retry with exponential backoff
+                                    setTimeout(() => fetchTaskStatus(attempt + 1), 500 * Math.pow(2, attempt));
+                                } else {
+                                    setTask((prev: any) => prev ? { ...prev, ...data.task } : data.task);
+                                    // Update queue context with authoritative status if terminal
+                                    if (queueDispatch && workspaceId && serverStatus && !['running', 'queued'].includes(serverStatus)) {
+                                        const mapped: 'completed' | 'failed' | 'cancelled' =
+                                            serverStatus === 'failed' ? 'failed' :
+                                            serverStatus === 'cancelled' ? 'cancelled' : 'completed';
+                                        queueDispatch({ type: 'REPO_TASK_COMPLETED_OPTIMISTIC', repoId: workspaceId, taskId, status: mapped });
+                                    }
+                                }
+                            }
+                        })
+                        .catch(() => {
+                            if (attempt < 3) {
+                                setTimeout(() => fetchTaskStatus(attempt + 1), 500 * Math.pow(2, attempt));
+                            }
+                        });
+                };
+                fetchTaskStatus(0);
+                void refreshConversation(processId);
+            }, 0);
         };
 
         es.addEventListener('suggestions', (event: Event) => {

--- a/packages/coc/src/server/spa/client/react/repos/ActivityChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/ActivityChatDetail.tsx
@@ -271,6 +271,18 @@ export function ActivityChatDetail({ taskId, onBack, workspaceId, isPopOut = fal
 
     useQueuedTaskPoll({ taskId, task, setTask, setProcessDetails, setTurnsAndRef });
 
+    // Safety net: sync task.status from queue context when it reports a terminal
+    // status but the local task still shows 'running' (e.g. SSE onerror race).
+    useEffect(() => {
+        if (!workspaceId || !taskId || task?.status !== 'running') return;
+        const repo = queueState.repoQueueMap[workspaceId];
+        if (!repo) return;
+        const match = repo.history?.find((t: any) => t.id === taskId);
+        if (match && ['completed', 'failed', 'cancelled'].includes(match.status)) {
+            setTask((prev: any) => prev ? { ...prev, status: match.status } : prev);
+        }
+    }, [workspaceId, taskId, task?.status, queueState.repoQueueMap]); // eslint-disable-line react-hooks/exhaustive-deps
+
     const { handlePopOut, handleFloat } = useChatWindowActions({ task, taskId, workspaceId });
 
     // Fetch skills when workspaceId changes

--- a/packages/coc/test/spa/hooks/useChatSSE.test.ts
+++ b/packages/coc/test/spa/hooks/useChatSSE.test.ts
@@ -139,14 +139,18 @@ describe('useChatSSE', () => {
         renderHook(() => useChatSSE(makeOptions({ refreshConversation, setIsStreaming })));
         const es = MockEventSource.latest();
         act(() => { es.triggerError(); });
+        // onerror is deferred via setTimeout(0) — wait for it
+        await act(async () => { await new Promise(r => setTimeout(r, 0)); });
         expect(es.closed).toBe(true);
         expect(refreshConversation).toHaveBeenCalledWith('proc-1');
     });
 
-    it('calls onSendComplete on error so sending state and Stop button reset', () => {
+    it('calls onSendComplete on error so sending state and Stop button reset', async () => {
         const onSendComplete = vi.fn();
         renderHook(() => useChatSSE(makeOptions({ onSendComplete })));
         act(() => { MockEventSource.latest().triggerError(); });
+        // onerror is deferred via setTimeout(0) — wait for it
+        await act(async () => { await new Promise(r => setTimeout(r, 0)); });
         expect(onSendComplete).toHaveBeenCalled();
     });
 
@@ -159,7 +163,8 @@ describe('useChatSSE', () => {
         }));
         renderHook(() => useChatSSE(makeOptions({ setTask })));
         act(() => { MockEventSource.latest().triggerError(); });
-        // Wait for the fetch to resolve
+        // Wait for the deferred onerror handler and the fetch to resolve
+        await act(async () => { await new Promise(r => setTimeout(r, 0)); });
         await act(async () => { await new Promise(r => setTimeout(r, 0)); });
         const taskUpdater = setTask.mock.calls.find(call => typeof call[0] === 'function')?.[0];
         const prev = { id: 'task-1', status: 'running' };

--- a/packages/coc/test/spa/react/hooks/useChatSSE.test.ts
+++ b/packages/coc/test/spa/react/hooks/useChatSSE.test.ts
@@ -108,10 +108,12 @@ describe('useChatSSE', () => {
         expect(MockEventSource.instances).toHaveLength(0);
     });
 
-    it('calls setIsStreaming(false) on SSE onerror', () => {
+    it('calls setIsStreaming(false) on SSE onerror', async () => {
         const setIsStreaming = vi.fn();
         renderHook(() => useChatSSE(makeOptions({ setIsStreaming })));
         act(() => { MockEventSource.last._emitError(); });
+        // onerror is now deferred via setTimeout(0) — advance timers
+        await act(async () => { vi.advanceTimersByTime(0); });
         expect(setIsStreaming).toHaveBeenCalledWith(false);
     });
 
@@ -379,5 +381,143 @@ describe('useChatSSE', () => {
         // Then fire 'done' (should be suppressed)
         await act(async () => { es._emit('done', {}); });
         expect(refreshConversation).toHaveBeenCalledTimes(1);
+    });
+
+    it('onerror before done: defers via setTimeout so buffered done event fires first', async () => {
+        const setTask = vi.fn();
+        const onSendComplete = vi.fn();
+        const refreshConversation = vi.fn().mockResolvedValue(undefined);
+        renderHook(() => useChatSSE(makeOptions({ setTask, onSendComplete, refreshConversation })));
+        const es = MockEventSource.last;
+
+        // Simulate the race: onerror fires, then 'done' fires before setTimeout(0) runs
+        act(() => { es._emitError(); });
+        // At this point onerror has called setTimeout(..., 0) but the callback hasn't run yet.
+        // The 'done' event fires synchronously before the deferred handler:
+        await act(async () => { es._emit('done', {}); });
+        // finish() from 'done' should have set task to completed
+        const doneUpdater = setTask.mock.calls.find(([arg]: any) => typeof arg === 'function')?.[0];
+        expect(doneUpdater).toBeDefined();
+        expect(doneUpdater({ status: 'running' })).toEqual({ status: 'completed' });
+
+        // Now let the deferred onerror handler run — it should be suppressed by the finished guard
+        await act(async () => { vi.advanceTimersByTime(0); });
+        // onSendComplete was called once by finish() (via refreshConversation.finally), not by onerror
+        expect(onSendComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('onerror sets task.status to completed synchronously when no done event arrives', async () => {
+        const setTask = vi.fn();
+        const onSendComplete = vi.fn();
+        const refreshConversation = vi.fn().mockResolvedValue(undefined);
+        // Mock fetch for the retry fetch
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ task: { id: 'task-1', status: 'completed' } }),
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        renderHook(() => useChatSSE(makeOptions({ setTask, onSendComplete, refreshConversation })));
+        const es = MockEventSource.last;
+
+        // Fire onerror with no prior done event
+        act(() => { es._emitError(); });
+        // Advance past the setTimeout(0) deferral
+        await act(async () => { vi.advanceTimersByTime(0); });
+
+        // task.status should be optimistically set to 'completed'
+        const updater = setTask.mock.calls.find(([arg]: any) => typeof arg === 'function')?.[0];
+        expect(updater).toBeDefined();
+        expect(updater({ status: 'running' })).toEqual({ status: 'completed' });
+        // onSendComplete should have been called
+        expect(onSendComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('onerror dispatches REPO_TASK_COMPLETED_OPTIMISTIC', async () => {
+        const queueDispatch = vi.fn();
+        const refreshConversation = vi.fn().mockResolvedValue(undefined);
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ task: { id: 'task-1', status: 'completed' } }),
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        renderHook(() => useChatSSE(makeOptions({ queueDispatch, workspaceId: 'ws-1', refreshConversation })));
+        const es = MockEventSource.last;
+        act(() => { es._emitError(); });
+        await act(async () => { vi.advanceTimersByTime(0); });
+
+        expect(queueDispatch).toHaveBeenCalledWith({
+            type: 'REPO_TASK_COMPLETED_OPTIMISTIC',
+            repoId: 'ws-1',
+            taskId: 'task-1',
+            status: 'completed',
+        });
+    });
+
+    it('onerror retries fetch when server returns stale running status', async () => {
+        const setTask = vi.fn();
+        const refreshConversation = vi.fn().mockResolvedValue(undefined);
+        // First fetch returns stale 'running', second returns 'completed'
+        const mockFetch = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ task: { id: 'task-1', status: 'running' } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ task: { id: 'task-1', status: 'completed' } }),
+            });
+        vi.stubGlobal('fetch', mockFetch);
+
+        renderHook(() => useChatSSE(makeOptions({ setTask, refreshConversation })));
+        const es = MockEventSource.last;
+        act(() => { es._emitError(); });
+
+        // Run the deferred onerror handler
+        await act(async () => { vi.advanceTimersByTime(0); });
+        // Let the first fetch resolve
+        await act(async () => { await Promise.resolve(); });
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // First response was 'running' — should retry after 500ms
+        await act(async () => { vi.advanceTimersByTime(500); });
+        await act(async () => { await Promise.resolve(); });
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        // Second response was 'completed' — setTask should be called with server data
+        const serverUpdater = setTask.mock.calls.filter(([arg]: any) => typeof arg === 'function')
+            .map(([fn]: any) => fn)
+            .find((fn: any) => {
+                const result = fn({ id: 'task-1', status: 'running' });
+                return result?.status === 'completed' && result?.id === 'task-1';
+            });
+        expect(serverUpdater).toBeDefined();
+    });
+
+    it('onerror retries fetch on network error', async () => {
+        const refreshConversation = vi.fn().mockResolvedValue(undefined);
+        const mockFetch = vi.fn()
+            .mockRejectedValueOnce(new Error('network error'))
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ task: { id: 'task-1', status: 'completed' } }),
+            });
+        vi.stubGlobal('fetch', mockFetch);
+
+        renderHook(() => useChatSSE(makeOptions({ refreshConversation })));
+        const es = MockEventSource.last;
+        act(() => { es._emitError(); });
+
+        // Run the deferred onerror handler
+        await act(async () => { vi.advanceTimersByTime(0); });
+        // Let the first fetch reject
+        await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // Should retry after 500ms
+        await act(async () => { vi.advanceTimersByTime(500); });
+        await act(async () => { await Promise.resolve(); });
+        expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
The onerror handler now:
1. Defers via setTimeout(0) so buffered done/status events drain first
2. Optimistically sets task.status to completed immediately
3. Dispatches REPO_TASK_COMPLETED_OPTIMISTIC to sync queue context
4. Retries the queue fetch (3 attempts, exponential backoff) for stale status

ActivityChatDetail gains a safety-net useEffect that syncs task.status from the queue context when it reports a terminal status but local state still shows 'running'.