### PR TITLE
fix: revert accidental dep churn (vitest 1->4, monaco, mocha, esbuild) + fix latent test regressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1783,6 +1783,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1800,6 +1810,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1810,6 +1821,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1819,6 +1831,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1829,12 +1842,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2250,16 +2265,6 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
-    "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -2392,288 +2397,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",
@@ -3669,6 +3392,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -3679,6 +3403,7 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
@@ -3689,6 +3414,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/glob": {
@@ -3713,6 +3439,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -3733,6 +3460,7 @@
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -4036,86 +3764,146 @@
       "license": "ISC"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+    "node_modules/@vitest/expect/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
       },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4351,6 +4139,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
@@ -4361,24 +4150,28 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
@@ -4390,12 +4183,14 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -4408,6 +4203,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -4417,6 +4213,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -4426,12 +4223,14 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -4448,6 +4247,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -4461,6 +4261,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -4473,6 +4274,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -4487,6 +4289,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -4565,12 +4368,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/abort-controller": {
@@ -4589,6 +4394,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4601,6 +4407,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -4663,6 +4470,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -4680,6 +4488,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4696,6 +4505,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -4722,6 +4532,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -4741,6 +4552,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4777,6 +4589,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -4803,6 +4616,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz",
       "integrity": "sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -4825,6 +4639,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4868,6 +4683,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4930,6 +4746,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -4956,6 +4773,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4982,6 +4800,7 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -5031,6 +4850,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5084,6 +4904,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5094,6 +4915,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5106,12 +4928,14 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5186,6 +5010,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -5218,6 +5043,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5275,6 +5101,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5294,6 +5121,7 @@
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
       "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5324,6 +5152,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -5446,6 +5275,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -5484,6 +5314,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^3.1.0",
@@ -5495,6 +5326,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5504,12 +5336,14 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5519,6 +5353,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^7.0.1",
@@ -5533,6 +5368,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
@@ -5545,6 +5381,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.0",
@@ -5584,6 +5421,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -5593,6 +5431,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5628,6 +5467,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -5648,6 +5488,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
       "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-parent": "^6.0.1",
@@ -5813,6 +5654,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -5830,6 +5672,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -5847,6 +5690,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5891,6 +5735,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5981,6 +5826,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6011,6 +5857,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -6193,6 +6040,22 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dompurify/node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -6236,6 +6099,7 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6272,6 +6136,7 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -6325,6 +6190,7 @@
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
       "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -6393,6 +6259,7 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -6413,6 +6280,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-define-property": {
@@ -6437,6 +6305,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -6455,6 +6324,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6470,6 +6340,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
@@ -6528,6 +6399,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6537,6 +6409,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -6603,6 +6476,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -6763,6 +6637,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -6799,6 +6674,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -6811,6 +6687,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6820,6 +6697,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6979,6 +6857,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -7044,6 +6923,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7109,6 +6989,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7170,6 +7051,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -7237,6 +7119,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -7267,6 +7150,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -7287,6 +7171,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7296,6 +7181,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7305,6 +7191,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7387,6 +7274,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -7431,6 +7319,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -7443,6 +7332,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
@@ -7488,6 +7378,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -7537,6 +7428,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7550,6 +7442,7 @@
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.x"
@@ -7559,6 +7452,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7571,6 +7465,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7580,6 +7475,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7592,6 +7488,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
@@ -7619,6 +7516,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7646,6 +7544,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "he": "bin/he"
@@ -7893,6 +7792,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -7915,6 +7815,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7939,6 +7840,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -7956,6 +7858,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
@@ -7975,6 +7878,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -7990,6 +7894,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8002,6 +7907,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8018,6 +7924,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8041,6 +7948,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8069,6 +7977,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8086,6 +7995,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8118,6 +8028,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8127,6 +8038,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -8152,6 +8064,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -8171,6 +8084,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8215,6 +8129,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8227,6 +8142,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8239,6 +8155,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8248,6 +8165,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8294,6 +8212,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8312,6 +8231,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8324,6 +8244,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -8352,6 +8273,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8381,6 +8303,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8398,6 +8321,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -8413,6 +8337,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8425,6 +8350,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -8440,6 +8366,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8489,6 +8416,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -8549,6 +8477,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -8567,6 +8510,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -8581,6 +8525,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8590,6 +8535,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8722,6 +8668,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -9213,6 +9160,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -9259,6 +9207,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -9328,6 +9277,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^2.4.2"
@@ -9492,6 +9442,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -9535,6 +9486,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9544,6 +9496,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -9632,6 +9585,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
@@ -9663,6 +9617,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
       "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "3.2.3",
@@ -9706,6 +9661,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9715,6 +9671,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -9724,6 +9681,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
       "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.1",
@@ -9746,6 +9704,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -9755,6 +9714,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -9764,6 +9724,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -9776,6 +9737,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9791,6 +9753,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -9808,6 +9771,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9820,6 +9784,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -9833,6 +9798,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -9846,6 +9812,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9858,12 +9825,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -9879,6 +9848,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -9891,6 +9861,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9900,6 +9871,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
       "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.0.4"
@@ -9912,6 +9884,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9921,6 +9894,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
       "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -9933,6 +9907,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10029,6 +10004,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -10055,6 +10031,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
       "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "object.getownpropertydescriptors": "^2.0.3",
@@ -10065,6 +10042,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -10092,12 +10070,14 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10181,6 +10161,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10190,6 +10171,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.1.2",
@@ -10205,6 +10187,7 @@
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.9.tgz",
       "integrity": "sha512-mt8YM6XwsTTovI+kdZdHSxoyF2DI59up034orlC9NfweclcWOt7CVascNNLp6U+bjFVCVCIh9PwS76tDM/rH8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array.prototype.reduce": "^1.0.8",
@@ -10438,6 +10421,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
@@ -10510,6 +10494,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10632,6 +10617,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10692,12 +10678,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10943,6 +10931,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11795,6 +11784,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -11817,6 +11807,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -11837,6 +11828,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11846,6 +11838,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11855,6 +11848,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/resolve": {
@@ -11978,40 +11972,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -12111,6 +12071,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
       "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.9",
@@ -12130,6 +12091,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
@@ -12156,6 +12118,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12172,12 +12135,14 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12240,6 +12205,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -12259,6 +12225,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12275,6 +12242,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -12287,6 +12255,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/secure-json-parse": {
@@ -12322,6 +12291,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
       "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -12331,12 +12301,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -12354,6 +12326,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -12369,6 +12342,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -12602,6 +12576,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -12612,6 +12587,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12641,6 +12617,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
@@ -12680,6 +12657,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12755,6 +12733,7 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -12776,6 +12755,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -12794,6 +12774,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -12925,6 +12906,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -12995,6 +12977,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13063,6 +13046,7 @@
       "version": "5.44.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
       "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -13081,6 +13065,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
       "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -13114,7 +13099,45 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -13183,6 +13206,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -13199,6 +13223,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -13216,6 +13241,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13288,6 +13314,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -13530,6 +13557,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13544,6 +13572,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13563,6 +13592,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -13584,6 +13614,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -13644,6 +13675,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13701,6 +13733,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14311,6 +14344,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -14334,6 +14368,7 @@
       "version": "5.105.4",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -14453,6 +14488,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -14515,6 +14551,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -14534,6 +14571,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14561,12 +14599,14 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -14585,12 +14625,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -14629,6 +14671,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2"
@@ -14638,6 +14681,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14647,6 +14691,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14656,6 +14701,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -14669,6 +14715,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -14891,6 +14938,7 @@
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^5.0.0",
@@ -14909,6 +14957,7 @@
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -14919,6 +14968,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat": "^4.1.0",
@@ -14933,6 +14983,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
       "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "is-buffer": "~2.0.3"
@@ -14945,6 +14996,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14954,12 +15006,14 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -14972,6 +15026,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14981,6 +15036,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -14994,6 +15050,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -15009,6 +15066,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -15021,6 +15079,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -15030,6 +15089,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^7.0.1",
@@ -15044,6 +15104,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
@@ -15056,6 +15117,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yauzl": {
@@ -15131,11 +15193,9 @@
         "@xterm/xterm": "6.0.0",
         "azure-devops-node-api": "^14.1.0",
         "commander": "^12.1.0",
-        "copy-webpack-plugin": "14.0.0",
         "diff": "^5.2.0",
         "js-yaml": "^4.1.0",
-        "mocha": "7.2.0",
-        "monaco-editor": "^0.53.0",
+        "monaco-editor": "^0.55.1",
         "pino": "^9.0.0",
         "pino-pretty": "^11.0.0",
         "react": "^18.3.1",
@@ -15160,9 +15220,9 @@
         "@types/react-dom": "^18.3.1",
         "@types/turndown": "^5.0.6",
         "@types/ws": "^8.5.0",
-        "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/coverage-v8": "^1.6.1",
         "autoprefixer": "^10.4.0",
-        "esbuild": "^0.28.0",
+        "esbuild": "^0.21.5",
         "fast-check": "^4.6.0",
         "highlight.js": "^11.9.0",
         "jsdom": "^27.0.1",
@@ -15171,7 +15231,7 @@
         "postcss-cli": "^11.0.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.3.0",
-        "vitest": "^4.1.5"
+        "vitest": "^1.0.0"
       },
       "engines": {
         "node": ">=24"
@@ -15596,80 +15656,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "packages/coc-client/node_modules/@vitest/expect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "chai": "^4.3.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/coc-client/node_modules/@vitest/runner": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "1.6.1",
-        "p-limit": "^5.0.0",
-        "pathe": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/coc-client/node_modules/@vitest/snapshot": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "pretty-format": "^29.7.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/coc-client/node_modules/@vitest/spy": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^2.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/coc-client/node_modules/@vitest/utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "diff-sequences": "^29.6.3",
-        "estree-walker": "^3.0.3",
-        "loupe": "^2.3.7",
-        "pretty-format": "^29.7.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "packages/coc-client/node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -15736,22 +15722,6 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
-      }
-    },
-    "packages/coc-client/node_modules/p-limit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/coc-client/node_modules/pathe": {
@@ -15908,19 +15878,6 @@
         }
       }
     },
-    "packages/coc-client/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/coc-server": {
       "name": "@plusplusoneplusplus/coc-server",
       "version": "1.0.0",
@@ -15940,6 +15897,404 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/coc/node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/coc/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/coc/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/coc/node_modules/@tiptap/core": {
@@ -16216,61 +16571,41 @@
       }
     },
     "packages/coc/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
+        "vitest": "1.6.1"
       }
     },
-    "packages/coc/node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+    "packages/coc/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.5",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
+      "engines": {
+        "node": "*"
       }
     },
     "packages/coc/node_modules/azure-devops-node-api": {
@@ -16310,6 +16645,25 @@
         "ieee754": "^1.2.1"
       }
     },
+    "packages/coc/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/coc/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -16319,24 +16673,91 @@
         "node": ">=18"
       }
     },
+    "packages/coc/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "packages/coc/node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
       "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
       "license": "MIT"
     },
-    "packages/coc/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+    "packages/coc/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
+    },
+    "packages/coc/node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "packages/coc/node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/coc/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/coc/node_modules/pino-pretty": {
       "version": "11.3.0",
@@ -16385,6 +16806,13 @@
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
     },
+    "packages/coc/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/coc/node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -16425,23 +16853,21 @@
       }
     },
     "packages/coc/node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -16450,33 +16876,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -16493,89 +16909,62 @@
         },
         "terser": {
           "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
         }
       }
     },
     "packages/coc/node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
-          "optional": true
-        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -16586,9 +16975,6 @@
         },
         "jsdom": {
           "optional": true
-        },
-        "vite": {
-          "optional": false
         }
       }
     },
@@ -17321,11 +17707,8 @@
         "azure-devops-node-api": "^14.1.0",
         "better-sqlite3": "^11.9.1",
         "commander": "^12.1.0",
-        "copy-webpack-plugin": "14.0.0",
         "diff": "^5.2.0",
         "js-yaml": "^4.1.0",
-        "mocha": "7.2.0",
-        "monaco-editor": "0.53.0",
         "pino": "^9.x",
         "pino-pretty": "^11.x"
       },
@@ -17335,13 +17718,411 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^20.0.0",
-        "@vitest/coverage-v8": "^4.1.5",
-        "esbuild": "^0.28.0",
+        "@vitest/coverage-v8": "^1.6.1",
+        "esbuild": "^0.21.5",
         "typescript": "^5.3.0",
-        "vitest": "^4.1.5"
+        "vitest": "^1.0.0"
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "packages/deep-wiki/node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/deep-wiki/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/deep-wiki/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/deep-wiki/node_modules/@types/node": {
@@ -17355,61 +18136,41 @@
       }
     },
     "packages/deep-wiki/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
+        "vitest": "1.6.1"
       }
     },
-    "packages/deep-wiki/node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+    "packages/deep-wiki/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.5",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
+      "engines": {
+        "node": "*"
       }
     },
     "packages/deep-wiki/node_modules/azure-devops-node-api": {
@@ -17449,6 +18210,25 @@
         "ieee754": "^1.2.1"
       }
     },
+    "packages/deep-wiki/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/deep-wiki/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -17458,24 +18238,69 @@
         "node": ">=18"
       }
     },
+    "packages/deep-wiki/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "packages/deep-wiki/node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
       "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
       "license": "MIT"
     },
-    "packages/deep-wiki/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+    "packages/deep-wiki/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
+    },
+    "packages/deep-wiki/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/deep-wiki/node_modules/pino-pretty": {
       "version": "11.3.0",
@@ -17524,6 +18349,13 @@
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
     },
