### PR TITLE
fix(coc): derive routeWebSocket URL from server.url in e2e test 8.4

### DIFF
--- a/packages/coc/test/e2e/websocket-recovery.spec.ts
+++ b/packages/coc/test/e2e/websocket-recovery.spec.ts
@@ -221,8 +221,11 @@ test.describe('Section 8: Server Restart Recovery', () => {
 
             let activeRoute: WebSocketRoute | null = null;
 
-            // Intercept WebSocket connections so we can control disconnect/reconnect
-            await page.routeWebSocket(`ws://127.0.0.1:${server.port}/ws`, async (ws) => {
+            // Intercept WebSocket connections so we can control disconnect/reconnect.
+            // The SPA builds the WS URL from `location.host`, so derive the pattern
+            // from `server.url` to handle display-host mapping (e.g. 127.0.0.1 → localhost).
+            const wsUrl = `${server.url.replace(/^http/, 'ws')}/ws`;
+            await page.routeWebSocket(wsUrl, async (ws) => {
                 activeRoute = ws;
                 ws.connectToServer();
             });


### PR DESCRIPTION
## Summary
- E2E test `websocket-recovery.spec.ts` test `8.4` has been failing on `main` since commit `b0e8ca9d` (`feat(coc): change default bind address from 0.0.0.0 to 127.0.0.1`).
- That commit added `127.0.0.1` to the list of hosts that `createExecutionServer` collapses to `localhost` for `displayHost`/`server.url`. The SPA builds its WS URL from `location.host`, so it now connects to `ws://localhost:PORT/ws` — but the test's `page.routeWebSocket` pattern was hardcoded to `ws://127.0.0.1:PORT/ws`, so the route never fired, `activeRoute` stayed `null`, the simulated close was a no-op, and the "Connection lost — reconnecting…" toast never appeared.
- Derive the WS URL from `server.url` so the pattern stays aligned with whatever display host the server reports.

## Test plan
- [x] `npx tsc --noEmit` in `packages/coc` passes
- [ ] CI: E2E shard 4 (which contains `websocket-recovery.spec.ts`) goes green
- [ ] CI: build (ubuntu/mac/windows) stays green

Made with [Cursor](https://cursor.com)