### PR TITLE
feat(generate-plan): upgrade to unified file attachment support

### DIFF
--- a/packages/coc/src/server/spa/client/react/tasks/GenerateTaskDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/tasks/GenerateTaskDialog.tsx
@@ -6,13 +6,14 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Dialog, FloatingDialog, Button, ImageLightbox } from '../ui';
+import { Dialog, FloatingDialog, Button } from '../ui';
 import { RichTextInput } from '../shared/RichTextInput';
 import type { RichTextInputHandle } from '../shared/RichTextInput';
 import { useBreakpoint } from '../hooks/ui/useBreakpoint';
 import { useQueueTaskGeneration } from '../queue/hooks/useQueueTaskGeneration';
 import { usePreferences } from '../hooks/preferences/usePreferences';
-import { useImagePaste } from '../features/chat/hooks/useImagePaste';
+import { useFileAttachments } from '../features/chat/hooks/useFileAttachments';
+import { AttachmentPreviews } from '../ui/AttachmentPreviews';
 import { useGlobalToast } from '../contexts/ToastContext';
 import { useMinimizedDialog } from '../contexts/MinimizedDialogsContext';
 import { type TaskFolder, filterGitMetadataFolders } from './hooks/useTaskTree';
@@ -143,11 +144,10 @@ export function GenerateTaskDialog({
     const { status, taskId, error, enqueue, reset } =
         useQueueTaskGeneration(wsId);
 
-    // --- image paste ---
-    const { images, addFromPaste, removeImage, clearImages } = useImagePaste();
-
-    // --- image lightbox ---
-    const [viewImageIndex, setViewImageIndex] = useState<number | null>(null);
+    // --- file attachments (images + arbitrary files via paste / file-picker / drag-drop) ---
+    const { attachments, images, addFromPaste, addFromFileInput, removeAttachment, clearAttachments, error: attachmentError, clearError: clearAttachmentError } = useFileAttachments();
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isDragOver, setIsDragOver] = useState(false);
 
     // --- fetch models on mount ---
     useEffect(() => {
@@ -182,10 +182,32 @@ export function GenerateTaskDialog({
     useEffect(() => {
         if (status === 'queued') {
             addToast(`Task queued${taskId ? ` (${taskId.slice(0, 8)})` : ''}`, 'success');
-            clearImages();
+            clearAttachments();
             onSuccess(taskId || '');
         }
-    }, [status, taskId, addToast, clearImages, onSuccess]);
+    }, [status, taskId, addToast, clearAttachments, onSuccess]);
+
+    // --- drag & drop ---
+    const handleDragOver = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragOver(true);
+    }, []);
+
+    const handleDragLeave = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragOver(false);
+    }, []);
+
+    const handleDrop = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragOver(false);
+        if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+            addFromFileInput(e.dataTransfer.files);
+        }
+    }, [addFromFileInput]);
 
     const handleGenerate = useCallback(() => {
         let finalModel = model;
@@ -252,45 +274,74 @@ export function GenerateTaskDialog({
         <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1">
                     <label className="text-xs text-[#616161] dark:text-[#999]">Prompt</label>
-                    <RichTextInput
-                        ref={richTextRef}
-                        id="gen-task-prompt"
-                        className="w-full px-2 py-1.5 text-sm rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-white dark:bg-[#3c3c3c] text-[#1e1e1e] dark:text-[#cccccc] min-h-[80px]"
-                        onChange={(value) => setPrompt(value)}
-                        onKeyDown={e => {
-                            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && prompt.trim() && !isSubmitting && !isQueued) {
-                                e.preventDefault();
-                                handleGenerate();
+                    {/* Hidden file input for the attach button */}
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept="image/*"
+                        className="hidden"
+                        data-testid="gen-task-file-input-hidden"
+                        onChange={(e) => {
+                            if (e.target.files && e.target.files.length > 0) {
+                                addFromFileInput(e.target.files);
                             }
+                            e.target.value = '';
                         }}
-                        onPaste={isSubmitting || isQueued ? undefined : addFromPaste}
-                        disabled={isSubmitting || isQueued}
-                        placeholder="Describe the task to generate…"
-                        data-testid="gen-task-prompt-input"
                     />
-                    {/* Image preview strip */}
-                    {images.length > 0 && (
-                        <div id="gen-task-images" className="flex flex-wrap gap-2 mt-1">
-                            {images.map((img, i) => (
-                                <div key={i} className="relative group">
-                                    <img
-                                        src={img}
-                                        alt={`Attachment ${i + 1}`}
-                                        className="w-[80px] h-[80px] object-cover rounded border border-[#e0e0e0] dark:border-[#3c3c3c] cursor-zoom-in"
-                                        onClick={() => setViewImageIndex(i)}
-                                    />
-                                    <button
-                                        className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-red-500 text-white text-xs flex items-center justify-center opacity-80 hover:opacity-100"
-                                        onClick={() => removeImage(i)}
-                                        aria-label={`Remove image ${i + 1}`}
-                                        disabled={isSubmitting || isQueued}
-                                    >
-                                        ×
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
+                    {attachmentError && (
+                        <div className="text-xs text-[#f14c4c] mb-1" data-testid="gen-task-attachment-error">{attachmentError}</div>
                     )}
+                    <div
+                        className={`relative rounded border-2 border-dashed transition-colors ${
+                            isDragOver
+                                ? 'border-[#0078d4] bg-[#0078d4]/5 dark:bg-[#0078d4]/10'
+                                : 'border-transparent'
+                        }`}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onDrop={handleDrop}
+                        data-testid="gen-task-drop-zone"
+                    >
+                        {isDragOver && (
+                            <div className="absolute inset-0 flex items-center justify-center bg-[#0078d4]/5 dark:bg-[#0078d4]/10 rounded pointer-events-none z-10" data-testid="gen-task-drop-zone-overlay">
+                                <span className="text-sm font-medium text-[#0078d4]">📎 Drop files here</span>
+                            </div>
+                        )}
+                        <RichTextInput
+                            ref={richTextRef}
+                            id="gen-task-prompt"
+                            className="w-full px-2 py-1.5 text-sm rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-white dark:bg-[#3c3c3c] text-[#1e1e1e] dark:text-[#cccccc] min-h-[80px]"
+                            onChange={(value) => setPrompt(value)}
+                            onKeyDown={e => {
+                                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && prompt.trim() && !isSubmitting && !isQueued) {
+                                    e.preventDefault();
+                                    handleGenerate();
+                                }
+                            }}
+                            onPaste={isSubmitting || isQueued ? undefined : addFromPaste}
+                            disabled={isSubmitting || isQueued}
+                            placeholder="Describe the task to generate…"
+                            data-testid="gen-task-prompt-input"
+                        />
+                    </div>
+                    <div className="flex items-center gap-2 mt-1">
+                        <button
+                            type="button"
+                            disabled={isSubmitting || isQueued}
+                            onClick={() => fileInputRef.current?.click()}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded border border-[#d0d0d0] dark:border-[#3c3c3c] bg-white dark:bg-[#1f1f1f] text-[#848484] hover:text-[#1e1e1e] dark:hover:text-[#cccccc] cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#0078d4]/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                            data-testid="gen-task-attach-btn"
+                            aria-label="Attach image"
+                            title="Attach images or drag & drop"
+                        >
+                            📎 Attach
+                        </button>
+                        <span className="text-[11px] text-[#a0a0a0] dark:text-[#666]">
+                            or paste images (Ctrl+V) / drag &amp; drop
+                        </span>
+                    </div>
+                    <AttachmentPreviews attachments={attachments} onRemove={removeAttachment} data-testid="gen-task-attachment-previews" />
                 </div>
 
                 {/* Task name (optional) */}
@@ -477,13 +528,6 @@ export function GenerateTaskDialog({
                         </div>
                     )}
                 </div>
-
-                {/* Image lightbox */}
-                <ImageLightbox
-                    src={viewImageIndex !== null ? images[viewImageIndex] : null}
-                    alt={viewImageIndex !== null ? `Attachment ${viewImageIndex + 1}` : undefined}
-                    onClose={() => setViewImageIndex(null)}
-                />
 
                 {/* Error banner with Retry */}
                 {isError && (

--- a/packages/coc/test/spa/react/GenerateTaskDialog.test.tsx
+++ b/packages/coc/test/spa/react/GenerateTaskDialog.test.tsx
@@ -18,24 +18,31 @@ vi.mock('../../../src/server/spa/client/react/hooks/preferences/usePreferences',
     usePreferences: vi.fn(),
 }));
 
-const mockClearImages = vi.fn();
+const mockClearAttachments = vi.fn();
 const mockAddFromPaste = vi.fn();
-const mockRemoveImage = vi.fn();
+const mockRemoveAttachment = vi.fn();
+const mockAddFromFileInput = vi.fn();
+const mockClearError = vi.fn();
 
-vi.mock('../../../src/server/spa/client/react/features/chat/hooks/useImagePaste', () => ({
-    useImagePaste: vi.fn(() => ({
+vi.mock('../../../src/server/spa/client/react/features/chat/hooks/useFileAttachments', () => ({
+    useFileAttachments: vi.fn(() => ({
+        attachments: [],
         images: [],
         addFromPaste: mockAddFromPaste,
-        removeImage: mockRemoveImage,
-        clearImages: mockClearImages,
+        addFromFileInput: mockAddFromFileInput,
+        removeAttachment: mockRemoveAttachment,
+        clearAttachments: mockClearAttachments,
+        error: null,
+        clearError: mockClearError,
+        toPayload: vi.fn(() => []),
     })),
 }));
 
-import { useImagePaste } from '../../../src/server/spa/client/react/features/chat/hooks/useImagePaste';
+import { useFileAttachments } from '../../../src/server/spa/client/react/features/chat/hooks/useFileAttachments';
 
 const mockUseQueueTaskGeneration = useQueueTaskGeneration as Mock;
 const mockUsePreferences = usePreferences as Mock;
-const mockUseImagePaste = useImagePaste as Mock;
+const mockUseFileAttachments = useFileAttachments as Mock;
 
 function makeHookReturn(overrides: Record<string, unknown> = {}) {
     return {
@@ -62,9 +69,11 @@ beforeEach(() => {
     mockPersistModel.mockReset();
     mockPersistDepth.mockReset();
     mockPersistEffort.mockReset();
-    mockClearImages.mockReset();
+    mockClearAttachments.mockReset();
     mockAddFromPaste.mockReset();
-    mockRemoveImage.mockReset();
+    mockRemoveAttachment.mockReset();
+    mockAddFromFileInput.mockReset();
+    mockClearError.mockReset();
     global.fetch = mockFetch;
     mockUseQueueTaskGeneration.mockReturnValue(makeHookReturn());
     mockUsePreferences.mockReturnValue({
@@ -77,11 +86,16 @@ beforeEach(() => {
         setEffort: mockPersistEffort,
         loaded: true,
     });
-    mockUseImagePaste.mockReturnValue({
+    mockUseFileAttachments.mockReturnValue({
+        attachments: [],
         images: [],
         addFromPaste: mockAddFromPaste,
-        removeImage: mockRemoveImage,
-        clearImages: mockClearImages,
+        addFromFileInput: mockAddFromFileInput,
+        removeAttachment: mockRemoveAttachment,
+        clearAttachments: mockClearAttachments,
+        error: null,
+        clearError: mockClearError,
+        toPayload: vi.fn(() => []),
     });
 
     // Default fetch: models + tasks
@@ -1189,40 +1203,53 @@ describe('GenerateTaskDialog', () => {
         expect(lowBtn.className).toContain('bg-[#0078d4]/10');
     });
 
-    // ── image paste tests ────────────────────────────────────────────────────
+    // ── attachment tests ─────────────────────────────────────────────────────
 
-    it('renders image previews when images are present', async () => {
-        mockUseImagePaste.mockReturnValue({
+    it('renders attachment previews when attachments are present', async () => {
+        mockUseFileAttachments.mockReturnValue({
+            attachments: [
+                { id: 'a1', name: 'img1.png', mimeType: 'image/png', size: 100, dataUrl: 'data:image/png;base64,abc', category: 'image' },
+                { id: 'a2', name: 'img2.jpeg', mimeType: 'image/jpeg', size: 200, dataUrl: 'data:image/jpeg;base64,def', category: 'image' },
+            ],
             images: ['data:image/png;base64,abc', 'data:image/jpeg;base64,def'],
             addFromPaste: mockAddFromPaste,
-            removeImage: mockRemoveImage,
-            clearImages: mockClearImages,
+            addFromFileInput: mockAddFromFileInput,
+            removeAttachment: mockRemoveAttachment,
+            clearAttachments: mockClearAttachments,
+            error: null,
+            clearError: mockClearError,
+            toPayload: vi.fn(() => []),
         });
 
         await act(async () => { renderDialog(); });
 
-        const imagesContainer = document.getElementById('gen-task-images');
-        expect(imagesContainer).toBeDefined();
-        expect(imagesContainer).not.toBeNull();
-        const imgs = imagesContainer!.querySelectorAll('img');
+        const previewContainer = screen.getByTestId('gen-task-attachment-previews');
+        expect(previewContainer).toBeTruthy();
+        const imgs = previewContainer.querySelectorAll('[data-testid="attachment-preview-image"]');
         expect(imgs).toHaveLength(2);
     });
 
-    it('does not render image previews when no images', async () => {
+    it('does not render attachment previews when no attachments', async () => {
         await act(async () => { renderDialog(); });
 
-        const imagesContainer = document.getElementById('gen-task-images');
-        expect(imagesContainer).toBeNull();
+        expect(screen.queryByTestId('gen-task-attachment-previews')).toBeNull();
     });
 
     it('submit sends images in enqueue payload', async () => {
         const enqueueSpy = vi.fn();
         mockUseQueueTaskGeneration.mockReturnValue(makeHookReturn({ enqueue: enqueueSpy }));
-        mockUseImagePaste.mockReturnValue({
+        mockUseFileAttachments.mockReturnValue({
+            attachments: [
+                { id: 'a1', name: 'img1.png', mimeType: 'image/png', size: 100, dataUrl: 'data:image/png;base64,abc', category: 'image' },
+            ],
             images: ['data:image/png;base64,abc'],
             addFromPaste: mockAddFromPaste,
-            removeImage: mockRemoveImage,
-            clearImages: mockClearImages,
+            addFromFileInput: mockAddFromFileInput,
+            removeAttachment: mockRemoveAttachment,
+            clearAttachments: mockClearAttachments,
+            error: null,
+            clearError: mockClearError,
+            toPayload: vi.fn(() => []),
         });
 
         await act(async () => { renderDialog(); });
@@ -1263,7 +1290,7 @@ describe('GenerateTaskDialog', () => {
         );
     });
 
-    it('clears images after successful queue', async () => {
+    it('clears attachments after successful queue', async () => {
         mockUseQueueTaskGeneration.mockReturnValue(
             makeHookReturn({
                 status: 'queued',
@@ -1273,39 +1300,54 @@ describe('GenerateTaskDialog', () => {
 
         await act(async () => { renderDialog(); });
 
-        expect(mockClearImages).toHaveBeenCalled();
+        expect(mockClearAttachments).toHaveBeenCalled();
     });
 
-    it('remove button calls removeImage with correct index', async () => {
-        mockUseImagePaste.mockReturnValue({
+    it('remove button calls removeAttachment with correct id', async () => {
+        mockUseFileAttachments.mockReturnValue({
+            attachments: [
+                { id: 'a1', name: 'img1.png', mimeType: 'image/png', size: 100, dataUrl: 'data:image/png;base64,abc', category: 'image' },
+                { id: 'a2', name: 'img2.jpeg', mimeType: 'image/jpeg', size: 200, dataUrl: 'data:image/jpeg;base64,def', category: 'image' },
+            ],
             images: ['data:image/png;base64,abc', 'data:image/jpeg;base64,def'],
             addFromPaste: mockAddFromPaste,
-            removeImage: mockRemoveImage,
-            clearImages: mockClearImages,
+            addFromFileInput: mockAddFromFileInput,
+            removeAttachment: mockRemoveAttachment,
+            clearAttachments: mockClearAttachments,
+            error: null,
+            clearError: mockClearError,
+            toPayload: vi.fn(() => []),
         });
 
         await act(async () => { renderDialog(); });
 
-        const removeButtons = document.querySelectorAll('[aria-label^="Remove image"]');
+        const removeButtons = screen.getAllByTestId(/^remove-attachment-/);
         expect(removeButtons).toHaveLength(2);
 
         fireEvent.click(removeButtons[1]);
-        expect(mockRemoveImage).toHaveBeenCalledWith(1);
+        expect(mockRemoveAttachment).toHaveBeenCalledWith('a2');
     });
 
     it('clicking a thumbnail opens the lightbox', async () => {
-        mockUseImagePaste.mockReturnValue({
+        mockUseFileAttachments.mockReturnValue({
+            attachments: [
+                { id: 'a1', name: 'img1.png', mimeType: 'image/png', size: 100, dataUrl: 'data:image/png;base64,abc', category: 'image' },
+            ],
             images: ['data:image/png;base64,abc'],
             addFromPaste: mockAddFromPaste,
-            removeImage: mockRemoveImage,
-            clearImages: mockClearImages,
+            addFromFileInput: mockAddFromFileInput,
+            removeAttachment: mockRemoveAttachment,
+            clearAttachments: mockClearAttachments,
+            error: null,
+            clearError: mockClearError,
+            toPayload: vi.fn(() => []),
         });
 
         await act(async () => { renderDialog(); });
 
         expect(screen.queryByTestId('image-lightbox')).toBeNull();
 
-        const img = document.querySelector('#gen-task-images img')!;
+        const img = screen.getByTestId('gen-task-attachment-previews').querySelector('img')!;
         fireEvent.click(img);
 
         expect(screen.getByTestId('image-lightbox')).toBeTruthy();
@@ -1314,19 +1356,87 @@ describe('GenerateTaskDialog', () => {
     });
 
     it('remove button does not open the lightbox', async () => {
-        mockUseImagePaste.mockReturnValue({
+        mockUseFileAttachments.mockReturnValue({
+            attachments: [
+                { id: 'a1', name: 'img1.png', mimeType: 'image/png', size: 100, dataUrl: 'data:image/png;base64,abc', category: 'image' },
+            ],
             images: ['data:image/png;base64,abc'],
             addFromPaste: mockAddFromPaste,
-            removeImage: mockRemoveImage,
-            clearImages: mockClearImages,
+            addFromFileInput: mockAddFromFileInput,
+            removeAttachment: mockRemoveAttachment,
+            clearAttachments: mockClearAttachments,
+            error: null,
+            clearError: mockClearError,
+            toPayload: vi.fn(() => []),
         });
 
         await act(async () => { renderDialog(); });
 
-        const removeBtn = document.querySelector('[aria-label="Remove image 1"]')!;
+        const removeBtn = screen.getByTestId('remove-attachment-a1');
         fireEvent.click(removeBtn);
 
         expect(screen.queryByTestId('image-lightbox')).toBeNull();
+    });
+
+    it('renders attach button that opens file picker', async () => {
+        await act(async () => { renderDialog(); });
+
+        const attachBtn = screen.getByTestId('gen-task-attach-btn');
+        expect(attachBtn).toBeTruthy();
+        expect(attachBtn.textContent).toContain('Attach');
+    });
+
+    it('renders drag-and-drop zone', async () => {
+        await act(async () => { renderDialog(); });
+
+        const dropZone = screen.getByTestId('gen-task-drop-zone');
+        expect(dropZone).toBeTruthy();
+    });
+
+    it('shows drop overlay on dragOver and hides on dragLeave', async () => {
+        await act(async () => { renderDialog(); });
+
+        const dropZone = screen.getByTestId('gen-task-drop-zone');
+
+        expect(screen.queryByTestId('gen-task-drop-zone-overlay')).toBeNull();
+
+        fireEvent.dragOver(dropZone);
+        expect(screen.getByTestId('gen-task-drop-zone-overlay')).toBeTruthy();
+
+        fireEvent.dragLeave(dropZone);
+        expect(screen.queryByTestId('gen-task-drop-zone-overlay')).toBeNull();
+    });
+
+    it('displays attachment error when present', async () => {
+        mockUseFileAttachments.mockReturnValue({
+            attachments: [],
+            images: [],
+            addFromPaste: mockAddFromPaste,
+            addFromFileInput: mockAddFromFileInput,
+            removeAttachment: mockRemoveAttachment,
+            clearAttachments: mockClearAttachments,
+            error: 'File too large!',
+            clearError: mockClearError,
+            toPayload: vi.fn(() => []),
+        });
+
+        await act(async () => { renderDialog(); });
+
+        const errorEl = screen.getByTestId('gen-task-attachment-error');
+        expect(errorEl).toBeTruthy();
+        expect(errorEl.textContent).toBe('File too large!');
+    });
+
+    it('does not display attachment error when null', async () => {
+        await act(async () => { renderDialog(); });
+
+        expect(screen.queryByTestId('gen-task-attachment-error')).toBeNull();
+    });
+
+    it('renders hint text for paste/drag instructions', async () => {
+        await act(async () => { renderDialog(); });
+
+        expect(screen.getByText(/paste images/)).toBeTruthy();
     });
 
     // ── Ctrl+Enter keyboard shortcut tests ──────────────────────────────────


### PR DESCRIPTION
## Summary

Upgrade the Generate Plan dialog from the basic useImagePaste hook to the feature-rich useFileAttachments hook, matching the Enqueue AI Task dialog's attachment capabilities.

## Changes

### UI Enhancements
- Attach button: Opens native file picker for selecting images
- Drag-and-drop zone: Visual overlay feedback when dragging files over the prompt area
- Attachment previews: Shared AttachmentPreviews component with lightbox, remove buttons, and non-image file type support (replacing custom inline image previews)
- Error display: Validation messages for oversized files or exceeding the attachment limit
- Hint text: Instructions for paste (Ctrl+V) and drag-and-drop below the prompt

### Technical
- Replace useImagePaste hook with useFileAttachments (unified file handling with backward-compatible images array for the enqueue payload)
- Remove standalone ImageLightbox (now handled by AttachmentPreviews internally)
- Add drag handlers (dragOver, dragLeave, drop) wired to addFromFileInput

### Tests
- Migrate all existing image paste tests to use useFileAttachments mock
- Add 7 new test cases covering: attach button, drop zone, drag overlay, error display, and hint text
- All 89 tests pass
