### PR TITLE
ci: split build job into parallel per-package jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,25 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+  forge-test:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -45,6 +63,47 @@ jobs:
         run: npm run coverage
         working-directory: packages/forge
 
+      - name: Generate diff coverage report
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        run: bash ../../scripts/coverage-diff.sh origin/main || true
+        working-directory: packages/forge
+
+      - name: Upload forge coverage report
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: forge-coverage
+          path: packages/forge/coverage/
+          retention-days: 14
+
+  coc-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [24.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build forge package
+        run: npm run build
+        working-directory: packages/forge
+
       - name: Build coc-client package
         run: npm run build
         working-directory: packages/coc-client
@@ -63,6 +122,47 @@ jobs:
         run: npm run coverage
         working-directory: packages/coc
 
+      - name: Generate diff coverage report
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        run: bash ../../scripts/coverage-diff.sh origin/main || true
+        working-directory: packages/coc
+
+      - name: Upload coc coverage report
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coc-coverage
+          path: packages/coc/coverage/
+          retention-days: 14
+
+  deep-wiki-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [24.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build forge package
+        run: npm run build
+        working-directory: packages/forge
+
       - name: Run deep-wiki tests
         if: matrix.os != 'ubuntu-latest'
         run: npm run test:run
@@ -73,14 +173,42 @@ jobs:
         run: npm run coverage
         working-directory: packages/deep-wiki
 
-      - name: Build coc package
-        run: npm run build
-        working-directory: packages/coc
+      - name: Generate diff coverage report
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        run: bash ../../scripts/coverage-diff.sh origin/main || true
+        working-directory: packages/deep-wiki
 
-      - name: Lint
-        run: npm run lint
+      - name: Upload deep-wiki coverage report
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: deep-wiki-coverage
+          path: packages/deep-wiki/coverage/
+          retention-days: 14
 
-      - name: Compile
+  extension-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [24.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile extension (builds all packages and webpacks extension)
         run: npm run compile
 
       - name: Compile tests
@@ -99,30 +227,37 @@ jobs:
         if: runner.os != 'Linux'
         run: npm run test:extension
 
-      - name: Generate diff coverage report
-        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+  ci:
+    runs-on: ubuntu-latest
+    needs: [lint, forge-test, coc-test, deep-wiki-test, extension-test]
+    if: always()
+    steps:
+      - name: Verify all required jobs succeeded
         run: |
-          for pkg in forge coc deep-wiki; do
-            echo "==> Generating diff coverage for $pkg"
-            cd packages/$pkg
-            bash ../../scripts/coverage-diff.sh origin/main || true
-            cd ../..
+          declare -A results=(
+            [lint]="${{ needs.lint.result }}"
+            [forge-test]="${{ needs.forge-test.result }}"
+            [coc-test]="${{ needs.coc-test.result }}"
+            [deep-wiki-test]="${{ needs.deep-wiki-test.result }}"
+            [extension-test]="${{ needs.extension-test.result }}"
+          )
+          failed=0
+          for job in "${!results[@]}"; do
+            status="${results[$job]}"
+            echo "$job: $status"
+            if [[ "$status" != "success" ]]; then
+              failed=1
+            fi
           done
-
-      - name: Upload coverage reports
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports
-          path: |
-            packages/forge/coverage/
-            packages/coc/coverage/
-            packages/deep-wiki/coverage/
-          retention-days: 14
+          if [[ $failed -ne 0 ]]; then
+            echo "::error::One or more required CI jobs did not succeed."
+            exit 1
+          fi
+          echo "All required CI jobs succeeded."
 
   package:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [lint, forge-test, coc-test, deep-wiki-test, extension-test]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        shard: [1, 2, 3]
         node-version: [24.x]
 
     steps:
@@ -112,23 +113,78 @@ jobs:
         run: npm run build:client
         working-directory: packages/coc
 
-      - name: Run coc tests
+      - name: Run coc tests (shard ${{ matrix.shard }}/3)
         if: matrix.os != 'ubuntu-latest'
-        run: npm run test:run
+        run: npm run test:run -- --shard=${{ matrix.shard }}/3
         working-directory: packages/coc
 
-      - name: Run coc tests with coverage
+      - name: Run coc tests with coverage (shard ${{ matrix.shard }}/3)
         if: matrix.os == 'ubuntu-latest'
-        run: npm run coverage
+        run: npm run coverage -- --shard=${{ matrix.shard }}/3
         working-directory: packages/coc
+
+      - name: Upload coc coverage shard
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coc-coverage-shard-${{ matrix.shard }}
+          path: packages/coc/coverage/coverage-final.json
+          retention-days: 1
+
+  coc-coverage:
+    runs-on: ubuntu-latest
+    needs: [coc-test]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Download coc coverage shards
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coc-coverage-shard-*
+          path: packages/coc/coverage-shards/
+
+      - name: Aggregate sharded coverage into lcov.info
+        working-directory: packages/coc
+        run: |
+          set -euo pipefail
+          mkdir -p .nyc_output coverage
+          i=0
+          for f in coverage-shards/coc-coverage-shard-*/coverage-final.json; do
+            if [ -f "$f" ]; then
+              i=$((i+1))
+              cp "$f" ".nyc_output/shard-$i.json"
+              echo "==> Loaded shard $i from $f"
+            fi
+          done
+          if [ "$i" -eq 0 ]; then
+            echo "ERROR: no coverage-final.json shard inputs found under coverage-shards/" >&2
+            exit 1
+          fi
+          npx --yes nyc@15 report \
+            --temp-dir .nyc_output \
+            --report-dir coverage \
+            --reporter=lcov \
+            --reporter=cobertura \
+            --reporter=html \
+            --reporter=text
 
       - name: Generate diff coverage report
-        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
-        run: bash ../../scripts/coverage-diff.sh origin/main || true
+        if: github.event_name == 'pull_request'
         working-directory: packages/coc
+        env:
+          SKIP_TESTS: '1'
+        run: bash ../../scripts/coverage-diff.sh origin/main || true
 
-      - name: Upload coc coverage report
-        if: matrix.os == 'ubuntu-latest'
+      - name: Upload merged coc coverage
         uses: actions/upload-artifact@v4
         with:
           name: coc-coverage
@@ -229,7 +285,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-latest
-    needs: [lint, forge-test, coc-test, deep-wiki-test, extension-test]
+    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, extension-test]
     if: always()
     steps:
       - name: Verify all required jobs succeeded
@@ -238,6 +294,7 @@ jobs:
             [lint]="${{ needs.lint.result }}"
             [forge-test]="${{ needs.forge-test.result }}"
             [coc-test]="${{ needs.coc-test.result }}"
+            [coc-coverage]="${{ needs.coc-coverage.result }}"
             [deep-wiki-test]="${{ needs.deep-wiki-test.result }}"
             [extension-test]="${{ needs.extension-test.result }}"
           )

--- a/packages/coc/vitest.config.ts
+++ b/packages/coc/vitest.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
         globalSetup: ['test/global-setup.ts'],
         coverage: {
             provider: 'v8',
-            reporter: ['text', 'html', 'lcov', 'cobertura'],
+            // 'json' produces coverage-final.json (istanbul format) which is required to
+            // merge coverage across CI shards via `nyc report --temp-dir`. Without it,
+            // sharded coverage runs only emit lcov.info per shard, which cannot be
+            // accurately merged.
+            reporter: ['text', 'html', 'lcov', 'cobertura', 'json'],
             reportsDirectory: './coverage',
             include: ['src/**/*.ts'],
             exclude: ['src/**/*.d.ts', 'src/**/index.ts']

--- a/scripts/coverage-diff.sh
+++ b/scripts/coverage-diff.sh
@@ -4,6 +4,11 @@
 # Usage: bash scripts/coverage-diff.sh [base_branch]
 #   base_branch  Branch to diff against (default: main)
 #
+# Environment variables:
+#   SKIP_TESTS=1  Skip the test re-run and reuse an existing coverage/lcov.info.
+#                 Useful when coverage was already produced upstream (e.g., merged
+#                 from CI shards) and only the diff-filter step is needed.
+#
 # Must be run from a package directory (e.g., packages/forge/).
 # Produces filtered coverage in coverage/coverage-diff/.
 
@@ -18,9 +23,13 @@ DIFF_DIR="$COVERAGE_DIR/coverage-diff"
 LCOV_FULL="$COVERAGE_DIR/lcov.info"
 LCOV_FILTERED="$DIFF_DIR/lcov.info"
 
-# Step 1: Run tests with coverage
-echo "==> Running tests with coverage..."
-npx vitest run --coverage
+# Step 1: Run tests with coverage (unless coverage was already produced upstream)
+if [ "${SKIP_TESTS:-}" = "1" ]; then
+  echo "==> SKIP_TESTS=1, reusing existing $LCOV_FULL..."
+else
+  echo "==> Running tests with coverage..."
+  npx vitest run --coverage
+fi
 
 if [ ! -f "$LCOV_FULL" ]; then
   echo "ERROR: $LCOV_FULL not found. Ensure lcov reporter is configured in vitest.config.ts."


### PR DESCRIPTION
Split the monolithic build matrix job into independent lint, forge-test, coc-test, deep-wiki-test, and extension-test jobs that run in parallel. Add a ci aggregator job (single status check for branch protection) and keep package as the VSIX builder gated on all checks.