### PR TITLE
feat(coc): add tunnel ID field to Add Agent dialog

### DIFF
--- a/packages/coc/src/server/spa/client/react/repos/AddAgentDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/AddAgentDialog.tsx
@@ -8,14 +8,25 @@ import { Dialog, Button } from '../ui';
 interface AddAgentDialogProps {
     open: boolean;
     onClose: () => void;
-    onAdd: (address: string, name?: string) => Promise<any>;
+    onAdd: (address: string, name?: string, tunnelId?: string) => Promise<any>;
+}
+
+function isDevTunnelAddress(address: string): boolean {
+    try {
+        return new URL(address).hostname.endsWith('.devtunnels.ms');
+    } catch {
+        return false;
+    }
 }
 
 export function AddAgentDialog({ open, onClose, onAdd }: AddAgentDialogProps) {
     const [address, setAddress] = useState('');
     const [name, setName] = useState('');
+    const [tunnelId, setTunnelId] = useState('');
     const [adding, setAdding] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const showTunnelId = isDevTunnelAddress(address);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -23,9 +34,10 @@ export function AddAgentDialog({ open, onClose, onAdd }: AddAgentDialogProps) {
         setAdding(true);
         setError(null);
         try {
-            await onAdd(address.trim(), name.trim() || undefined);
+            await onAdd(address.trim(), name.trim() || undefined, tunnelId.trim() || undefined);
             setAddress('');
             setName('');
+            setTunnelId('');
             onClose();
         } catch (err) {
             setError(err instanceof Error ? err.message : String(err));
@@ -60,6 +72,21 @@ export function AddAgentDialog({ open, onClose, onAdd }: AddAgentDialogProps) {
                         onChange={e => setName(e.target.value)}
                     />
                 </label>
+                {showTunnelId && (
+                    <label className="text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc]">
+                        Tunnel ID
+                        <input
+                            type="text"
+                            className="mt-1 w-full h-8 px-2 text-xs rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] outline-none focus:border-[#0078d4] font-mono"
+                            placeholder="e.g. amusing-book-s4hcgw2.usw2"
+                            value={tunnelId}
+                            onChange={e => setTunnelId(e.target.value)}
+                        />
+                        <span className="text-[10px] text-[#6e6e6e] dark:text-[#888888] block mt-0.5">
+                            For server-side auth (no browser popup). Run <code>devtunnel list</code> to find it.
+                        </span>
+                    </label>
+                )}
                 {error && (
                     <div className="text-xs text-[#f14c4c] bg-[#f14c4c]/10 rounded px-2 py-1">{error}</div>
                 )}

--- a/packages/coc/test/spa/react/repos/AddAgentDialog.test.tsx
+++ b/packages/coc/test/spa/react/repos/AddAgentDialog.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Tests for AddAgentDialog — form fields, conditional tunnel ID, onAdd wiring.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { AddAgentDialog } from '../../../../src/server/spa/client/react/repos/AddAgentDialog';
+
+function renderDialog(props: Partial<Parameters<typeof AddAgentDialog>[0]> = {}) {
+    const onClose = vi.fn();
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    render(
+        <AddAgentDialog
+            open={true}
+            onClose={onClose}
+            onAdd={onAdd}
+            {...props}
+        />
+    );
+    return { onClose, onAdd };
+}
+
+function addressInput() {
+    return screen.getByPlaceholderText('http://localhost:4000') as HTMLInputElement;
+}
+
+function nameInput() {
+    return screen.getByPlaceholderText('My Agent') as HTMLInputElement;
+}
+
+function tunnelInput() {
+    return screen.queryByPlaceholderText(/amusing-book/i) as HTMLInputElement | null;
+}
+
+function submitButton() {
+    return screen.getByRole('button', { name: /add agent/i });
+}
+
+describe('AddAgentDialog — initial render', () => {
+    it('renders the address and name fields', () => {
+        renderDialog();
+        expect(addressInput()).toBeTruthy();
+        expect(nameInput()).toBeTruthy();
+    });
+
+    it('does not show tunnel ID field for a non-devtunnel address', () => {
+        renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000' } });
+        expect(tunnelInput()).toBeNull();
+    });
+
+    it('does not render when open=false', () => {
+        render(
+            <AddAgentDialog open={false} onClose={vi.fn()} onAdd={vi.fn().mockResolvedValue(undefined)} />
+        );
+        expect(screen.queryByPlaceholderText('http://localhost:4000')).toBeNull();
+    });
+});
+
+describe('AddAgentDialog — conditional tunnel ID field', () => {
+    it('shows tunnel ID field when address ends with .devtunnels.ms', () => {
+        renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'https://my-tunnel.devtunnels.ms' } });
+        expect(tunnelInput()).toBeTruthy();
+    });
+
+    it('shows hint text alongside the tunnel ID field', () => {
+        renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'https://my-tunnel.devtunnels.ms' } });
+        expect(screen.getByText(/server-side auth/i)).toBeTruthy();
+    });
+
+    it('hides tunnel ID field when address is changed back to a non-devtunnel URL', () => {
+        renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'https://my-tunnel.devtunnels.ms' } });
+        expect(tunnelInput()).toBeTruthy();
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000' } });
+        expect(tunnelInput()).toBeNull();
+    });
+
+    it('does not show tunnel ID field for a URL that merely contains devtunnels.ms as a path', () => {
+        renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000/devtunnels.ms' } });
+        expect(tunnelInput()).toBeNull();
+    });
+});
+
+describe('AddAgentDialog — onAdd callback', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('calls onAdd with trimmed address and no name/tunnelId when only address is provided', async () => {
+        const { onAdd } = renderDialog();
+        fireEvent.change(addressInput(), { target: { value: '  http://localhost:4000  ' } });
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() => expect(onAdd).toHaveBeenCalledWith('http://localhost:4000', undefined, undefined));
+    });
+
+    it('calls onAdd with name when name field is filled', async () => {
+        const { onAdd } = renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000' } });
+        fireEvent.change(nameInput(), { target: { value: 'My Agent' } });
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() => expect(onAdd).toHaveBeenCalledWith('http://localhost:4000', 'My Agent', undefined));
+    });
+
+    it('calls onAdd with tunnelId when address is a devtunnel URL and tunnelId is filled', async () => {
+        const { onAdd } = renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'https://my-tunnel.devtunnels.ms' } });
+        const tid = tunnelInput()!;
+        fireEvent.change(tid, { target: { value: 'amusing-book-s4hcgw2.usw2' } });
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() =>
+            expect(onAdd).toHaveBeenCalledWith(
+                'https://my-tunnel.devtunnels.ms',
+                undefined,
+                'amusing-book-s4hcgw2.usw2',
+            )
+        );
+    });
+
+    it('passes undefined tunnelId when tunnel field is left empty for a devtunnel address', async () => {
+        const { onAdd } = renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'https://my-tunnel.devtunnels.ms' } });
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() =>
+            expect(onAdd).toHaveBeenCalledWith('https://my-tunnel.devtunnels.ms', undefined, undefined)
+        );
+    });
+});
+
+describe('AddAgentDialog — error handling', () => {
+    it('shows error message when onAdd rejects', async () => {
+        const onAdd = vi.fn().mockRejectedValue(new Error('Connection refused'));
+        render(<AddAgentDialog open={true} onClose={vi.fn()} onAdd={onAdd} />);
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000' } });
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() => expect(screen.getByText('Connection refused')).toBeTruthy());
+    });
+
+    it('clears previous error on a new successful submit', async () => {
+        const onAdd = vi.fn()
+            .mockRejectedValueOnce(new Error('Timeout'))
+            .mockResolvedValue(undefined);
+        render(<AddAgentDialog open={true} onClose={vi.fn()} onAdd={onAdd} />);
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000' } });
+
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() => expect(screen.getByText('Timeout')).toBeTruthy());
+
+        await act(async () => { fireEvent.submit(addressInput().closest('form')!); });
+        await waitFor(() => expect(screen.queryByText('Timeout')).toBeNull());
+    });
+});
+
+describe('AddAgentDialog — submit button state', () => {
+    it('disables submit when address is empty', () => {
+        renderDialog();
+        expect(submitButton()).toHaveAttribute('disabled');
+    });
+
+    it('enables submit when address has content', () => {
+        renderDialog();
+        fireEvent.change(addressInput(), { target: { value: 'http://localhost:4000' } });
+        expect(submitButton()).not.toHaveAttribute('disabled');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a conditional Tunnel ID input to the **Add Agent** dialog, matching the edit form behavior
- The field is shown only when the address URL ends with `.devtunnels.ms`
- Updates the `onAdd` callback signature from `(address, name?)` to `(address, name?, tunnelId?)`
- Resets tunnel ID state on successful submit
- Adds 15 tests covering conditional rendering, onAdd wiring, error handling, and submit button state

Previously, users had to add the agent first (without a tunnel ID) and then click the pencil edit button to set one. Now the field is available directly in the Add dialog.

## Test plan
- [ ] Add an agent with a `.devtunnels.ms` address — tunnel ID field appears
- [ ] Add an agent with a local address — tunnel ID field absent
- [ ] Fill in tunnel ID and verify it is saved on the new agent
- [ ] Change address from devtunnels to localhost — tunnel ID field disappears
- [ ] All 15 new unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)