+    "packages/deep-wiki/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/deep-wiki/node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -17564,23 +18396,21 @@
       }
     },
     "packages/deep-wiki/node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -17589,33 +18419,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -17632,89 +18452,62 @@
         },
         "terser": {
           "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
         }
       }
     },
     "packages/deep-wiki/node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
-          "optional": true
-        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -17725,9 +18518,6 @@
         },
         "jsdom": {
           "optional": true
-        },
-        "vite": {
-          "optional": false
         }
       }
     },
@@ -17740,12 +18530,8 @@
         "@octokit/rest": "^22.0.1",
         "azure-devops-node-api": "^14.1.0",
         "better-sqlite3": "^11.9.1",
-        "copy-webpack-plugin": "14.0.0",
         "diff": "^5.2.0",
-        "esbuild": "0.28.0",
         "js-yaml": "^4.1.0",
-        "mocha": "7.2.0",
-        "monaco-editor": "0.53.0",
         "pino": "^9.x"
       },
       "devDependencies": {
@@ -17754,13 +18540,411 @@
         "@types/diff": "^5.2.0",
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^20.0.0",
-        "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/coverage-v8": "^1.6.1",
         "pino-pretty": "^13.x",
         "typescript": "^5.3.0",
-        "vitest": "^4.1.5"
+        "vitest": "^1.0.0"
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "packages/forge/node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/forge/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/forge/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/forge/node_modules/@types/node": {
@@ -17774,61 +18958,41 @@
       }
     },
     "packages/forge/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
+        "vitest": "1.6.1"
       }
     },
-    "packages/forge/node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+    "packages/forge/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.5",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
+      "engines": {
+        "node": "*"
       }
     },
     "packages/forge/node_modules/azure-devops-node-api": {
@@ -17844,18 +19008,89 @@
         "node": ">= 16.0.0"
       }
     },
-    "packages/forge/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+    "packages/forge/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/forge/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
       "engines": {
         "node": ">=12"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
+    },
+    "packages/forge/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "packages/forge/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/forge/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/forge/node_modules/typed-rest-client": {
       "version": "2.1.0",
@@ -17888,23 +19123,21 @@
       }
     },
     "packages/forge/node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -17913,33 +19146,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -17956,89 +19179,62 @@
         },
         "terser": {
           "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
         }
       }
     },
     "packages/forge/node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
-          "optional": true
-        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -18049,9 +19245,6 @@
         },
         "jsdom": {
           "optional": true
-        },
-        "vite": {
-          "optional": false
         }
       }
     },

--- a/packages/coc/package.json
+++ b/packages/coc/package.json
@@ -49,11 +49,9 @@
     "@xterm/xterm": "6.0.0",
     "azure-devops-node-api": "^14.1.0",
     "commander": "^12.1.0",
-    "copy-webpack-plugin": "14.0.0",
     "diff": "^5.2.0",
     "js-yaml": "^4.1.0",
-    "mocha": "7.2.0",
-    "monaco-editor": "^0.53.0",
+    "monaco-editor": "^0.55.1",
     "pino": "^9.0.0",
     "pino-pretty": "^11.0.0",
     "react": "^18.3.1",
@@ -75,9 +73,9 @@
     "@types/react-dom": "^18.3.1",
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.5.0",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/coverage-v8": "^1.6.1",
     "autoprefixer": "^10.4.0",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.21.5",
     "fast-check": "^4.6.0",
     "highlight.js": "^11.9.0",
     "jsdom": "^27.0.1",
@@ -86,7 +84,7 @@
     "postcss-cli": "^11.0.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
-    "vitest": "^4.1.5"
+    "vitest": "^1.0.0"
   },
   "optionalDependencies": {
     "node-pty": "^1.0.0"

--- a/packages/coc/test/server/api-commit-chat-routes.test.ts
+++ b/packages/coc/test/server/api-commit-chat-routes.test.ts
@@ -26,26 +26,26 @@ import type { MockProcessStore } from './helpers/mock-process-store';
 // Mock child_process to prevent real git calls from co-registered git routes
 // ============================================================================
 
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: vi.fn(() => ''),
     execFileSync: vi.fn(() => ''),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(),
             getBranchStatus: vi.fn(),
             hasUncommittedChanges: vi.fn(),
             hasUncommittedChanges: vi.fn(),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(),
             getCurrentBranch: vi.fn(),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/api-handler-batch.test.ts
+++ b/packages/coc/test/server/api-handler-batch.test.ts
@@ -80,23 +80,23 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => true),
-            getBranchStatus: vi.fn(async () => ({ name: 'main', isDetached: false, ahead: 1, behind: 0, hasUncommittedChanges: true })),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+            getBranchStatus: vi.fn(async function () { return ({ name: 'main', isDetached: false, ahead: 1, behind: 0, hasUncommittedChanges: true }); }),
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-            stageFile: vi.fn(async () => ({ success: true })),
-            unstageFile: vi.fn(async () => ({ success: true })),
-            stageFiles: vi.fn(async () => ({ success: true, staged: 2, errors: [] })),
-            unstageFiles: vi.fn(async () => ({ success: true, unstaged: 2, errors: [] })),
-            discardChanges: vi.fn(async () => ({ success: true })),
+            stageFile: vi.fn(async function () { return ({ success: true }); }),
+            unstageFile: vi.fn(async function () { return ({ success: true }); }),
+            stageFiles: vi.fn(async function () { return ({ success: true, staged: 2, errors: [] }); }),
+            unstageFiles: vi.fn(async function () { return ({ success: true, unstaged: 2, errors: [] }); }),
+            discardChanges: vi.fn(async function () { return ({ success: true }); }),
             getFileDiff: vi.fn(async () => ''),
-            deleteUntrackedFile: vi.fn(async () => ({ success: true })),
-        })),
+            deleteUntrackedFile: vi.fn(async function () { return ({ success: true }); }),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/api-handler-summaries.test.ts
+++ b/packages/coc/test/server/api-handler-summaries.test.ts
@@ -20,9 +20,9 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({})),
-        GitRangeService: vi.fn().mockImplementation(() => ({})),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({})),
+        BranchService: vi.fn().mockImplementation(function () { return ({}); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({}); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({}); }),
     };
 });
 

--- a/packages/coc/test/server/batch-git-info-isolation.test.ts
+++ b/packages/coc/test/server/batch-git-info-isolation.test.ts
@@ -26,16 +26,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => false),
-            getBranchStatus: vi.fn(async () => ({ ahead: 0, behind: 0, branch: 'main' })),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+            getBranchStatus: vi.fn(async function () { return ({ ahead: 0, behind: 0, branch: 'main' }); }),
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });

--- a/packages/coc/test/server/batch-operations.test.ts
+++ b/packages/coc/test/server/batch-operations.test.ts
@@ -26,16 +26,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => false),
-            getBranchStatus: vi.fn(async () => ({ ahead: 0, behind: 0, branch: 'main' })),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+            getBranchStatus: vi.fn(async function () { return ({ ahead: 0, behind: 0, branch: 'main' }); }),
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });

--- a/packages/coc/test/server/commit-chat-binding-api.test.ts
+++ b/packages/coc/test/server/commit-chat-binding-api.test.ts
@@ -27,26 +27,26 @@ import { CommitChatBindingStore } from '../../src/server/processes/commit-chat-b
 // Mocks — child_process and forge services (required by api-handler)
 // ============================================================================
 
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: vi.fn(() => ''),
     execFileSync: vi.fn(() => ''),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(),
             getBranchStatus: vi.fn(),
             hasUncommittedChanges: vi.fn(),
             hasUncommittedChanges: vi.fn(),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(),
             getCurrentBranch: vi.fn(),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/cors.test.ts
+++ b/packages/coc/test/server/cors.test.ts
@@ -24,16 +24,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => false),
             getBranchStatus: vi.fn(async () => null),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });

--- a/packages/coc/test/server/create-bug-tool.test.ts
+++ b/packages/coc/test/server/create-bug-tool.test.ts
@@ -11,12 +11,12 @@ import * as os from 'os';
 // Mock FileWorkItemStore before importing the tool
 const mockAddWorkItem = vi.fn();
 const mockSavePlanVersion = vi.fn();
-vi.mock('../../src/server/work-items/work-item-store', () => ({
-    FileWorkItemStore: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/work-items/work-item-store', function () { return ({
+    FileWorkItemStore: vi.fn().mockImplementation(function () { return ({
         addWorkItem: mockAddWorkItem,
         savePlanVersion: mockSavePlanVersion,
-    })),
-}));
+    }); }),
+}); });
 
 import { createBugTool, type CreateBugArgs } from '../../src/server/llm-tools/create-bug-tool';
 

--- a/packages/coc/test/server/create-work-item-tool.test.ts
+++ b/packages/coc/test/server/create-work-item-tool.test.ts
@@ -12,12 +12,12 @@ import * as fs from 'fs/promises';
 // Mock FileWorkItemStore before importing the tool
 const mockAddWorkItem = vi.fn();
 const mockSavePlanVersion = vi.fn();
-vi.mock('../../src/server/work-items/work-item-store', () => ({
-    FileWorkItemStore: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/work-items/work-item-store', function () { return ({
+    FileWorkItemStore: vi.fn().mockImplementation(function () { return ({
         addWorkItem: mockAddWorkItem,
         savePlanVersion: mockSavePlanVersion,
-    })),
-}));
+    }); }),
+}); });
 
 import { createWorkItemTool, type CreateWorkItemArgs } from '../../src/server/llm-tools/create-work-item-tool';
 

--- a/packages/coc/test/server/diff-truncation.test.ts
+++ b/packages/coc/test/server/diff-truncation.test.ts
@@ -64,10 +64,10 @@ describe('truncateDiffIfNeeded', () => {
 
 const mockExecSync = vi.fn();
 const mockExecFileSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: (...args: any[]) => mockExecFileSync(...args),
-}));
+}); });
 
 const mockGetBranchStatus = vi.fn();
 const mockGetAllChanges = vi.fn();
@@ -82,11 +82,11 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     return {
         ...actual,
         execGit: (...args: any[]) => mockForgeExecGit(...args),
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: mockGetBranchStatus,
             getRepoState: vi.fn().mockReturnValue({}),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: mockGetAllChanges,
             getFileDiff: mockGetFileDiff,
             stageFile: vi.fn(),
@@ -95,12 +95,12 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             stageFiles: vi.fn(),
             unstageFiles: vi.fn(),
             deleteUntrackedFile: vi.fn(),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             detectCommitRange: mockDetectCommitRange,
             getFileDiff: mockRangeGetFileDiff,
             getRangeDiff: vi.fn().mockReturnValue(''),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/error-shapes.test.ts
+++ b/packages/coc/test/server/error-shapes.test.ts
@@ -27,16 +27,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => false),
             getBranchStatus: vi.fn(async () => null),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });

--- a/packages/coc/test/server/git-api-status-normalization.test.ts
+++ b/packages/coc/test/server/git-api-status-normalization.test.ts
@@ -38,21 +38,21 @@ const mockStageFiles = vi.fn();
 const mockUnstageFiles = vi.fn();
 
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: vi.fn(),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
     return {
         ...actual,
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             detectCommitRange: mockDetectCommitRange,
             getRangeDiff: mockGetRangeDiff,
             getFileDiff: mockGetFileDiff,
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: mockGetAllChanges,
             stageFile: mockStageFile,
             unstageFile: mockUnstageFile,
@@ -61,7 +61,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             getFileDiff: mockGetWorkingFileDiff,
             stageFiles: mockStageFiles,
             unstageFiles: mockUnstageFiles,
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/git-api.test.ts
+++ b/packages/coc/test/server/git-api.test.ts
@@ -28,10 +28,10 @@ import { gitCache } from '../../src/server/git/git-cache';
 const mockExecSync = vi.fn();
 const mockExecFileSync = vi.fn();
 const mockForgeExecGit = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: (...args: any[]) => mockExecFileSync(...args),
-}));
+}); });
 
 // ============================================================================
 // Mock BranchService and GitRangeService
@@ -45,14 +45,14 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
             hasUncommittedChanges: vi.fn(async (...args: any[]) => mockHasUncommittedChanges(...args)),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async (...args: any[]) => mockGetCurrentBranch(...args)),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
         execGit: (...args: any[]) => mockForgeExecGit(...args),
     };

--- a/packages/coc/test/server/git-branch-edge-cases.test.ts
+++ b/packages/coc/test/server/git-branch-edge-cases.test.ts
@@ -55,7 +55,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     return {
         ...actual,
         execGit: (...args: any[]) => mockForgeExecGit(...args),
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
             hasUncommittedChanges: vi.fn(async (...args: any[]) => mockHasUncommittedChanges(...args)),
             getLocalBranchesPaginated: mockGetLocalBranchesPaginated,
@@ -72,21 +72,21 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             popStash: mockPopStash,
             rebaseAutosquash: mockRebaseAutosquash,
             cherryPick: mockCherryPick,
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn().mockReturnValue('main'),
             getCurrentBranch: vi.fn().mockResolvedValue('main'),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 
 // Mock child_process to prevent real git calls
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: vi.fn(),
-}));
+}); });
 
 // ============================================================================
 // Test Helpers

