### PR TITLE
Ignore Claude worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ test-results/
 # Build debugging artifacts
 build-errors.txt
 esbuild-check.css
+
+# Claude worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to the root `.gitignore` so local Claude-managed worktrees stay out of version control.

## Testing
- Not run (not requested)