### PR TITLE
fix: browse symlinked directories + add React ErrorBoundary

### DIFF
--- a/packages/coc/src/server/routes/api-fs-routes.ts
+++ b/packages/coc/src/server/routes/api-fs-routes.ts
@@ -47,7 +47,20 @@ export function browseDirectory(dirPath: string, showHidden = false): {
         const entries: Array<{ name: string; type: 'directory'; isGitRepo: boolean }> = [];
 
         for (const entry of rawEntries) {
-            if (!entry.isDirectory()) continue;
+            let isDir = entry.isDirectory();
+
+            // Symlinks report isDirectory()=false; resolve the target to check.
+            if (!isDir && entry.isSymbolicLink()) {
+                try {
+                    const realStat = fs.statSync(path.join(dirPath, entry.name));
+                    isDir = realStat.isDirectory();
+                } catch {
+                    // Broken symlink — skip gracefully
+                    continue;
+                }
+            }
+
+            if (!isDir) continue;
             if (!showHidden && entry.name.startsWith('.')) continue;
 
             const fullPath = path.join(dirPath, entry.name);

--- a/packages/coc/src/server/spa/client/index.tsx
+++ b/packages/coc/src/server/spa/client/index.tsx
@@ -12,6 +12,7 @@ import { createRoot } from 'react-dom/client';
 import { App } from './react/App';
 import { PopOutActivityShell } from './react/layout/PopOutActivityShell';
 import { PopOutMarkdownShell } from './react/layout/PopOutMarkdownShell';
+import { ErrorBoundary } from './react/shared/ErrorBoundary';
 import './react/file-path-preview';
 import './react/repos/explorer/monaco-setup';
 
@@ -20,9 +21,9 @@ if (!container) throw new Error('No #app-root element found');
 const root = createRoot(container);
 
 if (window.location.hash.startsWith('#popout/activity/')) {
-    root.render(<PopOutActivityShell />);
+    root.render(<ErrorBoundary><PopOutActivityShell /></ErrorBoundary>);
 } else if (window.location.hash.startsWith('#popout/markdown')) {
-    root.render(<PopOutMarkdownShell />);
+    root.render(<ErrorBoundary><PopOutMarkdownShell /></ErrorBoundary>);
 } else {
     root.render(<App />);
 }

--- a/packages/coc/src/server/spa/client/react/App.tsx
+++ b/packages/coc/src/server/spa/client/react/App.tsx
@@ -21,7 +21,7 @@ import { Router } from './layout/Router';
 import { FloatingChatManager } from './layout/FloatingChatManager';
 import { useWebSocket } from './hooks/useWebSocket';
 import { fetchApi } from './hooks/useApi';
-import { ToastContainer, useToast } from './shared';
+import { ToastContainer, useToast, ErrorBoundary } from './shared';
 import { toForwardSlashes } from '@plusplusoneplusplus/forge/utils/path-utils';
 import { MarkdownReviewDialog } from './processes/MarkdownReviewDialog';
 import { EnqueueDialog } from './queue/EnqueueDialog';
@@ -398,18 +398,20 @@ function AppInner() {
                 <FloatingChatManager />
                 <BottomNav />
                 <ToastContainer toasts={toasts} removeToast={removeToast} />
-                <EnqueueDialog />
-                <RunScriptDialog />
-                <MarkdownReviewDialog
-                    open={reviewDialog.open}
-                    onClose={() => setReviewDialog(prev => ({ ...prev, open: false }))}
-                    onMinimize={handleMinimizeReview}
-                    wsId={reviewDialog.wsId}
-                    filePath={reviewDialog.filePath}
-                    displayPath={reviewDialog.displayPath}
-                    fetchMode={reviewDialog.fetchMode}
-                    initialScrollTop={reviewDialog.scrollTop}
-                />
+                <ErrorBoundary label="Dialog error" inline>
+                    <EnqueueDialog />
+                    <RunScriptDialog />
+                    <MarkdownReviewDialog
+                        open={reviewDialog.open}
+                        onClose={() => setReviewDialog(prev => ({ ...prev, open: false }))}
+                        onMinimize={handleMinimizeReview}
+                        wsId={reviewDialog.wsId}
+                        filePath={reviewDialog.filePath}
+                        displayPath={reviewDialog.displayPath}
+                        fetchMode={reviewDialog.fetchMode}
+                        initialScrollTop={reviewDialog.scrollTop}
+                    />
+                </ErrorBoundary>
                 <MinimizedDialogsTray />
             </ReposProvider>
         </ToastProvider>
@@ -418,24 +420,26 @@ function AppInner() {
 
 export function App() {
     return (
-        <AppProvider>
-            <QueueProvider>
-                <WorkItemProvider>
-                <NotificationProvider>
-                    <PopOutProvider>
-                        <MarkdownPopOutProvider>
-                            <FloatingChatsProvider>
-                            <MinimizedDialogsProvider>
-                                <ThemeProvider>
-                                    <AppInner />
-                                </ThemeProvider>
-                            </MinimizedDialogsProvider>
-                        </FloatingChatsProvider>
-                        </MarkdownPopOutProvider>
-                    </PopOutProvider>
-                </NotificationProvider>
-                </WorkItemProvider>
-            </QueueProvider>
-        </AppProvider>
+        <ErrorBoundary>
+            <AppProvider>
+                <QueueProvider>
+                    <WorkItemProvider>
+                    <NotificationProvider>
+                        <PopOutProvider>
+                            <MarkdownPopOutProvider>
+                                <FloatingChatsProvider>
+                                <MinimizedDialogsProvider>
+                                    <ThemeProvider>
+                                        <AppInner />
+                                    </ThemeProvider>
+                                </MinimizedDialogsProvider>
+                            </FloatingChatsProvider>
+                            </MarkdownPopOutProvider>
+                        </PopOutProvider>
+                    </NotificationProvider>
+                    </WorkItemProvider>
+                </QueueProvider>
+            </AppProvider>
+        </ErrorBoundary>
     );
 }

--- a/packages/coc/src/server/spa/client/react/shared/ErrorBoundary.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/ErrorBoundary.tsx
@@ -1,0 +1,91 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+interface ErrorBoundaryProps {
+    children: ReactNode;
+    /** Shown in the fallback UI heading. Defaults to "Something went wrong". */
+    label?: string;
+    /** When true, renders a compact inline error instead of a full-page overlay. */
+    inline?: boolean;
+}
+
+interface ErrorBoundaryState {
+    error: Error | null;
+}
+
+/**
+ * Generic React ErrorBoundary.
+ *
+ * - **Top-level** (`inline=false`, default): full-screen overlay with reload button.
+ * - **Inline** (`inline=true`): compact card suitable for wrapping dialogs or panels.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    state: ErrorBoundaryState = { error: null };
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { error };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        console.error('[ErrorBoundary]', this.props.label ?? 'Uncaught render error', error, info.componentStack);
+    }
+
+    private handleReload = () => {
+        window.location.reload();
+    };
+
+    private handleDismiss = () => {
+        this.setState({ error: null });
+    };
+
+    render() {
+        if (!this.state.error) {
+            return this.props.children;
+        }
+
+        const heading = this.props.label ?? 'Something went wrong';
+
+        if (this.props.inline) {
+            return (
+                <div
+                    role="alert"
+                    className="flex flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[#1e1e1e] dark:text-[#cccccc]"
+                >
+                    <span className="text-2xl">⚠️</span>
+                    <p className="font-semibold">{heading}</p>
+                    <p className="text-xs text-[#848484] max-w-xs break-words">{this.state.error.message}</p>
+                    <div className="flex gap-2">
+                        <button
+                            onClick={this.handleDismiss}
+                            className="px-3 py-1 rounded text-xs bg-[#e8e8e8] dark:bg-[#3c3c3c] hover:bg-[#d4d4d4] dark:hover:bg-[#505050] transition-colors"
+                        >
+                            Dismiss
+                        </button>
+                        <button
+                            onClick={this.handleReload}
+                            className="px-3 py-1 rounded text-xs bg-[#0078d4] text-white hover:bg-[#106ebe] transition-colors"
+                        >
+                            Reload
+                        </button>
+                    </div>
+                </div>
+            );
+        }
+
+        return (
+            <div
+                role="alert"
+                className="fixed inset-0 z-[99999] flex flex-col items-center justify-center gap-4 bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc]"
+            >
+                <span className="text-5xl">😵</span>
+                <h1 className="text-lg font-semibold">{heading}</h1>
+                <p className="text-sm text-[#848484] max-w-md text-center break-words">{this.state.error.message}</p>
+                <button
+                    onClick={this.handleReload}
+                    className="mt-2 px-4 py-2 rounded bg-[#0078d4] text-white text-sm hover:bg-[#106ebe] transition-colors"
+                >
+                    Reload
+                </button>
+            </div>
+        );
+    }
+}

--- a/packages/coc/src/server/spa/client/react/shared/index.ts
+++ b/packages/coc/src/server/spa/client/react/shared/index.ts
@@ -15,6 +15,7 @@ export type { ToastProps } from './Toast';
 export { SourceEditor } from './SourceEditor';
 export type { SourceEditorProps } from './SourceEditor';
 export { cn } from './cn';
+export { ErrorBoundary } from './ErrorBoundary';
 export { ImagePreviews } from './ImagePreviews';
 export type { ImagePreviewsProps } from './ImagePreviews';
 export { ImageGallery } from './ImageGallery';

--- a/packages/coc/test/server/api-handler.test.ts
+++ b/packages/coc/test/server/api-handler.test.ts
@@ -1259,6 +1259,60 @@ describe('API Handler', () => {
 
             fs.rmSync(tmpDir, { recursive: true, force: true });
         });
+
+        it('should include symlinked directories', async () => {
+            const srv = await startServer();
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browse-symlink-'));
+            const realDir = path.join(tmpDir, 'real-dir');
+            fs.mkdirSync(realDir);
+            // Create a symlink pointing to the real directory
+            fs.symlinkSync(realDir, path.join(tmpDir, 'linked-dir'), 'dir');
+
+            const res = await request(`${srv.url}/api/fs/browse?path=${encodeURIComponent(tmpDir)}`);
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            const names = body.entries.map((e: any) => e.name);
+            expect(names).toContain('real-dir');
+            expect(names).toContain('linked-dir');
+            expect(body.entries).toHaveLength(2);
+
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it('should skip broken symlinks gracefully', async () => {
+            const srv = await startServer();
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browse-broken-sym-'));
+            fs.mkdirSync(path.join(tmpDir, 'valid-dir'));
+            // Symlink pointing to a non-existent target
+            fs.symlinkSync(path.join(tmpDir, 'nonexistent'), path.join(tmpDir, 'broken-link'), 'dir');
+
+            const res = await request(`${srv.url}/api/fs/browse?path=${encodeURIComponent(tmpDir)}`);
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            // Broken symlink should be skipped, only valid-dir returned
+            expect(body.entries).toHaveLength(1);
+            expect(body.entries[0].name).toBe('valid-dir');
+
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it('should detect git repo via symlinked directory', async () => {
+            const srv = await startServer();
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browse-symgit-'));
+            const realRepo = path.join(tmpDir, 'real-repo');
+            fs.mkdirSync(realRepo);
+            fs.mkdirSync(path.join(realRepo, '.git'));
+            fs.symlinkSync(realRepo, path.join(tmpDir, 'sym-repo'), 'dir');
+
+            const res = await request(`${srv.url}/api/fs/browse?path=${encodeURIComponent(tmpDir)}`);
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            const symEntry = body.entries.find((e: any) => e.name === 'sym-repo');
+            expect(symEntry).toBeDefined();
+            expect(symEntry.isGitRepo).toBe(true);
+
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
     });
 
     // ========================================================================


### PR DESCRIPTION
- browseDirectory() now resolves symlinks via fs.statSync() so symlinked folders (e.g. OneDrive on macOS) appear in the Add Repo browser
- Broken symlinks are gracefully skipped (no crash)
- Add top-level ErrorBoundary wrapping App root to prevent white-screen crashes on unhandled render errors
- Add inline ErrorBoundary around portal dialog components
- ErrorBoundary on pop-out shells (activity, markdown)
- Show user-friendly error UI with Reload/Dismiss buttons
- 3 new tests: symlink dirs, broken symlinks, git detection via symlink