--- a/packages/coc/test/server/git-branch-range-api.test.ts
+++ b/packages/coc/test/server/git-branch-range-api.test.ts
@@ -29,19 +29,19 @@ const mockGetRangeDiff = vi.fn();
 const mockGetFileDiff = vi.fn();
 
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
     return {
         ...actual,
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             detectCommitRange: mockDetectCommitRange,
             getRangeDiff: mockGetRangeDiff,
             getFileDiff: mockGetFileDiff,
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/git-branch-range-edge.test.ts
+++ b/packages/coc/test/server/git-branch-range-edge.test.ts
@@ -31,21 +31,21 @@ const mockGetRangeDiff = vi.fn();
 const mockGetFileDiff = vi.fn();
 
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
     return {
         ...actual,
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             detectCommitRange: mockDetectCommitRange,
             getRangeDiff: mockGetRangeDiff,
             getFileDiff: mockGetFileDiff,
             getCurrentBranch: vi.fn().mockReturnValue('main'),
             getCurrentBranch: vi.fn().mockResolvedValue('main'),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/git-branches-api.test.ts
+++ b/packages/coc/test/server/git-branches-api.test.ts
@@ -79,7 +79,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     return {
         ...actual,
         execGit: (...args: any[]) => mockForgeExecGit(...args),
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getLocalBranchesPaginated: mockGetLocalBranchesPaginated,
             getRemoteBranchesPaginated: mockGetRemoteBranchesPaginated,
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
@@ -102,16 +102,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             mergeAbort: mockMergeAbort,
             rewordCommit: mockRewordCommit,
             pushUpTo: mockPushUpTo,
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });
 
 // Mock child_process to prevent real git calls from other routes
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
-}));
+}); });
 
 // ============================================================================
 // Test Helpers

--- a/packages/coc/test/server/git-cache-api.test.ts
+++ b/packages/coc/test/server/git-cache-api.test.ts
@@ -21,9 +21,9 @@ import type { MockProcessStore } from './helpers/mock-process-store';
 // ============================================================================
 
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
-}));
+}); });
 
 // ============================================================================
 // Mock GitRangeService (used by branch-range endpoint) and BranchService
@@ -42,11 +42,11 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             detectCommitRange = mockDetectCommitRange;
             getCurrentBranch = vi.fn().mockResolvedValue('main');
         },
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
             hasUncommittedChanges: vi.fn().mockReturnValue(false),
             hasUncommittedChanges: vi.fn().mockResolvedValue(false),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/git-commit-edge-cases.test.ts
+++ b/packages/coc/test/server/git-commit-edge-cases.test.ts
@@ -29,10 +29,10 @@ import { gitCache } from '../../src/server/git/git-cache';
 
 const mockExecSync = vi.fn();
 const mockExecFileSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: (...args: any[]) => mockExecFileSync(...args),
-}));
+}); });
 
 // ============================================================================
 // Mock forge: execGit (used by execGitArgsSync and readGitFileAtCommit),
@@ -49,14 +49,14 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     return {
         ...actual,
         execGit: (...args: any[]) => mockExecGit(...args),
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: mockGetBranchStatus,
             hasUncommittedChanges: mockHasUncommittedChanges,
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: mockGetCurrentBranch,
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/git-conflict-scenarios.test.ts
+++ b/packages/coc/test/server/git-conflict-scenarios.test.ts
@@ -56,7 +56,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     return {
         ...actual,
         execGit: (...args: any[]) => mockForgeExecGit(...args),
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
             hasUncommittedChanges: vi.fn(async (...args: any[]) => mockHasUncommittedChanges(...args)),
             getLocalBranchesPaginated: mockGetLocalBranchesPaginated,
@@ -73,20 +73,20 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             push: mockPush,
             pull: mockPull,
             fetch: mockFetch,
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn().mockResolvedValue('main'),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 
 // Mock child_process to prevent real git calls
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: vi.fn(),
-}));
+}); });
 
 // ============================================================================
 // Test Helpers

--- a/packages/coc/test/server/git-ops-tracking.test.ts
+++ b/packages/coc/test/server/git-ops-tracking.test.ts
@@ -51,7 +51,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
             hasUncommittedChanges: vi.fn(async (...args: any[]) => mockHasUncommittedChanges(...args)),
             getLocalBranchesPaginated: mockGetLocalBranchesPaginated,
@@ -68,21 +68,21 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             popStash: mockPopStash,
             rebaseAutosquash: mockRebaseAutosquash,
             cherryPick: mockCherryPick,
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn().mockReturnValue('main'),
             getCurrentBranch: vi.fn().mockResolvedValue('main'),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 
 // Mock child_process to prevent real git calls
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: vi.fn(),
-}));
+}); });
 
 // ============================================================================
 // Test Helpers

--- a/packages/coc/test/server/git-stash-push-pull.test.ts
+++ b/packages/coc/test/server/git-stash-push-pull.test.ts
@@ -56,7 +56,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(async (...args: any[]) => mockGetBranchStatus(...args)),
             hasUncommittedChanges: vi.fn(async (...args: any[]) => mockHasUncommittedChanges(...args)),
             getLocalBranchesPaginated: mockGetLocalBranchesPaginated,
@@ -73,21 +73,21 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             popStash: mockPopStash,
             rebaseAutosquash: mockRebaseAutosquash,
             cherryPick: mockCherryPick,
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn().mockReturnValue('main'),
             getCurrentBranch: vi.fn().mockResolvedValue('main'),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
     };
 });
 
 // Mock child_process to prevent real git calls
 const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: (...args: any[]) => mockExecSync(...args),
     execFileSync: vi.fn(),
-}));
+}); });
 
 // ============================================================================
 // Test Helpers

--- a/packages/coc/test/server/git-working-tree-diff-api.test.ts
+++ b/packages/coc/test/server/git-working-tree-diff-api.test.ts
@@ -27,14 +27,14 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
     return {
         ...actual,
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: mockGetAllChanges,
             stageFile: vi.fn().mockResolvedValue({ success: true }),
             unstageFile: vi.fn().mockResolvedValue({ success: true }),
             discardChanges: vi.fn().mockResolvedValue({ success: true }),
             deleteUntrackedFile: vi.fn().mockResolvedValue({ success: true }),
             getFileDiff: mockGetFileDiff,
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/git-working-tree-edge.test.ts
+++ b/packages/coc/test/server/git-working-tree-edge.test.ts
@@ -41,7 +41,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
     return {
         ...actual,
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: mockGetAllChanges,
             stageFile: mockStageFile,
             unstageFile: mockUnstageFile,
@@ -50,15 +50,15 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             getFileDiff: mockGetFileDiff,
             stageFiles: mockStageFiles,
             unstageFiles: mockUnstageFiles,
-        })),
+        }); }),
     };
 });
 
 // Mock child_process to prevent real git calls
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: vi.fn(),
     execFileSync: vi.fn(),
-}));
+}); });
 
 // ============================================================================
 // Test Helpers

--- a/packages/coc/test/server/not-found-responses.test.ts
+++ b/packages/coc/test/server/not-found-responses.test.ts
@@ -28,16 +28,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => false),
             getBranchStatus: vi.fn(async () => null),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });

--- a/packages/coc/test/server/pr-routes.test.ts
+++ b/packages/coc/test/server/pr-routes.test.ts
@@ -15,22 +15,22 @@ import type { PullRequest, CommentThread, Reviewer } from '@plusplusoneplusplus/
 
 // ── Mock ProviderFactory and RepoTreeService ─────────────────────────────────
 
-vi.mock('../../src/server/providers/provider-factory', () => ({
+vi.mock('../../src/server/providers/provider-factory', function () { return ({
     ProviderFactory: {
         detectProviderType: vi.fn().mockReturnValue('github'),
         createPullRequestsService: vi.fn(),
     },
-}));
+}); });
 
-vi.mock('../../src/server/repos/tree-service', () => ({
-    RepoTreeService: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/repos/tree-service', function () { return ({
+    RepoTreeService: vi.fn().mockImplementation(function () { return ({
         resolveRepo: vi.fn(),
-    })),
-}));
+    }); }),
+}); });
 
-vi.mock('../../src/server/providers/providers-config', () => ({
+vi.mock('../../src/server/providers/providers-config', function () { return ({
     readProvidersConfig: vi.fn().mockResolvedValue({ providers: {} }),
-}));
+}); });
 
 import { ProviderFactory } from '../../src/server/providers/provider-factory';
 import { RepoTreeService } from '../../src/server/repos/tree-service';
@@ -126,9 +126,9 @@ beforeEach(async () => {
         getDiff: vi.fn().mockResolvedValue('diff --git a/foo.ts b/foo.ts\n'),
     };
 
-    (RepoTreeService as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    (RepoTreeService as ReturnType<typeof vi.fn>).mockImplementation(function () { return ({
         resolveRepo: mockResolveRepo = vi.fn().mockResolvedValue(mockRepoInfo),
-    }));
+    }); });
     (ProviderFactory.createPullRequestsService as ReturnType<typeof vi.fn>).mockResolvedValue(mockSvc);
 
     server = makeServer(dataDir);

--- a/packages/coc/test/server/queue-executor-bridge-executor-dispatch.test.ts
+++ b/packages/coc/test/server/queue-executor-bridge-executor-dispatch.test.ts
@@ -40,51 +40,51 @@ vi.mock('fs', async (importOriginal) => {
 
 // WorkflowExecutor mock — records calls for dispatch assertions
 const mockWorkflowExecute = vi.fn();
-vi.mock('../../src/server/executors/workflow-executor', () => ({
-    WorkflowExecutor: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/executors/workflow-executor', function () { return ({
+    WorkflowExecutor: vi.fn().mockImplementation(function () { return ({
         execute: mockWorkflowExecute,
-    })),
-}));
+    }); }),
+}); });
 
 // ShellExecutor mock — records calls for dispatch assertions
 const mockShellExecute = vi.fn();
-vi.mock('../../src/server/executors/shell-executor', () => ({
-    ShellExecutor: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/executors/shell-executor', function () { return ({
+    ShellExecutor: vi.fn().mockImplementation(function () { return ({
         execute: mockShellExecute,
-    })),
-}));
+    }); }),
+}); });
 
 // FollowUpExecutor mock — records calls for dispatch assertions
 const mockFollowUpExecuteFollowUp = vi.fn();
-vi.mock('../../src/server/executors/follow-up-executor', () => ({
-    FollowUpExecutor: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/executors/follow-up-executor', function () { return ({
+    FollowUpExecutor: vi.fn().mockImplementation(function () { return ({
         executeFollowUp: mockFollowUpExecuteFollowUp,
-    })),
-}));
+    }); }),
+}); });
 
 // ChatExecutor mock — records calls for dispatch assertions
 const mockChatExecute = vi.fn();
-vi.mock('../../src/server/executors/chat-executor', () => ({
-    ChatExecutor: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/executors/chat-executor', function () { return ({
+    ChatExecutor: vi.fn().mockImplementation(function () { return ({
         execute: mockChatExecute,
-    })),
-}));
+    }); }),
+}); });
 
 // PlanExecutor mock — records calls for dispatch assertions
 const mockPlanExecute = vi.fn();
-vi.mock('../../src/server/executors/plan-executor', () => ({
-    PlanExecutor: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/executors/plan-executor', function () { return ({
+    PlanExecutor: vi.fn().mockImplementation(function () { return ({
         execute: mockPlanExecute,
-    })),
-}));
+    }); }),
+}); });
 
 // AutopilotExecutor mock — records calls for dispatch assertions
 const mockAutopilotExecute = vi.fn();
-vi.mock('../../src/server/executors/autopilot-executor', () => ({
-    AutopilotExecutor: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/executors/autopilot-executor', function () { return ({
+    AutopilotExecutor: vi.fn().mockImplementation(function () { return ({
         execute: mockAutopilotExecute,
-    })),
-}));
+    }); }),
+}); });
 
 // Forge mock — prevent real getCopilotSDKService and other side-effects
 const sdkMocks = createMockSDKService();
@@ -99,9 +99,9 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     };
 });
 
-vi.mock('../../src/ai-invoker', () => ({
+vi.mock('../../src/ai-invoker', function () { return ({
     createCLIAIInvoker: vi.fn().mockReturnValue(vi.fn()),
-}));
+}); });
 
 vi.mock('../../src/server/queue/image-blob-store', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../src/server/queue/image-blob-store')>();

--- a/packages/coc/test/server/required-fields.test.ts
+++ b/packages/coc/test/server/required-fields.test.ts
@@ -28,16 +28,16 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             hasUncommittedChanges: vi.fn(async () => false),
             getBranchStatus: vi.fn(async () => null),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(async () => 'main'),
-        })),
-        WorkingTreeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        WorkingTreeService: vi.fn().mockImplementation(function () { return ({
             getAllChanges: vi.fn(async () => []),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
     };
 });

--- a/packages/coc/test/server/spa/client/admin/AdminPanel-scratchpad.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/AdminPanel-scratchpad.test.tsx
@@ -11,6 +11,7 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 vi.mock('@plusplusoneplusplus/forge', () => ({}));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/server/spa/client/admin/StorageSection.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/StorageSection.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/server/spa/client/hooks/useScratchpadEnabled.test.ts
+++ b/packages/coc/test/server/spa/client/hooks/useScratchpadEnabled.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     isTerminalEnabled: () => false,
     isNotesEnabled: () => false,

--- a/packages/coc/test/server/spa/client/hooks/useSendMessage-attachments.test.tsx
+++ b/packages/coc/test/server/spa/client/hooks/useSendMessage-attachments.test.tsx
@@ -19,6 +19,7 @@ const mockFetch = vi.fn().mockResolvedValue({
 vi.stubGlobal('fetch', mockFetch);
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/server/spa/client/notesApi.test.ts
+++ b/packages/coc/test/server/spa/client/notesApi.test.ts
@@ -3,6 +3,7 @@ import { notesApi } from '../../../../src/server/spa/client/react/features/notes
 import { resetSpaCocClientForTests } from '../../../../src/server/spa/client/react/api/cocClient';
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/server/spa/client/preferencesApi.test.ts
+++ b/packages/coc/test/server/spa/client/preferencesApi.test.ts
@@ -3,6 +3,7 @@ import { getWorkspacePreferences, patchWorkspacePreferences } from
     '../../../../src/server/spa/client/react/hooks/preferences/preferencesApi';
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/server/spa/client/processes/dag/ItemConversationPanel-send-label.test.tsx
+++ b/packages/coc/test/server/spa/client/processes/dag/ItemConversationPanel-send-label.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../../../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/server/spa/client/repos/ChatListPane-chat-search.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ChatListPane-chat-search.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../../../../src/server/spa/client/react/ui/cn', () => ({
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     isRalphEnabled: () => false,
 }));

