### PR TITLE
Add .agents/skills symlink to shared skill directory

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.github/skills


### PR DESCRIPTION
## Summary
- Add a repository-local `.agents/skills` symlink that points to the existing `.github/skills` folder
- Enable Codex to resolve the shared skill set from the expected `.agents` path without duplicating files

## Testing
- Not run (not requested)