### PR TITLE
fix(coc): remove stale container auth import

### DIFF
--- a/packages/coc/src/server/spa/client/react/contexts/ContainerAgentContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/ContainerAgentContext.tsx
@@ -12,7 +12,7 @@ import {
     useCallback,
     type ReactNode,
 } from 'react';
-import { isContainerMode, getRawApiBase, setServerAuthAgents } from '../utils/config';
+import { isContainerMode, getRawApiBase } from '../utils/config';
 
 /** Fetch from container-level endpoints (not agent-proxied). */
 async function fetchContainerApi(path: string, options?: RequestInit): Promise<any> {
@@ -60,8 +60,6 @@ export function ContainerAgentProvider({ children }: { children: ReactNode }) {
             const data = await fetchContainerApi('/container/agents');
             const list: ContainerAgent[] = Array.isArray(data) ? data : [];
             setAgents(list);
-            // Register which agents have server-side tunnel auth
-            setServerAuthAgents(list.filter(a => !!a.tunnelId).map(a => a.id));
         } catch {
             setAgents([]);
         }

--- a/packages/coc/test/spa/container-agent-context-regression.test.ts
+++ b/packages/coc/test/spa/container-agent-context-regression.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression coverage for container agent context imports.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CONTEXT_PATH = path.join(
+    __dirname,
+    '..',
+    '..',
+    'src',
+    'server',
+    'spa',
+    'client',
+    'react',
+    'contexts',
+    'ContainerAgentContext.tsx',
+);
+
+describe('ContainerAgentContext regression', () => {
+    it('does not import the reverted server-auth agent registry', () => {
+        const source = fs.readFileSync(CONTEXT_PATH, 'utf-8');
+
+        expect(source).not.toContain('setServerAuthAgents');
+    });
+});


### PR DESCRIPTION
Remove the leftover setServerAuthAgents import and registration that was reintroduced after the devtunnel auth revert, while keeping tunnel metadata support in the agent context. Add regression coverage to prevent the stale import from returning.