--- a/packages/coc/test/server/spa/client/repos/NewChatArea.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/NewChatArea.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../../../../../src/server/spa/client/react/contexts/AppContext', () => 
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     isRalphEnabled: () => false,
 }));

--- a/packages/coc/test/server/spa/client/repos/RalphStartPanel.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/RalphStartPanel.test.tsx
@@ -11,6 +11,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     isRalphEnabled: () => true,
 }));

--- a/packages/coc/test/server/spa/client/repos/RepoDetail-layout-mode.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/RepoDetail-layout-mode.test.tsx
@@ -117,6 +117,7 @@ vi.mock('../../../../../src/server/spa/client/react/layout/MobileTabBar', () => 
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
     isTerminalEnabled: () => false,
     isNotesEnabled: () => false,

--- a/packages/coc/test/server/spa/client/repos/memory/BoundedMemoryTab.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/memory/BoundedMemoryTab.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../../../../../../src/server/spa/client/react/ui/Dialog', () => ({
 
 // Mock getApiBase used by the promotion panel
 vi.mock('../../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000',
 }));
 

--- a/packages/coc/test/server/spa/client/terminal-view-pin.test.tsx
+++ b/packages/coc/test/server/spa/client/terminal-view-pin.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../../../../src/server/spa/client/react/features/terminal/TerminalPanel
 });
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/server/spa/client/useDisplaySettings-scratchpad.test.ts
+++ b/packages/coc/test/server/spa/client/useDisplaySettings-scratchpad.test.ts
@@ -8,6 +8,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 // Mock config module before importing useDisplaySettings
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     isTerminalEnabled: () => false,
     isNotesEnabled: () => false,

--- a/packages/coc/test/server/spa/client/workflow-api.test.ts
+++ b/packages/coc/test/server/spa/client/workflow-api.test.ts
@@ -12,6 +12,7 @@ import {
 import { resetSpaCocClientForTests } from '../../../../src/server/spa/client/react/api/cocClient';
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/server/templates-handler.test.ts
+++ b/packages/coc/test/server/templates-handler.test.ts
@@ -25,12 +25,12 @@ import type { ProcessStore, Workspace } from '@plusplusoneplusplus/forge';
 const mockGetCommit = vi.fn();
 const mockDispose = vi.fn();
 
-vi.mock('@plusplusoneplusplus/forge/git', () => ({
-    GitLogService: vi.fn().mockImplementation(() => ({
+vi.mock('@plusplusoneplusplus/forge/git', function () { return ({
+    GitLogService: vi.fn().mockImplementation(function () { return ({
         getCommit: mockGetCommit,
         dispose: mockDispose,
-    })),
-}));
+    }); }),
+}); });
 
 // ============================================================================
 // Helpers

--- a/packages/coc/test/server/update-work-item-tool.test.ts
+++ b/packages/coc/test/server/update-work-item-tool.test.ts
@@ -12,13 +12,13 @@ import * as os from 'os';
 const mockGetWorkItem = vi.fn();
 const mockUpdateWorkItem = vi.fn();
 const mockSavePlanVersion = vi.fn();
-vi.mock('../../src/server/work-items/work-item-store', () => ({
-    FileWorkItemStore: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/server/work-items/work-item-store', function () { return ({
+    FileWorkItemStore: vi.fn().mockImplementation(function () { return ({
         getWorkItem: mockGetWorkItem,
         updateWorkItem: mockUpdateWorkItem,
         savePlanVersion: mockSavePlanVersion,
-    })),
-}));
+    }); }),
+}); });
 
 import { createUpdateWorkItemTool } from '../../src/server/llm-tools/update-work-item-tool';
 

--- a/packages/coc/test/server/workspace-discovery-edge.test.ts
+++ b/packages/coc/test/server/workspace-discovery-edge.test.ts
@@ -27,30 +27,30 @@ import type { MockProcessStore } from './helpers/mock-process-store';
 
 // ── Silence git / git-related calls ──────────────────────────────────────────
 
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: vi.fn(() => ''),
     execFileSync: vi.fn(() => ''),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(),
             getBranchStatus: vi.fn(),
             hasUncommittedChanges: vi.fn(),
             hasUncommittedChanges: vi.fn(),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(),
             getCurrentBranch: vi.fn(),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
