### PR TITLE
fix: AddRepoDialog dismissed on click due to popover outside-click handler

### DIFF
--- a/packages/coc/src/server/spa/client/react/repos/RepoManagementPopover.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/RepoManagementPopover.tsx
@@ -31,6 +31,12 @@ export function RepoManagementPopover({ open, onClose, repos, onRefresh }: RepoM
             if (target.id === 'hamburger-btn' || target.closest('#hamburger-btn')) {
                 return;
             }
+            // Don't close when clicking inside a dialog portal (e.g., AddRepoDialog).
+            // Dialogs render via createPortal to document.body, placing their DOM
+            // outside this container, but they are logically children of the popover.
+            if (target.closest('[data-testid="dialog-overlay"]')) {
+                return;
+            }
             if (containerRef.current && !containerRef.current.contains(target)) {
                 onClose();
             }

--- a/packages/coc/src/server/spa/client/react/ui/Dialog.tsx
+++ b/packages/coc/src/server/spa/client/react/ui/Dialog.tsx
@@ -65,6 +65,7 @@ export function Dialog({ open, onClose, onMinimize, title, children, footer, cla
             data-testid="dialog-overlay"
             className={overlayClass}
             onClick={isMobile ? undefined : (onMinimize ?? onClose)}
+            onMouseDown={e => e.stopPropagation()}
             style={hidden ? { display: 'none' } : undefined}
             aria-hidden={hidden || undefined}
         >

--- a/packages/coc/test/spa/react/repos/RepoManagementPopover.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoManagementPopover.test.tsx
@@ -82,6 +82,23 @@ describe('RepoManagementPopover', () => {
         addSpy.mockRestore();
     });
 
+    it('does not call onClose when clicking inside a dialog portal', () => {
+        const onClose = vi.fn();
+        render(
+            <div>
+                <RepoManagementPopover open={true} onClose={onClose} repos={[]} onRefresh={vi.fn()} />
+                {/* Simulate a dialog portal rendered to document.body (outside the popover) */}
+                <div data-testid="dialog-overlay">
+                    <div data-testid="dialog-panel">
+                        <span data-testid="dialog-content">Dialog content</span>
+                    </div>
+                </div>
+            </div>
+        );
+        fireEvent.mouseDown(screen.getByTestId('dialog-content'));
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
     it('has role=dialog and aria-modal=true for accessibility', () => {
         render(
             <RepoManagementPopover open={true} onClose={vi.fn()} repos={[]} onRefresh={vi.fn()} />

--- a/packages/coc/test/spa/shared/Dialog.test.tsx
+++ b/packages/coc/test/spa/shared/Dialog.test.tsx
@@ -191,4 +191,39 @@ describe('Dialog', () => {
         expect(document.querySelector('[data-testid="dialog-minimize-btn"]')).not.toBeNull();
         expect(document.querySelector('[data-testid="dialog-close-btn"]')).not.toBeNull();
     });
+
+    // ── mousedown propagation tests ─────────────────────────────────────────
+
+    it('mousedown inside dialog does not propagate to document-level handlers', () => {
+        const documentHandler = vi.fn();
+        document.addEventListener('mousedown', documentHandler);
+        try {
+            render(
+                <Dialog open={true} onClose={vi.fn()} title="Test">
+                    <span>Inner Content</span>
+                </Dialog>
+            );
+            fireEvent.mouseDown(screen.getByText('Inner Content'));
+            expect(documentHandler).not.toHaveBeenCalled();
+        } finally {
+            document.removeEventListener('mousedown', documentHandler);
+        }
+    });
+
+    it('mousedown on dialog overlay does not propagate to document-level handlers', () => {
+        const documentHandler = vi.fn();
+        document.addEventListener('mousedown', documentHandler);
+        try {
+            render(
+                <Dialog open={true} onClose={vi.fn()} title="Test">
+                    Content
+                </Dialog>
+            );
+            const overlay = document.querySelector('[data-testid="dialog-overlay"]') as HTMLElement;
+            fireEvent.mouseDown(overlay);
+            expect(documentHandler).not.toHaveBeenCalled();
+        } finally {
+            document.removeEventListener('mousedown', documentHandler);
+        }
+    });
 });


### PR DESCRIPTION
## Problem

When opening the **Add Repository** dialog via the repo management popover (hamburger menu -> + Add -> Add Repository), clicking **anywhere** inside the dialog causes it to immediately disappear. Users cannot interact with the dialog at all — typing in inputs, clicking color swatches, or pressing buttons all dismiss it.

## Root Cause

`RepoManagementPopover` registers a `mousedown` handler on `document` to close itself on outside clicks. The `AddRepoDialog` renders via `ReactDOM.createPortal(content, document.body)`, placing its DOM **outside** the popover container in the DOM tree. When clicking inside the dialog:

1. `mousedown` fires on the dialog element
2. The popover's document-level handler runs
3. `containerRef.current.contains(target)` returns `false` (portal is outside the popover container)
4. `onClose()` fires -> popover unmounts -> `ReposGrid` unmounts -> dialog disappears

### Why Playwright tests didn't catch this

Existing E2E tests use `dispatchEvent('click')` to open the dialog, which does **not** fire a `mousedown` event, so the popover's handler never triggers during tests.

## Fix

**Two-layer defense:**

1. **Dialog component** (`Dialog.tsx`): Added `onMouseDown` stopPropagation on the overlay div. This is the correct behavior for a modal dialog — it prevents document-level mousedown handlers from firing when a modal is active.

2. **RepoManagementPopover** (`RepoManagementPopover.tsx`): Added a defensive check — if the mousedown target is inside a `[data-testid="dialog-overlay"]`, skip the close logic. This guards against the portal-escapes-container pattern even without the Dialog-level fix.

## Tests Added

- **Dialog**: 2 new tests verifying `mousedown` inside the dialog panel and on the overlay does not propagate to document-level handlers
- **RepoManagementPopover**: 1 new test verifying clicking inside a dialog portal does not close the popover

All 4525 related tests pass across 219 test files.