### PR TITLE
feat(coc): add MCP OAuth subsystem (gated by mcpOauth.enabled)

### DIFF
--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -121,6 +121,10 @@ export interface CLIConfig {
     loops?: {
         enabled?: boolean;
     };
+    /** MCP OAuth support (auto-detect mcp.oauth_required events). Disabled by default. */
+    mcpOauth?: {
+        enabled?: boolean;
+    };
     /** Vim-style navigation configuration (hjkl pane focus, j/k message stepping). Disabled by default. */
     vimNavigation?: {
         enabled?: boolean;
@@ -281,6 +285,10 @@ export interface ResolvedCLIConfig {
     loops: {
         enabled: boolean;
     };
+    /** MCP OAuth subsystem configuration. */
+    mcpOauth: {
+        enabled: boolean;
+    };
     /** Vim-style navigation configuration. */
     vimNavigation: {
         enabled: boolean;
@@ -400,6 +408,9 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
         enabled: false,
     },
     loops: {
+        enabled: false,
+    },
+    mcpOauth: {
         enabled: false,
     },
     vimNavigation: {

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -32,6 +32,7 @@ export type ResolvedConfigNamespaceValues = Pick<
     | 'ralph'
     | 'vimNavigation'
     | 'loops'
+    | 'mcpOauth'
     | 'features'
     | 'memoryPromotion'
     | 'store'
@@ -67,6 +68,7 @@ const SERVERS_SOURCE_KEYS = ['servers.enabled'] as const;
 const RALPH_SOURCE_KEYS = ['ralph.enabled'] as const;
 const VIM_NAVIGATION_SOURCE_KEYS = ['vimNavigation.enabled'] as const;
 const LOOPS_SOURCE_KEYS = ['loops.enabled'] as const;
+const MCP_OAUTH_SOURCE_KEYS = ['mcpOauth.enabled'] as const;
 const FEATURES_SOURCE_KEYS = ['features.autoMemoryPromotion'] as const;
 
 const MEMORY_PROMOTION_SOURCE_KEYS = [
@@ -96,6 +98,7 @@ export const CONFIG_NAMESPACE_SOURCE_KEYS = [
     ...RALPH_SOURCE_KEYS,
     ...VIM_NAVIGATION_SOURCE_KEYS,
     ...LOOPS_SOURCE_KEYS,
+    ...MCP_OAUTH_SOURCE_KEYS,
     ...FEATURES_SOURCE_KEYS,
     ...MEMORY_PROMOTION_SOURCE_KEYS,
     ...MEMORY_PROMOTION_AI_NORMALIZATION_SOURCE_KEYS,
@@ -237,6 +240,11 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
             name: 'loops',
             sourceDescriptors: [source('loops.', ['loops'], LOOPS_SOURCE_KEYS)],
             merge: (base, override) => ({ loops: { enabled: override?.loops?.enabled ?? base.loops?.enabled ?? false } }),
+        },
+        {
+            name: 'mcpOauth',
+            sourceDescriptors: [source('mcpOauth.', ['mcpOauth'], MCP_OAUTH_SOURCE_KEYS)],
+            merge: (base, override) => ({ mcpOauth: { enabled: override?.mcpOauth?.enabled ?? base.mcpOauth?.enabled ?? false } }),
         },
         {
             name: 'features',

--- a/packages/coc/src/config/schema.ts
+++ b/packages/coc/src/config/schema.ts
@@ -100,6 +100,9 @@ export const CLIConfigSchema = z.object({
     loops: z.object({
         enabled: z.boolean().optional(),
     }).passthrough().optional(),
+    mcpOauth: z.object({
+        enabled: z.boolean().optional(),
+    }).passthrough().optional(),
     features: z.object({
         autoMemoryPromotion: z.boolean().optional(),
     }).passthrough().optional(),

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -100,6 +100,8 @@ export interface ChatModeExecutorOptions {
     resolveWorkspaceIdForPath: (rootPath: string) => Promise<string>;
     /** Late-bound loop infrastructure (getter because loop infra is created after executor registry). */
     getLoopInfra?: () => LoopInfraDeps | undefined;
+    /** Late-bound MCP OAuth manager (getter to allow optional/feature-flagged wiring). */
+    getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
 }
 
 /** Return type for the AI call result. */
@@ -139,6 +141,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
     protected readonly resolveSkillConfigFn: (wsId: string | undefined, workDir?: string) => Promise<{ skillDirectories?: string[]; disabledSkills?: string[] }>;
     protected readonly resolveWorkspaceIdForPathFn: (rootPath: string) => Promise<string>;
     protected readonly getLoopInfra?: () => LoopInfraDeps | undefined;
+    protected readonly getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
 
     constructor(store: ProcessStore, options: ChatModeExecutorOptions, dataDir?: string) {
         super(store, dataDir);
@@ -152,6 +155,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
         this.resolveSkillConfigFn = options.resolveSkillConfig;
         this.resolveWorkspaceIdForPathFn = options.resolveWorkspaceIdForPath;
         this.getLoopInfra = options.getLoopInfra;
+        this.getMcpOauthManager = options.getMcpOauthManager;
     }
 
     /**
@@ -527,6 +531,24 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
                     }
                     : toolEventHandler,
                 onBackgroundTasksChanged: this.buildBackgroundTaskHandler(processId),
+                onMcpOAuthRequired: (() => {
+                    const manager = this.getMcpOauthManager?.();
+                    if (!manager) return undefined;
+                    return (event: { serverName: string; serverUrl: string; authorizationUrl?: string; requestId: string }) => {
+                        try {
+                            manager.addPending({
+                                requestId: event.requestId,
+                                serverName: event.serverName,
+                                serverUrl: event.serverUrl,
+                                authorizationUrl: event.authorizationUrl,
+                                processId,
+                                workspaceId: payload.workspaceId,
+                            });
+                        } catch {
+                            // Non-fatal: OAuth dispatch must not interrupt the session.
+                        }
+                    };
+                })(),
             };
 
             let result;

--- a/packages/coc/src/server/executors/executor-registry.ts
+++ b/packages/coc/src/server/executors/executor-registry.ts
@@ -43,6 +43,7 @@ export interface ExecutorRegistryOptions {
     getMemoryStore?: (workspaceId: string) => import('@plusplusoneplusplus/forge').BoundedMemoryStore | undefined;
     getWsServer?: () => import('../streaming/websocket').ProcessWebSocketServer | undefined;
     getLoopInfra?: () => import('./chat-base-executor').LoopInfraDeps | undefined;
+    getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
 }
 
 /**
@@ -93,6 +94,7 @@ export class ExecutorRegistry {
             resolveSkillConfig: options.resolveSkillConfig,
             resolveWorkspaceIdForPath: options.resolveWorkspaceIdForPath,
             getLoopInfra: options.getLoopInfra,
+            getMcpOauthManager: options.getMcpOauthManager,
         };
 
         this.strategyRegistry = new TaskStrategyRegistry();

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -31,6 +31,7 @@ import { ensureMyWorkWorkspace } from './workspaces/my-work-workspace';
 import { ensureMyLifeWorkspace } from './workspaces/my-life-workspace';
 import { createScheduleInfrastructure } from './infrastructure/schedule-infrastructure';
 import { createLoopInfrastructure } from './infrastructure/loop-infrastructure';
+import { createMcpOauthInfrastructure } from './mcp-oauth';
 import { createCleanupInfrastructure } from './infrastructure/cleanup-infrastructure';
 import { createWebSocketInfrastructure } from './infrastructure/websocket-infrastructure';
 import { createWatcherInfrastructure } from './infrastructure/watcher-infrastructure';
@@ -76,6 +77,7 @@ interface CloseHandlerDeps {
     autoPromoteScheduler?: { dispose(): void };
     loopExecutor?: { shutdownAll(): void };
     loopInfraDispose?: () => void;
+    mcpOauthDispose?: () => void;
     activeSockets: Set<import('net').Socket>;
     server: http.Server;
 }
@@ -97,6 +99,7 @@ function buildCloseHandler(deps: CloseHandlerDeps): (opts?: ServerCloseOptions) 
         deps.scheduleInfraDispose();
         deps.loopExecutor?.shutdownAll();
         deps.loopInfraDispose?.();
+        deps.mcpOauthDispose?.();
         gitInfoCache.dispose();
         deps.notesGitTimerManager.dispose();
         deps.autoPromoteScheduler?.dispose();
@@ -160,6 +163,10 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     // Forward declaration — loop infra is created after queue infra
     let loopInfra: ReturnType<typeof createLoopInfrastructure> | undefined;
 
+    // MCP OAuth infra — gated by mcpOauth.enabled feature flag (default false).
+    const mcpOauthEnabled = resolvedConfig.mcpOauth?.enabled ?? false;
+    const mcpOauthInfra = mcpOauthEnabled ? createMcpOauthInfrastructure() : undefined;
+
     const { registry, bridge, queuePersistence, queueFacade } = createQueueInfrastructure(
         store, dataDir, options, defaultTimeoutMs,
         resolvedConfig.chat.followUpSuggestions, resolvedConfig.chat.askUser, () => wsServer,
@@ -201,6 +208,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
                 },
             };
         },
+        () => mcpOauthInfra?.manager,
     );
 
     // Finalize any orphaned 'running' / 'cancelling' processes left behind by
@@ -347,6 +355,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         remoteServerConnector,
         loopStore: loopInfra?.loopStore,
         loopExecutor: loopInfra?.loopExecutor,
+        mcpOauthManager: mcpOauthInfra?.manager,
     });
     // Restore auto-commit timers for all workspaces that had it enabled
     notesGitTimerManager.startAll(store, dataDir).catch(() => { /* best-effort */ });
@@ -354,7 +363,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     const rawHostname = os.hostname();
     const displayHostname = resolvedConfig.serve?.serverName || shortenHostname(rawHostname);
     const handler = createRequestHandler({
-        routes, spaHtml: () => generateDashboardHtml({ enableWiki: true, hostname: displayHostname, terminalEnabled: resolvedConfig.terminal?.enabled ?? true, notesEnabled: resolvedConfig.notes?.enabled ?? true, myWorkEnabled: resolvedConfig.myWork?.enabled ?? false, myLifeEnabled: resolvedConfig.myLife?.enabled ?? false, scratchpadEnabled: resolvedConfig.scratchpad?.enabled ?? false, scratchpadLayout: resolvedConfig.scratchpad?.layout ?? 'horizontal', workflowsEnabled: resolvedConfig.workflows?.enabled ?? false, pullRequestsEnabled: resolvedConfig.pullRequests?.enabled ?? false, serversEnabled: resolvedConfig.servers?.enabled ?? false, ralphEnabled: resolvedConfig.ralph?.enabled ?? false, vimNavigationEnabled: resolvedConfig.vimNavigation?.enabled ?? false, loopsEnabled, bindAddress: host }),
+        routes, spaHtml: () => generateDashboardHtml({ enableWiki: true, hostname: displayHostname, terminalEnabled: resolvedConfig.terminal?.enabled ?? true, notesEnabled: resolvedConfig.notes?.enabled ?? true, myWorkEnabled: resolvedConfig.myWork?.enabled ?? false, myLifeEnabled: resolvedConfig.myLife?.enabled ?? false, scratchpadEnabled: resolvedConfig.scratchpad?.enabled ?? false, scratchpadLayout: resolvedConfig.scratchpad?.layout ?? 'horizontal', workflowsEnabled: resolvedConfig.workflows?.enabled ?? false, pullRequestsEnabled: resolvedConfig.pullRequests?.enabled ?? false, serversEnabled: resolvedConfig.servers?.enabled ?? false, ralphEnabled: resolvedConfig.ralph?.enabled ?? false, vimNavigationEnabled: resolvedConfig.vimNavigation?.enabled ?? false, loopsEnabled, mcpOauthEnabled, bindAddress: host }),
         store, spaETag: getBundleETag,
         staticDir: path.join(__dirname, 'spa', 'client', 'dist'),
         getIconSvg: () => generateIconSvg(rawHostname),
@@ -410,6 +419,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
             autoPromoteScheduler,
             loopExecutor: loopInfra?.loopExecutor,
             loopInfraDispose: loopInfra?.dispose,
+            mcpOauthDispose: mcpOauthInfra?.dispose,
             activeSockets, server,
         }),
     };

--- a/packages/coc/src/server/infrastructure/queue-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/queue-infrastructure.ts
@@ -62,6 +62,7 @@ export function createQueueInfrastructure(
     getWsServer: () => ProcessWebSocketServer,
     memoryPromotion: MemoryPromoteConfig | undefined,
     getLoopInfra?: () => import('../executors/chat-base-executor').LoopInfraDeps | undefined,
+    getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined,
 ): QueueInfrastructure {
     // Obtain SQLite DB handle: reuse from SqliteProcessStore, or create in-memory for tests.
     let db: Database.Database;
@@ -91,6 +92,7 @@ export function createQueueInfrastructure(
         memoryPromotion,
         initialDelayMs: options.queue?.restartPickupDelayMs,
         getLoopInfra,
+        getMcpOauthManager,
     });
 
     const queuePersistence = new SqliteQueuePersistence(bridge, db, {

--- a/packages/coc/src/server/mcp-oauth/index.ts
+++ b/packages/coc/src/server/mcp-oauth/index.ts
@@ -1,0 +1,11 @@
+/**
+ * MCP OAuth subsystem barrel export.
+ */
+
+export * from './mcp-oauth-types';
+export { McpOauthManager, DEFAULT_MCP_OAUTH_TTL_MS } from './mcp-oauth-manager';
+export type { McpOauthManagerOptions } from './mcp-oauth-manager';
+export { createMcpOauthInfrastructure } from './mcp-oauth-infrastructure';
+export type { McpOauthInfrastructure } from './mcp-oauth-infrastructure';
+export { registerMcpOauthRoutes } from './mcp-oauth-routes';
+export type { McpOauthRouteContext } from './mcp-oauth-routes';

--- a/packages/coc/src/server/mcp-oauth/mcp-oauth-infrastructure.ts
+++ b/packages/coc/src/server/mcp-oauth/mcp-oauth-infrastructure.ts
@@ -1,0 +1,21 @@
+/**
+ * MCP OAuth Infrastructure Builder
+ *
+ * Constructs the McpOauthManager and returns a dispose hook the server
+ * can call on shutdown. Mirrors the loop-infrastructure pattern.
+ */
+
+import { McpOauthManager, type McpOauthManagerOptions } from './mcp-oauth-manager';
+
+export interface McpOauthInfrastructure {
+    manager: McpOauthManager;
+    dispose: () => void;
+}
+
+export function createMcpOauthInfrastructure(options: McpOauthManagerOptions = {}): McpOauthInfrastructure {
+    const manager = new McpOauthManager(options);
+    return {
+        manager,
+        dispose: () => manager.clear(),
+    };
+}

--- a/packages/coc/src/server/mcp-oauth/mcp-oauth-manager.ts
+++ b/packages/coc/src/server/mcp-oauth/mcp-oauth-manager.ts
@@ -1,0 +1,109 @@
+/**
+ * In-memory manager for pending MCP OAuth requests.
+ *
+ * Tracks pending OAuth flows initiated by the Copilot SDK's
+ * `mcp.oauth_required` event. Entries auto-expire after `ttlMs` so stale
+ * PKCE windows don't accumulate forever.
+ *
+ * No persistence: OAuth handshakes are short-lived and don't survive a
+ * server restart. Pending requests are cleared on shutdown.
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+    PendingMcpOAuth,
+    PendingMcpOAuthStatus,
+    RegisterMcpOAuthInput,
+} from './mcp-oauth-types';
+
+/** Default TTL for a pending PKCE flow (10 minutes). */
+export const DEFAULT_MCP_OAUTH_TTL_MS = 10 * 60 * 1000;
+
+export interface McpOauthManagerOptions {
+    /** Override the auto-expiry window. */
+    ttlMs?: number;
+    /** Test seam for the current wall-clock time. */
+    now?: () => number;
+}
+
+export class McpOauthManager {
+    private readonly entries = new Map<string, PendingMcpOAuth>();
+    private readonly ttlMs: number;
+    private readonly now: () => number;
+
+    constructor(options: McpOauthManagerOptions = {}) {
+        this.ttlMs = options.ttlMs ?? DEFAULT_MCP_OAUTH_TTL_MS;
+        this.now = options.now ?? (() => Date.now());
+    }
+
+    /** Register (or refresh) a pending OAuth request. */
+    addPending(input: RegisterMcpOAuthInput): PendingMcpOAuth {
+        this.sweepExpired();
+        const id = input.requestId && input.requestId.length > 0 ? input.requestId : randomUUID();
+        const now = this.now();
+        const existing = this.entries.get(id);
+        const entry: PendingMcpOAuth = {
+            id,
+            serverName: input.serverName,
+            serverUrl: input.serverUrl,
+            authorizationUrl: input.authorizationUrl ?? existing?.authorizationUrl,
+            processId: input.processId ?? existing?.processId,
+            workspaceId: input.workspaceId ?? existing?.workspaceId,
+            status: 'pending',
+            createdAt: existing?.createdAt ?? now,
+            updatedAt: now,
+            error: undefined,
+        };
+        this.entries.set(id, entry);
+        return entry;
+    }
+
+    /** Get a pending OAuth request by id. */
+    getPending(id: string): PendingMcpOAuth | undefined {
+        this.sweepExpired();
+        return this.entries.get(id);
+    }
+
+    /** List all known OAuth requests (including resolved ones still in the TTL window). */
+    listPending(filter?: { status?: PendingMcpOAuthStatus; processId?: string; workspaceId?: string }): PendingMcpOAuth[] {
+        this.sweepExpired();
+        const all = Array.from(this.entries.values()).sort((a, b) => a.createdAt - b.createdAt);
+        if (!filter) return all;
+        return all.filter(entry => {
+            if (filter.status && entry.status !== filter.status) return false;
+            if (filter.processId && entry.processId !== filter.processId) return false;
+            if (filter.workspaceId && entry.workspaceId !== filter.workspaceId) return false;
+            return true;
+        });
+    }
+
+    /** Mark a request as resolved. */
+    resolve(id: string, status: 'completed' | 'failed', error?: string): PendingMcpOAuth | undefined {
+        const entry = this.entries.get(id);
+        if (!entry) return undefined;
+        entry.status = status;
+        entry.updatedAt = this.now();
+        if (status === 'failed') entry.error = error;
+        return entry;
+    }
+
+    /** Remove a request by id. Returns true if it existed. */
+    remove(id: string): boolean {
+        return this.entries.delete(id);
+    }
+
+    /** Drop everything (used at shutdown). */
+    clear(): void {
+        this.entries.clear();
+    }
+
+    /** Drop entries older than the TTL. */
+    sweepExpired(): void {
+        const cutoff = this.now() - this.ttlMs;
+        for (const [id, entry] of this.entries) {
+            if (entry.updatedAt < cutoff) {
+                this.entries.delete(id);
+            }
+        }
+    }
+}

--- a/packages/coc/src/server/mcp-oauth/mcp-oauth-routes.ts
+++ b/packages/coc/src/server/mcp-oauth/mcp-oauth-routes.ts
@@ -1,0 +1,122 @@
+/**
+ * MCP OAuth REST API Handler
+ *
+ * Routes:
+ *   GET    /api/mcp-oauth/pending          List pending OAuth requests
+ *   GET    /api/mcp-oauth/pending/:id      Fetch a specific pending request
+ *   POST   /api/mcp-oauth/pending/:id/resolve  Mark a request as completed/failed
+ *   DELETE /api/mcp-oauth/pending/:id      Remove a pending request
+ *
+ * Filtering is supported via the `?status=`, `?workspaceId=`, and
+ * `?processId=` query parameters on the list endpoint.
+ */
+
+import type * as http from 'http';
+import { sendJson, sendError } from '../shared/router';
+import { parseBodyOrReject } from '../shared/handler-utils';
+import type { Route } from '../types';
+import type { McpOauthManager } from './mcp-oauth-manager';
+import type { PendingMcpOAuth, PendingMcpOAuthStatus } from './mcp-oauth-types';
+
+export interface McpOauthRouteContext {
+    manager: McpOauthManager;
+}
+
+function serialize(entry: PendingMcpOAuth): Record<string, unknown> {
+    return {
+        id: entry.id,
+        serverName: entry.serverName,
+        serverUrl: entry.serverUrl,
+        authorizationUrl: entry.authorizationUrl,
+        processId: entry.processId,
+        workspaceId: entry.workspaceId,
+        status: entry.status,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+        error: entry.error,
+    };
+}
+
+function getQueryParam(req: http.IncomingMessage, key: string): string | undefined {
+    if (!req.url) return undefined;
+    const qIdx = req.url.indexOf('?');
+    if (qIdx < 0) return undefined;
+    const search = new URLSearchParams(req.url.slice(qIdx + 1));
+    const value = search.get(key);
+    return value !== null ? value : undefined;
+}
+
+const PENDING_LIST = /^\/api\/mcp-oauth\/pending\/?$/;
+const PENDING_ITEM = /^\/api\/mcp-oauth\/pending\/([^/]+)$/;
+const PENDING_RESOLVE = /^\/api\/mcp-oauth\/pending\/([^/]+)\/resolve$/;
+
+export function registerMcpOauthRoutes(routes: Route[], ctx: McpOauthRouteContext): void {
+    const { manager } = ctx;
+
+    // List
+    routes.push({
+        method: 'GET',
+        pattern: PENDING_LIST,
+        handler: (req: http.IncomingMessage, res: http.ServerResponse) => {
+            const status = getQueryParam(req, 'status') as PendingMcpOAuthStatus | undefined;
+            const workspaceId = getQueryParam(req, 'workspaceId');
+            const processId = getQueryParam(req, 'processId');
+            const items = manager.listPending({ status, workspaceId, processId }).map(serialize);
+            sendJson(res, { items });
+        },
+    });
+
+    // Get
+    routes.push({
+        method: 'GET',
+        pattern: PENDING_ITEM,
+        handler: (_req: http.IncomingMessage, res: http.ServerResponse, match) => {
+            const id = decodeURIComponent(match![1]);
+            const entry = manager.getPending(id);
+            if (!entry) {
+                sendError(res, 404, 'Pending OAuth request not found');
+                return;
+            }
+            sendJson(res, serialize(entry));
+        },
+    });
+
+    // Resolve
+    routes.push({
+        method: 'POST',
+        pattern: PENDING_RESOLVE,
+        handler: async (req: http.IncomingMessage, res: http.ServerResponse, match) => {
+            const id = decodeURIComponent(match![1]);
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+            const status = (body as Record<string, unknown>).status;
+            if (status !== 'completed' && status !== 'failed') {
+                sendError(res, 400, "Body must include status: 'completed' | 'failed'");
+                return;
+            }
+            const rawError = (body as Record<string, unknown>).error;
+            const error = typeof rawError === 'string' ? rawError : undefined;
+            const entry = manager.resolve(id, status, error);
+            if (!entry) {
+                sendError(res, 404, 'Pending OAuth request not found');
+                return;
+            }
+            sendJson(res, serialize(entry));
+        },
+    });
+
+    // Delete
+    routes.push({
+        method: 'DELETE',
+        pattern: PENDING_ITEM,
+        handler: (_req: http.IncomingMessage, res: http.ServerResponse, match) => {
+            const id = decodeURIComponent(match![1]);
+            const removed = manager.remove(id);
+            if (!removed) {
+                sendError(res, 404, 'Pending OAuth request not found');
+                return;
+            }
+            sendJson(res, { removed: true, id });
+        },
+    });
+}

--- a/packages/coc/src/server/mcp-oauth/mcp-oauth-types.ts
+++ b/packages/coc/src/server/mcp-oauth/mcp-oauth-types.ts
@@ -1,0 +1,47 @@
+/**
+ * Types for the MCP OAuth subsystem.
+ *
+ * Captures pending OAuth requests surfaced by the Copilot SDK's
+ * `mcp.oauth_required` event so the dashboard can prompt the user to
+ * complete the browser-based authorization flow.
+ */
+
+export type PendingMcpOAuthStatus = 'pending' | 'completed' | 'failed';
+
+export interface PendingMcpOAuth {
+    /** Stable id (the SDK requestId when available, else a generated uuid). */
+    id: string;
+    /** Display name of the MCP server requiring OAuth. */
+    serverName: string;
+    /** URL of the MCP server requiring OAuth. */
+    serverUrl: string;
+    /**
+     * Authorization URL the user must open in a browser to complete the
+     * flow. Undefined when the SDK build does not expose a proactive login
+     * RPC; consumers should still surface `serverName` so the user can
+     * authenticate out-of-band.
+     */
+    authorizationUrl?: string;
+    /** Process (conversation) id that triggered the OAuth requirement. */
+    processId?: string;
+    /** Workspace id associated with the triggering process. */
+    workspaceId?: string;
+    /** Lifecycle status. */
+    status: PendingMcpOAuthStatus;
+    /** Wall-clock creation timestamp (ms since epoch). */
+    createdAt: number;
+    /** Last update timestamp (ms since epoch). */
+    updatedAt: number;
+    /** Optional failure reason when status === 'failed'. */
+    error?: string;
+}
+
+/** Input shape for registering a new pending OAuth request. */
+export interface RegisterMcpOAuthInput {
+    requestId?: string;
+    serverName: string;
+    serverUrl: string;
+    authorizationUrl?: string;
+    processId?: string;
+    workspaceId?: string;
+}

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -24,6 +24,7 @@ export interface CLITaskExecutorOptions {
     memoryPromotion?: MemoryPromoteConfig;
     getWsServer?: () => import('../streaming/websocket').ProcessWebSocketServer | undefined;
     getLoopInfra?: () => import('../executors/chat-base-executor').LoopInfraDeps | undefined;
+    getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
 }
 export interface QueueExecutorBridgeOptions extends CLITaskExecutorOptions {
     maxConcurrency?: number; sharedConcurrency?: number; exclusiveConcurrency?: number;
@@ -102,6 +103,7 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
             onBackgroundReview: (pid: string, wsId: string, turns: ConversationTurn[]) => this.enqueueBackgroundReview(pid, wsId, turns),
             getWsServer: options.getWsServer,
             getLoopInfra: options.getLoopInfra,
+            getMcpOauthManager: options.getMcpOauthManager,
         });
         this.getLoopInfra = options.getLoopInfra;
     }

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -78,6 +78,8 @@ import { registerRalphPromoteRoutes } from './ralph-promote-routes';
 import { registerLoopRoutes } from '../loops/loop-handler';
 import type { LoopStore } from '../loops/loop-store';
 import type { LoopExecutor } from '../loops/loop-executor';
+import { registerMcpOauthRoutes } from '../mcp-oauth';
+import type { McpOauthManager } from '../mcp-oauth';
 
 /** Collect git commits made between headBefore and current HEAD. Non-fatal — returns [] on error. */
 function collectWorkItemCommits(
@@ -120,6 +122,7 @@ export interface RegisterRoutesOptions {
     remoteServerConnector?: DevTunnelConnector;
     loopStore?: LoopStore;
     loopExecutor?: LoopExecutor;
+    mcpOauthManager?: McpOauthManager;
 }
 
 export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions): { wikiManager: WikiManager | undefined } {
@@ -225,6 +228,11 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
                 }
             },
         });
+    }
+
+    // MCP OAuth routes (feature-flagged via mcpOauth.enabled)
+    if (opts.mcpOauthManager) {
+        registerMcpOauthRoutes(routes, { manager: opts.mcpOauthManager });
     }
 
     registerMemoryRoutes(routes, dataDir);

--- a/packages/coc/src/server/spa/client/react/utils/config.ts
+++ b/packages/coc/src/server/spa/client/react/utils/config.ts
@@ -20,6 +20,7 @@ interface DashboardConfig {
     vimNavigationEnabled?: boolean;
     containerMode?: boolean;
     loopsEnabled?: boolean;
+    mcpOauthEnabled?: boolean;
     bindAddress?: string;
 }
 
@@ -119,6 +120,10 @@ export function isContainerMode(): boolean {
 
 export function isLoopsEnabled(): boolean {
     return getConfig().loopsEnabled === true;
+}
+
+export function isMcpOauthEnabled(): boolean {
+    return getConfig().mcpOauthEnabled === true;
 }
 
 /** Returns the raw bind address the server is listening on (e.g., '0.0.0.0'), if known. */

--- a/packages/coc/src/server/spa/html-template.ts
+++ b/packages/coc/src/server/spa/html-template.ts
@@ -94,6 +94,7 @@ export function generateDashboardHtml(options: DashboardOptions = {}): string {
         vimNavigationEnabled,
         containerMode,
         loopsEnabled,
+        mcpOauthEnabled,
         reviewFilePath,
         projectDir,
         bindAddress,
@@ -141,7 +142,8 @@ ${getBundleCss()}
             ralphEnabled: ${!!ralphEnabled},
             vimNavigationEnabled: ${!!vimNavigationEnabled},
             containerMode: ${!!containerMode},
-            loopsEnabled: ${!!loopsEnabled}${bindAddress ? `,
+            loopsEnabled: ${!!loopsEnabled},
+            mcpOauthEnabled: ${!!mcpOauthEnabled}${bindAddress ? `,
             bindAddress: '${escapeHtml(bindAddress)}'` : ''}
         };
     </script>${reviewFilePath ? `

--- a/packages/coc/src/server/spa/types.ts
+++ b/packages/coc/src/server/spa/types.ts
@@ -35,6 +35,8 @@ export interface DashboardOptions {
     vimNavigationEnabled?: boolean;
     /** Whether the loops/recurring follow-up subsystem is enabled in server config. */
     loopsEnabled?: boolean;
+    /** Whether the MCP OAuth auto-detection subsystem is enabled in server config. */
+    mcpOauthEnabled?: boolean;
     /** When set, injects __REVIEW_CONFIG__ for the review editor page. */
     reviewFilePath?: string;
     /** Server project directory (for display in review editor). */

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -792,6 +792,8 @@ timeout: 300
                 '  enabled: true',
                 'loops:',
                 '  enabled: true',
+                'mcpOauth:',
+                '  enabled: true',
                 'features:',
                 '  autoMemoryPromotion: true',
                 'memoryPromotion:',
@@ -937,6 +939,9 @@ timeout: 300
                     "enabled": true,
                   },
                   "mcpConfig": "\${HOME}/mcp.json",
+                  "mcpOauth": {
+                    "enabled": false,
+                  },
                   "memoryPromotion": {
                     "aiNormalization": {
                       "enabled": true,
@@ -1032,6 +1037,7 @@ timeout: 300
                   "groupSingleLineMessages": "file",
                   "loops.enabled": "file",
                   "mcpConfig": "file",
+                  "mcpOauth.enabled": "default",
                   "memoryPromotion.aiNormalization.enabled": "file",
                   "memoryPromotion.aiNormalization.model": "file",
                   "memoryPromotion.aiNormalization.timeoutMs": "file",

--- a/packages/coc/test/server/mcp-oauth/mcp-oauth-infrastructure.test.ts
+++ b/packages/coc/test/server/mcp-oauth/mcp-oauth-infrastructure.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Tests for createMcpOauthInfrastructure.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createMcpOauthInfrastructure } from '../../../src/server/mcp-oauth/mcp-oauth-infrastructure';
+
+describe('createMcpOauthInfrastructure', () => {
+    it('returns a manager and a working dispose hook', () => {
+        const infra = createMcpOauthInfrastructure();
+        expect(infra.manager).toBeDefined();
+        infra.manager.addPending({ requestId: '1', serverName: 's', serverUrl: 'u' });
+        expect(infra.manager.listPending().length).toBe(1);
+        infra.dispose();
+        expect(infra.manager.listPending().length).toBe(0);
+    });
+
+    it('passes ttlMs and now overrides through to the manager', () => {
+        let now = 0;
+        const infra = createMcpOauthInfrastructure({ ttlMs: 500, now: () => now });
+        infra.manager.addPending({ requestId: '1', serverName: 's', serverUrl: 'u' });
+        now = 2_000;
+        expect(infra.manager.listPending()).toEqual([]);
+    });
+});

--- a/packages/coc/test/server/mcp-oauth/mcp-oauth-manager.test.ts
+++ b/packages/coc/test/server/mcp-oauth/mcp-oauth-manager.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for McpOauthManager (in-memory store of pending OAuth requests).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { McpOauthManager, DEFAULT_MCP_OAUTH_TTL_MS } from '../../../src/server/mcp-oauth/mcp-oauth-manager';
+
+describe('McpOauthManager', () => {
+    it('uses requestId as stable id when supplied', () => {
+        const mgr = new McpOauthManager();
+        const entry = mgr.addPending({
+            requestId: 'req-1',
+            serverName: 'github',
+            serverUrl: 'https://example.com/mcp',
+        });
+        expect(entry.id).toBe('req-1');
+        expect(entry.status).toBe('pending');
+        expect(mgr.getPending('req-1')).toEqual(entry);
+    });
+
+    it('generates a uuid when requestId is missing', () => {
+        const mgr = new McpOauthManager();
+        const entry = mgr.addPending({ serverName: 'a', serverUrl: 'b' });
+        expect(entry.id).toMatch(/[0-9a-f-]{8,}/);
+    });
+
+    it('preserves createdAt across re-registration but updates updatedAt', () => {
+        let now = 1_000;
+        const mgr = new McpOauthManager({ now: () => now });
+        const first = mgr.addPending({ requestId: 'r', serverName: 's', serverUrl: 'u' });
+        expect(first.createdAt).toBe(1_000);
+        now = 2_500;
+        const second = mgr.addPending({
+            requestId: 'r',
+            serverName: 's',
+            serverUrl: 'u',
+            authorizationUrl: 'https://login',
+            processId: 'proc-1',
+            workspaceId: 'ws-1',
+        });
+        expect(second.createdAt).toBe(1_000);
+        expect(second.updatedAt).toBe(2_500);
+        expect(second.authorizationUrl).toBe('https://login');
+        expect(second.processId).toBe('proc-1');
+        expect(second.workspaceId).toBe('ws-1');
+    });
+
+    it('filters listPending by status / processId / workspaceId', () => {
+        const mgr = new McpOauthManager();
+        mgr.addPending({ requestId: 'a', serverName: 's', serverUrl: 'u', processId: 'p1', workspaceId: 'w1' });
+        mgr.addPending({ requestId: 'b', serverName: 's', serverUrl: 'u', processId: 'p2', workspaceId: 'w1' });
+        mgr.resolve('b', 'completed');
+        expect(mgr.listPending().length).toBe(2);
+        expect(mgr.listPending({ status: 'pending' }).map(e => e.id)).toEqual(['a']);
+        expect(mgr.listPending({ status: 'completed' }).map(e => e.id)).toEqual(['b']);
+        expect(mgr.listPending({ processId: 'p2' }).map(e => e.id)).toEqual(['b']);
+        expect(mgr.listPending({ workspaceId: 'w1' }).map(e => e.id).sort()).toEqual(['a', 'b']);
+    });
+
+    it('resolve records status and optional error', () => {
+        const mgr = new McpOauthManager();
+        mgr.addPending({ requestId: 'x', serverName: 's', serverUrl: 'u' });
+        const ok = mgr.resolve('x', 'failed', 'denied');
+        expect(ok?.status).toBe('failed');
+        expect(ok?.error).toBe('denied');
+        expect(mgr.resolve('missing', 'completed')).toBeUndefined();
+    });
+
+    it('remove returns false when entry is missing', () => {
+        const mgr = new McpOauthManager();
+        expect(mgr.remove('nope')).toBe(false);
+        mgr.addPending({ requestId: 'k', serverName: 's', serverUrl: 'u' });
+        expect(mgr.remove('k')).toBe(true);
+        expect(mgr.getPending('k')).toBeUndefined();
+    });
+
+    it('sweepExpired drops entries older than ttl', () => {
+        let now = 0;
+        const mgr = new McpOauthManager({ ttlMs: 1_000, now: () => now });
+        mgr.addPending({ requestId: 'old', serverName: 's', serverUrl: 'u' });
+        now = 5_000;
+        mgr.addPending({ requestId: 'new', serverName: 's', serverUrl: 'u' });
+        expect(mgr.listPending().map(e => e.id)).toEqual(['new']);
+    });
+
+    it('clear empties the store', () => {
+        const mgr = new McpOauthManager();
+        mgr.addPending({ requestId: '1', serverName: 's', serverUrl: 'u' });
+        mgr.addPending({ requestId: '2', serverName: 's', serverUrl: 'u' });
+        mgr.clear();
+        expect(mgr.listPending()).toEqual([]);
+    });
+
+    it('exports DEFAULT_MCP_OAUTH_TTL_MS at 10 minutes', () => {
+        expect(DEFAULT_MCP_OAUTH_TTL_MS).toBe(10 * 60 * 1000);
+    });
+});

--- a/packages/coc/test/server/mcp-oauth/mcp-oauth-routes.test.ts
+++ b/packages/coc/test/server/mcp-oauth/mcp-oauth-routes.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for MCP OAuth REST routes (mcp-oauth-routes.ts).
+ *
+ * Uses in-memory stubs to exercise route logic without HTTP I/O.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { McpOauthManager } from '../../../src/server/mcp-oauth/mcp-oauth-manager';
+import { registerMcpOauthRoutes } from '../../../src/server/mcp-oauth/mcp-oauth-routes';
+import type { Route } from '../../../src/server/types';
+
+interface FakeRes {
+    statusCode: number;
+    body: any;
+    headers: Record<string, string>;
+    writeHead: (status: number, headers?: Record<string, string>) => void;
+    end: (data?: string) => void;
+    setHeader: (name: string, value: string) => void;
+}
+
+function createFakeRes(): FakeRes {
+    const res: any = {
+        statusCode: 200,
+        body: null,
+        headers: {},
+        writeHead(status: number, headers?: Record<string, string>) {
+            res.statusCode = status;
+            if (headers) Object.assign(res.headers, headers);
+        },
+        end(data?: string) {
+            if (data) {
+                try { res.body = JSON.parse(data); } catch { res.body = data; }
+            }
+        },
+        setHeader(name: string, value: string) {
+            res.headers[name.toLowerCase()] = value;
+        },
+    };
+    return res;
+}
+
+function createFakeReq(method: string, url: string, body?: Record<string, unknown>) {
+    const chunks: Buffer[] = [];
+    if (body) chunks.push(Buffer.from(JSON.stringify(body)));
+    return {
+        method,
+        url,
+        headers: { 'content-type': 'application/json' },
+        on(event: string, cb: (data?: Buffer) => void) {
+            if (event === 'data') for (const c of chunks) cb(c);
+            if (event === 'end') cb();
+            return this;
+        },
+    } as any;
+}
+
+async function dispatch(
+    routes: Route[],
+    method: string,
+    fullUrl: string,
+    body?: Record<string, unknown>,
+): Promise<FakeRes> {
+    const path = fullUrl.split('?')[0];
+    const route = routes.find(r => r.method === method && (r.pattern as RegExp).test(path));
+    if (!route) throw new Error(`No route matched ${method} ${path}`);
+    const match = path.match(route.pattern as RegExp) as RegExpMatchArray;
+    const res = createFakeRes();
+    const req = createFakeReq(method, fullUrl, body);
+    await (route.handler as any)(req, res, match);
+    return res;
+}
+
+describe('MCP OAuth REST routes', () => {
+    let routes: Route[];
+    let manager: McpOauthManager;
+
+    beforeEach(() => {
+        manager = new McpOauthManager();
+        routes = [];
+        registerMcpOauthRoutes(routes, { manager });
+    });
+
+    it('GET /pending returns empty list when no entries', async () => {
+        const res = await dispatch(routes, 'GET', '/api/mcp-oauth/pending');
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ items: [] });
+    });
+
+    it('GET /pending returns all entries', async () => {
+        manager.addPending({ requestId: 'a', serverName: 's', serverUrl: 'u' });
+        manager.addPending({ requestId: 'b', serverName: 's', serverUrl: 'u' });
+        const res = await dispatch(routes, 'GET', '/api/mcp-oauth/pending');
+        expect(res.statusCode).toBe(200);
+        expect(res.body.items.map((i: any) => i.id).sort()).toEqual(['a', 'b']);
+    });
+
+    it('GET /pending honors ?status and ?workspaceId filters', async () => {
+        manager.addPending({ requestId: 'a', serverName: 's', serverUrl: 'u', workspaceId: 'w1' });
+        manager.addPending({ requestId: 'b', serverName: 's', serverUrl: 'u', workspaceId: 'w2' });
+        manager.resolve('b', 'completed');
+        const filtered = await dispatch(routes, 'GET', '/api/mcp-oauth/pending?status=pending');
+        expect(filtered.body.items.map((i: any) => i.id)).toEqual(['a']);
+        const byWs = await dispatch(routes, 'GET', '/api/mcp-oauth/pending?workspaceId=w2');
+        expect(byWs.body.items.map((i: any) => i.id)).toEqual(['b']);
+    });
+
+    it('GET /pending/:id returns entry or 404', async () => {
+        manager.addPending({ requestId: 'x', serverName: 's', serverUrl: 'u' });
+        const ok = await dispatch(routes, 'GET', '/api/mcp-oauth/pending/x');
+        expect(ok.statusCode).toBe(200);
+        expect(ok.body.id).toBe('x');
+        const miss = await dispatch(routes, 'GET', '/api/mcp-oauth/pending/nope');
+        expect(miss.statusCode).toBe(404);
+    });
+
+    it('POST /pending/:id/resolve marks status', async () => {
+        manager.addPending({ requestId: 'x', serverName: 's', serverUrl: 'u' });
+        const res = await dispatch(routes, 'POST', '/api/mcp-oauth/pending/x/resolve', { status: 'completed' });
+        expect(res.statusCode).toBe(200);
+        expect(res.body.status).toBe('completed');
+        expect(manager.getPending('x')?.status).toBe('completed');
+    });
+
+    it('POST /pending/:id/resolve rejects invalid status', async () => {
+        manager.addPending({ requestId: 'x', serverName: 's', serverUrl: 'u' });
+        const res = await dispatch(routes, 'POST', '/api/mcp-oauth/pending/x/resolve', { status: 'bogus' });
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('POST /pending/:id/resolve 404s when not found', async () => {
+        const res = await dispatch(routes, 'POST', '/api/mcp-oauth/pending/nope/resolve', { status: 'completed' });
+        expect(res.statusCode).toBe(404);
+    });
+
+    it('DELETE /pending/:id removes entry', async () => {
+        manager.addPending({ requestId: 'x', serverName: 's', serverUrl: 'u' });
+        const res = await dispatch(routes, 'DELETE', '/api/mcp-oauth/pending/x');
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ removed: true, id: 'x' });
+        expect(manager.getPending('x')).toBeUndefined();
+    });
+
+    it('DELETE /pending/:id 404s when missing', async () => {
+        const res = await dispatch(routes, 'DELETE', '/api/mcp-oauth/pending/nope');
+        expect(res.statusCode).toBe(404);
+    });
+});

--- a/packages/forge/src/ai/index.ts
+++ b/packages/forge/src/ai/index.ts
@@ -50,6 +50,7 @@ export {
     Attachment,
     // Message types
     SendMessageOptions,
+    McpOAuthEvent,
     SystemMessageConfig,
     TokenUsage,
     SDKInvocationResult,

--- a/packages/forge/src/copilot-sdk-wrapper/index.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/index.ts
@@ -17,6 +17,7 @@ export {
     Attachment,
     // Message types
     SendMessageOptions,
+    McpOAuthEvent,
     // System message types
     SystemMessageConfig,
     TokenUsage,

--- a/packages/forge/src/copilot-sdk-wrapper/request-runner.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/request-runner.ts
@@ -192,6 +192,46 @@ export class RequestRunner {
             const sessionLog = createSessionLogger(session.sessionId);
             options.onSessionCreated?.(session.sessionId);
 
+            if (options.onMcpOAuthRequired && typeof session.on === 'function') {
+                try {
+                    session.on('mcp.oauth_required', (event: { id?: string; data: { requestId: string; serverName: string; serverUrl: string } }) => {
+                        const evtData = event.data;
+                        // Defensive: try the experimental RPC if the SDK exposes it.
+                        // The method may not exist on the installed SDK build, so we
+                        // probe it dynamically and never let a failure here disrupt
+                        // the session.
+                        const rpc = (session as unknown as { rpc?: { mcp?: { oauth?: { login?: (p: { serverName: string }) => Promise<{ authorizationUrl?: string }> } } } }).rpc;
+                        const loginFn = rpc?.mcp?.oauth?.login;
+                        const dispatch = (authorizationUrl?: string) => {
+                            try {
+                                options.onMcpOAuthRequired!({
+                                    serverName: evtData.serverName,
+                                    serverUrl: evtData.serverUrl,
+                                    authorizationUrl,
+                                    requestId: evtData.requestId,
+                                    sessionId: session!.sessionId,
+                                });
+                            } catch (cbErr) {
+                                sessionLog.warn({ err: cbErr instanceof Error ? cbErr.message : String(cbErr) }, 'onMcpOAuthRequired callback threw');
+                            }
+                        };
+                        if (typeof loginFn === 'function') {
+                            Promise.resolve()
+                                .then(() => loginFn.call(rpc!.mcp!.oauth, { serverName: evtData.serverName }))
+                                .then(loginResult => dispatch(loginResult?.authorizationUrl))
+                                .catch(loginErr => {
+                                    sessionLog.warn({ serverName: evtData.serverName, err: loginErr instanceof Error ? loginErr.message : String(loginErr) }, 'mcp.oauth.login RPC failed; dispatching without URL');
+                                    dispatch(undefined);
+                                });
+                        } else {
+                            dispatch(undefined);
+                        }
+                    });
+                } catch (subErr) {
+                    sessionLog.warn({ err: subErr instanceof Error ? subErr.message : String(subErr) }, 'Failed to subscribe to mcp.oauth_required');
+                }
+            }
+
             if (switchModelAfterSessionCreate) {
                 await session.setModel(options.model!, { reasoningEffort: options.reasoningEffort });
                 sessionLog.debug({ model: options.model, reasoningEffort: options.reasoningEffort }, 'Model set after session creation');

--- a/packages/forge/src/copilot-sdk-wrapper/types.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/types.ts
@@ -477,6 +477,48 @@ export interface SendMessageOptions {
      * Defaults to `'immediate'` when omitted.
      */
     deliveryMode?: DeliveryMode;
+
+    /**
+     * Callback invoked when the underlying SDK session emits an
+     * `mcp.oauth_required` event for an MCP server requiring OAuth.
+     *
+     * The runner subscribes to the event on the per-request session and
+     * forwards each occurrence to this callback. When the SDK exposes a
+     * proactive `session.rpc.mcp.oauth.login` RPC, the runner invokes it
+     * defensively and includes the resulting `authorizationUrl` in the
+     * event. Otherwise `authorizationUrl` is left undefined and consumers
+     * should surface the `serverName`/`serverUrl` so the user can complete
+     * authentication out-of-band.
+     *
+     * The handler is observational only: it must not throw, and it must
+     * not block message dispatch.
+     *
+     * @experimental Subject to change as the SDK exposes a stable RPC.
+     */
+    onMcpOAuthRequired?: (event: McpOAuthEvent) => void;
+}
+
+/**
+ * Event emitted when an MCP server requires OAuth authentication during a
+ * Copilot SDK session.
+ *
+ * @experimental
+ */
+export interface McpOAuthEvent {
+    /** Display name of the MCP server requiring OAuth. */
+    serverName: string;
+    /** URL of the MCP server requiring OAuth. */
+    serverUrl: string;
+    /**
+     * Authorization URL the user must open in a browser to complete the
+     * OAuth flow. Undefined if cached tokens are valid or the proactive
+     * login RPC is not exposed by the SDK build in use.
+     */
+    authorizationUrl?: string;
+    /** Unique identifier for this OAuth request (matches the SDK event id). */
+    requestId: string;
+    /** SDK session that emitted the event. */
+    sessionId: string;
 }
 
 /**

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -175,6 +175,7 @@ export {
     MCPControlOptions,
     Attachment,
     SendMessageOptions,
+    McpOAuthEvent,
     SystemMessageConfig,
     SDKInvocationResult,
     SDKAvailabilityResult,


### PR DESCRIPTION
Detects 'mcp.oauth_required' events from the Copilot SDK and exposes pending OAuth requests via REST so the dashboard can prompt the user to complete the browser flow. The optional 'session.rpc.mcp.oauth.login()' RPC is probed defensively; if absent, the event is dispatched without an authorizationUrl.

Forge:

- Add McpOAuthEvent type and onMcpOAuthRequired callback to SendMessageOptions

- Wire mcp.oauth_required subscription in request-runner with defensive RPC probing

CoC:

- New mcp-oauth subsystem: McpOauthManager (in-memory, TTL 10m), infrastructure factory, REST routes (GET/POST/DELETE /api/mcp-oauth/pending[/:id[/resolve]])

- Add 'mcpOauth.enabled' config namespace (default false)

- Plumb getMcpOauthManager through queue/executor/chat-base-executor; register addPending callback in sendOptions

- Wire infrastructure + routes into server bootstrap with shutdown disposal

- Expose mcpOauthEnabled flag to dashboard SPA config

Tests: 20 new unit tests (manager, infrastructure, routes)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
