### PR TITLE
docs(coc): warn that coc serve binds to 0.0.0.0 by default

### DIFF
--- a/packages/coc/README.md
+++ b/packages/coc/README.md
@@ -48,6 +48,22 @@ List pipeline packages in a directory.
 ### `coc serve`
 Start the AI Execution Dashboard web server (default port 4000).
 
+> ⚠️ **Security note:** By default, `coc serve` binds to `0.0.0.0`, which accepts
+> connections from **any network interface** — not just localhost. On shared or
+> public networks this can expose the dashboard to unauthorized access. To
+> restrict access to your local machine only, use:
+>
+> ```bash
+> coc serve --host 127.0.0.1
+> ```
+>
+> Or set it permanently in `~/.coc/config.yaml`:
+>
+> ```yaml
+> serve:
+>   host: 127.0.0.1
+> ```
+
 ## Features
 
 ### YAML Pipeline Execution


### PR DESCRIPTION
## Problem

`coc serve` defaults to binding on `0.0.0.0:4000`, which accepts connections from **all network interfaces** — not just localhost. On shared or public networks, this can expose the AI dashboard to unauthorized access.

## Changes

Added a security warning to the CoC README (`packages/coc/README.md`) under the `coc serve` command section, documenting:

- The default `0.0.0.0` bind address and its security implications
- How to restrict to localhost via `--host 127.0.0.1` CLI flag
- How to set it permanently in `~/.coc/config.yaml`

## Scope

Documentation-only change — single file: `packages/coc/README.md`