### PR TITLE
feat(coc): loop awareness, follow-up mode, MRU skill menu, and UI improvements

### DIFF
--- a/.changeset/fix-loop-badge-eas7mz.md
+++ b/.changeset/fix-loop-badge-eas7mz.md
@@ -1,0 +1,5 @@
+---
+"@plusplusoneplusplus/coc": patch
+---
+
+Persist workspaceId on loop rows to fix missing LoopBadge in ChatHeader after server restart

--- a/.changeset/loop-icon-svg-swap.md
+++ b/.changeset/loop-icon-svg-swap.md
@@ -1,0 +1,5 @@
+---
+"@plusplusoneplusplus/coc": patch
+---
+
+Replace 🔁 emoji with a shared `LoopIcon` SVG (Heroicons arrow-path) in ChatListPane, LoopBadge, LoopManagementPanel, and ConversationTurnBubble. Color emoji ignored CSS `color` on most platforms, so the active (green) vs paused (amber) distinction was invisible; the SVG uses `stroke="currentColor"` and respects the wrapping element's `text-…` class.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Standalone CLI for YAML AI workflows. Consumes `forge`. Server functionality (HT
 - **Infrastructure:** `loop-infrastructure.ts` factory creates LoopStore + LoopExecutor + ScheduleTimerRegistry. Wired into `createExecutionServer`. On shutdown, active loops are paused with `pausedReason: 'server-restart'` (no auto-resume).
 - **Dashboard UI:** `LoopBadge` (header badge with active count), `LoopManagementPanel` (list/pause/resume/cancel), turn source badge on `ConversationTurnBubble` for loop/wakeup turns.
 - **Turn metadata:** `turnSource` field on `ConversationTurn` (`{ source: 'loop'|'wakeup', loopId/wakeupId }`) propagated through follow-up executor pipeline.
+- **Follow-up mode resolution:** `resolveFollowUpMode(store, processId, explicit?)` in `executors/follow-up-mode.ts` is the single source of truth for "what mode does this follow-up run in?". Every programmatic follow-up enqueue site (loop ticks, wakeup timer, requeue) must call it and set `payload.mode`. `validateAndParseTask` only defaults `payload.mode` to `autopilot` for new chats (no `processId`); REST follow-ups must supply mode. `FollowUpExecutor.executeFollowUp` requires `mode` and logs a fail-loud warning + defaults to `'ask'` if missing.
 
 **Testing:** 627+ Vitest test files under `packages/coc/test/server/`.
 

--- a/packages/coc-client/src/contracts/preferences.ts
+++ b/packages/coc-client/src/contracts/preferences.ts
@@ -30,6 +30,8 @@ export interface PerRepoPreferences {
   lastEffort?: string;
   lastSkills?: Record<string, string[] | undefined>;
   skillUsageMap?: Record<string, string>;
+  /** Commit-scoped skill usage timestamps for the Git tab context menu (skillName → ISO timestamp). */
+  commitSkillUsageMap?: Record<string, string>;
   linkedRepoIds?: string[];
   disabledLlmTools?: string[];
   filesViewMode?: 'flat' | 'tree';

--- a/packages/coc-client/src/domains/preferences.ts
+++ b/packages/coc-client/src/domains/preferences.ts
@@ -76,8 +76,21 @@ export class PreferencesClient {
     });
   }
 
+  recordCommitSkillUsage(workspaceId: string, skillName: string): Promise<SkillUsageResponse> {
+    return this.transport.request<SkillUsageResponse>(repoPreferencesPath(workspaceId, '/commit-skill-usage'), {
+      method: 'PATCH',
+      body: { skillName },
+    });
+  }
+
   getSkillUsage(workspaceId: string, query?: SkillUsageQuery): Promise<SkillUsageListResponse> {
     return this.transport.request<SkillUsageListResponse>(repoPreferencesPath(workspaceId, '/skill-usage'), {
+      query: serializeSkillUsageQuery(query),
+    });
+  }
+
+  getCommitSkillUsage(workspaceId: string, query?: SkillUsageQuery): Promise<SkillUsageListResponse> {
+    return this.transport.request<SkillUsageListResponse>(repoPreferencesPath(workspaceId, '/commit-skill-usage'), {
       query: serializeSkillUsageQuery(query),
     });
   }