-        GitOpsStore: vi.fn().mockImplementation(() => ({
+        GitOpsStore: vi.fn().mockImplementation(function () { return ({
             markStaleRunningJobs: vi.fn().mockResolvedValue(undefined),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/server/workspaces-discover.test.ts
+++ b/packages/coc/test/server/workspaces-discover.test.ts
@@ -15,30 +15,30 @@ import type { MockProcessStore } from './helpers/mock-process-store';
 
 // ── Silence git-related calls ─────────────────────────────────────────────
 
-vi.mock('child_process', () => ({
+vi.mock('child_process', function () { return ({
     execSync: vi.fn(() => ''),
     execFileSync: vi.fn(() => ''),
-}));
+}); });
 
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
         ...actual,
-        BranchService: vi.fn().mockImplementation(() => ({
+        BranchService: vi.fn().mockImplementation(function () { return ({
             getBranchStatus: vi.fn(),
             getBranchStatus: vi.fn(),
             hasUncommittedChanges: vi.fn(),
             hasUncommittedChanges: vi.fn(),
-        })),
-        GitRangeService: vi.fn().mockImplementation(() => ({
+        }); }),
+        GitRangeService: vi.fn().mockImplementation(function () { return ({
             getCurrentBranch: vi.fn(),
             getCurrentBranch: vi.fn(),
             detectCommitRange: vi.fn(),
-        })),
+        }); }),
         detectRemoteUrl: vi.fn(async () => undefined),
-        GitOpsStore: vi.fn().mockImplementation(() => ({
+        GitOpsStore: vi.fn().mockImplementation(function () { return ({
             markStaleRunningJobs: vi.fn().mockResolvedValue(undefined),
-        })),
+        }); }),
     };
 });
 

--- a/packages/coc/test/spa/react/MarkdownReviewDialog.test.tsx
+++ b/packages/coc/test/spa/react/MarkdownReviewDialog.test.tsx
@@ -77,6 +77,7 @@ vi.mock('../../../src/server/spa/client/react/shared/SourceEditor', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/MarkdownReviewEditor-guards.test.tsx
+++ b/packages/coc/test/spa/react/MarkdownReviewEditor-guards.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../../../src/server/spa/client/react/shared/SourceEditor', () => ({
 
 /* ── Mock getApiBase ── */
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/MarkdownReviewEditor-refresh.test.tsx
+++ b/packages/coc/test/spa/react/MarkdownReviewEditor-refresh.test.tsx
@@ -67,6 +67,7 @@ vi.mock('../../../src/server/spa/client/react/shared/SourceEditor', () => ({
 
 /* ── Mock getApiBase ── */
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/MarkdownReviewEditor-rich.test.tsx
+++ b/packages/coc/test/spa/react/MarkdownReviewEditor-rich.test.tsx
@@ -103,6 +103,7 @@ vi.mock('../../../src/server/spa/client/react/shared/SourceEditor', () => ({
 
 /* ── Mock getApiBase ── */
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/MarkdownReviewEditor-source.test.tsx
+++ b/packages/coc/test/spa/react/MarkdownReviewEditor-source.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../../../src/server/spa/client/react/shared/SourceEditor', () => ({
 
 /* ── Mock getApiBase ── */
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/ProcessesQueue.test.tsx
+++ b/packages/coc/test/spa/react/ProcessesQueue.test.tsx
@@ -20,27 +20,27 @@ import { ChatDetail } from '../../../src/server/spa/client/react/features/chat/C
 
 // Mock useDisplaySettings — controls report_intent visibility
 const mockDisplaySettings = { showReportIntent: false };
-vi.mock('../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({
+vi.mock('../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', function () { return ({
     useDisplaySettings: () => mockDisplaySettings,
     invalidateDisplaySettings: vi.fn(),
-}));
+}); });
 
-vi.mock('../../../src/server/spa/client/react/features/chat/hooks/useContainerWidth', () => ({
-    useContainerWidth: () => ({ width: 800, tier: 'wide', isWide: true, isMedium: false, isNarrow: false }),
-}));
+vi.mock('../../../src/server/spa/client/react/features/chat/hooks/useContainerWidth', function () { return ({
+    useContainerWidth: function () { return ({ width: 800, tier: 'wide', isWide: true, isMedium: false, isNarrow: false }); },
+}); });
 
-vi.mock('../../../src/server/spa/client/react/contexts/ChatPreferencesContext', () => ({
+vi.mock('../../../src/server/spa/client/react/contexts/ChatPreferencesContext', function () { return ({
     ChatPrefsSync: () => null,
-    useChatPrefs: () => ({
+    useChatPrefs: function () { return ({
         archivedChatIds: new Set<string>(),
         unarchiveChat: vi.fn(),
         pinnedChatIds: new Set<string>(),
         pinChat: vi.fn(),
         unpinChat: vi.fn(),
         archiveChat: vi.fn(),
-    }),
+    }); },
     ChatPreferencesProvider: ({ children }: { children: React.ReactNode }) => children,
-}));
+}); });
 
 vi.mock('../../../src/server/spa/client/react/utils/config', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
@@ -929,7 +929,7 @@ describe('ChatDetail metadata popover', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             type: 'queue-ai-clarification',
@@ -946,20 +946,20 @@ describe('ChatDetail metadata popover', () => {
                                 { role: 'assistant', content: 'Your last question was ...', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith('/api/queue/task-meta-1') && method === 'GET') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-meta-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-meta-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
             return Promise.resolve({
                 ok: false,
                 status: 404,
-                json: async () => ({ error: 'not found' }),
+                json: async function () { return ({ error: 'not found' }); },
             });
         });
         (global as any).fetch = fetchMock;
@@ -1009,7 +1009,7 @@ describe('ChatDetail follow-up input', () => {
                     return Promise.resolve({
                         ok: true,
                         status: 200,
-                        json: async () => ({
+                        json: async function () { return ({
                             process: {
                                 id: processId,
                                 status: 'completed',
@@ -1020,14 +1020,14 @@ describe('ChatDetail follow-up input', () => {
                                     { role: 'assistant', content: 'First answer', timeline: [] },
                                 ],
                             },
-                        }),
+                        }); },
                     });
                 }
 
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1040,7 +1040,7 @@ describe('ChatDetail follow-up input', () => {
                                 { role: 'assistant', content: 'Follow-up answer', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
 
@@ -1048,7 +1048,7 @@ describe('ChatDetail follow-up input', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 202,
-                    json: async () => ({ processId, turnIndex: 2 }),
+                    json: async function () { return ({ processId, turnIndex: 2 }); },
                 });
             }
 
@@ -1056,14 +1056,14 @@ describe('ChatDetail follow-up input', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-follow-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-follow-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
 
             return Promise.resolve({
                 ok: false,
                 status: 404,
-                json: async () => ({ error: 'not found' }),
+                json: async function () { return ({ error: 'not found' }); },
             });
         });
 
@@ -1113,7 +1113,7 @@ describe('ChatDetail follow-up input', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1124,7 +1124,7 @@ describe('ChatDetail follow-up input', () => {
                                 { role: 'assistant', content: 'Done', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
 
@@ -1132,7 +1132,7 @@ describe('ChatDetail follow-up input', () => {
                 return Promise.resolve({
                     ok: false,
                     status: 410,
-                    json: async () => ({ error: 'session_expired' }),
+                    json: async function () { return ({ error: 'session_expired' }); },
                 });
             }
 
@@ -1140,14 +1140,14 @@ describe('ChatDetail follow-up input', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-expired-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-expired-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
 
             return Promise.resolve({
                 ok: false,
                 status: 404,
-                json: async () => ({ error: 'not found' }),
+                json: async function () { return ({ error: 'not found' }); },
             });
         });
 
@@ -1198,7 +1198,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1207,17 +1207,17 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'assistant', content: 'Hi', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith('/api/queue/task-hooks-1')) {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-hooks-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-hooks-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
         (global as any).EventSource = undefined;
 
@@ -1244,7 +1244,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1255,24 +1255,24 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'assistant', content: 'A', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith(`/api/processes/${processId}/message`) && method === 'POST') {
                 return Promise.resolve({
                     ok: false,
                     status: 500,
-                    json: async () => ({ error: 'Internal server error' }),
+                    json: async function () { return ({ error: 'Internal server error' }); },
                 });
             }
             if (url.endsWith('/api/queue/task-err-1') && method === 'GET') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-err-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-err-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
         (global as any).EventSource = undefined;
 
@@ -1306,7 +1306,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1317,7 +1317,7 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'assistant', content: 'A', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith(`/api/processes/${processId}/message`) && method === 'POST') {
@@ -1327,10 +1327,10 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-retry-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-retry-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
         (global as any).EventSource = undefined;
 
@@ -1363,7 +1363,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1372,17 +1372,17 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'assistant', content: 'pong', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith('/api/queue/task-scroll-1')) {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-scroll-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-scroll-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
         (global as any).EventSource = undefined;
 
@@ -1409,7 +1409,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1418,17 +1418,17 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'assistant', content: 'There', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith('/api/queue/task-rel-1')) {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-rel-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-rel-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
         (global as any).EventSource = undefined;
 
@@ -1457,7 +1457,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'running',
@@ -1465,24 +1465,24 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'user', content: 'Go', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith('/api/queue/task-stream-1')) {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-stream-1', processId, status: 'running', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-stream-1', processId, status: 'running', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
-        (global as any).EventSource = vi.fn().mockImplementation(() => ({
+        (global as any).EventSource = vi.fn().mockImplementation(function () { return ({
             addEventListener: vi.fn(),
             close: vi.fn(),
             onmessage: null,
             onerror: null,
-        }));
+        }); });
 
         const { container } = render(
             <Wrap>
@@ -1509,7 +1509,7 @@ describe('ChatDetail semantic hooks', () => {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({
+                    json: async function () { return ({
                         process: {
                             id: processId,
                             status: 'completed',
@@ -1520,24 +1520,24 @@ describe('ChatDetail semantic hooks', () => {
                                 { role: 'assistant', content: 'A', timeline: [] },
                             ],
                         },
-                    }),
+                    }); },
                 });
             }
             if (url.endsWith(`/api/processes/${processId}/message`) && method === 'POST') {
                 return Promise.resolve({
                     ok: false,
                     status: 410,
-                    json: async () => ({ error: 'session_expired' }),
+                    json: async function () { return ({ error: 'session_expired' }); },
                 });
             }
             if (url.endsWith('/api/queue/task-410-1') && method === 'GET') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
-                    json: async () => ({ task: { id: 'task-410-1', processId, status: 'completed', type: 'chat' } }),
+                    json: async function () { return ({ task: { id: 'task-410-1', processId, status: 'completed', type: 'chat' } }); },
                 });
             }
-            return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+            return Promise.resolve({ ok: false, status: 404, json: async function () { return ({}); } });
         });
         (global as any).EventSource = undefined;
 

--- a/packages/coc/test/spa/react/ProcessesSidebar.test.tsx
+++ b/packages/coc/test/spa/react/ProcessesSidebar.test.tsx
@@ -60,6 +60,7 @@ vi.mock('../../../src/server/spa/client/react/utils/workspace', () => ({
 
 // Stub config
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/QueueFrozenVisual.test.tsx
+++ b/packages/coc/test/spa/react/QueueFrozenVisual.test.tsx
@@ -67,6 +67,7 @@ vi.mock('../../../src/server/spa/client/react/hooks/preferences/useDisplaySettin
     invalidateDisplaySettings: vi.fn(),
 }));
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getWsPath: () => '/ws',
     getWsUrl: () => 'ws://localhost/ws',

--- a/packages/coc/test/spa/react/RepoSchedulesTab-edit.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab-edit.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/RepoSchedulesTab-lifecycle.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab-lifecycle.test.tsx
@@ -71,6 +71,7 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/RepoSchedulesTab-split-panel.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab-split-panel.test.tsx
@@ -71,6 +71,7 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/RepoSchedulesTab.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/RepoTemplatesTab.test.tsx
+++ b/packages/coc/test/spa/react/RepoTemplatesTab.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/ReposView.test.tsx
+++ b/packages/coc/test/spa/react/ReposView.test.tsx
@@ -990,7 +990,9 @@ describe('ReposContext — async git-info', () => {
     it('fetches git-info via batch endpoint in phase 2', () => {
         const phase2Idx = source.indexOf('Phase 2');
         expect(phase2Idx).toBeGreaterThan(-1);
-        const phase2Body = source.substring(phase2Idx, phase2Idx + 800);
+        // Window widened to 2500 so container-mode branching (added in
+        // a0bc2fb40) doesn't push the non-container batch call out of range.
+        const phase2Body = source.substring(phase2Idx, phase2Idx + 2500);
         expect(phase2Body).toContain('getWorkspaceGitInfoBatch');
     });
 

--- a/packages/coc/test/spa/react/Router.test.ts
+++ b/packages/coc/test/spa/react/Router.test.ts
@@ -2283,8 +2283,8 @@ describe('memory sub-tab deep-link parsing', () => {
 // ─── admin sub-tab deep-link parsing ────────────────────────────
 
 describe('admin sub-tab deep-link parsing', () => {
-    it('VALID_ADMIN_SUB_TABS contains all 6 tabs', () => {
-        expect(VALID_ADMIN_SUB_TABS).toEqual(new Set(['settings', 'providers', 'data', 'server', 'prompts', 'database']));
+    it('VALID_ADMIN_SUB_TABS contains all 7 tabs', () => {
+        expect(VALID_ADMIN_SUB_TABS).toEqual(new Set(['settings', 'providers', 'data', 'server', 'prompts', 'database', 'agents']));
     });
 
     it('returns "settings" for #admin/settings', () => {

--- a/packages/coc/test/spa/react/RunHistoryList.test.tsx
+++ b/packages/coc/test/spa/react/RunHistoryList.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/ScheduleDetail-nowrap.test.tsx
+++ b/packages/coc/test/spa/react/ScheduleDetail-nowrap.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/ScheduleDetail.test.tsx
+++ b/packages/coc/test/spa/react/ScheduleDetail.test.tsx
@@ -101,6 +101,7 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/SearchIntegration.test.tsx
+++ b/packages/coc/test/spa/react/SearchIntegration.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../src/server/spa/client/react/utils/workspace', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/WikiAdminForceRerun.test.tsx
+++ b/packages/coc/test/spa/react/WikiAdminForceRerun.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     getDashboardConfig: () => ({ apiBase: 'http://localhost:4000/api' }),
 }));

--- a/packages/coc/test/spa/react/WikiComponentAnchor.test.tsx
+++ b/packages/coc/test/spa/react/WikiComponentAnchor.test.tsx
@@ -14,6 +14,7 @@ import { render, screen, fireEvent, waitFor, configure } from '@testing-library/
 configure({ asyncUtilTimeout: 5000 });
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     getDashboardConfig: () => ({ apiBase: 'http://localhost:4000/api' }),
 }));

--- a/packages/coc/test/spa/react/hooks/useChatPreferences.test.ts
+++ b/packages/coc/test/spa/react/hooks/useChatPreferences.test.ts
@@ -13,6 +13,7 @@ global.fetch = fetchMock as any;
 
 // Mock getApiBase to return empty string
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useChatSSE.test.ts
+++ b/packages/coc/test/spa/react/hooks/useChatSSE.test.ts
@@ -54,6 +54,7 @@ class MockEventSource {
 }
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useFilesViewMode.test.ts
+++ b/packages/coc/test/spa/react/hooks/useFilesViewMode.test.ts
@@ -14,6 +14,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 
 // Mock getApiBase before importing the hook
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useRecentSkills.test.ts
+++ b/packages/coc/test/spa/react/hooks/useRecentSkills.test.ts
@@ -12,6 +12,7 @@ global.fetch = fetchMock as any;
 
 // Mock getApiBase
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useSendMessage-ralph.test.ts
+++ b/packages/coc/test/spa/react/hooks/useSendMessage-ralph.test.ts
@@ -15,6 +15,7 @@ import { renderHook, act } from '@testing-library/react';
 // ── Mocks ────────────────────────────────────────────────────────────
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useSendMessage.test.ts
+++ b/packages/coc/test/spa/react/hooks/useSendMessage.test.ts
@@ -10,6 +10,7 @@ import type { UseSendMessageOptions } from '../../../../src/server/spa/client/re
 // ── Mocks ────────────────────────────────────────────────────────────
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useSkillTemplates.test.ts
+++ b/packages/coc/test/spa/react/hooks/useSkillTemplates.test.ts
@@ -12,6 +12,7 @@ global.fetch = fetchMock as any;
 
 // Mock getApiBase
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useTerminalWebSocket.test.ts
+++ b/packages/coc/test/spa/react/hooks/useTerminalWebSocket.test.ts
@@ -47,6 +47,7 @@ class MockWebSocket {
 }
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getWsPath: () => '/ws',
     getWsUrl: () => 'ws://localhost/ws',

--- a/packages/coc/test/spa/react/hooks/useUiLayoutMode.test.ts
+++ b/packages/coc/test/spa/react/hooks/useUiLayoutMode.test.ts
@@ -8,6 +8,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 
 // Mock getApiBase before importing the hook
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/hooks/useWebSocket.test.ts
+++ b/packages/coc/test/spa/react/hooks/useWebSocket.test.ts
@@ -51,6 +51,7 @@ class MockWebSocket {
 }
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getWsPath: () => '/ws',
     getWsUrl: () => 'ws://localhost/ws',

--- a/packages/coc/test/spa/react/layout/BottomNav.test.tsx
+++ b/packages/coc/test/spa/react/layout/BottomNav.test.tsx
@@ -9,11 +9,11 @@ import { BottomNav } from '../../../../src/server/spa/client/react/layout/Bottom
 
 // ── Mock ResizeObserver (not available in jsdom) ──────────────────────
 
-vi.stubGlobal('ResizeObserver', vi.fn().mockImplementation(() => ({
+vi.stubGlobal('ResizeObserver', vi.fn().mockImplementation(function () { return ({
     observe: vi.fn(),
     unobserve: vi.fn(),
     disconnect: vi.fn(),
-})));
+}); }));
 
 // ── Mock AppContext ────────────────────────────────────────────────────
 
@@ -22,17 +22,17 @@ let mockActiveTab = 'repos';
 let mockSelectedRepoId: string | null = null;
 let mockActiveRepoSubTab = 'info';
 
-vi.mock('../../../../src/server/spa/client/react/contexts/AppContext', () => ({
-    useApp: () => ({
+vi.mock('../../../../src/server/spa/client/react/contexts/AppContext', function () { return ({
+    useApp: function () { return ({
         state: {
             activeTab: mockActiveTab,
             selectedRepoId: mockSelectedRepoId,
             activeRepoSubTab: mockActiveRepoSubTab,
         },
         dispatch: mockDispatch,
-    }),
+    }); },
     AppProvider: ({ children }: { children: React.ReactNode }) => children,
-}));
+}); });
 
 describe('BottomNav', () => {
     let viewportCleanup: (() => void) | undefined;

--- a/packages/coc/test/spa/react/layout/PopOutMarkdownShell.test.tsx
+++ b/packages/coc/test/spa/react/layout/PopOutMarkdownShell.test.tsx
@@ -59,6 +59,7 @@ vi.mock('../../../../src/server/spa/client/react/shared/SourceEditor', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/pending-task-info.test.tsx
+++ b/packages/coc/test/spa/react/pending-task-info.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../../src/server/spa/client/react/contexts/ChatPreferencesContext', 
 
 // Mock config to return predictable API base
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getWsPath: () => '/ws',
     getWsUrl: () => 'ws://localhost/ws',

--- a/packages/coc/test/spa/react/queue/PendingTaskComponents.test.tsx
+++ b/packages/coc/test/spa/react/queue/PendingTaskComponents.test.tsx
@@ -22,6 +22,7 @@ import { PendingTaskPayload, MetaRow, FilePathValue } from '../../../../src/serv
 
 // Mock config for fetchApi (used internally by PendingTaskPayload for images)
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getWsPath: () => '/ws',
     getWsUrl: () => 'ws://localhost/ws',

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
@@ -45,6 +45,7 @@ const { mockState } = vi.hoisted(() => ({
 
 // Config
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getWsPath: () => '/ws',
     getWsUrl: () => 'ws://localhost/ws',

--- a/packages/coc/test/spa/react/repos/ChatListPane.activity-ralph.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane.activity-ralph.test.tsx
@@ -89,6 +89,7 @@ vi.mock('../../../../src/server/spa/client/react/features/workflow/hooks/useWork
 
 // ❗ Critical: enable ralph so applyRalphGrouping actually groups.
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => true,
 }));

--- a/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
@@ -121,6 +121,7 @@ vi.mock('../../../../src/server/spa/client/react/features/workflow/hooks/useWork
 
 // ── Utilities / config ──
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => false,
 }));

--- a/packages/coc/test/spa/react/repos/CreateScheduleForm.test.tsx
+++ b/packages/coc/test/spa/react/repos/CreateScheduleForm.test.tsx
@@ -21,6 +21,7 @@ const { mockSchedulesClient, mockModelsClient, mockFeatureFlags } = vi.hoisted((
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/DiffMiniMap.test.tsx
+++ b/packages/coc/test/spa/react/repos/DiffMiniMap.test.tsx
@@ -299,11 +299,11 @@ describe('DiffMiniMap', () => {
         });
         globalThis.cancelAnimationFrame = vi.fn();
         // Provide a no-op ResizeObserver for jsdom
-        globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+        globalThis.ResizeObserver = vi.fn().mockImplementation(function () { return ({
             observe: vi.fn(),
             unobserve: vi.fn(),
             disconnect: vi.fn(),
-        }));
+        }); });
     });
 
     afterEach(() => {

--- a/packages/coc/test/spa/react/repos/NewChatArea.test.tsx
+++ b/packages/coc/test/spa/react/repos/NewChatArea.test.tsx
@@ -62,6 +62,7 @@ vi.mock('../../../../src/server/spa/client/react/contexts/AppContext', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getConfig: () => ({ apiBasePath: '/api' }),
     isRalphEnabled: () => false,

--- a/packages/coc/test/spa/react/repos/NotesSettingsSection.test.tsx
+++ b/packages/coc/test/spa/react/repos/NotesSettingsSection.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../../../src/server/spa/client/react/contexts/ToastContext', () => (
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/repos/PromptScheduleForm.test.tsx
+++ b/packages/coc/test/spa/react/repos/PromptScheduleForm.test.tsx
@@ -20,6 +20,7 @@ const { mockSchedulesClient, mockModelsClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/RepoCopilotTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoCopilotTab.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/repos/RepoPreferencesSection.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoPreferencesSection.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../../../src/server/spa/client/react/contexts/ReposContext', () => (
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/RunScriptTemplatesSection.test.tsx
+++ b/packages/coc/test/spa/react/repos/RunScriptTemplatesSection.test.tsx
@@ -14,6 +14,7 @@ import { ToastProvider } from '../../../../src/server/spa/client/react/contexts/
 // ── Mocks ───────────────────────────────────────────────────────────────────
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/repos/TemplatesTab.script-templates.test.tsx
+++ b/packages/coc/test/spa/react/repos/TemplatesTab.script-templates.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/repos/TemplatesTab.skill-templates.test.tsx
+++ b/packages/coc/test/spa/react/repos/TemplatesTab.skill-templates.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
 }));
 

--- a/packages/coc/test/spa/react/repos/TerminalPanel.behavior.test.tsx
+++ b/packages/coc/test/spa/react/repos/TerminalPanel.behavior.test.tsx
@@ -5,47 +5,47 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const terminalWebSocketMock = vi.hoisted(() => ({
+const terminalWebSocketMock = vi.hoisted(function () { return ({
     connect: vi.fn(),
     disconnect: vi.fn(),
     sendInput: vi.fn(),
     sendResize: vi.fn(),
-}));
+}); });
 
-vi.mock('@xterm/xterm', () => ({
-    Terminal: vi.fn().mockImplementation(() => ({
+vi.mock('@xterm/xterm', function () { return ({
+    Terminal: vi.fn().mockImplementation(function () { return ({
         cols: 98,
         rows: 41,
         loadAddon: vi.fn(),
         open: vi.fn(),
         dispose: vi.fn(),
         write: vi.fn(),
-        onData: vi.fn(() => ({ dispose: vi.fn() })),
+        onData: vi.fn(function () { return ({ dispose: vi.fn() }); }),
         options: {},
-    })),
-}));
+    }); }),
+}); });
 
-vi.mock('@xterm/addon-fit', () => ({
-    FitAddon: vi.fn().mockImplementation(() => ({
+vi.mock('@xterm/addon-fit', function () { return ({
+    FitAddon: vi.fn().mockImplementation(function () { return ({
         fit: vi.fn(),
-    })),
-}));
+    }); }),
+}); });
 
-vi.mock('@xterm/addon-web-links', () => ({
-    WebLinksAddon: vi.fn().mockImplementation(() => ({})),
-}));
+vi.mock('@xterm/addon-web-links', function () { return ({
+    WebLinksAddon: vi.fn().mockImplementation(function () { return ({}); }),
+}); });
 
-vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+vi.mock('@xterm/xterm/css/xterm.css', function () { return ({}); });
 
-vi.mock('../../../../src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket', () => ({
-    useTerminalWebSocket: () => ({
+vi.mock('../../../../src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket', function () { return ({
+    useTerminalWebSocket: function () { return ({
         status: 'closed',
         connect: terminalWebSocketMock.connect,
         disconnect: terminalWebSocketMock.disconnect,
         sendInput: terminalWebSocketMock.sendInput,
         sendResize: terminalWebSocketMock.sendResize,
-    }),
-}));
+    }); },
+}); });
 
 import { TerminalPanel } from '../../../../src/server/spa/client/react/features/terminal/TerminalPanel';
 

--- a/packages/coc/test/spa/react/repos/TerminalView.test.ts
+++ b/packages/coc/test/spa/react/repos/TerminalView.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../../../src/server/spa/client/react/features/terminal/TerminalPanel
 });
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/repos/compact-input-bar.test.tsx
+++ b/packages/coc/test/spa/react/repos/compact-input-bar.test.tsx
@@ -54,6 +54,7 @@ vi.mock('../../../../src/server/spa/client/react/contexts/AppContext', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
     getConfig: () => ({ apiBasePath: '/api' }),
     isRalphEnabled: () => false,

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestsTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestsTab.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 
 // Mock getApiBase so fetch URLs are predictable.
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/pull-requests/attention-groups-layout.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/attention-groups-layout.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { AttentionGroup } from '../../../../../src/server/spa/client/react/features/pull-requests/pr-attention-groups';
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/pull-requests/batch-selection.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/batch-selection.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AttentionGroup } from '../../../../../src/server/spa/client/react/features/pull-requests/pr-attention-groups';
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/repos/pull-requests/pull-requests-tab-panel-switch.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/pull-requests-tab-panel-switch.test.tsx
@@ -6,6 +6,7 @@ const mockFetchApi = vi.hoisted(() => vi.fn());
 const mockSelectedPrId = vi.hoisted(() => ({ value: null as number | string | null }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/shared/ReferencesDropdown.test.tsx
+++ b/packages/coc/test/spa/react/shared/ReferencesDropdown.test.tsx
@@ -7,16 +7,16 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 
 // ── Hoisted mutable mock state ─────────────────────────────────────────────
 
-const { mockBreakpoint } = vi.hoisted(() => ({
+const { mockBreakpoint } = vi.hoisted(function () { return ({
     mockBreakpoint: { isMobile: false, isTablet: false, isDesktop: true, breakpoint: 'desktop' as const },
-}));
+}); });
 
-vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', function () { return ({
     useBreakpoint: () => mockBreakpoint,
-}));
+}); });
 
 // BottomSheet stub — renders inline for testability (avoids portal complexity)
-vi.mock('../../../../src/server/spa/client/react/ui/BottomSheet', () => ({
+vi.mock('../../../../src/server/spa/client/react/ui/BottomSheet', function () { return ({
     BottomSheet: ({ isOpen, onClose, title, children }: any) =>
         isOpen ? (
             <div data-testid="bottomsheet-mock" data-title={title}>
@@ -24,7 +24,7 @@ vi.mock('../../../../src/server/spa/client/react/ui/BottomSheet', () => ({
                 {children}
             </div>
         ) : null,
-}));
+}); });
 
 import {
     computeReferencesDropdownPlacement,
@@ -54,7 +54,7 @@ function mockTriggerRect(rect: Partial<DOMRect>) {
         right: 760,
         bottom: 48,
         left: 660,
-        toJSON: () => ({}),
+        toJSON: function () { return ({}); },
         ...rect,
     } as DOMRect);
 }

--- a/packages/coc/test/spa/react/task-actions.test.tsx
+++ b/packages/coc/test/spa/react/task-actions.test.tsx
@@ -14,6 +14,7 @@ import { TaskProvider, useTaskContext } from '../../../src/server/spa/client/rea
 import { TaskActions } from '../../../src/server/spa/client/react/tasks/TaskActions';
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/useFileActions.test.ts
+++ b/packages/coc/test/spa/react/useFileActions.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFileActions } from '../../../src/server/spa/client/react/tasks/hooks/useFileActions';
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/useFolderActions.test.ts
+++ b/packages/coc/test/spa/react/useFolderActions.test.ts
@@ -8,6 +8,7 @@ import { useFolderActions } from '../../../src/server/spa/client/react/tasks/hoo
 
 // Stub getApiBase to return a known prefix
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/useProcessSearch.test.ts
+++ b/packages/coc/test/spa/react/useProcessSearch.test.ts
@@ -8,6 +8,7 @@ import { useProcessSearch } from '../../../src/server/spa/client/react/processes
 
 // Stub config
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/test/spa/react/useQueueTaskGeneration.test.tsx
+++ b/packages/coc/test/spa/react/useQueueTaskGeneration.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../src/server/spa/client/react/queue/hooks/useQueueTaskGeneration';
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/useTaskGeneration.test.tsx
+++ b/packages/coc/test/spa/react/useTaskGeneration.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../src/server/spa/client/react/tasks/hooks/useTaskGeneration';
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '/api',
 }));
 

--- a/packages/coc/test/spa/react/wiki/WikiViewMobile.test.tsx
+++ b/packages/coc/test/spa/react/wiki/WikiViewMobile.test.tsx
@@ -76,6 +76,7 @@ vi.mock('../../../../src/server/spa/client/react/ui/BottomSheet', () => ({
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
     getApiBase: () => '',
 }));
 

--- a/packages/coc/vitest.config.ts
+++ b/packages/coc/vitest.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     },
     test: {
         globals: true,
+        environment: 'node',
+        include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
         setupFiles: ['test/setup.ts'],
         globalSetup: ['test/global-setup.ts'],
         coverage: {
@@ -25,6 +27,10 @@ export default defineConfig({
         },
         testTimeout: 60000,
         hookTimeout: 60000,
+        environmentMatchGlobs: [
+            ['test/spa/**/*.test.tsx', 'jsdom'],
+            ['test/spa/**/*.test.ts', 'jsdom'],
+        ],
         // Use child_process forks instead of worker_threads. Worker threads
         // on macOS Apple Silicon (Node 24 + vitest 1.6) can crash with
         // SIGSEGV on shutdown when test files load native addons (notably
@@ -41,28 +47,5 @@ export default defineConfig({
         // passed at that point, so swallow the cleanup-time error rather
         // than fail an otherwise-green run.
         dangerouslyIgnoreUnhandledErrors: true,
-        // Vitest 4 removed `environmentMatchGlobs`; the supported migration
-        // is to split env-specific test sets into projects. SPA tests run
-        // in jsdom; everything else runs in node. Both inherit the shared
-        // root settings above via `extends: true`.
-        projects: [
-            {
-                extends: true,
-                test: {
-                    name: 'jsdom',
-                    include: ['test/spa/**/*.test.ts', 'test/spa/**/*.test.tsx'],
-                    environment: 'jsdom',
-                },
-            },
-            {
-                extends: true,
-                test: {
-                    name: 'node',
-                    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-                    exclude: ['test/spa/**/*.test.ts', 'test/spa/**/*.test.tsx'],
-                    environment: 'node',
-                },
-            },
-        ],
     }
 });

--- a/packages/coc/vitest.config.ts
+++ b/packages/coc/vitest.config.ts
@@ -14,8 +14,6 @@ export default defineConfig({
     },
     test: {
         globals: true,
-        environment: 'node',
-        include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
         setupFiles: ['test/setup.ts'],
         globalSetup: ['test/global-setup.ts'],
         coverage: {
@@ -27,10 +25,6 @@ export default defineConfig({
         },
         testTimeout: 60000,
         hookTimeout: 60000,
-        environmentMatchGlobs: [
-            ['test/spa/**/*.test.tsx', 'jsdom'],
-            ['test/spa/**/*.test.ts', 'jsdom'],
-        ],
         // Use child_process forks instead of worker_threads. Worker threads
         // on macOS Apple Silicon (Node 24 + vitest 1.6) can crash with
         // SIGSEGV on shutdown when test files load native addons (notably
@@ -47,5 +41,28 @@ export default defineConfig({
         // passed at that point, so swallow the cleanup-time error rather
         // than fail an otherwise-green run.
         dangerouslyIgnoreUnhandledErrors: true,
+        // Vitest 4 removed `environmentMatchGlobs`; the supported migration
+        // is to split env-specific test sets into projects. SPA tests run
+        // in jsdom; everything else runs in node. Both inherit the shared
+        // root settings above via `extends: true`.
+        projects: [
+            {
+                extends: true,
+                test: {
+                    name: 'jsdom',
+                    include: ['test/spa/**/*.test.ts', 'test/spa/**/*.test.tsx'],
+                    environment: 'jsdom',
+                },
+            },
+            {
+                extends: true,
+                test: {
+                    name: 'node',
+                    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+                    exclude: ['test/spa/**/*.test.ts', 'test/spa/**/*.test.tsx'],
+                    environment: 'node',
+                },
+            },
+        ],
     }
 });

--- a/packages/deep-wiki/package.json
+++ b/packages/deep-wiki/package.json
@@ -30,23 +30,20 @@
     "@octokit/rest": "^22.0.1",
     "@plusplusoneplusplus/forge": "^1.2.0",
     "azure-devops-node-api": "^14.1.0",
-    "better-sqlite3": "^11.9.1",
     "commander": "^12.1.0",
-    "copy-webpack-plugin": "14.0.0",
     "diff": "^5.2.0",
     "js-yaml": "^4.1.0",
-    "mocha": "7.2.0",
-    "monaco-editor": "0.53.0",
     "pino": "^9.x",
-    "pino-pretty": "^11.x"
+    "pino-pretty": "^11.x",
+    "better-sqlite3": "^11.9.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^20.0.0",
-    "@vitest/coverage-v8": "^4.1.5",
-    "esbuild": "^0.28.0",
+    "@vitest/coverage-v8": "^1.6.1",
+    "esbuild": "^0.21.5",
     "typescript": "^5.3.0",
-    "vitest": "^4.1.5"
+    "vitest": "^1.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/deep-wiki/test/commands/discovery-error-recovery.test.ts
+++ b/packages/deep-wiki/test/commands/discovery-error-recovery.test.ts
@@ -20,7 +20,7 @@ import * as os from 'os';
 // Mocks — identical pattern to phase-runners.test.ts
 // ============================================================================
 
-vi.mock('../../src/ai-invoker', () => ({
+vi.mock('../../src/ai-invoker', function () { return ({
     checkAIAvailability: vi.fn().mockResolvedValue({ available: true }),
     createAnalysisInvoker: vi.fn().mockReturnValue(vi.fn().mockResolvedValue({
         success: true,
@@ -42,24 +42,24 @@ vi.mock('../../src/ai-invoker', () => ({
         success: true,
         response: '# Article\n\nContent.',
     })),
-}));
+}); });
 
-vi.mock('../../src/discovery', () => ({
+vi.mock('../../src/discovery', function () { return ({
     discoverComponentGraph: vi.fn().mockResolvedValue({ graph: {}, duration: 1 }),
     runIterativeDiscovery: vi.fn(),
-}));
+}); });
 
-vi.mock('../../src/consolidation', () => ({
+vi.mock('../../src/consolidation', function () { return ({
     consolidateComponents: vi.fn(),
-}));
+}); });
 
-vi.mock('../../src/analysis', () => ({
+vi.mock('../../src/analysis', function () { return ({
     analyzeComponents: vi.fn().mockResolvedValue({
         analyses: [],
         duration: 1000,
     }),
     parseAnalysisResponse: vi.fn(),
-}));
+}); });
 
 vi.mock('../../src/writing', async (importOriginal) => {
     const actual = await importOriginal() as Record<string, unknown>;
@@ -80,12 +80,12 @@ vi.mock('../../src/writing/website-generator', async (importOriginal) => {
     };
 });
 
-vi.mock('../../src/seeds', () => ({
+vi.mock('../../src/seeds', function () { return ({
     generateThemeSeeds: vi.fn(),
     parseSeedFile: vi.fn(),
-}));
+}); });
 
-vi.mock('../../src/cache', () => ({
+vi.mock('../../src/cache', function () { return ({
     getCachedGraph: vi.fn().mockResolvedValue(null),
     getCachedGraphAny: vi.fn().mockReturnValue(null),
     saveGraph: vi.fn().mockResolvedValue(undefined),
@@ -141,17 +141,17 @@ vi.mock('../../src/cache', () => ({
     saveDiscoveryMetadata: vi.fn(),
     getDiscoveryMetadata: vi.fn().mockReturnValue(null),
     getDiscoveryCacheDir: vi.fn().mockReturnValue('/mock/.wiki-cache/discovery'),
-}));
+}); });
 
-vi.mock('../../src/logger', () => ({
-    Spinner: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/logger', function () { return ({
+    Spinner: vi.fn().mockImplementation(function () { return ({
         start: vi.fn(),
         update: vi.fn(),
         stop: vi.fn(),
         succeed: vi.fn(),
         fail: vi.fn(),
         warn: vi.fn(),
-    })),
+    }); }),
     printSuccess: vi.fn(),
     printError: vi.fn(),
     printWarning: vi.fn(),
@@ -163,7 +163,7 @@ vi.mock('../../src/logger', () => ({
     green: (s: string) => s,
     cyan: (s: string) => s,
     yellow: (s: string) => s,
-}));
+}); });
 
 // ============================================================================
 // Imports (after mocks)

--- a/packages/deep-wiki/test/commands/generate.test.ts
+++ b/packages/deep-wiki/test/commands/generate.test.ts
@@ -18,7 +18,7 @@ import * as yaml from 'js-yaml';
 // ============================================================================
 
 // Mock AI invoker
-vi.mock('../../src/ai-invoker', () => ({
+vi.mock('../../src/ai-invoker', function () { return ({
     checkAIAvailability: vi.fn().mockResolvedValue({ available: true }),
     createAnalysisInvoker: vi.fn().mockReturnValue(vi.fn().mockResolvedValue({
         success: true,
@@ -40,10 +40,10 @@ vi.mock('../../src/ai-invoker', () => ({
         success: true,
         response: '# Test Article\n\nContent here.',
     })),
-}));
+}); });
 
 // Mock discovery
-vi.mock('../../src/discovery', () => ({
+vi.mock('../../src/discovery', function () { return ({
     discoverComponentGraph: vi.fn().mockResolvedValue({
         graph: {
             project: {
@@ -91,10 +91,10 @@ vi.mock('../../src/discovery', () => ({
         categories: [{ name: 'core', description: 'Core' }],
         architectureNotes: 'Iterative discovery',
     }),
-}));
+}); });
 
 // Mock analysis component
-vi.mock('../../src/analysis', () => ({
+vi.mock('../../src/analysis', function () { return ({
     analyzeComponents: vi.fn().mockResolvedValue({
         analyses: [{
             componentId: 'test-module',
@@ -112,7 +112,7 @@ vi.mock('../../src/analysis', () => ({
         duration: 1000,
     }),
     parseAnalysisResponse: vi.fn(),
-}));
+}); });
 
 // Mock writing component — keep writeWikiOutput and buildReducePromptTemplate as real implementations
 // so existing tests that depend on file writes continue to work.
@@ -134,17 +134,17 @@ vi.mock('../../src/writing', async (importOriginal) => {
 });
 
 // Mock seeds
-vi.mock('../../src/seeds', () => ({
+vi.mock('../../src/seeds', function () { return ({
     generateThemeSeeds: vi.fn().mockResolvedValue([
         { theme: 'auth', description: 'Auth', hints: ['auth'] },
     ]),
     parseSeedFile: vi.fn().mockReturnValue([
         { theme: 'auth', description: 'Auth', hints: ['auth'] },
     ]),
-}));
+}); });
 
 // Mock cache
-vi.mock('../../src/cache', () => ({
+vi.mock('../../src/cache', function () { return ({
     getCachedGraph: vi.fn().mockResolvedValue(null),
     getCachedGraphAny: vi.fn().mockReturnValue(null),
     saveGraph: vi.fn().mockResolvedValue(undefined),
@@ -205,7 +205,7 @@ vi.mock('../../src/cache', () => ({
     saveDiscoveryMetadata: vi.fn(),
     getDiscoveryMetadata: vi.fn().mockReturnValue(null),
     getDiscoveryCacheDir: vi.fn().mockReturnValue('/mock/.wiki-cache/discovery'),
-}));
+}); });
 
 // Mock website generator — keep real exports, only mock generateWebsite
 vi.mock('../../src/writing/website-generator', async (importOriginal) => {
@@ -217,15 +217,15 @@ vi.mock('../../src/writing/website-generator', async (importOriginal) => {
 });
 
 // Suppress logger output during tests
-vi.mock('../../src/logger', () => ({
-    Spinner: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/logger', function () { return ({
+    Spinner: vi.fn().mockImplementation(function () { return ({
         start: vi.fn(),
         update: vi.fn(),
         stop: vi.fn(),
         succeed: vi.fn(),
         fail: vi.fn(),
         warn: vi.fn(),
-    })),
+    }); }),
     printSuccess: vi.fn(),
     printError: vi.fn(),
     printWarning: vi.fn(),
@@ -237,7 +237,7 @@ vi.mock('../../src/logger', () => ({
     cyan: (s: string) => s,
     yellow: (s: string) => s,
     gray: (s: string) => s,
-}));
+}); });
 
 import { executeGenerate } from '../../src/commands/generate';
 import { EXIT_CODES } from '../../src/cli';

--- a/packages/deep-wiki/test/commands/phases/phase-runners.test.ts
+++ b/packages/deep-wiki/test/commands/phases/phase-runners.test.ts
@@ -16,7 +16,7 @@ import * as os from 'os';
 // Mocks — identical pattern to generate.test.ts
 // ============================================================================
 
-vi.mock('../../../src/ai-invoker', () => ({
+vi.mock('../../../src/ai-invoker', function () { return ({
     checkAIAvailability: vi.fn().mockResolvedValue({ available: true }),
     createAnalysisInvoker: vi.fn().mockReturnValue(vi.fn().mockResolvedValue({
         success: true,
@@ -42,9 +42,9 @@ vi.mock('../../../src/ai-invoker', () => ({
         success: true,
         response: '{}',
     })),
-}));
+}); });
 
-vi.mock('../../../src/discovery', () => ({
+vi.mock('../../../src/discovery', function () { return ({
     discoverComponentGraph: vi.fn().mockResolvedValue({
         graph: {
             project: {
@@ -71,9 +71,9 @@ vi.mock('../../../src/discovery', () => ({
         duration: 1000,
     }),
     runIterativeDiscovery: vi.fn(),
-}));
+}); });
 
-vi.mock('../../../src/consolidation', () => ({
+vi.mock('../../../src/consolidation', function () { return ({
     consolidateComponents: vi.fn().mockResolvedValue({
         graph: {
             project: {
@@ -101,9 +101,9 @@ vi.mock('../../../src/consolidation', () => ({
         afterRuleBasedCount: 1,
         finalCount: 1,
     }),
-}));
+}); });
 
-vi.mock('../../../src/analysis', () => ({
+vi.mock('../../../src/analysis', function () { return ({
     analyzeComponents: vi.fn().mockResolvedValue({
         analyses: [{
             componentId: 'test-module',
@@ -121,7 +121,7 @@ vi.mock('../../../src/analysis', () => ({
         duration: 1000,
     }),
     parseAnalysisResponse: vi.fn(),
-}));
+}); });
 
 vi.mock('../../../src/writing', async (importOriginal) => {
     const actual = await importOriginal() as Record<string, unknown>;
@@ -148,16 +148,16 @@ vi.mock('../../../src/writing/website-generator', async (importOriginal) => {
     };
 });
 
-vi.mock('../../../src/seeds', () => ({
+vi.mock('../../../src/seeds', function () { return ({
     generateThemeSeeds: vi.fn().mockResolvedValue([
         { theme: 'auth', description: 'Auth', hints: ['auth'] },
     ]),
     parseSeedFile: vi.fn().mockReturnValue([
         { theme: 'auth', description: 'Auth', hints: ['auth'] },
     ]),
-}));
+}); });
 
-vi.mock('../../../src/cache', () => ({
+vi.mock('../../../src/cache', function () { return ({
     getCachedGraph: vi.fn().mockResolvedValue(null),
     getCachedGraphAny: vi.fn().mockReturnValue(null),
     saveGraph: vi.fn().mockResolvedValue(undefined),
@@ -213,17 +213,17 @@ vi.mock('../../../src/cache', () => ({
     saveDiscoveryMetadata: vi.fn(),
     getDiscoveryMetadata: vi.fn().mockReturnValue(null),
     getDiscoveryCacheDir: vi.fn().mockReturnValue('/mock/.wiki-cache/discovery'),
-}));
+}); });
 
-vi.mock('../../../src/logger', () => ({
-    Spinner: vi.fn().mockImplementation(() => ({
+vi.mock('../../../src/logger', function () { return ({
+    Spinner: vi.fn().mockImplementation(function () { return ({
         start: vi.fn(),
         update: vi.fn(),
         stop: vi.fn(),
         succeed: vi.fn(),
         fail: vi.fn(),
         warn: vi.fn(),
-    })),
+    }); }),
     printSuccess: vi.fn(),
     printError: vi.fn(),
     printWarning: vi.fn(),
@@ -235,7 +235,7 @@ vi.mock('../../../src/logger', () => ({
     cyan: (s: string) => s,
     yellow: (s: string) => s,
     gray: (s: string) => s,
-}));
+}); });
 
 // ============================================================================
 // Imports (after mocks)

--- a/packages/deep-wiki/test/theme/theme-pipeline-integration.test.ts
+++ b/packages/deep-wiki/test/theme/theme-pipeline-integration.test.ts
@@ -75,15 +75,15 @@ const {
 // Mocks
 // ============================================================================
 
-vi.mock('../../src/ai-invoker', () => ({
+vi.mock('../../src/ai-invoker', function () { return ({
     checkAIAvailability: vi.fn().mockResolvedValue({ available: true }),
-}));
+}); });
 
-vi.mock('../../src/cache', () => ({
+vi.mock('../../src/cache', function () { return ({
     getFolderHeadHash: vi.fn().mockResolvedValue('abc123def456abc123def456abc123def456abc1'),
-}));
+}); });
 
-vi.mock('../../src/cache/theme-cache', () => ({
+vi.mock('../../src/cache/theme-cache', function () { return ({
     getCachedThemeProbe: vi.fn().mockReturnValue(null),
     saveThemeProbe: vi.fn(),
     getCachedThemeOutline: vi.fn().mockReturnValue(null),
@@ -94,9 +94,9 @@ vi.mock('../../src/cache/theme-cache', () => ({
     saveThemeArticle: vi.fn(),
     isThemeCacheValid: vi.fn().mockReturnValue(false),
     clearThemeCache: vi.fn().mockReturnValue(false),
-}));
+}); });
 
-vi.mock('../../src/theme', () => ({
+vi.mock('../../src/theme', function () { return ({
     loadWikiGraph: vi.fn().mockReturnValue(null),
     listThemeAreas: vi.fn().mockReturnValue([]),
     checkThemeCoverage: vi.fn().mockReturnValue({ status: 'new', relatedComponents: [] }),
@@ -106,21 +106,21 @@ vi.mock('../../src/theme', () => ({
     generateThemeArticles: vi.fn().mockResolvedValue(MOCK_ARTICLES),
     writeThemeArticles: vi.fn().mockReturnValue({ writtenFiles: ['index.md', 'auth.md'], themeDir: 'themes/authentication' }),
     integrateThemeIntoWiki: vi.fn().mockReturnValue({ writtenFiles: ['index.md', 'auth.md'], updatedFiles: [] }),
-}));
+}); });
 
-vi.mock('../../src/writing', () => ({
+vi.mock('../../src/writing', function () { return ({
     generateWebsite: vi.fn().mockReturnValue(['index.html']),
-}));
+}); });
 
-vi.mock('../../src/logger', () => ({
-    Spinner: vi.fn().mockImplementation(() => ({
+vi.mock('../../src/logger', function () { return ({
+    Spinner: vi.fn().mockImplementation(function () { return ({
         start: vi.fn(),
         update: vi.fn(),
         stop: vi.fn(),
         succeed: vi.fn(),
         fail: vi.fn(),
         warn: vi.fn(),
-    })),
+    }); }),
     printSuccess: vi.fn(),
     printError: vi.fn(),
     printWarning: vi.fn(),
@@ -129,7 +129,7 @@ vi.mock('../../src/logger', () => ({
     printKeyValue: vi.fn(),
     bold: (s: string) => s,
     gray: (s: string) => s,
-}));
+}); });
 
 // ============================================================================
 // Imports (after mocks)

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -94,12 +94,8 @@
     "@octokit/rest": "^22.0.1",
     "azure-devops-node-api": "^14.1.0",
     "better-sqlite3": "^11.9.1",
-    "copy-webpack-plugin": "14.0.0",
     "diff": "^5.2.0",
-    "esbuild": "0.28.0",
     "js-yaml": "^4.1.0",
-    "mocha": "7.2.0",
-    "monaco-editor": "0.53.0",
     "pino": "^9.x"
   },
   "devDependencies": {
@@ -108,10 +104,10 @@
     "@types/diff": "^5.2.0",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^20.0.0",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/coverage-v8": "^1.6.1",
     "pino-pretty": "^13.x",
     "typescript": "^5.3.0",
-    "vitest": "^4.1.5"
+    "vitest": "^1.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/forge/test/ado/ado-connection-factory.test.ts
+++ b/packages/forge/test/ado/ado-connection-factory.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('azure-devops-node-api', () => {
-    const mockWebApi = vi.fn().mockImplementation(() => ({
-        getWorkItemTrackingApi: vi.fn(),
-    }));
+    // Use a regular function (not arrow) so the mock is constructible with `new`.
+    // In vitest 4, mocks invoke their implementation as a constructor when called
+    // with `new`, and arrow functions do not have [[Construct]].
+    const mockWebApi = vi.fn(function (this: any) {
+        this.getWorkItemTrackingApi = vi.fn();
+    });
     return {
         WebApi: mockWebApi,
         getBearerHandler: vi.fn().mockReturnValue({ token: 'mock-bearer-handler' }),
@@ -228,7 +231,7 @@ describe('AdoConnectionFactory', () => {
 
     describe('connect — error handling', () => {
         it('returns connected false when WebApi constructor throws', async () => {
-            vi.mocked(azdev.WebApi).mockImplementationOnce(() => {
+            vi.mocked(azdev.WebApi).mockImplementationOnce(function (this: any) {
                 throw new Error('network failure');
             });
             mockedExecAsync

--- a/packages/forge/test/ado/ado-identity-resolver.test.ts
+++ b/packages/forge/test/ado/ado-identity-resolver.test.ts
@@ -9,7 +9,9 @@ vi.mock('https', () => ({
 }));
 vi.mock('azure-devops-node-api', () => ({
     getBearerHandler: vi.fn(() => ({ token: 'fake-token' })),
-    WebApi: vi.fn(() => ({})),
+    // Use a regular function (not arrow) so the mock is constructible with `new`.
+    // In vitest 4, arrow functions cannot be invoked as constructors.
+    WebApi: vi.fn(function (this: any) {}),
 }));
 
 import * as fs from 'fs/promises';

--- a/packages/forge/test/memory/with-tool-call-cache.test.ts
+++ b/packages/forge/test/memory/with-tool-call-cache.test.ts
@@ -58,17 +58,19 @@ describe('withToolCallCache', () => {
         baseOpts = { model: 'test-model' };
         cacheOpts = { store: mockStore, filter: alwaysFilter };
 
-        // Setup ToolCallCapture mock
+        // Setup ToolCallCapture mock — use a regular function (not arrow) so the mock
+        // is constructible with `new`. In vitest 4, mocks invoke their implementation
+        // as a constructor when called with `new`, and arrow functions cannot be.
         mockCaptureHandler = vi.fn();
-        (ToolCallCapture as unknown as Mock).mockImplementation(() => ({
-            createToolEventHandler: vi.fn().mockReturnValue(mockCaptureHandler),
-        }));
+        (ToolCallCapture as unknown as Mock).mockImplementation(function (this: any) {
+            this.createToolEventHandler = vi.fn().mockReturnValue(mockCaptureHandler);
+        });
 
-        // Setup ToolCallCacheAggregator mock
+        // Setup ToolCallCacheAggregator mock (same reasoning as above).
         mockAggregateIfNeeded = vi.fn().mockResolvedValue(false);
-        (ToolCallCacheAggregator as unknown as Mock).mockImplementation(() => ({
-            aggregateIfNeeded: mockAggregateIfNeeded,
-        }));
+        (ToolCallCacheAggregator as unknown as Mock).mockImplementation(function (this: any) {
+            this.aggregateIfNeeded = mockAggregateIfNeeded;
+        });
     });
 
     it('wires onToolEvent correctly', async () => {
@@ -140,7 +142,7 @@ describe('withToolCallCache', () => {
     });
 
     it('graceful on capture creation error', async () => {
-        (ToolCallCapture as unknown as Mock).mockImplementation(() => {
+        (ToolCallCapture as unknown as Mock).mockImplementation(function (this: any) {
             throw new Error('capture init failed');
         });
 

--- a/scripts/build-coc-publish.ps1
+++ b/scripts/build-coc-publish.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-  Build forge and coc, then verify the tarball includes forge.
+  Build forge, coc, and coc-client, then verify the tarballs.
 .DESCRIPTION
   Run from the monorepo root:  .\scripts\build-coc-publish.ps1
 #>
@@ -42,8 +42,32 @@ if ($entries -match 'node_modules[\\/]@plusplusoneplusplus[\\/]forge') {
 Remove-Item -Force $tarball -ErrorAction SilentlyContinue
 
 Write-Host ""
+Write-Host "==> Packing and verifying coc-client tarball..."
+Set-Location (Join-Path $RepoRoot 'packages' 'coc-client')
+$clientTarball = (npm pack 2>&1 | Select-Object -Last 1).Trim()
+$clientEntries = tar tzf $clientTarball 2>&1 | Out-String
+
+if ($clientEntries -match 'dist/') {
+    $clientCount = ($clientEntries -split "`n" | Where-Object { $_ -match 'dist/' }).Count
+    Write-Host "`n✅  coc-client dist is present in the tarball ($clientCount files)."
+} else {
+    Remove-Item -Force $clientTarball -ErrorAction SilentlyContinue
+    Write-Host "`n❌  dist/ was NOT found in the coc-client tarball. Run 'npm run build' in packages/coc-client."
+    exit 1
+}
+Remove-Item -Force $clientTarball -ErrorAction SilentlyContinue
+
+Write-Host ""
 Write-Host "=== Next steps (manual) ==="
+Write-Host ""
+Write-Host "  # coc"
 Write-Host "  cd packages\coc"
+Write-Host "  npm version patch   # or minor / major"
+Write-Host "  npm login            # if needed"
+Write-Host "  npm publish"
+Write-Host ""
+Write-Host "  # coc-client"
+Write-Host "  cd packages\coc-client"
 Write-Host "  npm version patch   # or minor / major"
 Write-Host "  npm login            # if needed"
 Write-Host "  npm publish"

--- a/scripts/build-coc-publish.sh
+++ b/scripts/build-coc-publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build forge and coc, then verify the tarball includes forge.
+# Build forge, coc, and coc-client, then verify the tarballs.
 # Run from the monorepo root: ./scripts/build-coc-publish.sh
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -33,8 +33,30 @@ fi
 rm -f "$TARBALL"
 
 echo ""
+echo "==> Packing and verifying coc-client tarball..."
+cd "$REPO_ROOT/packages/coc-client"
+CLIENT_TARBALL=$(npm pack 2>&1 | tail -1)
+if tar tzf "$CLIENT_TARBALL" | grep -q "dist/"; then
+  CLIENT_FILES=$(tar tzf "$CLIENT_TARBALL" | grep -c "dist/")
+  echo "✅  coc-client dist is present in the tarball ($CLIENT_FILES files)."
+else
+  rm -f "$CLIENT_TARBALL"
+  echo "❌  dist/ was NOT found in the coc-client tarball. Run 'npm run build' in packages/coc-client."
+  exit 1
+fi
+rm -f "$CLIENT_TARBALL"
+
+echo ""
 echo "=== Next steps (manual) ==="
+echo ""
+echo "  # coc"
 echo "  cd packages/coc"
+echo "  npm version patch   # or minor / major"
+echo "  npm login            # if needed"
+echo "  npm publish"
+echo ""
+echo "  # coc-client"
+echo "  cd packages/coc-client"
 echo "  npm version patch   # or minor / major"
 echo "  npm login            # if needed"
 echo "  npm publish"

--- a/scripts/coccontainer-serve-loop.ps1
+++ b/scripts/coccontainer-serve-loop.ps1
@@ -4,7 +4,7 @@
     Hit POST /api/admin/restart from any browser/node to trigger a rebuild + restart.
 
 .DESCRIPTION
-    1. Builds all packages (forge → coc → coccontainer) and npm-links them.
+    1. Builds all packages (forge -> coc -> coccontainer) and npm-links them.
     2. Starts `coccontainer serve --no-open`.
     3. When the server exits with code 75 (restart requested), loops back to step 1.
     4. Any other exit code (0 = clean shutdown, Ctrl+C, etc.) stops the loop.
@@ -43,7 +43,7 @@ function Build-CocContainer {
             return $false
         }
         Write-Host "`n=== Building coccontainer packages ===" -ForegroundColor Cyan
-        # Build forge → coccontainer, then npm link
+        # Build forge -> coccontainer, then npm link
         Push-Location (Join-Path $repoRoot "packages\forge")
         npm run build
         if ($LASTEXITCODE -ne 0) { Pop-Location; Write-Host "forge build failed" -ForegroundColor Red; return $false }


### PR DESCRIPTION
## Summary

Rebase commit [`ed35a48b0`](https://github.com/plusplusoneplusplus/shortcuts/commit/ed35a48b0) ("fix: resolve rebase conflicts and duplicate declarations") shipped much more than its title suggested. Hidden inside a 5,995-line `package-lock.json` diff were four major-version churns and three bogus runtime deps that none of these packages actually use, plus a latent regression from container-mode that broke 700+ tests:

| Dep | Before | After | Verdict |
|---|---|---|---|
| `vitest` (coc/forge/deep-wiki) | `^1.0.0` | `^4.1.5` | **major** — the test-failure source |
| `@vitest/coverage-v8` (×3) | `^1.6.1` | `^4.1.5` | **major** |
| `esbuild` (×3) | `^0.21.5` | `^0.28.0` | major |
| `monaco-editor` (coc) | `^0.55.1` | `^0.53.0` | **DOWNGRADE** — accidental |
| `mocha 7.2.0` | — | added to **forge & deep-wiki** runtime deps | unused — bogus |
| `copy-webpack-plugin 14.0.0` | — | added to **forge & deep-wiki** runtime deps | unused — bogus |
| `monaco-editor 0.53.0` | — | added to **forge & deep-wiki** runtime deps | unused — bogus |

The vitest 4 jump exposed (didn't cause) a real latent regression from the same PR's container-mode commits (`a0bc2fb40`, `1e79cb597`): `AppProvider`'s new `useEffect` calls `isContainerMode()`, and the 72 SPA tests that partial-mock `react/utils/config` without listing that export trip vitest's strict-mock check on **both** vitest 1.6 and 4.x.

## What this PR does

**Dependency reverts (restore pre-rebase manifests):**
- Revert all six dep changes in `packages/coc`, `packages/forge`, `packages/deep-wiki` to their pre-`ed35a48b0` versions
- Restore `vitest.config.ts` to `environmentMatchGlobs` (vitest 1.6 has no `projects`)
- Regenerate `package-lock.json`

**Latent regression fixes (needed regardless of vitest version):**
- Add `isContainerMode: () => false,` to the 72 SPA test mock factories that hit `AppProvider` indirectly. Tests that actually exercise container mode (`RepoTabStrip*.test.tsx`) already declared this correctly and are untouched.
- `scripts/coccontainer-serve-loop.ps1`: replace two non-ASCII arrows (`→`) with `->` so the existing "non-ASCII .ps1 must have a UTF-8 BOM" guard test passes.
- `Router.test.ts`: update `VALID_ADMIN_SUB_TABS` expectation to include the new `agents` admin tab.
- `ReposView.test.tsx`: widen the phase-2 source-search window from 800 → 2500 chars so container-mode branching in `ReposContext` doesn't push `getWorkspaceGitInfoBatch` out of range.

The function-expression mock conversions from the original commits (`b066a54d6`, `90fd1e2df`) remain in place — function expressions work identically on vitest 1.x and 4.x, so they become defensive future-proofing rather than load-bearing fixes.

## Verification

Full test suites green locally on macOS:

| Package | Tests | Result |
|---|---|---|
| coc | 23,552 | all pass |
| forge | 5,107 | all pass |
| deep-wiki | 1,837 | all pass |
| **total** | **30,496** | **all pass** |

`npm run build:packages` also succeeds for all three packages.

## Test plan

- [x] `npm run test:run` in `packages/coc` — 23552 pass, 39 skipped, 8 todo, 0 fail
- [x] `npm run test:run` in `packages/forge` — 5107 pass, 18 skipped, 0 fail
- [x] `npm run test:run` in `packages/deep-wiki` — 1837 pass, 0 fail
- [x] `npm run build:packages` succeeds
- [ ] CI green on Linux, macOS, Windows
- [ ] E2E checks green