### PR TITLE
fix: prevent portal-rendered dialogs from closing RepoManagementPopover

### DIFF
--- a/packages/coc/src/server/spa/client/react/repos/RepoManagementPopover.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/RepoManagementPopover.tsx
@@ -32,6 +32,12 @@ export function RepoManagementPopover({ open, onClose, repos, onRefresh }: RepoM
                 target.id === 'repo-picker-btn' || target.closest('#repo-picker-btn')) {
                 return;
             }
+            // Don't close when clicking inside a portal-rendered dialog (e.g. AddRepoDialog,
+            // AddFolderDialog). These render via createPortal to document.body, so their DOM
+            // is outside containerRef even though they are logically children.
+            if (target.closest('[data-testid="dialog-overlay"]')) {
+                return;
+            }
             if (containerRef.current && !containerRef.current.contains(target)) {
                 onClose();
             }

--- a/packages/coc/test/spa/react/repos/RepoManagementPopover.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoManagementPopover.test.tsx
@@ -82,6 +82,40 @@ describe('RepoManagementPopover', () => {
         addSpy.mockRestore();
     });
 
+    it('does not call onClose when clicking inside a portal-rendered dialog overlay', () => {
+        const onClose = vi.fn();
+        render(
+            <div>
+                <RepoManagementPopover open={true} onClose={onClose} repos={[]} onRefresh={vi.fn()} />
+                <div data-testid="dialog-overlay">
+                    <button data-testid="dialog-browse-btn">Browse</button>
+                </div>
+            </div>
+        );
+        // Click the button inside the dialog overlay (simulates AddRepoDialog Browse button)
+        fireEvent.mouseDown(screen.getByTestId('dialog-browse-btn'));
+        expect(onClose).not.toHaveBeenCalled();
+
+        // Click the overlay itself
+        fireEvent.mouseDown(screen.getByTestId('dialog-overlay'));
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('still closes when clicking outside both popover and dialog overlay', () => {
+        const onClose = vi.fn();
+        render(
+            <div>
+                <RepoManagementPopover open={true} onClose={onClose} repos={[]} onRefresh={vi.fn()} />
+                <div data-testid="dialog-overlay">
+                    <button>Browse</button>
+                </div>
+                <div data-testid="genuine-outside" />
+            </div>
+        );
+        fireEvent.mouseDown(screen.getByTestId('genuine-outside'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('has role=dialog and aria-modal=true for accessibility', () => {
         render(
             <RepoManagementPopover open={true} onClose={vi.fn()} repos={[]} onRefresh={vi.fn()} />


### PR DESCRIPTION
Add a guard in handleMouseDown to skip closing when the click target is inside a [data-testid='dialog-overlay'] element. AddRepoDialog and AddFolderDialog render via createPortal to document.body, placing their DOM outside the popover container. Without this guard, any click inside those dialogs triggered onClose(), destroying dialog state.