--- a/packages/coc-client/test/domains/preferences.test.ts
+++ b/packages/coc-client/test/domains/preferences.test.ts
@@ -12,6 +12,9 @@ describe('PreferencesClient', () => {
     await client.getRepo('repo/a');
     await client.patchRepo('repo/a', { lastDepth: 'deep' });
     await client.recordSkillUsage('repo/a', 'impl');
+    await client.recordCommitSkillUsage('repo/a', 'go-deep');
+    await client.getSkillUsage('repo/a');
+    await client.getCommitSkillUsage('repo/a');
     await client.getTaskSettings('repo/a');
     await client.updateTaskSettings('repo/a', { folderPaths: ['tasks', 'plans'] });
     await client.getLlmToolsConfig('repo/a');
@@ -23,6 +26,9 @@ describe('PreferencesClient', () => {
       { path: '/workspaces/repo%2Fa/preferences' },
       { path: '/workspaces/repo%2Fa/preferences', options: { method: 'PATCH', body: { lastDepth: 'deep' } } },
       { path: '/workspaces/repo%2Fa/preferences/skill-usage', options: { method: 'PATCH', body: { skillName: 'impl' } } },
+      { path: '/workspaces/repo%2Fa/preferences/commit-skill-usage', options: { method: 'PATCH', body: { skillName: 'go-deep' } } },
+      { path: '/workspaces/repo%2Fa/preferences/skill-usage' },
+      { path: '/workspaces/repo%2Fa/preferences/commit-skill-usage' },
       { path: '/workspaces/repo%2Fa/tasks/settings' },
       {
         path: '/workspaces/repo%2Fa/tasks/settings',

--- a/packages/coc/specs/repo-git-tab.spec.md
+++ b/packages/coc/specs/repo-git-tab.spec.md
@@ -472,7 +472,7 @@ The **Repository Git Tab** provides a full-featured git interface for browsing c
 | Cherry Pick | Confirmation required; `POST .../git/cherry-pick` |
 | Ask AI | Opens floating chat with commit hash + subject context |
 | Queue Task | Enqueues task with commit context |
-| Use Skill | Submenu of available skills (shown only when skills exist) |
+| Use Skill | Submenu showing top 5 most-recently-used skills (from `commitSkillUsageMap`), then a "More…" sub-submenu with remaining skills sorted alphabetically. When ≤5 skills installed, shows a flat recency-sorted list. |
 
 ### Commit Row — Non-HEAD commit
 
@@ -485,7 +485,7 @@ The **Repository Git Tab** provides a full-featured git interface for browsing c
 | Cherry Pick | Confirmation required; `POST .../git/cherry-pick` |
 | Ask AI | Opens floating chat with commit hash + subject context |
 | Queue Task | Enqueues task with commit context |
-| Use Skill | Submenu of available skills (shown only when skills exist) |
+| Use Skill | Submenu showing top 5 most-recently-used skills (from `commitSkillUsageMap`), then a "More…" sub-submenu with remaining skills sorted alphabetically. When ≤5 skills installed, shows a flat recency-sorted list. |
 
 ### Multi-commit (2+ selected)
 
@@ -495,7 +495,7 @@ The **Repository Git Tab** provides a full-featured git interface for browsing c
 | Squash N Commits | AI-powered squash task (shown when ≥2 selected) |
 | Ask AI | Enqueues AI task with combined diff context |
 | Queue Task | Enqueues task with combined context |
-| Use Skill | Submenu of available skills (shown only when skills exist) |
+| Use Skill | Submenu showing top 5 most-recently-used skills (from `commitSkillUsageMap`), then a "More…" sub-submenu with remaining skills sorted alphabetically. When ≤5 skills installed, shows a flat recency-sorted list. |
 
 ### Branch Header
 
@@ -503,7 +503,7 @@ The **Repository Git Tab** provides a full-featured git interface for browsing c
 |---|---|
 | Ask AI | Enqueues AI task with branch range context (diff if under 50KB, stat-only otherwise) |
 | Queue Task | Enqueues task with branch context |
-| Use Skill | Submenu of available skills (shown only when skills exist) |
+| Use Skill | Submenu showing top 5 most-recently-used skills (from `commitSkillUsageMap`), then a "More…" sub-submenu with remaining skills sorted alphabetically. When ≤5 skills installed, shows a flat recency-sorted list. |
 
 ### Diff Viewer (right-click on selected text)
 
@@ -739,6 +739,8 @@ The **Repository Git Tab** provides a full-featured git interface for browsing c
 |---|---|---|
 | `GET /api/workspaces/:id/skills` | Skill list for context menu | US-19 |
 | `POST /api/queue` | Task enqueue (AI, chat, skill, squash) | US-19, US-22, US-23 |
+| `GET /api/workspaces/:id/preferences/commit-skill-usage` | Commit-scoped skill MRU ordering | US-19 |
+| `PATCH /api/workspaces/:id/preferences/commit-skill-usage` | Record commit-scoped skill usage | US-19 |
 
 ---
 

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -180,6 +180,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
                 store: infra.store,
                 executor: infra.executor,
                 processId,
+                resolveWorkspaceId: infra.resolveWorkspaceId,
             },
         };
     }

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -68,6 +68,8 @@ import { buildChatToolBundle } from './chat-tool-builder';
 export interface LoopInfraDeps {
     store: import('../loops/loop-store').LoopStore;
     executor: import('../loops/loop-executor').LoopExecutor;
+    /** Loop event emitter (used by LLM tools to broadcast state changes). */
+    emit?: import('../loops/loop-executor').LoopEventEmit;
     resolveWorkspaceId: (processId: string) => Promise<string | undefined>;
     enqueueWakeup: (opts: {
         processId: string;
@@ -181,6 +183,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
                 executor: infra.executor,
                 processId,
                 resolveWorkspaceId: infra.resolveWorkspaceId,
+                emit: infra.emit,
             },
         };
     }

--- a/packages/coc/src/server/executors/follow-up-executor.ts
+++ b/packages/coc/src/server/executors/follow-up-executor.ts
@@ -145,7 +145,20 @@ export class FollowUpExecutor extends ChatBaseExecutor {
         const workingDirectory = process.workingDirectory || this.defaultWorkingDirectory;
 
         const previousMode = process.metadata?.mode as ChatMode | undefined;
-        const currentMode = mode ?? previousMode ?? 'ask';
+        let currentMode: ChatMode;
+        if (mode) {
+            currentMode = mode;
+        } else {
+            // Fail-loud: every enqueue site should resolve mode via
+            // resolveFollowUpMode() before reaching the executor. Falling
+            // through here means an enqueuer forgot to populate payload.mode.
+            logger.warn(
+                LogCategory.AI,
+                `[FollowUp] mode not provided for process ${processId}; defaulting to 'ask'. ` +
+                `This indicates a bug in the enqueue site — every follow-up enqueuer must resolve mode via resolveFollowUpMode().`,
+            );
+            currentMode = 'ask';
+        }
 
         const metadataUpdates: Record<string, unknown> = {};
         if (mode && mode !== previousMode) {

--- a/packages/coc/src/server/executors/follow-up-mode.ts
+++ b/packages/coc/src/server/executors/follow-up-mode.ts
@@ -1,0 +1,51 @@
+/**
+ * Follow-up Mode Resolver
+ *
+ * Single source of truth for "what mode does this follow-up run in?".
+ *
+ * Rule: an explicit mode (caller-supplied) always wins; otherwise inherit
+ * from the process's persisted `metadata.mode` (set when the process was
+ * first created and refreshed by `FollowUpExecutor` after each turn);
+ * otherwise default to `'ask'`.
+ *
+ * Resolve once at *enqueue* time so the queued task carries `payload.mode`,
+ * and the UI badge plus execution use the same value.
+ */
+
+import type { ProcessStore } from '@plusplusoneplusplus/forge';
+import type { ChatMode } from '../tasks/task-types';
+
+const VALID_MODES: ReadonlySet<ChatMode> = new Set<ChatMode>([
+    'ask',
+    'plan',
+    'autopilot',
+    'ralph',
+]);
+
+function isChatMode(value: unknown): value is ChatMode {
+    return typeof value === 'string' && VALID_MODES.has(value as ChatMode);
+}
+
+/**
+ * Resolve the follow-up mode for a given process.
+ *
+ * @param store    ProcessStore used to look up the persisted process.
+ * @param processId The conversation/process the follow-up targets.
+ * @param explicit Optional explicit override; bypasses lookup entirely.
+ * @returns The resolved {@link ChatMode}.
+ */
+export async function resolveFollowUpMode(
+    store: ProcessStore,
+    processId: string,
+    explicit?: ChatMode,
+): Promise<ChatMode> {
+    if (isChatMode(explicit)) return explicit;
+    try {
+        const proc = await store.getProcess(processId);
+        const prev = proc?.metadata?.mode;
+        if (isChatMode(prev)) return prev;
+    } catch {
+        // Fall through to default
+    }
+    return 'ask';
+}

--- a/packages/coc/src/server/executors/process-lifecycle-runner.ts
+++ b/packages/coc/src/server/executors/process-lifecycle-runner.ts
@@ -235,6 +235,22 @@ export class ProcessLifecycleRunner extends BaseExecutor {
                     ...(typeof ctx.wakeupId === 'string' ? { wakeupId: ctx.wakeupId } : {}),
                 };
             }
+            // Mark the target process as running BEFORE invoking the follow-up
+            // executor. This closes a race where the queue has already broadcast
+            // that this task is running while the process row still reads as
+            // 'completed' from the prior turn, which caused the same conversation
+            // to briefly appear in both Running Tasks and Completed Tasks in the
+            // Activity view. Fail loud — proceeding with inconsistent state would
+            // reintroduce the duplicate.
+            try {
+                await this.store.updateProcess(followUpPayload.processId!, { status: 'running' });
+            } catch (err) {
+                const errorMsg = err instanceof Error ? err.message : String(err);
+                logger.warn(LogCategory.AI, `[QueueExecutor] Failed to mark follow-up process ${followUpPayload.processId} as running: ${errorMsg}`);
+                await notifyLoopTickComplete(opts, ctx, false, logger);
+                if (imageTempDir) { cleanupTempDir(imageTempDir); }
+                return { success: false, error: err instanceof Error ? err : new Error(errorMsg), durationMs: Date.now() - startTime };
+            }
             try {
                 await opts.executeFollowUpFn(
                     followUpPayload.processId!,

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -177,6 +177,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
             return {
                 store: loopInfra.loopStore,
                 executor: loopInfra.loopExecutor,
+                emit: loopInfra.emit,
                 resolveWorkspaceId: async (processId: string) => {
                     try {
                         const taskId = processId.startsWith('queue_') ? processId.slice(6) : processId;
@@ -364,6 +365,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         loopStore: loopInfra?.loopStore,
         loopExecutor: loopInfra?.loopExecutor,
         mcpOauthManager: mcpOauthInfra?.manager,
+        loopEmit: loopInfra?.emit,
     });
     // Restore auto-commit timers for all workspaces that had it enabled
     notesGitTimerManager.startAll(store, dataDir).catch(() => { /* best-effort */ });

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -32,6 +32,7 @@ import { ensureMyLifeWorkspace } from './workspaces/my-life-workspace';
 import { createScheduleInfrastructure } from './infrastructure/schedule-infrastructure';
 import { createLoopInfrastructure } from './infrastructure/loop-infrastructure';
 import { createMcpOauthInfrastructure } from './mcp-oauth';
+import type { LoopInfrastructure } from './infrastructure/loop-infrastructure';
 import { createCleanupInfrastructure } from './infrastructure/cleanup-infrastructure';
 import { createWebSocketInfrastructure } from './infrastructure/websocket-infrastructure';
 import { createWatcherInfrastructure } from './infrastructure/watcher-infrastructure';
@@ -161,7 +162,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     let terminalInfra: import('./infrastructure/terminal-infrastructure').TerminalInfrastructure | undefined;
 
     // Forward declaration — loop infra is created after queue infra
-    let loopInfra: ReturnType<typeof createLoopInfrastructure> | undefined;
+    let loopInfra: LoopInfrastructure | undefined;
 
     // MCP OAuth infra — gated by mcpOauth.enabled feature flag (default false).
     const mcpOauthEnabled = resolvedConfig.mcpOauth?.enabled ?? false;
@@ -235,7 +236,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
 
     // Loop infrastructure — separate from schedules. Gated by loops.enabled feature flag (default false).
     if (loopsEnabled) {
-        loopInfra = createLoopInfrastructure({
+        loopInfra = await createLoopInfrastructure({
             dataDir,
             queueFacade,
             store,
@@ -246,6 +247,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
                         loopId: event.loop.id,
                         processId: event.loop.processId,
                         status: event.loop.status,
+                        workspaceId: event.loop.workspaceId,
                         timestamp: Date.now(),
                     });
                 } catch { /* best-effort broadcast */ }

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -189,20 +189,26 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
                         `wakeup:${opts.wakeupId}`,
                         () => {
                             const turnSource = { source: 'wakeup' as const, wakeupId: opts.wakeupId };
-                            bridge.executeFollowUp(
-                                opts.processId,
-                                opts.prompt,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                opts.model,
-                                turnSource,
-                            ).catch((err: unknown) => {
-                                const msg = err instanceof Error ? err.message : String(err);
-                                process.stderr.write(`[Wakeup] Failed to execute wakeup ${opts.wakeupId}: ${msg}\n`);
-                            });
+                            void (async () => {
+                                try {
+                                    const { resolveFollowUpMode } = await import('./executors/follow-up-mode');
+                                    const mode = await resolveFollowUpMode(store, opts.processId);
+                                    await bridge.executeFollowUp(
+                                        opts.processId,
+                                        opts.prompt,
+                                        undefined,
+                                        mode,
+                                        undefined,
+                                        undefined,
+                                        undefined,
+                                        opts.model,
+                                        turnSource,
+                                    );
+                                } catch (err) {
+                                    const msg = err instanceof Error ? err.message : String(err);
+                                    process.stderr.write(`[Wakeup] Failed to execute wakeup ${opts.wakeupId}: ${msg}\n`);
+                                }
+                            })();
                         },
                         opts.delayMs,
                     );

--- a/packages/coc/src/server/infrastructure/loop-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/loop-infrastructure.ts
@@ -56,7 +56,7 @@ export interface LoopInfrastructureOptions {
  *
  * @returns LoopInfrastructure with store, executor, and dispose function.
  */
-export function createLoopInfrastructure(options: LoopInfrastructureOptions): LoopInfrastructure {
+export async function createLoopInfrastructure(options: LoopInfrastructureOptions): Promise<LoopInfrastructure> {
     const { dataDir, queueFacade, store, emit, resolveWorkspaceId } = options;
 
     // Obtain SQLite DB handle: reuse from SqliteProcessStore, or open processes.db in dataDir.
@@ -88,14 +88,31 @@ export function createLoopInfrastructure(options: LoopInfrastructureOptions): Lo
     // Restore active loop timers from the persisted nextTickAt values.
     loopExecutor.armAll();
 
+    // Backfill workspaceId for legacy rows that lack it.
+    const allLoops = loopStore.getAll();
+    let backfilled = 0;
+    for (const loop of allLoops) {
+        if (loop.workspaceId == null) {
+            try {
+                const wsId = await resolveWorkspaceId(loop.processId);
+                if (wsId) {
+                    loop.workspaceId = wsId;
+                    loopStore.update(loop);
+                    backfilled++;
+                }
+            } catch { /* best-effort backfill */ }
+        }
+    }
+
     // Log startup state after timers have been restored.
     const activeCount = loopStore.getActive().length;
-    const pausedCount = loopStore.getAll().filter(l => l.status === 'paused').length;
-    if (activeCount > 0 || pausedCount > 0) {
+    const pausedCount = allLoops.filter(l => l.status === 'paused').length;
+    if (activeCount > 0 || pausedCount > 0 || backfilled > 0) {
         const logger = getLogger();
         logger.info(
             LogCategory.AI,
-            `[LoopInfra] Loaded ${activeCount} active, ${pausedCount} paused loop(s) from DB`,
+            `[LoopInfra] Loaded ${activeCount} active, ${pausedCount} paused loop(s) from DB` +
+            (backfilled > 0 ? `, backfilled workspaceId on ${backfilled} loop(s)` : ''),
         );
     }
 

--- a/packages/coc/src/server/infrastructure/loop-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/loop-infrastructure.ts
@@ -28,6 +28,8 @@ export interface LoopInfrastructure {
     loopExecutor: LoopExecutor;
     /** Timer registry for scheduling loop ticks and wakeups. */
     timerRegistry: ScheduleTimerRegistry;
+    /** Loop event emitter (used by REST handler and LLM tools to broadcast state). */
+    emit: LoopEventEmit;
     /** Close owned resources. Call on server shutdown. */
     dispose: () => void;
 }
@@ -123,5 +125,5 @@ export async function createLoopInfrastructure(options: LoopInfrastructureOption
         }
     };
 
-    return { loopStore, loopExecutor, timerRegistry, dispose };
+    return { loopStore, loopExecutor, timerRegistry, emit, dispose };
 }

--- a/packages/coc/src/server/llm-tools/loop-tools.ts
+++ b/packages/coc/src/server/llm-tools/loop-tools.ts
@@ -13,14 +13,14 @@
 
 import * as crypto from 'crypto';
 import { defineTool } from '@plusplusoneplusplus/forge';
-import type { LoopEntry } from '../loops/loop-types';
+import type { LoopEntry, LoopChangeEvent } from '../loops/loop-types';
 import {
     MIN_LOOP_INTERVAL_MS,
     MIN_WAKEUP_DELAY_MS,
     DEFAULT_LOOP_TTL_MS,
 } from '../loops/loop-types';
 import type { LoopStore } from '../loops/loop-store';
-import type { LoopExecutor } from '../loops/loop-executor';
+import type { LoopExecutor, LoopEventEmit } from '../loops/loop-executor';
 
 // ============================================================================
 // Shared deps type
@@ -33,6 +33,8 @@ export interface LoopToolDeps {
     processId: string;
     /** Resolve workspace ID for the process (used at loop creation time). */
     resolveWorkspaceId: (processId: string) => Promise<string | undefined>;
+    /** Optional emitter for broadcasting loop state changes via WebSocket. */
+    emit?: LoopEventEmit;
 }
 
 export interface WakeupToolDeps {
@@ -86,6 +88,15 @@ export interface ScheduleWakeupArgs {
     delay: string | number;
     /** Optional model override. */
     model?: string;
+}
+
+function safeEmit(emit: LoopEventEmit | undefined, event: LoopChangeEvent): void {
+    if (!emit) return;
+    try {
+        emit(event);
+    } catch {
+        // Best-effort broadcast — never fail the tool call.
+    }
 }
 
 // ============================================================================
@@ -203,6 +214,7 @@ export function createCreateLoopTool(deps: LoopToolDeps) {
             }
 
             deps.executor.armTimer(loop);
+            safeEmit(deps.emit, { type: 'loop-created', loop });
 
             return {
                 created: true,
@@ -254,6 +266,7 @@ export function createCancelLoopTool(deps: LoopToolDeps) {
             loop.status = 'cancelled';
             loop.nextTickAt = null;
             deps.store.update(loop);
+            safeEmit(deps.emit, { type: 'loop-cancelled', loop });
 
             return { cancelled: true, loopId: loop.id };
         },

--- a/packages/coc/src/server/llm-tools/loop-tools.ts
+++ b/packages/coc/src/server/llm-tools/loop-tools.ts
@@ -31,6 +31,8 @@ export interface LoopToolDeps {
     executor: LoopExecutor;
     /** The processId of the current conversation. */
     processId: string;
+    /** Resolve workspace ID for the process (used at loop creation time). */
+    resolveWorkspaceId: (processId: string) => Promise<string | undefined>;
 }
 
 export interface WakeupToolDeps {
@@ -175,6 +177,7 @@ export function createCreateLoopTool(deps: LoopToolDeps) {
             }
 
             const now = new Date();
+            const workspaceId = await deps.resolveWorkspaceId(deps.processId);
             const loop: LoopEntry = {
                 id: `loop_${crypto.randomUUID().replace(/-/g, '').substring(0, 12)}`,
                 processId: deps.processId,
@@ -190,6 +193,7 @@ export function createCreateLoopTool(deps: LoopToolDeps) {
                 pausedReason: null,
                 prompt: args.prompt,
                 model: args.model ?? null,
+                workspaceId,
             };
 
             try {

--- a/packages/coc/src/server/loops/loop-executor.ts
+++ b/packages/coc/src/server/loops/loop-executor.ts
@@ -19,6 +19,7 @@ import type { ScheduleTimerRegistry } from '../schedule/schedule-timer-registry'
 import type { LoopStore } from './loop-store';
 import type { LoopEntry, LoopChangeEvent } from './loop-types';
 import { MAX_CONSECUTIVE_FAILURES, MAX_CONSECUTIVE_WAKEUPS_PER_PROCESS } from './loop-types';
+import { resolveFollowUpMode } from '../executors/follow-up-mode';
 
 // ============================================================================
 // Types
@@ -260,11 +261,16 @@ export class LoopExecutor {
         const existingTask = queueManager.getTask(taskId);
 
         if (existingTask && existingTask.status === 'completed') {
-            // Requeue from history with the loop prompt
+            // Requeue from history with the loop prompt.
+            // Re-resolve mode (don't trust stale value on the existing task —
+            // the process's metadata.mode may have changed since the original
+            // turn was enqueued).
+            const mode = await resolveFollowUpMode(this.deps.processStore, loop.processId);
             queueManager.updateTask(taskId, {
                 displayName: `[Loop] ${loop.description || loop.prompt.substring(0, 40)}`,
                 payload: {
                     ...existingTask.payload,
+                    mode,
                     prompt: loop.prompt,
                     processId: loop.processId,
                     ...(loop.model ? { model: loop.model } : {}),
@@ -293,12 +299,14 @@ export class LoopExecutor {
     private async enqueueNewFollowUpTask(loop: LoopEntry): Promise<void> {
         const queueManager = this.deps.queueManager!;
         const workspaceId = await this.deps.resolveWorkspaceId(loop.processId);
+        const mode = await resolveFollowUpMode(this.deps.processStore, loop.processId);
 
         queueManager.enqueue({
             type: 'chat',
             priority: 'normal',
             payload: {
                 kind: 'chat',
+                mode,
                 prompt: loop.prompt,
                 processId: loop.processId,
                 ...(loop.model ? { model: loop.model } : {}),

--- a/packages/coc/src/server/loops/loop-handler.ts
+++ b/packages/coc/src/server/loops/loop-handler.ts
@@ -23,8 +23,6 @@ import type { LoopEntry, LoopStatus } from './loop-types';
 export interface LoopRouteContext {
     store: LoopStore;
     executor: LoopExecutor;
-    /** Resolve processId → workspaceId for filtering. */
-    resolveWorkspaceId: (processId: string) => Promise<string | undefined>;
 }
 
 // ============================================================================
@@ -47,6 +45,7 @@ function serializeLoop(loop: LoopEntry): Record<string, unknown> {
         pausedReason: loop.pausedReason,
         prompt: loop.prompt,
         model: loop.model,
+        ...(loop.workspaceId != null ? { workspaceId: loop.workspaceId } : {}),
     };
 }
 
@@ -83,20 +82,7 @@ function validatePatchFields(body: Record<string, unknown>): { valid: boolean; e
 // ============================================================================
 
 export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void {
-    const { store, executor, resolveWorkspaceId } = ctx;
-
-    // Helper to filter loops by workspace
-    async function getLoopsForWorkspace(workspaceId: string): Promise<LoopEntry[]> {
-        const allLoops = store.getAll();
-        const results: LoopEntry[] = [];
-        for (const loop of allLoops) {
-            const wsId = await resolveWorkspaceId(loop.processId);
-            if (wsId === workspaceId) {
-                results.push(loop);
-            }
-        }
-        return results;
-    }
+    const { store, executor } = ctx;
 
     // ------------------------------------------------------------------
     // GET /api/workspaces/:id/loops — List loops for a workspace
@@ -106,7 +92,7 @@ export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void
         pattern: /^\/api\/workspaces\/([^/]+)\/loops$/,
         handler: async (_req: http.IncomingMessage, res: http.ServerResponse, match) => {
             const workspaceId = decodeURIComponent(match![1]);
-            const loops = await getLoopsForWorkspace(workspaceId);
+            const loops = store.getByWorkspace(workspaceId);
             sendJSON(res, 200, { loops: loops.map(serializeLoop) });
         },
     });

--- a/packages/coc/src/server/loops/loop-handler.ts
+++ b/packages/coc/src/server/loops/loop-handler.ts
@@ -13,8 +13,8 @@ import { sendJSON, sendError } from '../core/api-handler';
 import { parseBodyOrReject } from '../shared/handler-utils';
 import type { Route } from '../types';
 import type { LoopStore } from './loop-store';
-import type { LoopExecutor } from './loop-executor';
-import type { LoopEntry, LoopStatus } from './loop-types';
+import type { LoopExecutor, LoopEventEmit } from './loop-executor';
+import type { LoopEntry, LoopStatus, LoopChangeEvent } from './loop-types';
 
 // ============================================================================
 // Types
@@ -23,6 +23,17 @@ import type { LoopEntry, LoopStatus } from './loop-types';
 export interface LoopRouteContext {
     store: LoopStore;
     executor: LoopExecutor;
+    /** Optional WebSocket emitter for broadcasting loop state changes. */
+    emit?: LoopEventEmit;
+}
+
+function safeEmit(emit: LoopEventEmit | undefined, event: LoopChangeEvent): void {
+    if (!emit) return;
+    try {
+        emit(event);
+    } catch {
+        // Best-effort broadcast — never fail the REST response.
+    }
 }
 
 // ============================================================================
@@ -82,7 +93,7 @@ function validatePatchFields(body: Record<string, unknown>): { valid: boolean; e
 // ============================================================================
 
 export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void {
-    const { store, executor } = ctx;
+    const { store, executor, emit } = ctx;
 
     // ------------------------------------------------------------------
     // GET /api/workspaces/:id/loops — List loops for a workspace
@@ -141,6 +152,7 @@ export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void
             if (body.model !== undefined) loop.model = (body.model as string) || null;
 
             store.update(loop);
+            safeEmit(emit, { type: 'loop-updated', loop });
             sendJSON(res, 200, { loop: serializeLoop(loop) });
         },
     });
@@ -162,6 +174,7 @@ export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void
             loop.status = 'cancelled';
             loop.nextTickAt = null;
             store.update(loop);
+            safeEmit(emit, { type: 'loop-cancelled', loop });
 
             sendJSON(res, 200, { deleted: true, loop: serializeLoop(loop) });
         },
@@ -193,6 +206,7 @@ export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void
             loop.pausedReason = reason;
             loop.nextTickAt = null;
             store.update(loop);
+            safeEmit(emit, { type: 'loop-paused', loop });
 
             sendJSON(res, 200, { loop: serializeLoop(loop) });
         },
@@ -219,6 +233,7 @@ export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void
                 loop.status = 'expired';
                 loop.nextTickAt = null;
                 store.update(loop);
+                safeEmit(emit, { type: 'loop-expired', loop });
                 return sendError(res, 400, 'Loop has expired and cannot be resumed');
             }
 
@@ -228,6 +243,7 @@ export function registerLoopRoutes(routes: Route[], ctx: LoopRouteContext): void
             loop.nextTickAt = new Date(Date.now() + loop.intervalMs).toISOString();
             store.update(loop);
             executor.armTimer(loop);
+            safeEmit(emit, { type: 'loop-resumed', loop });
 
             sendJSON(res, 200, { loop: serializeLoop(loop) });
         },

--- a/packages/coc/src/server/loops/loop-store.ts
+++ b/packages/coc/src/server/loops/loop-store.ts
@@ -25,6 +25,7 @@ export class LoopStore {
     private readonly stmtUpdate: Database.Statement;
     private readonly stmtGetById: Database.Statement;
     private readonly stmtGetByProcess: Database.Statement;
+    private readonly stmtGetByWorkspace: Database.Statement;
     private readonly stmtGetActive: Database.Statement;
     private readonly stmtGetAll: Database.Statement;
     private readonly stmtDelete: Database.Statement;
@@ -41,12 +42,12 @@ export class LoopStore {
                 id, process_id, description, interval_ms, status,
                 created_at, last_tick_at, next_tick_at, tick_count,
                 consecutive_failures, expires_at, paused_reason,
-                prompt, model
+                prompt, model, workspace_id
             ) VALUES (
                 @id, @processId, @description, @intervalMs, @status,
                 @createdAt, @lastTickAt, @nextTickAt, @tickCount,
                 @consecutiveFailures, @expiresAt, @pausedReason,
-                @prompt, @model
+                @prompt, @model, @workspaceId
             )
         `);
 
@@ -62,12 +63,14 @@ export class LoopStore {
                 expires_at = @expiresAt,
                 paused_reason = @pausedReason,
                 prompt = @prompt,
-                model = @model
+                model = @model,
+                workspace_id = @workspaceId
             WHERE id = @id
         `);
 
         this.stmtGetById = db.prepare('SELECT * FROM loops WHERE id = ?');
         this.stmtGetByProcess = db.prepare('SELECT * FROM loops WHERE process_id = ? ORDER BY created_at DESC');
+        this.stmtGetByWorkspace = db.prepare('SELECT * FROM loops WHERE workspace_id = ? ORDER BY created_at DESC');
         this.stmtGetActive = db.prepare("SELECT * FROM loops WHERE status = 'active' ORDER BY created_at ASC");
         this.stmtGetAll = db.prepare('SELECT * FROM loops ORDER BY created_at DESC');
         this.stmtDelete = db.prepare('DELETE FROM loops WHERE id = ?');
@@ -109,6 +112,12 @@ export class LoopStore {
     /** Get all loops for a given process, newest first. */
     getByProcess(processId: string): LoopEntry[] {
         const rows = this.stmtGetByProcess.all(processId) as LoopRow[];
+        return rows.map(rowToEntry);
+    }
+
+    /** Get all loops for a given workspace, newest first. */
+    getByWorkspace(workspaceId: string): LoopEntry[] {
+        const rows = this.stmtGetByWorkspace.all(workspaceId) as LoopRow[];
         return rows.map(rowToEntry);
     }
 
@@ -171,12 +180,21 @@ export class LoopStore {
                 expires_at            TEXT NOT NULL,
                 paused_reason         TEXT,
                 prompt                TEXT NOT NULL DEFAULT '',
-                model                 TEXT
+                model                 TEXT,
+                workspace_id          TEXT
             )
         `);
+
+        // Migrate existing databases that lack the workspace_id column.
+        const cols = this.db.pragma('table_info(loops)') as Array<{ name: string }>;
+        if (!cols.some(c => c.name === 'workspace_id')) {
+            this.db.exec('ALTER TABLE loops ADD COLUMN workspace_id TEXT');
+        }
+
         this.db.exec(`
             CREATE INDEX IF NOT EXISTS idx_loops_process_id ON loops(process_id);
             CREATE INDEX IF NOT EXISTS idx_loops_status ON loops(status);
+            CREATE INDEX IF NOT EXISTS idx_loops_workspace_id ON loops(workspace_id);
         `);
     }
 }
@@ -200,6 +218,7 @@ interface LoopRow {
     paused_reason: string | null;
     prompt: string;
     model: string | null;
+    workspace_id: string | null;
 }
 
 function rowToEntry(row: LoopRow): LoopEntry {
@@ -218,6 +237,7 @@ function rowToEntry(row: LoopRow): LoopEntry {
         pausedReason: row.paused_reason,
         prompt: row.prompt,
         model: row.model,
+        ...(row.workspace_id != null ? { workspaceId: row.workspace_id } : {}),
     };
 }
 
@@ -237,5 +257,6 @@ function toRow(entry: LoopEntry): Record<string, unknown> {
         pausedReason: entry.pausedReason ?? null,
         prompt: entry.prompt,
         model: entry.model ?? null,
+        workspaceId: entry.workspaceId ?? null,
     };
 }

--- a/packages/coc/src/server/loops/loop-types.ts
+++ b/packages/coc/src/server/loops/loop-types.ts
@@ -62,6 +62,14 @@ export interface LoopEntry {
 
     /** Optional model override for loop ticks. */
     model: string | null;
+
+    /**
+     * Workspace (repo) this loop belongs to.
+     * Persisted at creation time so the workspace filter does not depend
+     * on live in-memory task state. May be `undefined` for legacy rows
+     * that were created before this field existed.
+     */
+    workspaceId?: string;
 }
 
 // ============================================================================

--- a/packages/coc/src/server/openapi.yaml
+++ b/packages/coc/src/server/openapi.yaml
@@ -490,6 +490,78 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/workspaces/{id}/preferences/commit-skill-usage:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: URL-encoded workspace identifier.
+        schema:
+          type: string
+
+    get:
+      operationId: getCommitSkillUsage
+      summary: Read commit-scoped skill usage timestamps
+      description: >-
+        Returns commit-scoped skill usage entries from `commitSkillUsageMap`,
+        optionally filtered by exact skill name and entries recorded at or after `since`.
+      tags: [Preferences]
+      parameters:
+        - name: skillName
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Exact skill name to include.
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Only include usage timestamps at or after this ISO timestamp.
+      responses:
+        '200':
+          description: Matching skill usage entries sorted by newest timestamp first.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SkillUsageListResponse'
+        '400':
+          description: Invalid `since` value.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    patch:
+      operationId: recordCommitSkillUsage
+      summary: Record a commit-scoped skill usage timestamp
+      description: >-
+        Records the current timestamp for the given skill name in the repo's
+        `commitSkillUsageMap`. Used to order the Git tab "Use Skill" context
+        menu by recency, separate from the general `skillUsageMap`.
+      tags: [Preferences]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SkillUsageRequest'
+      responses:
+        '200':
+          description: The recorded skill name and timestamp.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SkillUsageResponse'
+        '400':
+          description: Missing or empty `skillName`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   # ── Seen-State ──────────────────────────────────────────────
 
   /api/workspaces/{id}/seen-state:

--- a/packages/coc/src/server/preferences-handler.ts
+++ b/packages/coc/src/server/preferences-handler.ts
@@ -174,6 +174,11 @@ export interface PerRepoPreferences {
     lastSkills?: LastSkillsByMode;
     /** Skill usage timestamps for ordering skill dropdowns (skillName → ISO timestamp). */
     skillUsageMap?: Record<string, string>;
+    /** Skill usage timestamps for the Git tab commit/range "Use Skill"
+     *  context menu (skillName → ISO timestamp). Scoped to the Git tab so
+     *  ordering reflects only commit-based runs, not Enqueue / Work-Item /
+     *  other surfaces. */
+    commitSkillUsageMap?: Record<string, string>;
     /** IDs of workspaces whose skill folders are linked via "Extra Skill Folders". */
     linkedRepoIds?: string[];
     /** Saved run-script templates from the Run Script dialog. */
@@ -534,6 +539,18 @@ export function validatePerRepoPreferences(raw: unknown): PerRepoPreferences {
         }
         if (Object.keys(validated).length > 0) {
             result.skillUsageMap = validated;
+        }
+    }
+
+    if (typeof obj.commitSkillUsageMap === 'object' && obj.commitSkillUsageMap !== null && !Array.isArray(obj.commitSkillUsageMap)) {
+        const validated: Record<string, string> = {};
+        for (const [key, value] of Object.entries(obj.commitSkillUsageMap as Record<string, unknown>)) {
+            if (typeof key === 'string' && key.length > 0 && typeof value === 'string') {
+                validated[key] = value;
+            }
+        }
+        if (Object.keys(validated).length > 0) {
+            result.commitSkillUsageMap = validated;
         }
     }
 
@@ -1082,6 +1099,58 @@ export function registerPreferencesRoutes(routes: Route[], dataDir: string): voi
             const timestamp = new Date().toISOString();
             const usageMap = { ...(existingRepo.skillUsageMap ?? {}), [skillName]: timestamp };
             const merged: PerRepoPreferences = { ...existingRepo, skillUsageMap: usageMap };
+            writeRepoPreferences(dataDir, repoId, merged);
+            sendJSON(res, 200, { skillName, timestamp });
+        },
+    });
+
+    // ------------------------------------------------------------------
+    // GET /api/workspaces/:id/preferences/commit-skill-usage — Read commit-scoped skill usage
+    // ------------------------------------------------------------------
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/workspaces\/([^/]+)\/preferences\/commit-skill-usage$/,
+        handler: async (req, res, match) => {
+            const parsed = new URL(req.url ?? '/', 'http://localhost');
+            const skillName = parsed.searchParams.get('skillName') ?? undefined;
+            const since = parsed.searchParams.get('since') ?? undefined;
+
+            if (since && Number.isNaN(Date.parse(since))) {
+                return sendError(res, 400, '`since` must be an ISO date-time string');
+            }
+
+            const repoId = decodeURIComponent(match![1]);
+            const usageMap = readRepoPreferences(dataDir, repoId).commitSkillUsageMap ?? {};
+            const usage: SkillUsageEntry[] = Object.entries(usageMap)
+                .filter(([name]) => !skillName || name === skillName)
+                .filter(([, timestamp]) => !since || timestamp >= since)
+                .sort((a, b) => b[1].localeCompare(a[1]))
+                .map(([name, timestamp]) => ({ skillName: name, timestamp }));
+
+            sendJSON(res, 200, { usage });
+        },
+    });
+
+    // ------------------------------------------------------------------
+    // PATCH /api/workspaces/:id/preferences/commit-skill-usage — Record a commit-scoped skill usage
+    // ------------------------------------------------------------------
+    routes.push({
+        method: 'PATCH',
+        pattern: /^\/api\/workspaces\/([^/]+)\/preferences\/commit-skill-usage$/,
+        handler: async (req, res, match) => {
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+
+            if (!body || typeof body.skillName !== 'string' || body.skillName.length === 0) {
+                return sendError(res, 400, '`skillName` is required');
+            }
+
+            const repoId = decodeURIComponent(match![1]);
+            const skillName: string = body.skillName;
+            const existingRepo = readRepoPreferences(dataDir, repoId);
+            const timestamp = new Date().toISOString();
+            const usageMap = { ...(existingRepo.commitSkillUsageMap ?? {}), [skillName]: timestamp };
+            const merged: PerRepoPreferences = { ...existingRepo, commitSkillUsageMap: usageMap };
             writeRepoPreferences(dataDir, repoId, merged);
             sendJSON(res, 200, { skillName, timestamp });
         },

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -77,7 +77,7 @@ import { registerRalphContinueRoutes } from './ralph-continue-routes';
 import { registerRalphPromoteRoutes } from './ralph-promote-routes';
 import { registerLoopRoutes } from '../loops/loop-handler';
 import type { LoopStore } from '../loops/loop-store';
-import type { LoopExecutor } from '../loops/loop-executor';
+import type { LoopExecutor, LoopEventEmit } from '../loops/loop-executor';
 import { registerMcpOauthRoutes } from '../mcp-oauth';
 import type { McpOauthManager } from '../mcp-oauth';
 
@@ -123,6 +123,7 @@ export interface RegisterRoutesOptions {
     loopStore?: LoopStore;
     loopExecutor?: LoopExecutor;
     mcpOauthManager?: McpOauthManager;
+    loopEmit?: LoopEventEmit;
 }
 
 export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions): { wikiManager: WikiManager | undefined } {
@@ -217,6 +218,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         registerLoopRoutes(routes, {
             store: opts.loopStore,
             executor: opts.loopExecutor,
+            emit: opts.loopEmit,
         });
     }
 

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -217,16 +217,6 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         registerLoopRoutes(routes, {
             store: opts.loopStore,
             executor: opts.loopExecutor,
-            resolveWorkspaceId: async (processId: string) => {
-                // Look up workspace via the queue task (which carries repoId)
-                try {
-                    const taskId = processId.startsWith('queue_') ? processId.slice(6) : processId;
-                    const task = bridge.getTask(taskId);
-                    return task?.repoId;
-                } catch {
-                    return undefined;
-                }
-            },
         });
     }
 

--- a/packages/coc/src/server/routes/queue-shared.ts
+++ b/packages/coc/src/server/routes/queue-shared.ts
@@ -276,7 +276,13 @@ export function validateAndParseTask(taskSpec: any): TaskValidationResult {
 
     if (taskSpec.type === 'chat' || taskSpec.type === 'custom') {
         if (!payload.kind) payload.kind = 'chat';
-        if (!payload.mode) payload.mode = 'autopilot';
+        // Default mode to 'autopilot' only for *new* chats (no processId).
+        // Follow-ups (processId set) must arrive with mode already resolved by
+        // the caller — programmatic enqueuers go through resolveFollowUpMode,
+        // and REST callers must supply mode explicitly. Leaving payload.mode
+        // unset on a follow-up is treated as a bug and surfaced as a warning
+        // in FollowUpExecutor.
+        if (!payload.mode && !payload.processId) payload.mode = 'autopilot';
     }
     if (taskSpec.type === TaskDefs.runScript.kind && !payload.kind) payload.kind = TaskDefs.runScript.kind;
     if (taskSpec.type === TaskDefs.runWorkflow.kind && !payload.kind) payload.kind = TaskDefs.runWorkflow.kind;

--- a/packages/coc/src/server/spa/client/react/App.tsx
+++ b/packages/coc/src/server/spa/client/react/App.tsx
@@ -163,6 +163,12 @@ function AppInner() {
     const onMessage = useCallback((msg: any) => {
         if (!msg || !msg.type) return;
 
+        // Rebroadcast loop-* WebSocket messages as a generic custom event so
+        // useLoops / useAllLoops hooks refresh without each switch case here.
+        if (typeof msg.type === 'string' && msg.type.startsWith('loop-')) {
+            window.dispatchEvent(new CustomEvent('coc-ws-message', { detail: msg }));
+        }
+
         switch (msg.type) {
             case 'process-added':
                 if (msg.process) appDispatch({ type: 'PROCESS_ADDED', process: msg.process });

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -32,6 +32,7 @@ import { RalphSessionRow } from './RalphSessionRow';
 import { isRalphEnabled, isLoopsEnabled } from '../../utils/config';
 import { getListModeConfig } from './list-mode-config';
 import { useAllLoops, type ProcessLoopState } from './hooks/useAllLoops';
+import { LoopIcon } from './icons/LoopIcon';
 import { isRalphTask } from '../../../../../tasks/task-types';
 
 /** Primary task types surfaced as individual filter options. */
@@ -1373,9 +1374,10 @@ export function ChatListPane({
                                             : 'text-[#8a5a00] dark:text-[#fbbf24]',
                                     )}
                                     title={state === 'active' ? 'Has active loops' : 'Has paused loops'}
-                                    aria-hidden="true"
                                     data-testid="loop-indicator"
-                                >🔁</span>
+                                >
+                                    <LoopIcon className="w-3 h-3" />
+                                </span>
                             );
                         })()}
                     </span>
@@ -1964,7 +1966,7 @@ export function ChatListPane({
                                 id: 'loops' as const,
                                 label: 'Loops',
                                 count: scopeCounts.loops,
-                                icon: <span className="text-[11px]" aria-hidden="true">🔁</span>,
+                                icon: <LoopIcon className="w-3 h-3" />,
                                 hidden: !loopsEnabled,
                             },
                             {

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -1376,7 +1376,7 @@ export function ChatListPane({
                                     title={state === 'active' ? 'Has active loops' : 'Has paused loops'}
                                     data-testid="loop-indicator"
                                 >
-                                    <LoopIcon className="w-3 h-3" />
+                                    <LoopIcon className="w-3.5 h-3.5" />
                                 </span>
                             );
                         })()}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -29,8 +29,9 @@ import { groupHistoryByPlanFile, type HistoryGroup } from '../git/history-groupi
 import { HistoryGroupHeader, computeAggregateMode } from '../git/commits/HistoryGroupHeader';
 import { groupByRalphSession, type RalphHistoryEntry, type RalphSession } from './ralph-session-grouping';
 import { RalphSessionRow } from './RalphSessionRow';
-import { isRalphEnabled } from '../../utils/config';
+import { isRalphEnabled, isLoopsEnabled } from '../../utils/config';
 import { getListModeConfig } from './list-mode-config';
+import { useAllLoops, type ProcessLoopState } from './hooks/useAllLoops';
 import { isRalphTask } from '../../../../../tasks/task-types';
 
 /** Primary task types surfaced as individual filter options. */
@@ -381,6 +382,10 @@ export function ChatListPane({
      */
     const excludedTypes = useMemo(() => new Set(appState.myWorkExcludedTypes), [appState.myWorkExcludedTypes]);
 
+    // Fetch all loops server-wide for inline indicators and the "Loops" scope tab.
+    const { loopStateByProcess, processIdsWithLoops, loopProcessCount } = useAllLoops();
+    const loopsEnabled = isLoopsEnabled();
+
     const [searchQuery, setSearchQueryRaw] = useState('');
     const [searchVisible, setSearchVisible] = useState(false);
     const searchInputRef = useRef<HTMLInputElement>(null);
@@ -395,15 +400,15 @@ export function ChatListPane({
      * Persisted in localStorage so the user's choice survives reloads.
      * Default is 'all' to preserve the pre-existing behavior of showing every task.
      */
-    const [activeScope, setActiveScopeState] = useState<'chat' | 'auto' | 'all'>(() => {
+    const [activeScope, setActiveScopeState] = useState<'chat' | 'auto' | 'loops' | 'all'>(() => {
         if (typeof window === 'undefined') return 'all';
         try {
             const saved = localStorage.getItem('coc-activity-scope');
-            if (saved === 'chat' || saved === 'auto' || saved === 'all') return saved;
+            if (saved === 'chat' || saved === 'auto' || saved === 'loops' || saved === 'all') return saved;
         } catch { /* ignore localStorage errors (e.g. private mode) */ }
         return 'all';
     });
-    const setActiveScope = useCallback((next: 'chat' | 'auto' | 'all') => {
+    const setActiveScope = useCallback((next: 'chat' | 'auto' | 'loops' | 'all') => {
         setActiveScopeState(next);
         try { localStorage.setItem('coc-activity-scope', next); } catch { /* ignore */ }
     }, []);
@@ -545,8 +550,9 @@ export function ChatListPane({
         if (activeScope === 'all') return true;
         if (activeScope === 'chat') return isChat(task);
         if (activeScope === 'auto') return isAutomation(task);
+        if (activeScope === 'loops') return processIdsWithLoops.has(task.id) || processIdsWithLoops.has(task.processId);
         return true;
-    }, [activeTab, activeScope]);
+    }, [activeTab, activeScope, processIdsWithLoops]);
 
     const tabFilteredRunning = useMemo(() => {
         if (activeTab === 'chats') return filteredRunning.filter(isChat);
@@ -572,12 +578,14 @@ export function ChatListPane({
         const all = [...running, ...liveQueue, ...history];
         let chat = 0;
         let auto = 0;
+        let loops = 0;
         for (const t of all) {
             if (isChat(t)) chat++;
             else if (isAutomation(t)) auto++;
+            if (processIdsWithLoops.has(t.id) || processIdsWithLoops.has(t.processId)) loops++;
         }
-        return { chat, auto, all: all.length };
-    }, [running, queued, history]);
+        return { chat, auto, loops, all: all.length };
+    }, [running, queued, history, processIdsWithLoops]);
 
     // Separate archived from non-archived history (uses tab-filtered history for proper exclusions)
     const { activeHistory, filteredArchived } = useMemo(() => {
@@ -1351,6 +1359,25 @@ export function ChatListPane({
                                 <span className={cn('shrink-0 text-[10px] font-medium', m.color)} data-testid="session-category-badge">{m.icon}</span>
                             ) : null;
                         })()}
+                        {(() => {
+                            if (!loopsEnabled) return null;
+                            const taskProcessId = task.processId || task.id;
+                            const state = loopStateByProcess.get(task.id) ?? loopStateByProcess.get(taskProcessId);
+                            if (!state) return null;
+                            return (
+                                <span
+                                    className={cn(
+                                        'shrink-0 text-[10px]',
+                                        state === 'active'
+                                            ? 'text-[#15703a] dark:text-[#4ade80]'
+                                            : 'text-[#8a5a00] dark:text-[#fbbf24]',
+                                    )}
+                                    title={state === 'active' ? 'Has active loops' : 'Has paused loops'}
+                                    aria-hidden="true"
+                                    data-testid="loop-indicator"
+                                >🔁</span>
+                            );
+                        })()}
                     </span>
                     <span className={cn('flex items-center gap-1', isAwaitingInput ? 'text-amber-700 dark:text-amber-300 font-medium' : 'text-[#848484] dark:text-[#999]')}>
                         <span className="chat-row-when text-[10.5px] font-mono tabular-nums whitespace-nowrap group-hover:hidden">
@@ -1433,6 +1460,8 @@ export function ChatListPane({
         onUnarchiveChat,
         onPinChat,
         onUnpinChat,
+        loopStateByProcess,
+        loopsEnabled,
         onSelectTask,
         historyLongPress,
     ]);
@@ -1905,15 +1934,16 @@ export function ChatListPane({
                     </div>
                 </div>
 
-                {/* Scope segmented control — Chats / Automations / All. Only
+                {/* Scope segmented control — Chats / [Loops] / Automations / All. Only
                     rendered in the Activity branch (`!activeTab`); Chats and
-                    Tasks tabs already have their own narrow scope. Inner spans
+                    Tasks tabs already have their own narrow scope. The Loops
+                    segment is only shown when loops.enabled is true. Inner spans
                     use `whitespace-nowrap` and `min-w-0 truncate` on the label
                     so narrow widths show ellipsis on the longest label
                     ("Automations") instead of wrapping the count below. */}
                 {!activeTab && (
                     <div
-                        className="grid grid-cols-3 gap-0 p-0.5 bg-[#f5f5f5] dark:bg-[#252526] border border-[#e0e0e0] dark:border-[#474749] rounded-md"
+                        className={cn('grid gap-0 p-0.5 bg-[#f5f5f5] dark:bg-[#252526] border border-[#e0e0e0] dark:border-[#474749] rounded-md', loopsEnabled ? 'grid-cols-4' : 'grid-cols-3')}
                         role="tablist"
                         aria-label="Activity scope"
                         data-testid="activity-scope-tabs"
@@ -1928,6 +1958,14 @@ export function ChatListPane({
                                         <path d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H6l-3 2.5V10a2 2 0 0 1-1-1.7Z" />
                                     </svg>
                                 ),
+                                hidden: false,
+                            },
+                            {
+                                id: 'loops' as const,
+                                label: 'Loops',
+                                count: scopeCounts.loops,
+                                icon: <span className="text-[11px]" aria-hidden="true">🔁</span>,
+                                hidden: !loopsEnabled,
                             },
                             {
                                 id: 'auto' as const,
@@ -1939,9 +1977,10 @@ export function ChatListPane({
                                         <path d="M7 1v2M7 11v2M1 7h2M11 7h2M2.8 2.8l1.4 1.4M9.8 9.8l1.4 1.4M2.8 11.2l1.4-1.4M9.8 4.2l1.4-1.4" />
                                     </svg>
                                 ),
+                                hidden: false,
                             },
-                            { id: 'all' as const, label: 'All', count: scopeCounts.all, icon: null },
-                        ]).map(scope => {
+                            { id: 'all' as const, label: 'All', count: scopeCounts.all, icon: null, hidden: false },
+                        ]).filter(s => !s.hidden).map(scope => {
                             const on = activeScope === scope.id;
                             return (
                                 <button

--- a/packages/coc/src/server/spa/client/react/features/chat/LoopBadge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/LoopBadge.tsx
@@ -4,6 +4,7 @@
  * Renders a small pill with a loop icon (🔁) and the count of non-cancelled loops.
  */
 import React from 'react';
+import { LoopIcon } from './icons/LoopIcon';
 
 export interface LoopBadgeProps {
     count: number;
@@ -26,7 +27,7 @@ export function LoopBadge({ count, hasActiveLoops, onClick }: LoopBadgeProps) {
             onClick={onClick}
             data-testid="loop-badge"
         >
-            <span aria-hidden="true">🔁</span>
+            <LoopIcon className="w-3 h-3" />
             <span>{count}</span>
         </button>
     );

--- a/packages/coc/src/server/spa/client/react/features/chat/LoopManagementPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/LoopManagementPanel.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { cn } from '../../ui/cn';
 import type { LoopEntry } from '@plusplusoneplusplus/coc-client';
+import { LoopIcon } from './icons/LoopIcon';
 
 export interface LoopManagementPanelProps {
     loops: LoopEntry[];
@@ -155,8 +156,9 @@ export function LoopManagementPanel({ loops, isOpen, onClose, onPause, onResume,
             data-testid="loop-management-panel"
         >
             <div className="px-3 py-2 border-b border-[#e0e0e0] dark:border-[#3c3c3c]">
-                <span className="text-[11px] font-semibold text-[#1e1e1e] dark:text-[#cccccc]">
-                    🔁 Loops ({loops.length})
+                <span className="text-[11px] font-semibold text-[#1e1e1e] dark:text-[#cccccc] inline-flex items-center gap-1">
+                    <LoopIcon className="w-3.5 h-3.5" />
+                    <span>Loops ({loops.length})</span>
                 </span>
             </div>
             {loops.length === 0 ? (

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -11,6 +11,7 @@ import { ToolCallView } from './tool-calls/ToolCallView';
 import { JsonResponseView } from '../../../ui/JsonResponseView';
 import { isJsonResponse } from '../../../ui/json-utils';
 import { mergeConsecutiveContentItems } from './timeline-utils';
+import { LoopIcon } from '../icons/LoopIcon';
 import { Marked } from 'marked';
 import { useDisplaySettings } from '../../../hooks/preferences/useDisplaySettings';
 import { useHtmlEmbedPreference } from '../../../hooks/preferences/useHtmlEmbedPreference';
@@ -1160,7 +1161,7 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
                             }
                             data-testid="turn-source-badge"
                         >
-                            <span aria-hidden="true">{turn.turnSource.source === 'loop' ? '🔁' : '⏰'}</span>
+                            <span aria-hidden="true">{turn.turnSource.source === 'loop' ? <LoopIcon className="w-3 h-3 inline-block" /> : '⏰'}</span>
                             <span>{turn.turnSource.source === 'loop' ? 'loop' : 'wakeup'}</span>
                         </span>
                     )}

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useAllLoops.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useAllLoops.ts
@@ -1,0 +1,107 @@
+/**
+ * useAllLoops — hook to fetch all loops server-wide and group by processId.
+ *
+ * Used by ChatListPane to show inline loop indicators and the "Loops" scope
+ * filter. Only fetches when `isLoopsEnabled()` is true. Listens for WebSocket
+ * loop events to keep state fresh.
+ */
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { getSpaCocClient } from '../../../api/cocClient';
+import { isLoopsEnabled } from '../../../utils/config';
+import type { LoopEntry } from '@plusplusoneplusplus/coc-client';
+
+export type ProcessLoopState = 'active' | 'paused' | null;
+
+export interface UseAllLoopsResult {
+    /** Map from processId → loop state ('active' if any active, 'paused' if only paused). */
+    loopStateByProcess: Map<string, ProcessLoopState>;
+    /** Set of processIds that have at least one active or paused loop. */
+    processIdsWithLoops: Set<string>;
+    /** Number of distinct processes with active or paused loops. */
+    loopProcessCount: number;
+    /** Whether the initial fetch is still in progress. */
+    loading: boolean;
+}
+
+const EMPTY_MAP = new Map<string, ProcessLoopState>();
+const EMPTY_SET = new Set<string>();
+const EMPTY_RESULT: UseAllLoopsResult = {
+    loopStateByProcess: EMPTY_MAP,
+    processIdsWithLoops: EMPTY_SET,
+    loopProcessCount: 0,
+    loading: false,
+};
+
+function groupByProcess(loops: LoopEntry[]): Map<string, ProcessLoopState> {
+    const map = new Map<string, ProcessLoopState>();
+    for (const loop of loops) {
+        if (loop.status !== 'active' && loop.status !== 'paused') continue;
+        const current = map.get(loop.processId);
+        // 'active' takes priority over 'paused'
+        if (current === 'active') continue;
+        map.set(loop.processId, loop.status === 'active' ? 'active' : 'paused');
+    }
+    return map;
+}
+
+export function useAllLoops(): UseAllLoopsResult {
+    const [loops, setLoops] = useState<LoopEntry[]>([]);
+    const [loading, setLoading] = useState(false);
+    const mountedRef = useRef(true);
+
+    const enabled = isLoopsEnabled();
+
+    const fetchLoops = useCallback(() => {
+        if (!enabled) {
+            setLoops([]);
+            return;
+        }
+        setLoading(true);
+        getSpaCocClient().loops.listAll()
+            .then((all) => {
+                if (!mountedRef.current) return;
+                setLoops(all);
+            })
+            .catch(() => { /* best-effort */ })
+            .finally(() => {
+                if (mountedRef.current) setLoading(false);
+            });
+    }, [enabled]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        fetchLoops();
+        return () => { mountedRef.current = false; };
+    }, [fetchLoops]);
+
+    // Listen for WebSocket loop events to refresh
+    useEffect(() => {
+        if (!enabled) return;
+
+        const handler = ((e: CustomEvent) => {
+            const msg = e.detail;
+            if (!msg?.type?.startsWith('loop-')) return;
+            fetchLoops();
+        }) as EventListener;
+
+        window.addEventListener('coc-ws-message' as any, handler);
+        return () => {
+            window.removeEventListener('coc-ws-message' as any, handler);
+        };
+    }, [enabled, fetchLoops]);
+
+    const loopStateByProcess = useMemo(() => groupByProcess(loops), [loops]);
+    const processIdsWithLoops = useMemo(
+        () => new Set(loopStateByProcess.keys()),
+        [loopStateByProcess],
+    );
+
+    if (!enabled) return EMPTY_RESULT;
+
+    return {
+        loopStateByProcess,
+        processIdsWithLoops,
+        loopProcessCount: processIdsWithLoops.size,
+        loading,
+    };
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useLoops.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useLoops.ts
@@ -69,28 +69,16 @@ export function useLoops(workspaceId: string | undefined, processId: string | nu
         if (!processId) return;
         if (!isLoopsEnabled()) return;
 
-        function handleWsMessage(event: MessageEvent) {
-            try {
-                const msg = JSON.parse(event.data);
-                if (!msg.type?.startsWith('loop-')) return;
-                if (msg.processId !== processId) return;
-                // Re-fetch on any loop event for this process
-                fetchLoops();
-            } catch { /* ignore parse errors */ }
-        }
-
-        // Attach to any existing WebSocket — we piggyback on the app's connection
-        // by listening to the custom event dispatched by the WS context
-        window.addEventListener('coc-ws-message' as any, ((e: CustomEvent) => {
+        const handler = ((e: CustomEvent) => {
             const msg = e.detail;
             if (!msg?.type?.startsWith('loop-')) return;
             if (msg.processId !== processId) return;
             fetchLoops();
-        }) as EventListener);
+        }) as EventListener;
 
+        window.addEventListener('coc-ws-message' as any, handler);
         return () => {
-            // Cleanup not strictly necessary for custom events on window,
-            // but good practice
+            window.removeEventListener('coc-ws-message' as any, handler);
         };
     }, [processId, fetchLoops]);
 

--- a/packages/coc/src/server/spa/client/react/features/chat/icons/LoopIcon.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/icons/LoopIcon.tsx
@@ -20,7 +20,7 @@ export function LoopIcon({ className, title, ...rest }: LoopIconProps) {
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth={2}
+            strokeWidth={2.25}
             strokeLinecap="round"
             strokeLinejoin="round"
             className={className}
@@ -30,8 +30,9 @@ export function LoopIcon({ className, title, ...rest }: LoopIconProps) {
             {...rest}
         >
             {title ? <title>{title}</title> : null}
-            {/* Heroicons arrow-path */}
-            <path d="M16.023 9.348h4.992V4.355M2.985 19.644l4.992-4.993M2.985 14.65a8.25 8.25 0 0 0 14.503 4.992m3.527-4.992A8.25 8.25 0 0 0 6.512 9.348" />
+            {/* Lucide rotate-cw — single circular arrow, reads cleanly at small sizes */}
+            <path d="M21 12a9 9 0 1 1-3.51-7.14" />
+            <polyline points="21 4 21 10 15 10" />
         </svg>
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/icons/LoopIcon.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/icons/LoopIcon.tsx
@@ -1,0 +1,37 @@
+/**
+ * LoopIcon — shared SVG glyph for loop/repeat indicators.
+ *
+ * Uses `stroke="currentColor"` so the rendered color follows the wrapping
+ * element's `text-…` class. This avoids the cross-platform color-emoji
+ * problem where 🔁 ignores CSS `color` on most operating systems.
+ */
+import React from 'react';
+
+export interface LoopIconProps {
+    className?: string;
+    title?: string;
+    'aria-hidden'?: boolean | 'true' | 'false';
+}
+
+export function LoopIcon({ className, title, ...rest }: LoopIconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            role={title ? 'img' : undefined}
+            aria-hidden={title ? undefined : true}
+            data-testid="loop-icon"
+            {...rest}
+        >
+            {title ? <title>{title}</title> : null}
+            {/* Heroicons arrow-path */}
+            <path d="M16.023 9.348h4.992V4.355M2.985 19.644l4.992-4.993M2.985 14.65a8.25 8.25 0 0 0 14.503 4.992m3.527-4.992A8.25 8.25 0 0 0 6.512 9.348" />
+        </svg>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
@@ -43,6 +43,7 @@ import { ContextMenu, type ContextMenuItem } from '../../tasks/comments/ContextM
 import type { GitCommitItem } from './commits/CommitList';
 import type { BranchRangeInfo } from './branches/BranchChanges';
 import { buildFixupGroups } from './fixup-utils';
+import { rankSkillsByRecency, MRU_SKILL_LIMIT } from './skill-menu-ranking';
 
 /**
  * Best-effort rebind of commit-chat binding when a hash changes.
@@ -171,6 +172,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
 
     // Skills + context menu state
     const [skills, setSkills] = useState<Array<{ name: string; description?: string }>>([]);
+    const [commitSkillUsageMap, setCommitSkillUsageMap] = useState<Record<string, string>>({});
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number; type: 'commit' | 'branch-range' | 'multi-commit'; commit?: GitCommitItem; commits?: GitCommitItem[] } | null>(null);
     const [enqueueToast, setEnqueueToast] = useState<string | null>(null);
     const [pendingSkillRun, setPendingSkillRun] = useState<{ skillName: string; type: 'commit' | 'multi-commit' | 'branch-range'; commit?: GitCommitItem; commits?: GitCommitItem[] } | null>(null);
@@ -363,7 +365,17 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
             .catch(() => {});
     }, [workspaceId]);
 
-    // Debounced search: when searchQuery changes, reset pagination and re-fetch
+    // Fetch commit-scoped skill usage map per workspace
+    useEffect(() => {
+        setCommitSkillUsageMap({});
+        getSpaCocClient().preferences.getRepo(workspaceId)
+            .then(prefs => {
+                if (prefs?.commitSkillUsageMap) {
+                    setCommitSkillUsageMap(prefs.commitSkillUsageMap);
+                }
+            })
+            .catch(() => {});
+    }, [workspaceId]);
     useEffect(() => {
         if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
         searchDebounceRef.current = setTimeout(() => {
@@ -922,6 +934,11 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setPendingSkillRun(null);
         setEnqueueToast(`Skill "${pendingSkillRun.skillName}" enqueued`);
         setTimeout(() => setEnqueueToast(null), 3000);
+
+        // Record commit-scoped skill usage (best-effort) and optimistic local update
+        const skillName = pendingSkillRun.skillName;
+        setCommitSkillUsageMap(prev => ({ ...prev, [skillName]: new Date().toISOString() }));
+        getSpaCocClient().preferences.recordCommitSkillUsage(workspaceId, skillName).catch(() => {});
     }, [pendingSkillRun, workspaceId, branchRangeData, branchName, state.workspaces]);
 
     const handleSquashCommits = useCallback(async () => {
@@ -1241,19 +1258,46 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
             if (items.length > 0) {
                 items.push({ label: '', separator: true, onClick: () => {} });
             }
-            items.push({
-                label: 'Use Skill',
-                icon: '⚡',
-                onClick: () => {},
-                children: skills.map(skill => ({
-                    label: skill.name,
-                    onClick: () => handleEnqueueSkill(skill.name),
-                })),
-            });
+            const ranked = rankSkillsByRecency(skills, commitSkillUsageMap);
+            if (ranked.length <= MRU_SKILL_LIMIT) {
+                items.push({
+                    label: 'Use Skill',
+                    icon: '⚡',
+                    onClick: () => {},
+                    children: ranked.map(skill => ({
+                        label: skill.name,
+                        onClick: () => handleEnqueueSkill(skill.name),
+                    })),
+                });
+            } else {
+                const top = ranked.slice(0, MRU_SKILL_LIMIT);
+                const rest = ranked.slice(MRU_SKILL_LIMIT)
+                    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+                items.push({
+                    label: 'Use Skill',
+                    icon: '⚡',
+                    onClick: () => {},
+                    children: [
+                        ...top.map(skill => ({
+                            label: skill.name,
+                            onClick: () => handleEnqueueSkill(skill.name),
+                        })),
+                        { label: '', separator: true, onClick: () => {} },
+                        {
+                            label: 'More…',
+                            onClick: () => {},
+                            children: rest.map(skill => ({
+                                label: skill.name,
+                                onClick: () => handleEnqueueSkill(skill.name),
+                            })),
+                        },
+                    ],
+                });
+            }
         }
 
         return items;
-    }, [contextMenu, skills, handleEnqueueSkill, handleSquashCommits, handleBranchAskAI, handleSelect, handleOpenAsPopup, handleHardReset, handleCherryPick, commits, closeContextMenu, queueDispatch, workspaceId, fixupGroupsForMenu, handleRebaseAutosquash, handlePushToCommit, unpushedCount]);
+    }, [contextMenu, skills, commitSkillUsageMap, handleEnqueueSkill, handleSquashCommits, handleBranchAskAI, handleSelect, handleOpenAsPopup, handleHardReset, handleCherryPick, commits, closeContextMenu, queueDispatch, workspaceId, fixupGroupsForMenu, handleRebaseAutosquash, handlePushToCommit, unpushedCount]);
 
     // Keyboard shortcuts:
     //   - R: refresh

--- a/packages/coc/src/server/spa/client/react/features/git/skill-menu-ranking.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/skill-menu-ranking.ts
@@ -1,0 +1,41 @@
+/**
+ * Skill Menu Ranking — orders skills by commit-scoped recency for the
+ * Git tab "Use Skill" context menu.
+ *
+ * Pure function with no React or DOM dependencies so it's easy to unit-test.
+ */
+
+/** Maximum number of skills shown as direct children of "Use Skill". */
+export const MRU_SKILL_LIMIT = 5;
+
+export interface RankedSkill {
+    name: string;
+}
+
+/**
+ * Rank skills by commit-scoped recency.
+ *
+ * - Skills with a timestamp in `usageMap` sort newest-first (descending ISO string).
+ * - Skills without a timestamp sort alphabetically by lowercased name.
+ * - Timestamped skills always precede untimestamped ones.
+ */
+export function rankSkillsByRecency(
+    skills: readonly RankedSkill[],
+    usageMap: Record<string, string>,
+): RankedSkill[] {
+    const used: RankedSkill[] = [];
+    const unused: RankedSkill[] = [];
+
+    for (const skill of skills) {
+        if (usageMap[skill.name]) {
+            used.push(skill);
+        } else {
+            unused.push(skill);
+        }
+    }
+
+    used.sort((a, b) => usageMap[b.name].localeCompare(usageMap[a.name]));
+    unused.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+
+    return [...used, ...unused];
+}

--- a/packages/coc/src/server/spa/client/react/tasks/comments/ContextMenu.tsx
+++ b/packages/coc/src/server/spa/client/react/tasks/comments/ContextMenu.tsx
@@ -146,6 +146,16 @@ function SubmenuItem({
                                 />
                             );
                         }
+                        if (child.children && child.children.length > 0) {
+                            return (
+                                <SubmenuItem
+                                    key={ci}
+                                    item={child}
+                                    idx={ci}
+                                    onClose={onClose}
+                                />
+                            );
+                        }
                         return (
                             <button
                                 key={ci}
@@ -214,17 +224,19 @@ export function ContextMenu({ position, items, onClose }: ContextMenuProps) {
 
     if (isMobile) {
         const flatItems: { item: ContextMenuItem; sectionHeader?: string }[] = [];
-        for (const item of items) {
-            if (item.separator) continue;
-            if (item.children && item.children.length > 0) {
-                flatItems.push({ item, sectionHeader: item.label });
-                for (const child of item.children) {
-                    if (!child.separator) flatItems.push({ item: child });
+        const flattenItems = (menuItems: ContextMenuItem[], parentLabel?: string) => {
+            for (const item of menuItems) {
+                if (item.separator) continue;
+                if (item.children && item.children.length > 0) {
+                    const header = parentLabel ? `${parentLabel} › ${item.label}` : item.label;
+                    flatItems.push({ item, sectionHeader: header });
+                    flattenItems(item.children, header);
+                } else {
+                    flatItems.push({ item });
                 }
-            } else {
-                flatItems.push({ item });
             }
-        }
+        };
+        flattenItems(items);
 
         return (
             <BottomSheet isOpen={true} onClose={onClose} data-testid="context-menu-bottomsheet">

--- a/packages/coc/src/server/streaming/websocket.ts
+++ b/packages/coc/src/server/streaming/websocket.ts
@@ -142,7 +142,7 @@ export type ServerMessage =
     | { type: 'turn-pinned'; processId: string; turnIndex: number; pinnedAt: string | null }
     | { type: 'turn-archived'; processId: string; turnIndex: number; archived: boolean }
     | { type: 'ralph-session-complete'; workspaceId: string; sessionId?: string; processId: string; totalIterations: number; reason: 'signal' | 'cap' }
-    | { type: 'loop-created' | 'loop-updated' | 'loop-paused' | 'loop-resumed' | 'loop-cancelled' | 'loop-expired' | 'loop-tick'; loopId: string; processId: string; status: string; timestamp: number };
+    | { type: 'loop-created' | 'loop-updated' | 'loop-paused' | 'loop-resumed' | 'loop-cancelled' | 'loop-expired' | 'loop-tick'; loopId: string; processId: string; status: string; workspaceId?: string; timestamp: number };
 
 /** Client → Server message types */
 export type ClientMessage =

--- a/packages/coc/test/server/executors/follow-up-executor.test.ts
+++ b/packages/coc/test/server/executors/follow-up-executor.test.ts
@@ -626,7 +626,9 @@ describe('FollowUpExecutor', () => {
         const executor = makeExecutor(store, {
             askUser: { enabled: true },
         });
-        await executor.executeFollowUp('proc-autopilot-user', 'continue autonomously');
+        // After the single-source-of-truth fix, callers must pass mode
+        // explicitly; the executor no longer infers it from process metadata.
+        await executor.executeFollowUp('proc-autopilot-user', 'continue autonomously', undefined, 'autopilot');
 
         expect(mockBuildChatToolBundle).toHaveBeenCalledWith(expect.objectContaining({
             askUser: expect.objectContaining({

--- a/packages/coc/test/server/executors/follow-up-mode.test.ts
+++ b/packages/coc/test/server/executors/follow-up-mode.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for resolveFollowUpMode helper.
+ *
+ * The resolver is the single source of truth for "what mode does this
+ * follow-up run in?". Explicit > process.metadata.mode > 'ask'.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveFollowUpMode } from '../../../src/server/executors/follow-up-mode';
+
+function makeStore(metadataMode?: unknown, throws = false) {
+    return {
+        getProcess: vi.fn(async () => {
+            if (throws) throw new Error('store error');
+            return {
+                id: 'p',
+                status: 'completed',
+                startTime: new Date(),
+                promptPreview: '',
+                ...(metadataMode === undefined ? {} : { metadata: { mode: metadataMode } }),
+            } as any;
+        }),
+    } as any;
+}
+
+describe('resolveFollowUpMode', () => {
+    it('returns the explicit mode when provided', async () => {
+        const store = makeStore('autopilot');
+        await expect(resolveFollowUpMode(store, 'p', 'plan')).resolves.toBe('plan');
+        expect(store.getProcess).not.toHaveBeenCalled();
+    });
+
+    it('falls back to process metadata.mode when explicit is undefined', async () => {
+        const store = makeStore('plan');
+        await expect(resolveFollowUpMode(store, 'p')).resolves.toBe('plan');
+    });
+
+    it('returns ask when process is missing', async () => {
+        const store = {
+            getProcess: vi.fn(async () => undefined),
+        } as any;
+        await expect(resolveFollowUpMode(store, 'missing')).resolves.toBe('ask');
+    });
+
+    it('returns ask when metadata.mode is absent', async () => {
+        const store = makeStore(undefined);
+        await expect(resolveFollowUpMode(store, 'p')).resolves.toBe('ask');
+    });
+
+    it('returns ask when metadata.mode is not a valid ChatMode', async () => {
+        const store = makeStore('garbage');
+        await expect(resolveFollowUpMode(store, 'p')).resolves.toBe('ask');
+    });
+
+    it('rejects an invalid explicit mode and falls through to metadata', async () => {
+        const store = makeStore('plan');
+        // Caller forced an invalid value (via `any`) — must fall through.
+        await expect(resolveFollowUpMode(store, 'p', 'bogus' as any)).resolves.toBe('plan');
+    });
+
+    it('returns ask when the store throws', async () => {
+        const store = makeStore(undefined, true);
+        await expect(resolveFollowUpMode(store, 'p')).resolves.toBe('ask');
+    });
+
+    it('accepts all valid ChatMode values from metadata', async () => {
+        for (const mode of ['ask', 'plan', 'autopilot', 'ralph'] as const) {
+            const store = makeStore(mode);
+            await expect(resolveFollowUpMode(store, 'p')).resolves.toBe(mode);
+        }
+    });
+});

--- a/packages/coc/test/server/executors/loop-tools-addon.test.ts
+++ b/packages/coc/test/server/executors/loop-tools-addon.test.ts
@@ -19,6 +19,7 @@ function makeMockLoopToolDeps() {
             disarmTimer: vi.fn(),
         } as any,
         processId: 'proc-test',
+        resolveWorkspaceId: vi.fn().mockResolvedValue('ws-test'),
     };
 }
 

--- a/packages/coc/test/server/executors/process-lifecycle-runner.test.ts
+++ b/packages/coc/test/server/executors/process-lifecycle-runner.test.ts
@@ -1113,3 +1113,96 @@ describe('ProcessLifecycleRunner — partial conversation turn on error', () => 
         expect(proc?.error).toBe('timeout');
     });
 });
+
+// ============================================================================
+// Follow-up lifecycle status ordering
+// ============================================================================
+
+describe('ProcessLifecycleRunner — follow-up lifecycle status ordering', () => {
+    let store: ReturnType<typeof createMockProcessStore>;
+    let runner: ProcessLifecycleRunner;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        store = createMockProcessStore();
+        runner = new ProcessLifecycleRunner(store as any, '/data-dir', vi.fn());
+    });
+
+    it('marks the target process as running BEFORE invoking executeFollowUpFn', async () => {
+        const processId = 'existing-process';
+        store.processes.set(processId, {
+            id: processId,
+            type: 'clarification',
+            promptPreview: 'test',
+            fullPrompt: 'test',
+            status: 'completed',
+            startTime: new Date(),
+            conversationTurns: [
+                { role: 'user', content: 'initial', timestamp: new Date(), turnIndex: 0, timeline: [] },
+                { role: 'assistant', content: 'reply', timestamp: new Date(), turnIndex: 1, timeline: [] },
+            ],
+        } as any);
+
+        const callOrder: string[] = [];
+        (store.updateProcess as any).mockImplementation(async (id: string, updates: any) => {
+            if (updates?.status === 'running' && id === processId) {
+                callOrder.push('updateProcess:running');
+            }
+            const existing = store.processes.get(id);
+            if (existing) { store.processes.set(id, { ...existing, ...updates }); }
+        });
+        const executeFollowUpFn = vi.fn(async () => {
+            callOrder.push('executeFollowUpFn');
+        });
+
+        const followUpTask = makeTask({
+            id: 'followup-task-1',
+            payload: {
+                kind: 'chat',
+                prompt: 'Follow-up question',
+                processId,
+                workspaceId: 'ws-abc',
+            } as any,
+        });
+
+        const result = await runner.run(followUpTask, makeOpts({ executeFollowUpFn }));
+
+        expect(result.success).toBe(true);
+        expect(executeFollowUpFn).toHaveBeenCalledOnce();
+        expect(callOrder.indexOf('updateProcess:running')).toBeGreaterThanOrEqual(0);
+        expect(callOrder.indexOf('updateProcess:running'))
+            .toBeLessThan(callOrder.indexOf('executeFollowUpFn'));
+    });
+
+    it('fails the task fail-loud if the pre-execution status update throws', async () => {
+        const processId = 'existing-process';
+        store.processes.set(processId, {
+            id: processId,
+            type: 'clarification',
+            promptPreview: 'test',
+            fullPrompt: 'test',
+            status: 'completed',
+            startTime: new Date(),
+            conversationTurns: [],
+        } as any);
+
+        (store.updateProcess as any).mockRejectedValueOnce(new Error('db down'));
+        const executeFollowUpFn = vi.fn().mockResolvedValue(undefined);
+
+        const followUpTask = makeTask({
+            id: 'followup-task-2',
+            payload: {
+                kind: 'chat',
+                prompt: 'Follow-up',
+                processId,
+                workspaceId: 'ws-abc',
+            } as any,
+        });
+
+        const result = await runner.run(followUpTask, makeOpts({ executeFollowUpFn }));
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toBe('db down');
+        expect(executeFollowUpFn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/coc/test/server/loop-executor.test.ts
+++ b/packages/coc/test/server/loop-executor.test.ts
@@ -604,10 +604,11 @@ describe('LoopExecutor', () => {
             expect(call.payload.context.source).toBe('loop');
         });
 
-        it('does not force autopilot mode in fallback enqueue payload', async () => {
-            // Regression: loop ticks must not flip an Ask/Plan conversation
-            // into Autopilot. The fallback enqueue path should omit `mode`
-            // so FollowUpExecutor preserves the process's existing mode.
+        it('inherits resolved follow-up mode into fallback enqueue payload', async () => {
+            // Loop ticks must not flip an Ask/Plan conversation into Autopilot.
+            // The resolver inspects the process's metadata.mode (defaulting to
+            // 'ask' when absent) and the resolved value is written onto
+            // payload.mode so the UI badge and execution agree.
             const { deps, store, timerRegistry, queueManager } = createDeps();
             const loop = makeLoop({ id: 'loop_mode_preserve', prompt: 'tick' });
             store.insert(loop);
@@ -619,9 +620,59 @@ describe('LoopExecutor', () => {
 
             expect(queueManager.enqueue).toHaveBeenCalled();
             const call = queueManager.enqueue.mock.calls[0][0];
-            expect(call.payload).not.toHaveProperty('mode');
+            expect(call.payload.mode).toBe('ask');
             expect(call.payload.context.loopId).toBe('loop_mode_preserve');
             expect(call.payload.context.source).toBe('loop');
+        });
+
+        it('uses process metadata.mode when resolving follow-up mode', async () => {
+            const { deps, store, timerRegistry, queueManager, processStore } = createDeps();
+            processStore.getProcess.mockImplementation(async (id: string) => ({
+                id,
+                status: 'completed',
+                workingDirectory: '/test',
+                metadata: { mode: 'plan' },
+            }));
+
+            const loop = makeLoop({ id: 'loop_plan', prompt: 'tick' });
+            store.insert(loop);
+
+            const executor = new LoopExecutor(deps);
+            executor.armAll();
+            await timerRegistry._fire('loop_plan');
+
+            expect(queueManager.enqueue).toHaveBeenCalled();
+            const call = queueManager.enqueue.mock.calls[0][0];
+            expect(call.payload.mode).toBe('plan');
+        });
+
+        it('overwrites stale mode on requeue with resolved mode', async () => {
+            const { deps, store, timerRegistry, queueManager, processStore } = createDeps();
+            processStore.getProcess.mockImplementation(async (id: string) => ({
+                id,
+                status: 'completed',
+                workingDirectory: '/test',
+                metadata: { mode: 'ask' },
+            }));
+
+            queueManager._tasks.set('proc_abc', {
+                id: 'proc_abc',
+                status: 'completed',
+                payload: { kind: 'chat', mode: 'autopilot', prompt: 'old prompt' },
+                processId: 'queue_proc_abc',
+            });
+
+            const loop = makeLoop({ id: 'loop_requeue_mode', prompt: 'new prompt' });
+            store.insert(loop);
+
+            const executor = new LoopExecutor(deps);
+            executor.armAll();
+            await timerRegistry._fire('loop_requeue_mode');
+
+            expect(queueManager.updateTask).toHaveBeenCalled();
+            const updateCall = queueManager.updateTask.mock.calls[0];
+            expect(updateCall[1].payload.mode).toBe('ask');
+            expect(updateCall[1].payload.prompt).toBe('new prompt');
         });
 
         it('requeues from history when task exists as completed', async () => {

--- a/packages/coc/test/server/loop-handler.test.ts
+++ b/packages/coc/test/server/loop-handler.test.ts
@@ -115,6 +115,7 @@ describe('Loop REST API Handler', () => {
     let routes: Route[];
     let mockExecutor: any;
     let resolveWorkspaceId: (processId: string) => Promise<string | undefined>;
+    let emit: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         db = new Database(':memory:');
@@ -133,7 +134,8 @@ describe('Loop REST API Handler', () => {
             return undefined;
         });
 
-        const ctx: LoopRouteContext = { store, executor: mockExecutor };
+        emit = vi.fn();
+        const ctx: LoopRouteContext = { store, executor: mockExecutor, emit };
         registerLoopRoutes(routes, ctx);
     });
 
@@ -409,5 +411,110 @@ describe('Loop REST API Handler', () => {
             expect(resB.body.loops).toHaveLength(1);
             expect(resB.body.loops[0].id).toBe('loop_b');
         });
+    });
+});
+
+// ============================================================================
+// Event emission via `emit` callback
+// ============================================================================
+
+describe('Loop REST API Handler — event emission', () => {
+    let db: Database.Database;
+    let store: LoopStore;
+    let routes: Route[];
+    let mockExecutor: any;
+    let emit: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        db = new Database(':memory:');
+        store = new LoopStore(db);
+        routes = [];
+        mockExecutor = { armTimer: vi.fn(), disarmTimer: vi.fn() };
+        emit = vi.fn();
+        registerLoopRoutes(routes, { store, executor: mockExecutor, emit });
+    });
+
+    function insert(loop: LoopEntry) { store.insert(loop); }
+
+    it('emits loop-paused after POST pause', async () => {
+        const loop = makeLoop({ id: 'loop_e1', status: 'active', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+        insert(loop);
+        const res = await dispatch(routes, 'POST', '/api/workspaces/ws1/loops/loop_e1/pause', { reason: 'user-paused' });
+        expect(res.statusCode).toBe(200);
+        expect(emit).toHaveBeenCalledTimes(1);
+        const evt = emit.mock.calls[0][0];
+        expect(evt.type).toBe('loop-paused');
+        expect(evt.loop.id).toBe('loop_e1');
+        expect(evt.loop.processId).toBe('proc_ws1_a');
+        expect(evt.loop.workspaceId).toBe('ws1');
+        expect(evt.loop.status).toBe('paused');
+    });
+
+    it('emits loop-resumed after POST resume', async () => {
+        const loop = makeLoop({ id: 'loop_e2', status: 'paused', pausedReason: 'test', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+        insert(loop);
+        const res = await dispatch(routes, 'POST', '/api/workspaces/ws1/loops/loop_e2/resume');
+        expect(res.statusCode).toBe(200);
+        expect(emit).toHaveBeenCalledTimes(1);
+        const evt = emit.mock.calls[0][0];
+        expect(evt.type).toBe('loop-resumed');
+        expect(evt.loop.id).toBe('loop_e2');
+        expect(evt.loop.status).toBe('active');
+        expect(evt.loop.workspaceId).toBe('ws1');
+    });
+
+    it('emits loop-cancelled after DELETE', async () => {
+        const loop = makeLoop({ id: 'loop_e3', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+        insert(loop);
+        const res = await dispatch(routes, 'DELETE', '/api/workspaces/ws1/loops/loop_e3');
+        expect(res.statusCode).toBe(200);
+        expect(emit).toHaveBeenCalledTimes(1);
+        const evt = emit.mock.calls[0][0];
+        expect(evt.type).toBe('loop-cancelled');
+        expect(evt.loop.id).toBe('loop_e3');
+        expect(evt.loop.status).toBe('cancelled');
+    });
+
+    it('emits loop-updated after PATCH', async () => {
+        const loop = makeLoop({ id: 'loop_e4', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+        insert(loop);
+        const res = await dispatch(routes, 'PATCH', '/api/workspaces/ws1/loops/loop_e4', { description: 'new' });
+        expect(res.statusCode).toBe(200);
+        expect(emit).toHaveBeenCalledTimes(1);
+        expect(emit.mock.calls[0][0].type).toBe('loop-updated');
+    });
+
+    it('emits loop-expired when resuming an already-expired loop', async () => {
+        const loop = makeLoop({
+            id: 'loop_e5',
+            status: 'paused',
+            pausedReason: 'test',
+            processId: 'proc_ws1_a',
+            workspaceId: 'ws1',
+            expiresAt: new Date(Date.now() - 1000).toISOString(),
+        });
+        insert(loop);
+        const res = await dispatch(routes, 'POST', '/api/workspaces/ws1/loops/loop_e5/resume');
+        expect(res.statusCode).toBe(400);
+        expect(emit).toHaveBeenCalledTimes(1);
+        expect(emit.mock.calls[0][0].type).toBe('loop-expired');
+    });
+
+    it('does not throw when emit callback throws', async () => {
+        emit.mockImplementation(() => { throw new Error('boom'); });
+        const loop = makeLoop({ id: 'loop_e6', status: 'active', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+        insert(loop);
+        const res = await dispatch(routes, 'POST', '/api/workspaces/ws1/loops/loop_e6/pause', {});
+        expect(res.statusCode).toBe(200);
+        expect(res.body.loop.status).toBe('paused');
+    });
+
+    it('still succeeds when no emit callback is provided', async () => {
+        const routesNoEmit: Route[] = [];
+        registerLoopRoutes(routesNoEmit, { store, executor: mockExecutor });
+        const loop = makeLoop({ id: 'loop_e7', status: 'active', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+        insert(loop);
+        const res = await dispatch(routesNoEmit, 'POST', '/api/workspaces/ws1/loops/loop_e7/pause', {});
+        expect(res.statusCode).toBe(200);
     });
 });

--- a/packages/coc/test/server/loop-handler.test.ts
+++ b/packages/coc/test/server/loop-handler.test.ts
@@ -133,7 +133,7 @@ describe('Loop REST API Handler', () => {
             return undefined;
         });
 
-        const ctx: LoopRouteContext = { store, executor: mockExecutor, resolveWorkspaceId };
+        const ctx: LoopRouteContext = { store, executor: mockExecutor };
         registerLoopRoutes(routes, ctx);
     });
 
@@ -149,9 +149,9 @@ describe('Loop REST API Handler', () => {
         });
 
         it('returns only loops for the given workspace', async () => {
-            const l1 = makeLoop({ id: 'loop_1', processId: 'proc_ws1_a' });
-            const l2 = makeLoop({ id: 'loop_2', processId: 'proc_ws2_a' });
-            const l3 = makeLoop({ id: 'loop_3', processId: 'proc_ws1_b' });
+            const l1 = makeLoop({ id: 'loop_1', processId: 'proc_ws1_a', workspaceId: 'ws1' });
+            const l2 = makeLoop({ id: 'loop_2', processId: 'proc_ws2_a', workspaceId: 'ws2' });
+            const l3 = makeLoop({ id: 'loop_3', processId: 'proc_ws1_b', workspaceId: 'ws1' });
             store.insert(l1);
             store.insert(l2);
             store.insert(l3);
@@ -333,8 +333,8 @@ describe('Loop REST API Handler', () => {
 
     describe('GET /api/loops (server-wide)', () => {
         it('returns all loops across workspaces', async () => {
-            store.insert(makeLoop({ id: 'loop_a', processId: 'proc_ws1_a' }));
-            store.insert(makeLoop({ id: 'loop_b', processId: 'proc_ws2_a' }));
+            store.insert(makeLoop({ id: 'loop_a', processId: 'proc_ws1_a', workspaceId: 'ws1' }));
+            store.insert(makeLoop({ id: 'loop_b', processId: 'proc_ws2_a', workspaceId: 'ws2' }));
 
             const res = await dispatch(routes, 'GET', '/api/loops');
             expect(res.statusCode).toBe(200);
@@ -358,6 +358,56 @@ describe('Loop REST API Handler', () => {
         it('returns 404 for unknown loop', async () => {
             const res = await dispatch(routes, 'GET', '/api/loops/nope');
             expect(res.statusCode).toBe(404);
+        });
+    });
+
+    // ========================================================================
+    // workspaceId stored-column filter
+    // ========================================================================
+
+    describe('workspaceId stored-column filter', () => {
+        it('workspace filter uses stored workspaceId, not resolver', async () => {
+            // Insert loops with explicit workspaceId — resolver is not called
+            store.insert(makeLoop({ id: 'loop_ws1', processId: 'proc_a', workspaceId: 'ws1' }));
+            store.insert(makeLoop({ id: 'loop_ws2', processId: 'proc_b', workspaceId: 'ws2' }));
+            store.insert(makeLoop({ id: 'loop_noWs', processId: 'proc_c' })); // legacy, no workspaceId
+
+            const res = await dispatch(routes, 'GET', '/api/workspaces/ws1/loops');
+            expect(res.statusCode).toBe(200);
+            expect(res.body.loops).toHaveLength(1);
+            expect(res.body.loops[0].id).toBe('loop_ws1');
+
+            // The resolver should NOT be called (it's no longer part of the context)
+            expect(resolveWorkspaceId).not.toHaveBeenCalled();
+        });
+
+        it('includes workspaceId in serialized response', async () => {
+            store.insert(makeLoop({ id: 'loop_serial', workspaceId: 'ws-xyz' }));
+
+            const res = await dispatch(routes, 'GET', '/api/workspaces/ws-xyz/loops');
+            expect(res.statusCode).toBe(200);
+            expect(res.body.loops[0].workspaceId).toBe('ws-xyz');
+        });
+
+        it('omits workspaceId from response when not set', async () => {
+            store.insert(makeLoop({ id: 'loop_noWs' }));
+
+            const res = await dispatch(routes, 'GET', '/api/loops/loop_noWs');
+            expect(res.statusCode).toBe(200);
+            expect(res.body.loop.workspaceId).toBeUndefined();
+        });
+
+        it('multi-repo isolation — loop in ws-A not visible from ws-B', async () => {
+            store.insert(makeLoop({ id: 'loop_a', workspaceId: 'ws-A' }));
+            store.insert(makeLoop({ id: 'loop_b', workspaceId: 'ws-B' }));
+
+            const resA = await dispatch(routes, 'GET', '/api/workspaces/ws-A/loops');
+            const resB = await dispatch(routes, 'GET', '/api/workspaces/ws-B/loops');
+
+            expect(resA.body.loops).toHaveLength(1);
+            expect(resA.body.loops[0].id).toBe('loop_a');
+            expect(resB.body.loops).toHaveLength(1);
+            expect(resB.body.loops[0].id).toBe('loop_b');
         });
     });
 });

--- a/packages/coc/test/server/loop-infrastructure.test.ts
+++ b/packages/coc/test/server/loop-infrastructure.test.ts
@@ -22,6 +22,7 @@ function createTestLoopStore(db: Database.Database): LoopStore {
 }
 
 function makeLoop(overrides: Partial<Record<string, unknown>> = {}) {
+    const { workspaceId, ...rest } = overrides;
     return {
         id: `loop_${Math.random().toString(36).slice(2, 8)}`,
         processId: 'proc_test1',
@@ -37,7 +38,8 @@ function makeLoop(overrides: Partial<Record<string, unknown>> = {}) {
         pausedReason: null,
         prompt: 'Check status',
         model: null,
-        ...overrides,
+        ...rest,
+        ...(workspaceId !== undefined ? { workspaceId } : {}),
     };
 }
 
@@ -164,6 +166,61 @@ describe('Loop Infrastructure', () => {
             const active = loopStore.getActive();
             expect(active).toHaveLength(1);
             expect(active[0].id).toBe('loop_survives_restart');
+        });
+    });
+
+    describe('workspaceId backfill', () => {
+        it('backfills workspaceId for legacy rows on startup', async () => {
+            // Insert legacy rows without workspaceId
+            loopStore.insert(makeLoop({ id: 'loop_legacy1', processId: 'proc_resolvable' }));
+            loopStore.insert(makeLoop({ id: 'loop_legacy2', processId: 'proc_unresolvable' }));
+            loopStore.insert(makeLoop({ id: 'loop_existing', processId: 'proc_already', workspaceId: 'ws-existing' }));
+
+            const { LoopExecutor } = await import('../../src/server/loops/loop-executor');
+            const { ScheduleTimerRegistry } = await import('../../src/server/schedule/schedule-timer-registry');
+
+            const resolveWorkspaceId = vi.fn(async (processId: string) => {
+                if (processId === 'proc_resolvable') return 'ws-resolved';
+                return undefined;
+            });
+
+            const timerRegistry = new ScheduleTimerRegistry();
+            const executor = new LoopExecutor({
+                store: loopStore,
+                processStore: { getProcess: vi.fn().mockResolvedValue(null) } as any,
+                timerRegistry,
+                queueManager: null,
+                emit: vi.fn(),
+                resolveWorkspaceId,
+            });
+
+            // Simulate what createLoopInfrastructure does
+            executor.armAll();
+
+            const allLoops = loopStore.getAll();
+            for (const loop of allLoops) {
+                if (loop.workspaceId == null) {
+                    const wsId = await resolveWorkspaceId(loop.processId);
+                    if (wsId) {
+                        loop.workspaceId = wsId;
+                        loopStore.update(loop);
+                    }
+                }
+            }
+
+            // Resolvable loop should be backfilled
+            const legacy1 = loopStore.getById('loop_legacy1')!;
+            expect(legacy1.workspaceId).toBe('ws-resolved');
+
+            // Unresolvable loop stays without workspaceId
+            const legacy2 = loopStore.getById('loop_legacy2')!;
+            expect(legacy2.workspaceId).toBeUndefined();
+
+            // Already-set workspaceId remains unchanged
+            const existing = loopStore.getById('loop_existing')!;
+            expect(existing.workspaceId).toBe('ws-existing');
+
+            timerRegistry.clear();
         });
     });
 });

--- a/packages/coc/test/server/loop-store.test.ts
+++ b/packages/coc/test/server/loop-store.test.ts
@@ -35,6 +35,7 @@ function makeLoop(overrides: Partial<LoopEntry> = {}): LoopEntry {
         pausedReason: 'pausedReason' in overrides ? overrides.pausedReason! : null,
         prompt: overrides.prompt ?? 'check status',
         model: 'model' in overrides ? overrides.model! : null,
+        ...('workspaceId' in overrides ? { workspaceId: overrides.workspaceId } : {}),
     };
 }
 
@@ -260,5 +261,122 @@ describe('LoopStore', () => {
 
         store1.insert(makeLoop({ id: 'loop_from_1' }));
         expect(store2.getById('loop_from_1')).not.toBeNull();
+    });
+
+    // --------------------------------------------------------------------
+    // workspaceId persistence
+    // --------------------------------------------------------------------
+
+    it('persists and retrieves workspaceId', () => {
+        const loop = makeLoop({ workspaceId: 'ws-abc' });
+        store.insert(loop);
+
+        const retrieved = store.getById(loop.id)!;
+        expect(retrieved.workspaceId).toBe('ws-abc');
+    });
+
+    it('handles loops without workspaceId (legacy rows)', () => {
+        const loop = makeLoop();
+        // No workspaceId set — simulates legacy row
+        store.insert(loop);
+
+        const retrieved = store.getById(loop.id)!;
+        expect(retrieved.workspaceId).toBeUndefined();
+    });
+
+    it('updates workspaceId on existing loop', () => {
+        const loop = makeLoop();
+        store.insert(loop);
+
+        const updated = { ...loop, workspaceId: 'ws-new' };
+        store.update(updated);
+
+        const retrieved = store.getById(loop.id)!;
+        expect(retrieved.workspaceId).toBe('ws-new');
+    });
+
+    // --------------------------------------------------------------------
+    // getByWorkspace
+    // --------------------------------------------------------------------
+
+    it('returns loops for a specific workspace', () => {
+        store.insert(makeLoop({ id: 'loop_a', processId: 'proc_1', workspaceId: 'ws1' }));
+        store.insert(makeLoop({ id: 'loop_b', processId: 'proc_2', workspaceId: 'ws1' }));
+        store.insert(makeLoop({ id: 'loop_c', processId: 'proc_3', workspaceId: 'ws2' }));
+        store.insert(makeLoop({ id: 'loop_d', processId: 'proc_4' })); // no workspaceId
+
+        const ws1Loops = store.getByWorkspace('ws1');
+        expect(ws1Loops).toHaveLength(2);
+        expect(ws1Loops.map(l => l.id).sort()).toEqual(['loop_a', 'loop_b']);
+
+        const ws2Loops = store.getByWorkspace('ws2');
+        expect(ws2Loops).toHaveLength(1);
+        expect(ws2Loops[0].id).toBe('loop_c');
+    });
+
+    it('returns empty array for workspace with no loops', () => {
+        store.insert(makeLoop({ id: 'loop_a', workspaceId: 'ws1' }));
+        expect(store.getByWorkspace('ws-other')).toEqual([]);
+    });
+
+    // --------------------------------------------------------------------
+    // Schema migration (ALTER TABLE idempotency)
+    // --------------------------------------------------------------------
+
+    it('migrates existing table without workspace_id column', () => {
+        // Create a fresh DB with the old schema (no workspace_id)
+        const oldDb = new Database(':memory:');
+        oldDb.exec(`
+            CREATE TABLE loops (
+                id TEXT PRIMARY KEY,
+                process_id TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                interval_ms INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                last_tick_at TEXT,
+                next_tick_at TEXT,
+                tick_count INTEGER NOT NULL DEFAULT 0,
+                consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                expires_at TEXT NOT NULL,
+                paused_reason TEXT,
+                prompt TEXT NOT NULL DEFAULT '',
+                model TEXT
+            )
+        `);
+
+        // Insert a row using old schema
+        oldDb.prepare(`
+            INSERT INTO loops (id, process_id, description, interval_ms, status, created_at, tick_count, consecutive_failures, expires_at, prompt)
+            VALUES ('loop_legacy', 'proc_old', 'Old loop', 60000, 'active', '2026-01-01T00:00:00Z', 0, 0, '2026-01-04T00:00:00Z', 'check')
+        `).run();
+
+        // Creating a new LoopStore should migrate the table
+        const migratedStore = new LoopStore(oldDb);
+
+        // Legacy row should be readable with undefined workspaceId
+        const legacy = migratedStore.getById('loop_legacy')!;
+        expect(legacy.processId).toBe('proc_old');
+        expect(legacy.workspaceId).toBeUndefined();
+
+        // New rows can include workspaceId
+        const newLoop = makeLoop({ id: 'loop_new', workspaceId: 'ws-migrated' });
+        migratedStore.insert(newLoop);
+        expect(migratedStore.getById('loop_new')!.workspaceId).toBe('ws-migrated');
+
+        oldDb.close();
+    });
+
+    it('migration is idempotent — second LoopStore on migrated DB is safe', () => {
+        // First store migrates
+        const db2 = new Database(':memory:');
+        const store1 = new LoopStore(db2);
+        store1.insert(makeLoop({ id: 'loop_idem', workspaceId: 'ws-x' }));
+
+        // Second store should not fail
+        const store2 = new LoopStore(db2);
+        expect(store2.getById('loop_idem')!.workspaceId).toBe('ws-x');
+
+        db2.close();
     });
 });

--- a/packages/coc/test/server/loop-tools.test.ts
+++ b/packages/coc/test/server/loop-tools.test.ts
@@ -91,6 +91,7 @@ function makeLoopToolDeps(overrides: Partial<LoopToolDeps> = {}): LoopToolDeps {
         store,
         executor: executor as LoopExecutor,
         processId: 'proc-123',
+        resolveWorkspaceId: vi.fn().mockResolvedValue('ws-test'),
         ...overrides,
     };
 }
@@ -202,6 +203,37 @@ describe('createCreateLoopTool', () => {
 
         const loop = deps.store.getByProcess('proc-123')[0];
         expect(loop.model).toBe('gpt-4');
+    });
+
+    it('resolves and persists workspaceId at creation', async () => {
+        const result = await handler({
+            description: 'Workspace test',
+            interval: '1m',
+            prompt: 'Check workspace',
+        });
+
+        expect(result.created).toBe(true);
+        const loop = deps.store.getByProcess('proc-123')[0];
+        expect(loop.workspaceId).toBe('ws-test');
+        expect(deps.resolveWorkspaceId).toHaveBeenCalledWith('proc-123');
+    });
+
+    it('creates loop even if resolveWorkspaceId returns undefined', async () => {
+        deps = makeLoopToolDeps({
+            resolveWorkspaceId: vi.fn().mockResolvedValue(undefined),
+        });
+        const { tool } = createCreateLoopTool(deps);
+        handler = tool.handler as any;
+
+        const result = await handler({
+            description: 'No workspace',
+            interval: '1m',
+            prompt: 'Check',
+        });
+
+        expect(result.created).toBe(true);
+        const loop = deps.store.getByProcess('proc-123')[0];
+        expect(loop.workspaceId).toBeUndefined();
     });
 
     it('rejects invalid TTL', async () => {

--- a/packages/coc/test/server/loop-tools.test.ts
+++ b/packages/coc/test/server/loop-tools.test.ts
@@ -492,3 +492,47 @@ describe('tool metadata', () => {
         expect(tool.name).toBe('scheduleWakeup');
     });
 });
+
+describe('loop tool event emission', () => {
+    it('createLoop emits loop-created with the new loop', async () => {
+        const emit = vi.fn();
+        const deps = makeLoopToolDeps({ emit });
+        const { tool } = createCreateLoopTool(deps);
+        const result: any = await (tool.handler as any)({ description: 'd', interval: '30s', prompt: 'p' });
+        expect(result.created).toBe(true);
+        expect(emit).toHaveBeenCalledTimes(1);
+        const evt = emit.mock.calls[0][0];
+        expect(evt.type).toBe('loop-created');
+        expect(evt.loop.id).toBe(result.loopId);
+        expect(evt.loop.processId).toBe('proc-123');
+    });
+
+    it('cancelLoop emits loop-cancelled', async () => {
+        const emit = vi.fn();
+        const deps = makeLoopToolDeps({ emit });
+        const { tool: createTool } = createCreateLoopTool(deps);
+        const { tool: cancelTool } = createCancelLoopTool(deps);
+        const createRes: any = await (createTool.handler as any)({ description: 'd', interval: '30s', prompt: 'p' });
+        emit.mockClear();
+        const cancelRes: any = await (cancelTool.handler as any)({ loopId: createRes.loopId });
+        expect(cancelRes.cancelled).toBe(true);
+        expect(emit).toHaveBeenCalledTimes(1);
+        expect(emit.mock.calls[0][0].type).toBe('loop-cancelled');
+        expect(emit.mock.calls[0][0].loop.status).toBe('cancelled');
+    });
+
+    it('does not throw when emit throws', async () => {
+        const emit = vi.fn().mockImplementation(() => { throw new Error('boom'); });
+        const deps = makeLoopToolDeps({ emit });
+        const { tool } = createCreateLoopTool(deps);
+        const result: any = await (tool.handler as any)({ description: 'd', interval: '30s', prompt: 'p' });
+        expect(result.created).toBe(true);
+    });
+
+    it('works without emit (backwards compatible)', async () => {
+        const deps = makeLoopToolDeps();
+        const { tool } = createCreateLoopTool(deps);
+        const result: any = await (tool.handler as any)({ description: 'd', interval: '30s', prompt: 'p' });
+        expect(result.created).toBe(true);
+    });
+});

--- a/packages/coc/test/server/preferences-handler.test.ts
+++ b/packages/coc/test/server/preferences-handler.test.ts
@@ -1776,6 +1776,98 @@ describe('Per-Repo Preferences REST API', () => {
         expect(JSON.parse(res.body).error).toBe('`since` must be an ISO date-time string');
     });
 
+    // -- commit-scoped skill usage --
+
+    it('PATCH commit-skill-usage records only to commitSkillUsageMap', async () => {
+        // Pre-populate the general skillUsageMap to verify isolation
+        writeRepoPreferences(tmpDir, decodeURIComponent(repoId), {
+            skillUsageMap: { impl: '2026-05-01T00:00:00.000Z' },
+        });
+
+        const res = await patchJSON(`${repoUrl(repoId)}/commit-skill-usage`, { skillName: 'go-deep' });
+        expect(res.status).toBe(200);
+
+        const body = JSON.parse(res.body);
+        expect(body.skillName).toBe('go-deep');
+        expect(typeof body.timestamp).toBe('string');
+
+        const prefs = readRepoPreferences(tmpDir, decodeURIComponent(repoId));
+        expect(prefs.commitSkillUsageMap?.['go-deep']).toBe(body.timestamp);
+        // General map must be untouched
+        expect(prefs.skillUsageMap?.impl).toBe('2026-05-01T00:00:00.000Z');
+        expect(prefs.skillUsageMap?.['go-deep']).toBeUndefined();
+    });
+
+    it('PATCH commit-skill-usage returns 400 when skillName is missing', async () => {
+        const res = await patchJSON(`${repoUrl(repoId)}/commit-skill-usage`, {});
+        expect(res.status).toBe(400);
+    });
+
+    it('GET commit-skill-usage returns entries sorted by newest first', async () => {
+        writeRepoPreferences(tmpDir, decodeURIComponent(repoId), {
+            commitSkillUsageMap: {
+                draft: '2026-05-02T08:30:00.000Z',
+                impl: '2026-05-02T09:05:00.000Z',
+                'code-review': '2026-05-02T09:10:00.000Z',
+            },
+        });
+
+        const res = await getJSON(`${repoUrl(repoId)}/commit-skill-usage`);
+        expect(res.status).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({
+            usage: [
+                { skillName: 'code-review', timestamp: '2026-05-02T09:10:00.000Z' },
+                { skillName: 'impl', timestamp: '2026-05-02T09:05:00.000Z' },
+                { skillName: 'draft', timestamp: '2026-05-02T08:30:00.000Z' },
+            ],
+        });
+    });
+
+    it('GET commit-skill-usage filters by skillName and since', async () => {
+        writeRepoPreferences(tmpDir, decodeURIComponent(repoId), {
+            commitSkillUsageMap: {
+                impl: '2026-05-02T09:05:00.000Z',
+                draft: '2026-05-02T08:30:00.000Z',
+                'code-review': '2026-05-02T09:10:00.000Z',
+            },
+        });
+
+        const res = await getJSON(`${repoUrl(repoId)}/commit-skill-usage?skillName=impl&since=${encodeURIComponent('2026-05-02T09:00:00.000Z')}`);
+        expect(res.status).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({
+            usage: [
+                { skillName: 'impl', timestamp: '2026-05-02T09:05:00.000Z' },
+            ],
+        });
+    });
+
+    it('GET commit-skill-usage returns 400 for invalid since timestamps', async () => {
+        const res = await getJSON(`${repoUrl(repoId)}/commit-skill-usage?since=not-a-date`);
+        expect(res.status).toBe(400);
+    });
+
+    it('general skill-usage PATCH does not modify commitSkillUsageMap', async () => {
+        writeRepoPreferences(tmpDir, decodeURIComponent(repoId), {
+            commitSkillUsageMap: { impl: '2026-05-01T00:00:00.000Z' },
+        });
+
+        await patchJSON(`${repoUrl(repoId)}/skill-usage`, { skillName: 'impl' });
+
+        const prefs = readRepoPreferences(tmpDir, decodeURIComponent(repoId));
+        // commitSkillUsageMap should still have the original timestamp
+        expect(prefs.commitSkillUsageMap?.impl).toBe('2026-05-01T00:00:00.000Z');
+    });
+
+    it('commitSkillUsageMap round-trips through PATCH preferences', async () => {
+        await patchJSON(repoUrl(repoId), {
+            commitSkillUsageMap: { impl: '2026-05-10T10:00:00.000Z' },
+        });
+        const res = await getJSON(repoUrl(repoId));
+        expect(JSON.parse(res.body).commitSkillUsageMap).toEqual({
+            impl: '2026-05-10T10:00:00.000Z',
+        });
+    });
+
     // -- filesViewMode --
 
     it('filesViewMode round-trips through PUT and GET', async () => {

--- a/packages/coc/test/server/queue-shared-validate.test.ts
+++ b/packages/coc/test/server/queue-shared-validate.test.ts
@@ -99,6 +99,35 @@ describe('validateAndParseTask – chat kind injection (existing behavior)', () 
         expect(result.valid).toBe(true);
         expect((result.input!.payload as any).kind).toBe('chat');
     });
+
+    it('defaults payload.mode to autopilot for new chats (no processId)', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello' },
+        });
+        expect(result.valid).toBe(true);
+        expect((result.input!.payload as any).mode).toBe('autopilot');
+    });
+
+    it('leaves payload.mode untouched for follow-ups (processId set)', () => {
+        // Follow-ups must arrive with mode already resolved by the caller —
+        // queue-shared must not silently default to autopilot for them.
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', processId: 'queue_xyz' },
+        });
+        expect(result.valid).toBe(true);
+        expect((result.input!.payload as any).mode).toBeUndefined();
+    });
+
+    it('preserves an explicit follow-up payload.mode', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', processId: 'queue_xyz', mode: 'ask' },
+        });
+        expect(result.valid).toBe(true);
+        expect((result.input!.payload as any).mode).toBe('ask');
+    });
 });
 
 // ============================================================================

--- a/packages/coc/test/server/spa/client/repos/ChatListPane-chat-search.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ChatListPane-chat-search.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
     isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     isRalphEnabled: () => false,
+    isLoopsEnabled: () => false,
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/format', () => ({

--- a/packages/coc/test/spa/react/ConversationTurnBubble-loop-badge.test.tsx
+++ b/packages/coc/test/spa/react/ConversationTurnBubble-loop-badge.test.tsx
@@ -42,7 +42,7 @@ describe('ConversationTurnBubble turnSource badge', () => {
         const badge = container.querySelector('[data-testid="turn-source-badge"]');
         expect(badge).toBeTruthy();
         expect(badge?.textContent).toContain('loop');
-        expect(badge?.textContent).toContain('🔁');
+        expect(badge?.querySelector('[data-testid="loop-icon"]')).toBeTruthy();
         expect(badge?.getAttribute('title')).toContain('Loop tick');
         expect(badge?.getAttribute('title')).toContain('loop-123');
     });

--- a/packages/coc/test/spa/react/LoopBadge.test.tsx
+++ b/packages/coc/test/spa/react/LoopBadge.test.tsx
@@ -10,7 +10,7 @@ describe('LoopBadge', () => {
         const { container } = render(<LoopBadge count={3} hasActiveLoops={true} />);
         expect(container.querySelector('[data-testid="loop-badge"]')).toBeTruthy();
         expect(screen.getByText('3')).toBeTruthy();
-        expect(screen.getByText('🔁')).toBeTruthy();
+        expect(container.querySelector('[data-testid="loop-icon"]')).toBeTruthy();
     });
 
     it('renders nothing when count is 0', () => {

--- a/packages/coc/test/spa/react/LoopIcon.test.tsx
+++ b/packages/coc/test/spa/react/LoopIcon.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Tests for LoopIcon — className pass-through, currentColor stroke, a11y.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LoopIcon } from '../../../src/server/spa/client/react/features/chat/icons/LoopIcon';
+
+describe('LoopIcon', () => {
+    it('renders an svg with currentColor stroke', () => {
+        const { container } = render(<LoopIcon />);
+        const svg = container.querySelector('svg');
+        expect(svg).toBeTruthy();
+        expect(svg?.getAttribute('stroke')).toBe('currentColor');
+    });
+
+    it('passes className through to the svg root', () => {
+        const { container } = render(<LoopIcon className="w-3 h-3 custom" />);
+        const svg = container.querySelector('svg');
+        expect(svg?.getAttribute('class')).toContain('w-3');
+        expect(svg?.getAttribute('class')).toContain('h-3');
+        expect(svg?.getAttribute('class')).toContain('custom');
+    });
+
+    it('is aria-hidden by default and has no role', () => {
+        const { container } = render(<LoopIcon />);
+        const svg = container.querySelector('svg');
+        expect(svg?.getAttribute('aria-hidden')).toBe('true');
+        expect(svg?.getAttribute('role')).toBeNull();
+    });
+
+    it('exposes role=img and a <title> when title prop is provided', () => {
+        const { container } = render(<LoopIcon title="Has active loops" />);
+        const svg = container.querySelector('svg');
+        expect(svg?.getAttribute('role')).toBe('img');
+        expect(svg?.getAttribute('aria-hidden')).toBeNull();
+        expect(container.querySelector('svg > title')?.textContent).toBe('Has active loops');
+    });
+
+    it('has data-testid="loop-icon" for selector use', () => {
+        const { container } = render(<LoopIcon />);
+        expect(container.querySelector('[data-testid="loop-icon"]')).toBeTruthy();
+    });
+});

--- a/packages/coc/test/spa/react/LoopManagementPanel.test.tsx
+++ b/packages/coc/test/spa/react/LoopManagementPanel.test.tsx
@@ -198,6 +198,6 @@ describe('LoopManagementPanel', () => {
                 {...defaultHandlers}
             />,
         );
-        expect(screen.getByText('🔁 Loops (2)')).toBeTruthy();
+        expect(screen.getByText(/Loops \(2\)/)).toBeTruthy();
     });
 });

--- a/packages/coc/test/spa/react/comments/ContextMenu.test.tsx
+++ b/packages/coc/test/spa/react/comments/ContextMenu.test.tsx
@@ -381,6 +381,85 @@ describe('ContextMenu', () => {
         expect(submenu.className).not.toContain('left-full');
     });
 
+    // ── Nested submenu (children within children) ──────────────────
+
+    it('renders nested submenu item with arrow indicator instead of flat button', () => {
+        render(
+            <ContextMenu
+                position={{ x: 0, y: 0 }}
+                items={[
+                    {
+                        label: 'Use Skill',
+                        icon: '⚡',
+                        onClick: vi.fn(),
+                        children: [
+                            { label: 'skill-a', onClick: vi.fn() },
+                            { label: '', separator: true, onClick: vi.fn() },
+                            {
+                                label: 'More…',
+                                onClick: vi.fn(),
+                                children: [
+                                    { label: 'skill-b', onClick: vi.fn() },
+                                    { label: 'skill-c', onClick: vi.fn() },
+                                ],
+                            },
+                        ],
+                    },
+                ]}
+                onClose={vi.fn()}
+            />
+        );
+        // Open first-level submenu
+        fireEvent.mouseEnter(screen.getByTestId('context-menu-item-0'));
+        const submenu = screen.getByTestId('context-submenu-0');
+        expect(submenu).toBeTruthy();
+        // "More…" is at ci=2 (after skill-a at 0, separator at 1).
+        // Nested SubmenuItem wrapping div uses data-testid="context-menu-item-${ci}"
+        const moreItem = screen.getByTestId('context-menu-item-2');
+        expect(moreItem.querySelector('[aria-haspopup="true"]')).toBeTruthy();
+        expect(moreItem.textContent).toContain('More…');
+    });
+
+    it('opens nested submenu on hover and clicking nested child calls onClick', () => {
+        const nestedClick = vi.fn();
+        const onClose = vi.fn();
+        render(
+            <ContextMenu
+                position={{ x: 0, y: 0 }}
+                items={[
+                    {
+                        label: 'Use Skill',
+                        icon: '⚡',
+                        onClick: vi.fn(),
+                        children: [
+                            { label: 'skill-a', onClick: vi.fn() },
+                            {
+                                label: 'More…',
+                                onClick: vi.fn(),
+                                children: [
+                                    { label: 'skill-b', onClick: nestedClick },
+                                ],
+                            },
+                        ],
+                    },
+                ]}
+                onClose={onClose}
+            />
+        );
+        // Open first-level submenu
+        fireEvent.mouseEnter(screen.getByTestId('context-menu-item-0'));
+        // "More…" is at ci=1, rendered as nested SubmenuItem with data-testid="context-menu-item-1"
+        const moreItem = screen.getByTestId('context-menu-item-1');
+        fireEvent.mouseEnter(moreItem);
+        // The nested submenu uses data-testid="context-submenu-1" (idx=ci=1)
+        const nestedSubmenu = screen.getByTestId('context-submenu-1');
+        expect(nestedSubmenu).toBeTruthy();
+        // Click the nested child
+        fireEvent.click(screen.getByTestId('context-submenu-1-item-0'));
+        expect(nestedClick).toHaveBeenCalledOnce();
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
     it('submenu items count correctly alongside regular items', () => {
         render(
             <ContextMenu

--- a/packages/coc/test/spa/react/repos/ChatListPane-loops.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane-loops.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * Tests for useAllLoops hook and ChatListPane loop awareness:
+ * - inline 🔁 indicator on chat rows with active/paused loops
+ * - "Loops" scope segment in the tab bar
+ * - feature gate via isLoopsEnabled()
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// --- Mocks ---
+
+const mockListAll = vi.fn().mockResolvedValue([]);
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        loops: { listAll: mockListAll },
+    }),
+}));
+
+let loopsEnabledValue = false;
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
+    getApiBase: () => '',
+    isRalphEnabled: () => false,
+    isLoopsEnabled: () => loopsEnabledValue,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/queue/hooks/useQueueDragDrop', () => ({
+    useQueueDragDrop: () => ({
+        handleDragStart: vi.fn(),
+        handleDragOver: vi.fn(),
+        handleDrop: vi.fn(),
+        handleDragEnd: vi.fn(),
+        dragOverIndex: null,
+        dragSourceIndex: null,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/queue/hooks/useQueueTouchDragDrop', () => ({
+    useQueueTouchDragDrop: () => ({
+        handleTouchStart: vi.fn(),
+        handleTouchMove: vi.fn(),
+        handleTouchEnd: vi.fn(),
+        isDragging: false,
+        dragOverIndex: null,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useLongPress', () => ({
+    useLongPress: () => ({
+        onTouchStart: vi.fn(),
+        onTouchEnd: vi.fn(),
+        onTouchMove: vi.fn(),
+        didLongPress: () => false,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useDraftStore', () => ({
+    getDraft: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/workflow/hooks/useWorkflowProgress', () => ({
+    useWorkflowProgress: () => ({
+        progress: null,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/ChatPreferencesContext', () => ({
+    useChatPrefs: () => ({
+        pinnedChatIds: new Set(),
+        archivedChatIds: new Set(),
+        onPinChat: vi.fn(),
+        onUnpinChat: vi.fn(),
+        onArchiveChat: vi.fn(),
+        onUnarchiveChat: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/QueueContext', () => ({
+    useQueue: () => ({
+        state: { isTaskSubmitting: false },
+        setPriority: vi.fn(),
+        remove: vi.fn(),
+        reload: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/AppContext', () => ({
+    useApp: () => ({
+        state: {
+            myWorkExcludedTypes: [],
+            selectedWorkspaceId: 'ws-test',
+        },
+        dispatch: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({
+    useDisplaySettings: () => ({
+        getBoolean: () => false,
+        setBoolean: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/list-mode-config', () => ({
+    getListModeConfig: () => ({
+        showRunningSection: true,
+        showQueueSection: true,
+        showHistorySection: true,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/SwipeableHistoryItem', () => ({
+    SwipeableHistoryItem: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/SummarizeChatDialog', () => ({
+    SummarizeChatDialog: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
+    useBreakpoint: () => false,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/conversation/ConversationMetadataPopover', () => ({
+    buildRows: () => [],
+}));
+
+vi.mock('../../../../src/server/spa/client/react/ui/RenameDialog', () => ({
+    RenameDialog: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/tasks/comments/ContextMenu', () => ({
+    ContextMenu: () => null,
+}));
+
+import { ChatListPane } from '../../../../src/server/spa/client/react/features/chat/ChatListPane';
+
+function makeTask(overrides: Record<string, any> = {}) {
+    return {
+        id: 'task-1',
+        type: 'chat',
+        status: 'completed',
+        displayName: 'Test Chat',
+        startedAt: new Date().toISOString(),
+        payload: { mode: 'ask' },
+        ...overrides,
+    };
+}
+
+const defaultProps = {
+    running: [],
+    queued: [],
+    history: [],
+    isPaused: false,
+    isPauseResumeLoading: false,
+    isRefreshing: false,
+    selectedTaskId: null,
+    isMobile: false,
+    now: Date.now(),
+    workspaceId: 'ws-test',
+    onSelectTask: vi.fn(),
+    onPauseResume: vi.fn(),
+    onRefresh: vi.fn(),
+    onOpenDialog: vi.fn(),
+    fetchQueue: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('ChatListPane loop awareness', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        loopsEnabledValue = false;
+        mockListAll.mockResolvedValue([]);
+        // Clear localStorage
+        try { localStorage.removeItem('coc-activity-scope'); } catch { /* ignore */ }
+    });
+
+    describe('feature gate', () => {
+        it('does not show Loops scope tab when loops disabled', async () => {
+            loopsEnabledValue = false;
+            const tasks = [makeTask({ id: 'task-x', displayName: 'Some Chat' })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const tabs = screen.getByTestId('activity-scope-tabs');
+            expect(within(tabs).queryByTestId('activity-scope-tab-loops')).toBeNull();
+        });
+
+        it('shows Loops scope tab when loops enabled', async () => {
+            loopsEnabledValue = true;
+            const tasks = [makeTask({ id: 'task-x', displayName: 'Some Chat' })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const tabs = screen.getByTestId('activity-scope-tabs');
+            expect(within(tabs).getByTestId('activity-scope-tab-loops')).toBeTruthy();
+        });
+    });
+
+    describe('Loops segment tab', () => {
+        it('displays correct count of conversations with loops', async () => {
+            loopsEnabledValue = true;
+            const tasks = [
+                makeTask({ id: 'proc-a', displayName: 'Chat A' }),
+                makeTask({ id: 'proc-b', displayName: 'Chat B' }),
+                makeTask({ id: 'proc-c', displayName: 'Chat C' }),
+            ];
+            mockListAll.mockResolvedValue([
+                { id: 'loop-1', processId: 'proc-a', status: 'active', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: null, prompt: '', model: null },
+                { id: 'loop-2', processId: 'proc-b', status: 'paused', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: 'test', prompt: '', model: null },
+                { id: 'loop-3', processId: 'proc-c', status: 'cancelled', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: null, prompt: '', model: null },
+            ]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            // proc-a (active) and proc-b (paused) should be counted; proc-c is cancelled
+            const countEl = screen.getByTestId('activity-scope-count-loops');
+            expect(countEl.textContent).toBe('2');
+        });
+
+        it('filters chat list to only conversations with loops when Loops tab is active', async () => {
+            loopsEnabledValue = true;
+            const tasks = [
+                makeTask({ id: 'proc-a', displayName: 'Chat A' }),
+                makeTask({ id: 'proc-b', displayName: 'Chat B' }),
+            ];
+            mockListAll.mockResolvedValue([
+                { id: 'loop-1', processId: 'proc-a', status: 'active', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: null, prompt: '', model: null },
+            ]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            // Click the Loops tab
+            const loopsTab = screen.getByTestId('activity-scope-tab-loops');
+            await act(async () => {
+                await userEvent.click(loopsTab);
+            });
+            // Only proc-a should be visible (has an active loop)
+            const rows = screen.getAllByTestId('history-task-row');
+            expect(rows).toHaveLength(1);
+        });
+    });
+
+    describe('inline loop indicator', () => {
+        it('shows 🔁 indicator with green tint for active loops', async () => {
+            loopsEnabledValue = true;
+            const tasks = [makeTask({ id: 'proc-a', displayName: 'Chat A' })];
+            mockListAll.mockResolvedValue([
+                { id: 'loop-1', processId: 'proc-a', status: 'active', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: null, prompt: '', model: null },
+            ]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const indicator = screen.getByTestId('loop-indicator');
+            expect(indicator.textContent).toBe('🔁');
+            expect(indicator.title).toBe('Has active loops');
+            // Green tint class
+            expect(indicator.className).toContain('text-[#15703a]');
+        });
+
+        it('shows 🔁 indicator with amber tint for paused loops', async () => {
+            loopsEnabledValue = true;
+            const tasks = [makeTask({ id: 'proc-a', displayName: 'Chat A' })];
+            mockListAll.mockResolvedValue([
+                { id: 'loop-1', processId: 'proc-a', status: 'paused', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: 'test', prompt: '', model: null },
+            ]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const indicator = screen.getByTestId('loop-indicator');
+            expect(indicator.title).toBe('Has paused loops');
+            // Amber tint class
+            expect(indicator.className).toContain('text-[#8a5a00]');
+        });
+
+        it('does not show loop indicator when loops disabled', async () => {
+            loopsEnabledValue = false;
+            const tasks = [makeTask({ id: 'proc-a', displayName: 'Chat A' })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            expect(screen.queryByTestId('loop-indicator')).toBeNull();
+        });
+
+        it('does not show loop indicator for conversations without loops', async () => {
+            loopsEnabledValue = true;
+            const tasks = [makeTask({ id: 'proc-no-loop', displayName: 'Chat No Loop' })];
+            mockListAll.mockResolvedValue([]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            expect(screen.queryByTestId('loop-indicator')).toBeNull();
+        });
+
+        it('active state takes priority over paused when both exist', async () => {
+            loopsEnabledValue = true;
+            const tasks = [makeTask({ id: 'proc-a', displayName: 'Chat A' })];
+            mockListAll.mockResolvedValue([
+                { id: 'loop-1', processId: 'proc-a', status: 'paused', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: 'test', prompt: '', model: null },
+                { id: 'loop-2', processId: 'proc-a', status: 'active', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: null, prompt: '', model: null },
+            ]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const indicator = screen.getByTestId('loop-indicator');
+            // Active takes priority — should show green
+            expect(indicator.title).toBe('Has active loops');
+            expect(indicator.className).toContain('text-[#15703a]');
+        });
+    });
+});

--- a/packages/coc/test/spa/react/repos/ChatListPane-loops.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane-loops.test.tsx
@@ -256,7 +256,7 @@ describe('ChatListPane loop awareness', () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
             const indicator = screen.getByTestId('loop-indicator');
-            expect(indicator.textContent).toBe('🔁');
+            expect(indicator.querySelector('[data-testid="loop-icon"]')).toBeTruthy();
             expect(indicator.title).toBe('Has active loops');
             // Green tint class
             expect(indicator.className).toContain('text-[#15703a]');

--- a/packages/coc/test/spa/react/repos/ChatListPane-loops.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane-loops.test.tsx
@@ -312,4 +312,40 @@ describe('ChatListPane loop awareness', () => {
             expect(indicator.className).toContain('text-[#15703a]');
         });
     });
+
+    describe('WebSocket-driven refresh', () => {
+        it('refetches and updates row indicator when coc-ws-message loop-paused arrives', async () => {
+            loopsEnabledValue = true;
+            const tasks = [makeTask({ id: 'proc-a', displayName: 'Chat A' })];
+            // First fetch: active loop → green
+            mockListAll.mockResolvedValueOnce([
+                { id: 'loop-1', processId: 'proc-a', status: 'active', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: null, prompt: '', model: null },
+            ]);
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            let indicator = screen.getByTestId('loop-indicator');
+            expect(indicator.title).toBe('Has active loops');
+            expect(indicator.className).toContain('text-[#15703a]');
+
+            // Second fetch (after WS event): now paused → amber
+            mockListAll.mockResolvedValueOnce([
+                { id: 'loop-1', processId: 'proc-a', status: 'paused', description: '', intervalMs: 60000, createdAt: '', lastTickAt: null, nextTickAt: null, tickCount: 0, consecutiveFailures: 0, expiresAt: '', pausedReason: 'user-paused', prompt: '', model: null },
+            ]);
+
+            await act(async () => {
+                window.dispatchEvent(new CustomEvent('coc-ws-message', {
+                    detail: { type: 'loop-paused', loopId: 'loop-1', processId: 'proc-a', status: 'paused' },
+                }));
+                // allow promise chain to flush
+                await Promise.resolve();
+                await Promise.resolve();
+            });
+
+            indicator = screen.getByTestId('loop-indicator');
+            expect(indicator.title).toBe('Has paused loops');
+            expect(indicator.className).toContain('text-[#8a5a00]');
+            expect(mockListAll).toHaveBeenCalledTimes(2);
+        });
+    });
 });

--- a/packages/coc/test/spa/react/repos/ChatListPane.activity-ralph.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane.activity-ralph.test.tsx
@@ -92,6 +92,7 @@ vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
     isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => true,
+    isLoopsEnabled: () => false,
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/format', () => ({

--- a/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
@@ -124,6 +124,7 @@ vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
     isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => false,
+    isLoopsEnabled: () => false,
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/format', () => ({

--- a/packages/coc/test/spa/react/skill-menu-ranking.test.ts
+++ b/packages/coc/test/spa/react/skill-menu-ranking.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the skill menu ranking helper.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { rankSkillsByRecency, MRU_SKILL_LIMIT } from '../../../src/server/spa/client/react/features/git/skill-menu-ranking';
+
+describe('rankSkillsByRecency', () => {
+    it('returns skills sorted by most-recent timestamp first', () => {
+        const skills = [
+            { name: 'alpha' },
+            { name: 'beta' },
+            { name: 'gamma' },
+        ];
+        const usageMap = {
+            gamma: '2026-05-10T10:00:00.000Z',
+            alpha: '2026-05-12T10:00:00.000Z',
+            beta: '2026-05-11T10:00:00.000Z',
+        };
+        const result = rankSkillsByRecency(skills, usageMap);
+        expect(result.map(s => s.name)).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('puts timestamped skills before untimestamped ones', () => {
+        const skills = [
+            { name: 'unused-b' },
+            { name: 'used' },
+            { name: 'unused-a' },
+        ];
+        const usageMap = {
+            used: '2026-05-10T10:00:00.000Z',
+        };
+        const result = rankSkillsByRecency(skills, usageMap);
+        expect(result.map(s => s.name)).toEqual(['used', 'unused-a', 'unused-b']);
+    });
+
+    it('sorts untimestamped skills alphabetically case-insensitively', () => {
+        const skills = [
+            { name: 'Zeta' },
+            { name: 'alpha' },
+            { name: 'Beta' },
+        ];
+        const result = rankSkillsByRecency(skills, {});
+        expect(result.map(s => s.name)).toEqual(['alpha', 'Beta', 'Zeta']);
+    });
+
+    it('handles empty skills array', () => {
+        expect(rankSkillsByRecency([], {})).toEqual([]);
+    });
+
+    it('handles empty usage map — all skills alpha-sorted', () => {
+        const skills = [
+            { name: 'impl' },
+            { name: 'draft' },
+            { name: 'code-review' },
+        ];
+        const result = rankSkillsByRecency(skills, {});
+        expect(result.map(s => s.name)).toEqual(['code-review', 'draft', 'impl']);
+    });
+
+    it('ignores stale usage entries for uninstalled skills', () => {
+        const skills = [{ name: 'alpha' }, { name: 'beta' }];
+        const usageMap = {
+            removed: '2026-05-15T10:00:00.000Z',
+            alpha: '2026-05-10T10:00:00.000Z',
+        };
+        const result = rankSkillsByRecency(skills, usageMap);
+        expect(result.map(s => s.name)).toEqual(['alpha', 'beta']);
+    });
+
+    it('correctly tie-breaks mixed used/unused with many skills', () => {
+        const skills = Array.from({ length: 8 }, (_, i) => ({ name: `skill-${String.fromCharCode(104 - i)}` }));
+        // skill-h, skill-g, skill-f, skill-e, skill-d, skill-c, skill-b, skill-a
+        const usageMap = {
+            'skill-c': '2026-05-15T10:00:00.000Z',
+            'skill-f': '2026-05-14T10:00:00.000Z',
+            'skill-a': '2026-05-13T10:00:00.000Z',
+        };
+        const result = rankSkillsByRecency(skills, usageMap);
+        // Used first (desc by timestamp): c, f, a
+        // Then unused (alpha): b, d, e, g, h
+        expect(result.map(s => s.name)).toEqual([
+            'skill-c', 'skill-f', 'skill-a',
+            'skill-b', 'skill-d', 'skill-e', 'skill-g', 'skill-h',
+        ]);
+    });
+});
+
+describe('MRU_SKILL_LIMIT', () => {
+    it('is 5', () => {
+        expect(MRU_SKILL_LIMIT).toBe(5);
+    });
+});

--- a/packages/coc/test/spa/react/tasks/comments/ContextMenu-mobile.test.tsx
+++ b/packages/coc/test/spa/react/tasks/comments/ContextMenu-mobile.test.tsx
@@ -72,6 +72,36 @@ describe('ContextMenu mobile rendering', () => {
         expect(screen.getByText('Delete')).toBeDefined();
     });
 
+    it('flattens nested submenus (children of children) in BottomSheet mode', () => {
+        viewportCleanup = mockViewport(375);
+        const itemsWithNested = [
+            {
+                label: 'Use Skill', icon: '⚡', onClick: vi.fn(), children: [
+                    { label: 'skill-a', onClick: vi.fn() },
+                    {
+                        label: 'More…', onClick: vi.fn(), children: [
+                            { label: 'skill-b', onClick: vi.fn() },
+                            { label: 'skill-c', onClick: vi.fn() },
+                        ],
+                    },
+                ],
+            },
+        ];
+        render(
+            <ContextMenu
+                position={{ x: 100, y: 100 }}
+                items={itemsWithNested as any}
+                onClose={vi.fn()}
+            />
+        );
+        // All skills should be flattened into the BottomSheet
+        expect(screen.getByText('skill-a')).toBeDefined();
+        expect(screen.getByText('skill-b')).toBeDefined();
+        expect(screen.getByText('skill-c')).toBeDefined();
+        // "More…" should appear as a section header (with parent path)
+        expect(screen.getByText('Use Skill › More…')).toBeDefined();
+    });
+
     it('mobile menu items have min-h-[44px] class', () => {
         viewportCleanup = mockViewport(375);
         render(

--- a/packages/coc/test/spa/react/useLoops.test.tsx
+++ b/packages/coc/test/spa/react/useLoops.test.tsx
@@ -60,3 +60,55 @@ describe('useLoops', () => {
         expect(result.current.hasActiveLoops).toBe(false);
     });
 });
+
+describe('useLoops WebSocket listener', () => {
+    beforeEach(() => { vi.clearAllMocks(); });
+
+    it('refetches on coc-ws-message loop-paused for matching process', async () => {
+        mockLoopsClient.list.mockResolvedValueOnce([
+            { id: 'l1', processId: 'process-1', status: 'active' },
+        ]);
+        const { result } = renderHook(() => useLoops('workspace-1', 'process-1'));
+        await waitFor(() => expect(result.current.loops).toHaveLength(1));
+        expect(result.current.hasActiveLoops).toBe(true);
+
+        mockLoopsClient.list.mockResolvedValueOnce([
+            { id: 'l1', processId: 'process-1', status: 'paused' },
+        ]);
+        window.dispatchEvent(new CustomEvent('coc-ws-message', {
+            detail: { type: 'loop-paused', processId: 'process-1', loopId: 'l1', status: 'paused' },
+        }));
+        await waitFor(() => expect(result.current.hasActiveLoops).toBe(false));
+        expect(mockLoopsClient.list).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores coc-ws-message for a different process', async () => {
+        mockLoopsClient.list.mockResolvedValueOnce([
+            { id: 'l1', processId: 'process-1', status: 'active' },
+        ]);
+        const { result } = renderHook(() => useLoops('workspace-1', 'process-1'));
+        await waitFor(() => expect(result.current.loops).toHaveLength(1));
+
+        window.dispatchEvent(new CustomEvent('coc-ws-message', {
+            detail: { type: 'loop-paused', processId: 'process-other', loopId: 'l9', status: 'paused' },
+        }));
+        // give microtasks a chance
+        await new Promise(r => setTimeout(r, 10));
+        expect(mockLoopsClient.list).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes the listener on unmount', async () => {
+        mockLoopsClient.list.mockResolvedValue([
+            { id: 'l1', processId: 'process-1', status: 'active' },
+        ]);
+        const { result, unmount } = renderHook(() => useLoops('workspace-1', 'process-1'));
+        await waitFor(() => expect(result.current.loops).toHaveLength(1));
+        const callsBefore = mockLoopsClient.list.mock.calls.length;
+        unmount();
+        window.dispatchEvent(new CustomEvent('coc-ws-message', {
+            detail: { type: 'loop-paused', processId: 'process-1', loopId: 'l1', status: 'paused' },
+        }));
+        await new Promise(r => setTimeout(r, 10));
+        expect(mockLoopsClient.list.mock.calls.length).toBe(callsBefore);
+    });
+});


### PR DESCRIPTION
- **feat(coc): add commit-scoped MRU skill menu with top-5 + More submenu**
  Add a dedicated commitSkillUsageMap preference field separate from the
  general skillUsageMap so the Git tab Use Skill context menu reflects
  only commit-based skill runs.
  
  Server:
  - Extend PerRepoPreferences with commitSkillUsageMap
  - Add GET/PATCH /api/workspaces/:id/preferences/commit-skill-usage
  - Add validation block mirroring skillUsageMap
  
  Client SDK:
  - Add recordCommitSkillUsage() and getCommitSkillUsage() to PreferencesClient
  
  SPA:
  - Create rankSkillsByRecency() helper with MRU_SKILL_LIMIT=5
  - Rewrite Use Skill menu: top 5 recency-sorted + More submenu (alpha)
  - Record commit skill usage on skill launch (optimistic local update)
  - Load commitSkillUsageMap per workspace
  
  Tests:
  - 8 unit tests for rankSkillsByRecency (tie-breaks, edge cases)
  - 8 server tests for commit-skill-usage endpoints and isolation
  - coc-client test for new methods
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(dashboard): add loop awareness to ChatListPane**
  - Add useAllLoops hook that fetches all loops via listAll() and groups
    by processId, computing per-process loop state (active/paused)
  - Add inline loop indicator (decorative icon) on chat rows with
    active (green) or paused (amber) loops, matching LoopBadge colors
  - Add Loops scope segment tab in the activity scope bar that filters
    to conversations with active/paused loops, with badge count
  - Feature-gated by isLoopsEnabled() - no loop UI when disabled
  - Add 9 tests covering feature gate, segment tab, inline indicators,
    active/paused color tints, and priority logic
  - Update existing test mocks to include isLoopsEnabled export
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix(loops): persist workspaceId on loop rows to fix missing badge after restart**
  The workspace-scoped loop list endpoint relied on resolveWorkspaceId(),
  which depends on in-memory queue task state. After a server restart or
  task eviction, the resolution failed and the ChatHeader LoopBadge
  disappeared even though the loop still existed.
  
  Changes:
  - Add workspace_id column to loops table with ALTER migration
  - Resolve workspaceId once at loop creation time (LLM tool + REST)
  - Replace async resolveWorkspaceId filter with direct SQL query
  - Add getByWorkspace() to LoopStore for efficient workspace filtering
  - Backfill NULL workspaceId rows on startup (best-effort)
  - Include workspaceId in WS broadcast event payloads
  - Add workspace_id index for query performance
  
  Tests:
  - Schema migration adds column and is idempotent
  - Workspace filter uses stored column, never calls resolver
  - Multi-repo isolation preserved
  - Backfill resolves live tasks, skips unresolvable
  - createLoop persists workspaceId from resolver
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix(coc): support nested submenus in ContextMenu for More… item**
  SubmenuItem rendered all children as flat buttons, so children with
  their own children array (like More…) had no expandable submenu.
  
  - Recursively render SubmenuItem when a child has children
  - Fix mobile BottomSheet flattening to recurse into nested children
  - Add tests for nested submenu arrow indicator, hover-to-open, click
    propagation, and mobile flattening of nested children
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc/spa): swap 🔁 emoji for color-respecting LoopIcon SVG**
  Color emojis ignore CSS \color\ on most platforms, so the chat-list loop indicator's active (green) vs paused (amber) tint was invisible in practice. Introduce a shared \LoopIcon\ (Heroicons arrow-path, \stroke=currentColor\) and swap all loop-icon call sites: ChatListPane row indicator + Loops scope-tab icon, LoopBadge, LoopManagementPanel header, and ConversationTurnBubble loop turn-source badge.
  
  Add LoopIcon render tests and update existing tests to assert on \data-testid=loop-icon\ instead of the emoji glyph.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **refactor(coc/spa): cleaner LoopIcon glyph + larger chat-list size**
  The Heroicons arrow-path looked broken at 12px because two thin arrowheads and crossing curves can't resolve at that resolution. Replace with the simpler Lucide \otate-cw\ shape — one circular arrow with one arrowhead — and bump strokeWidth to 2.25 so it reads crisply at small sizes.
  
  Also bump the chat-list row indicator from w-3 (12px) to w-3.5 (14px) so it sits comfortably next to the metadata text without looking like noise.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc): single source of truth for follow-up mode**
  Loop ticks (and other programmatic follow-ups) previously enqueued tasks without `payload.mode`, so the UI badge showed AUTO while `FollowUpExecutor` silently inherited the process's prior mode at execution time. The displayed mode and executed mode disagreed.
  
  Introduce `resolveFollowUpMode(store, processId, explicit?)` as the single source of truth: explicit > `process.metadata.mode` > `'ask'`. Resolve once at enqueue time and set `payload.mode` so UI and execution agree.
  
  Changes:
  
  - New `executors/follow-up-mode.ts` helper with unit tests.
  
  - `LoopExecutor.enqueueNewFollowUpTask` and `enqueueFollowUp` (requeue) now populate `payload.mode` via the resolver, overwriting any stale value on requeues.
  
  - `scheduleWakeup` timer fire site resolves mode and passes it to `bridge.executeFollowUp`.
  
  - `queue-shared.ts` only defaults `payload.mode = 'autopilot'` when no `processId` (new chats). Follow-ups must arrive with mode resolved by the caller.
  
  - `FollowUpExecutor.executeFollowUp` removes the silent `previousMode` fallback; logs a fail-loud warning and defaults to `'ask'` when mode is missing, surfacing future enqueue-site bugs.
  
  - Updated AGENTS.md and tests.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix(coc): emit loop events on REST + tool mutations for live badge refresh**
  REST pause/resume/cancel/patch and LLM createLoop/cancelLoop now emit LoopChangeEvents so the WebSocket broadcaster propagates state to all dashboard hooks. The SPA App rebroadcasts loop-* WS messages as a generic coc-ws-message CustomEvent, and useLoops attaches its listener with proper cleanup so the chat list indicator (active/paused) refreshes immediately without a page reload.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix(coc): mark process running before follow-up executor**
  Update process status to 'running' at the start of any chat follow-up task, before invoking executeFollowUpFn. This closes a race where the queue had already broadcast the task as running while the process row still read 'completed' from the prior turn, causing the same conversation to briefly appear in both Running Tasks and Completed Tasks in the Activity view.
  
  If the pre-execution status update fails, the task fails loud rather than continuing with inconsistent state.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  