### PR TITLE
Use real pull request commit data in the PR detail view

### DIFF
--- a/packages/coc-client/src/contracts/pull-requests.ts
+++ b/packages/coc-client/src/contracts/pull-requests.ts
@@ -50,3 +50,7 @@ export interface PullRequestThreadsResponse {
 export interface PullRequestReviewersResponse {
   reviewers: unknown[];
 }
+
+export interface PullRequestCommitsResponse {
+  commits: unknown[];
+}

--- a/packages/coc-client/src/domains/pull-requests.ts
+++ b/packages/coc-client/src/domains/pull-requests.ts
@@ -2,6 +2,7 @@ import type {
   ProviderConfigRequest,
   PullRequestListQuery,
   PullRequestListResponse,
+  PullRequestCommitsResponse,
   PullRequestReviewersResponse,
   PullRequestThreadsResponse,
   SanitizedProviderConfigResponse,
@@ -60,6 +61,12 @@ export class PullRequestsClient {
 
   getReviewers(repoId: string, prId: string, options?: Pick<CocRequestOptions, 'signal'>): Promise<PullRequestReviewersResponse> {
     return this.transport.request<PullRequestReviewersResponse>(`/repos/${encodePathSegment(repoId)}/pull-requests/${encodePathSegment(prId)}/reviewers`, {
+      signal: options?.signal,
+    });
+  }
+
+  getCommits(repoId: string, prId: string, options?: Pick<CocRequestOptions, 'signal'>): Promise<PullRequestCommitsResponse> {
+    return this.transport.request<PullRequestCommitsResponse>(`/repos/${encodePathSegment(repoId)}/pull-requests/${encodePathSegment(prId)}/commits`, {
       signal: options?.signal,
     });
   }

--- a/packages/coc-client/test/domains/pull-requests.mock.test.ts
+++ b/packages/coc-client/test/domains/pull-requests.mock.test.ts
@@ -136,6 +136,17 @@ describe('PullRequestsClient mock coverage', () => {
     expectEmptyRequest(mock.requests[0], 'GET', '/api/repos/repo%2Fa/pull-requests/42/reviewers');
   });
 
+  it('gets commits for a PR', async () => {
+    mock = await startMockServer();
+    const commits = [{ sha: 'abcdef1234567890', shortSha: 'abcdef1', title: 'Fix bug' }];
+    mock.on('GET', '/api/repos/repo%2Fa/pull-requests/42/commits', { body: { commits } });
+    const client = createClient(mock);
+
+    await expect(client.pullRequests.getCommits('repo/a', '42')).resolves.toEqual({ commits });
+
+    expectEmptyRequest(mock.requests[0], 'GET', '/api/repos/repo%2Fa/pull-requests/42/commits');
+  });
+
   it('gets unified diff as text/plain string via the raw-text transport path', async () => {
     mock = await startMockServer();
     const diff = '--- a/file.ts\n+++ b/file.ts\n@@ -1,3 +1,4 @@\n+import { foo } from "bar";\n export const x = 1;';

--- a/packages/coc-client/test/domains/pull-requests.test.ts
+++ b/packages/coc-client/test/domains/pull-requests.test.ts
@@ -49,6 +49,7 @@ describe('PullRequestsClient', () => {
     await client.get('repo/a', 'pr/1');
     await client.getThreads('repo/a', 'pr/1');
     await client.getReviewers('repo/a', 'pr/1');
+    await client.getCommits('repo/a', 'pr/1');
     await client.getDiff('repo/a', 'pr/1');
 
     expect(adapter.calls).toMatchObject([
@@ -59,6 +60,7 @@ describe('PullRequestsClient', () => {
       { path: '/repos/repo%2Fa/pull-requests/pr%2F1' },
       { path: '/repos/repo%2Fa/pull-requests/pr%2F1/threads' },
       { path: '/repos/repo%2Fa/pull-requests/pr%2F1/reviewers' },
+      { path: '/repos/repo%2Fa/pull-requests/pr%2F1/commits' },
       { path: '/repos/repo%2Fa/pull-requests/pr%2F1/diff' },
     ]);
   });
@@ -84,6 +86,7 @@ describe('PullRequestsClient', () => {
     await client.get('r1', '10', { signal: controller.signal });
     await client.getThreads('r1', '10', { signal: controller.signal });
     await client.getReviewers('r1', '10', { signal: controller.signal });
+    await client.getCommits('r1', '10', { signal: controller.signal });
     await client.getDiff('r1', '10', { signal: controller.signal });
 
     for (const call of adapter.calls) {
@@ -99,6 +102,7 @@ describe('PullRequestsClient', () => {
     await client.get('r1', '1');
     await client.getThreads('r1', '1');
     await client.getReviewers('r1', '1');
+    await client.getCommits('r1', '1');
     await client.getDiff('r1', '1');
 
     for (const call of adapter.calls) {

--- a/packages/coc/src/server/repos/pr-routes.ts
+++ b/packages/coc/src/server/repos/pr-routes.ts
@@ -8,6 +8,7 @@
  * GET  /api/repos/:repoId/pull-requests/:prId        — get single PR
  * GET  /api/repos/:repoId/pull-requests/:prId/threads    — get comment threads
  * GET  /api/repos/:repoId/pull-requests/:prId/reviewers  — get reviewers
+ * GET  /api/repos/:repoId/pull-requests/:prId/commits    — get commits
  * GET  /api/repos/:repoId/pull-requests/:prId/diff       — get unified diff
  *
  * Cross-platform compatible (Linux/Mac/Windows).
@@ -244,6 +245,47 @@ export function registerPrRoutes(routes: Route[], dataDir: string, service?: Rep
 
                 const reviewers = await prSvc.getReviewers(repoId, prId);
                 sendJson(res, { reviewers });
+            } catch (err) {
+                if (err instanceof Error && (err.message.includes('not found') || err.message.includes('404'))) {
+                    send404(res, err.message);
+                } else if (isAuthError(err)) {
+                    sendJson(res, { error: err instanceof Error ? err.message : String(err) }, 401);
+                } else {
+                    send500(res, err instanceof Error ? err.message : String(err));
+                }
+            }
+        },
+    });
+
+    // -- Get commits ----------------------------------------------------------
+
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/repos\/([^/]+)\/pull-requests\/([^/]+)\/commits$/,
+        handler: async (_req, res, match) => {
+            try {
+                const repoId = decodeURIComponent(match![1]);
+                const prId = decodeURIComponent(match![2]);
+
+                const repo = await svc.resolveRepo(repoId);
+                if (!repo) return send404(res, `Repo ${repoId} not found`);
+
+                const cfg = await readProvidersConfig(dataDir);
+                const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg);
+                if (!prSvc || isNoAdoCredentials(prSvc)) {
+                    if (isNoAdoCredentials(prSvc)) {
+                        return sendJson(res, { error: 'no-ado-credentials' }, 401);
+                    }
+                    const detected = ProviderFactory.detectProviderType(repo.remoteUrl ?? '');
+                    return sendJson(res, { error: 'unconfigured', detected, remoteUrl: repo.remoteUrl }, 401);
+                }
+
+                if (typeof prSvc.getCommits !== 'function') {
+                    return sendJson(res, { commits: [] });
+                }
+
+                const commits = await prSvc.getCommits(repoId, prId);
+                sendJson(res, { commits });
             } catch (err) {
                 if (err instanceof Error && (err.message.includes('not found') || err.message.includes('404'))) {
                     send404(res, err.message);

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PrCommitTable.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PrCommitTable.tsx
@@ -1,17 +1,26 @@
-/**
- * Commit intent table — shows each commit alongside an AI-detected
- * intent label (feat/fix/docs/test/refactor) and short note.
- */
+import { formatTimestamp } from './pr-utils';
 
-import { cn } from '../../ui';
-import { commitIntentClass } from './pr-mock-data';
-import type { AiCommitRow } from './pr-mock-data';
-
-interface PrCommitTableProps {
-    rows: AiCommitRow[];
+export interface PrCommitRow {
+    sha: string;
+    shortSha?: string;
+    title: string;
+    message?: string;
+    author?: {
+        displayName?: string;
+        email?: string;
+    };
+    authoredAt?: string | Date;
+    committedAt?: string | Date;
+    url?: string;
 }
 
-export function PrCommitTable({ rows }: PrCommitTableProps) {
+interface PrCommitTableProps {
+    rows: PrCommitRow[];
+    loading?: boolean;
+    error?: string | null;
+}
+
+export function PrCommitTable({ rows, loading = false, error = null }: PrCommitTableProps) {
     return (
         <div
             className="overflow-hidden rounded-[5px] border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
@@ -19,12 +28,20 @@ export function PrCommitTable({ rows }: PrCommitTableProps) {
         >
             <header className="flex min-h-[30px] items-center justify-between gap-1.5 border-b border-gray-200 bg-gray-50 px-2 py-1 dark:border-gray-700 dark:bg-gray-800/60">
                 <h2 className="m-0 text-[13px] font-semibold leading-tight text-gray-900 dark:text-gray-100">
-                    Commit intent
+                    Commits
                 </h2>
-                <span className="inline-flex min-h-[20px] items-center gap-1 rounded-full bg-purple-100 px-1.5 py-0.5 text-[11px] font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
-                    AI labels are editable
+                <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                    {loading ? 'Loading...' : `${rows.length} total`}
                 </span>
             </header>
+            {error && (
+                <div
+                    className="border-b border-red-200 bg-red-50 px-2 py-1.5 text-[11px] text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
+                    data-testid="pr-commits-error"
+                >
+                    Failed to load commits: {error}
+                </div>
+            )}
             <div className="overflow-x-auto">
                 <table className="w-full border-collapse text-[12px]">
                     <thead>
@@ -33,10 +50,10 @@ export function PrCommitTable({ rows }: PrCommitTableProps) {
                                 Commit
                             </th>
                             <th className="border-b border-gray-200 px-[7px] py-[5px] text-left text-[11px] font-semibold uppercase tracking-normal text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                                Intent
+                                Author
                             </th>
                             <th className="border-b border-gray-200 px-[7px] py-[5px] text-left text-[11px] font-semibold uppercase tracking-normal text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                                AI note
+                                Date
                             </th>
                             <th className="border-b border-gray-200 px-[7px] py-[5px] text-left text-[11px] font-semibold uppercase tracking-normal text-gray-500 dark:border-gray-700 dark:text-gray-400">
                                 Hash
@@ -44,30 +61,45 @@ export function PrCommitTable({ rows }: PrCommitTableProps) {
                         </tr>
                     </thead>
                     <tbody>
+                        {!loading && rows.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={4}
+                                    className="px-[7px] py-4 text-center text-[12px] text-gray-500 dark:text-gray-400"
+                                    data-testid="pr-commits-empty"
+                                >
+                                    No commits found
+                                </td>
+                            </tr>
+                        )}
                         {rows.map(row => (
                             <tr
-                                key={row.id}
+                                key={row.sha}
                                 className="border-b border-gray-100 last:border-0 dark:border-gray-800"
                                 data-testid="pr-commit-row"
                             >
                                 <td className="px-[7px] py-[5px] align-top text-[12px] text-gray-800 dark:text-gray-200">
-                                    {row.title}
+                                    {row.url ? (
+                                        <a
+                                            href={row.url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                                        >
+                                            {row.title || row.sha}
+                                        </a>
+                                    ) : (
+                                        <span className="font-medium">{row.title || row.sha}</span>
+                                    )}
                                 </td>
-                                <td className="px-[7px] py-[5px] align-top">
-                                    <span
-                                        className={cn(
-                                            'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-normal leading-[1.4]',
-                                            commitIntentClass(row.intent),
-                                        )}
-                                    >
-                                        {row.intent}
-                                    </span>
+                                <td className="px-[7px] py-[5px] align-top text-[11px] text-gray-600 dark:text-gray-300">
+                                    {row.author?.displayName || row.author?.email || 'Unknown'}
                                 </td>
                                 <td className="px-[7px] py-[5px] align-top text-[11px] text-gray-500 dark:text-gray-400">
-                                    {row.note}
+                                    {formatCommitDate(row.committedAt ?? row.authoredAt)}
                                 </td>
                                 <td className="px-[7px] py-[5px] align-top font-mono text-[11px] tabular-nums text-gray-500 dark:text-gray-400">
-                                    {row.hash}
+                                    {row.shortSha || row.sha.slice(0, 7)}
                                 </td>
                             </tr>
                         ))}
@@ -76,4 +108,9 @@ export function PrCommitTable({ rows }: PrCommitTableProps) {
             </div>
         </div>
     );
+}
+
+function formatCommitDate(value: string | Date | undefined): string {
+    if (!value) return '';
+    return formatTimestamp(value instanceof Date ? value.toISOString() : value);
 }

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -13,7 +13,6 @@
  *   - AI summary panel (risk, confidence, findings, metrics)
  *   - Persona lenses
  *   - Conversation timeline
- *   - Commit intent table (also: no commit REST endpoint exists yet)
  *   - Checks / merge-readiness (also: no check REST endpoint yet)
  *   - Inline AI annotations on file diffs
  *   - Assistant chat drawer
@@ -31,7 +30,7 @@ import { PrAiSummaryPanel } from './PrAiSummaryPanel';
 import { PrQuickReviewWorkflow } from './PrQuickReviewWorkflow';
 import { PrConversationPanel } from './PrConversationPanel';
 import { PrAiGroupedThreads } from './PrAiGroupedThreads';
-import { PrCommitTable } from './PrCommitTable';
+import { PrCommitTable, type PrCommitRow } from './PrCommitTable';
 import { PrChecksTable, PrMergeReadiness } from './PrChecksAndReadiness';
 import { PrFilesPanel } from './PrFilesPanel';
 import { PrAiAssistantDrawer } from './PrAiAssistantDrawer';
@@ -39,7 +38,6 @@ import {
     buildAiThreadGroupsFromThreads,
     getMockAiSummary,
     getMockCheckRows,
-    getMockCommitRows,
     getMockFiles,
     getMockMergeReadiness,
     getMockPersonaLenses,
@@ -83,6 +81,8 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
     const { state, dispatch } = useApp();
     const [pr, setPr] = useState<PullRequest | null>(null);
     const [threads, setThreads] = useState<CommentThread[]>([]);
+    const [commits, setCommits] = useState<PrCommitRow[]>([]);
+    const [commitsError, setCommitsError] = useState<string | null>(null);
     const [diff, setDiff] = useState<ParsedDiff>(EMPTY_DIFF);
     const [diffError, setDiffError] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
@@ -109,6 +109,8 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
         setError(null);
         setDiff(EMPTY_DIFF);
         setDiffError(null);
+        setCommits([]);
+        setCommitsError(null);
         const client = getSpaCocClient();
         const prIdStr = String(prId);
         const repoIdStr = String(repoId);
@@ -122,6 +124,13 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
                 .then(body => (body.threads ?? []) as CommentThread[])
                 .catch(() => [] as CommentThread[]),
             client.pullRequests
+                .getCommits(repoIdStr, prIdStr)
+                .then(body => ({ kind: 'ok' as const, commits: (body.commits ?? []) as PrCommitRow[] }))
+                .catch((err: unknown) => ({
+                    kind: 'err' as const,
+                    message: getSpaCocClientErrorMessage(err, 'Failed to load commits'),
+                })),
+            client.pullRequests
                 .getDiff(repoIdStr, prIdStr)
                 .then(text => ({ kind: 'ok' as const, parsed: parseUnifiedDiff(text) }))
                 .catch((err: unknown) => ({
@@ -129,9 +138,14 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
                     message: getSpaCocClientErrorMessage(err, 'Failed to load diff'),
                 })),
         ])
-            .then(([prData, threadsData, diffResult]) => {
+            .then(([prData, threadsData, commitsResult, diffResult]) => {
                 setPr(prData);
                 setThreads(threadsData);
+                if (commitsResult.kind === 'ok') {
+                    setCommits(commitsResult.commits);
+                } else {
+                    setCommitsError(commitsResult.message);
+                }
                 if (diffResult.kind === 'ok') {
                     setDiff(diffResult.parsed);
                 } else {
@@ -153,7 +167,6 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
     const personaLenses = useMemo(() => getMockPersonaLenses(), []);
     const timeline = useMemo(() => getMockTimeline(), []);
     const threadGroups = useMemo(() => buildAiThreadGroupsFromThreads(threads), [threads]);
-    const commitRows = useMemo(() => getMockCommitRows(), []);
     const checkRows = useMemo(() => getMockCheckRows(), []);
     const mergeReadiness = useMemo(() => getMockMergeReadiness(), []);
 
@@ -385,7 +398,7 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
                     {TAB_DEFINITIONS.map(tab => {
                         const isActive = detailTab === tab.id;
                         const count = tabCount(tab.id, {
-                            commits: commitRows.length,
+                            commits: commits.length,
                             files: diff.fileCount,
                             checks: checkRows.length,
                             overview: threads.length,
@@ -493,11 +506,7 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
 
                 {detailTab === 'commits' && (
                     <div className="w-full px-2.5 pb-7 pt-2" data-testid="commits-tab">
-                        <PreviewOnlyNotice
-                            label="Commit list is AI-mocked"
-                            body="The server does not yet expose a per-PR commit endpoint. Intent labels and the commit log shown below are placeholder fixtures."
-                        />
-                        <PrCommitTable rows={commitRows} />
+                        <PrCommitTable rows={commits} error={commitsError} />
                     </div>
                 )}
 

--- a/packages/coc/test/e2e/fixtures/pr-mock.ts
+++ b/packages/coc/test/e2e/fixtures/pr-mock.ts
@@ -10,11 +10,21 @@ import {
     MOCK_PR_THREADS,
 } from './pr-fixtures.js';
 
+interface MockPrCommit {
+    sha: string;
+    shortSha: string;
+    title: string;
+    author?: { displayName?: string; email?: string };
+    committedAt?: string;
+    url?: string;
+}
+
 export interface PrMockOptions {
     pullRequests?: PullRequest[];
     prDetail?: PullRequest;
     threads?: CommentThread[];
     reviewers?: Reviewer[];
+    commits?: MockPrCommit[];
     /** Body for GET /pull-requests/:id/diff (text/plain). Defaults to empty. */
     diff?: string;
     unconfigured?: boolean;
@@ -33,6 +43,16 @@ export async function setupPrRoutes(
         prDetail = MOCK_PR_OPEN,
         threads = MOCK_PR_THREADS,
         reviewers = [],
+        commits = [
+            {
+                sha: 'abcdef1234567890',
+                shortSha: 'abcdef1',
+                title: 'feat: detailed open PR',
+                author: { displayName: 'Alice Developer', email: 'alice@example.com' },
+                committedAt: '2024-01-15T12:00:00.000Z',
+                url: 'https://example.com/repos/org/repo/commit/abcdef1234567890',
+            },
+        ],
         diff = '',
         unconfigured = false,
         detectedProvider = null,
@@ -43,6 +63,7 @@ export async function setupPrRoutes(
 
     const threadsPattern   = `${base}/*/threads`;
     const reviewersPattern = `${base}/*/reviewers`;
+    const commitsPattern   = `${base}/*/commits`;
     const diffPattern      = `${base}/*/diff`;
     const detailPattern    = `${base}/*`;
     const listPattern      = `${base}?*`;
@@ -67,6 +88,14 @@ export async function setupPrRoutes(
             return route.fulfill({ status: 401, json: unconfiguredBody });
         }
         return route.fulfill({ status: 200, json: { reviewers } });
+    });
+
+    // commits
+    await page.route(commitsPattern, (route) => {
+        if (unconfigured) {
+            return route.fulfill({ status: 401, json: unconfiguredBody });
+        }
+        return route.fulfill({ status: 200, json: { commits } });
     });
 
     // diff — plain-text unified diff
@@ -110,6 +139,7 @@ export async function setupPrRoutes(
     return async () => {
         await page.unroute(threadsPattern);
         await page.unroute(reviewersPattern);
+        await page.unroute(commitsPattern);
         await page.unroute(diffPattern);
         await page.unroute(detailPattern);
         await page.unroute(listPattern);

--- a/packages/coc/test/server/pr-routes.test.ts
+++ b/packages/coc/test/server/pr-routes.test.ts
@@ -11,7 +11,7 @@ import { createRouter } from '../../src/server/shared/router';
 import { registerPrRoutes, clearPrListCache } from '../../src/server/repos/pr-routes';
 import type { Route } from '../../src/server/types';
 import type { IPullRequestsService } from '@plusplusoneplusplus/forge';
-import type { PullRequest, CommentThread, Reviewer } from '@plusplusoneplusplus/forge';
+import type { PullRequest, PullRequestCommit, CommentThread, Reviewer } from '@plusplusoneplusplus/forge';
 
 // ── Mock ProviderFactory and RepoTreeService ─────────────────────────────────
 
@@ -80,6 +80,17 @@ const mockReviewer: Reviewer = {
     isRequired: false,
 };
 
+const mockCommit: PullRequestCommit = {
+    sha: 'abcdef1234567890',
+    shortSha: 'abcdef1',
+    title: 'Add feature X',
+    message: 'Add feature X\n\nDetailed body',
+    author: { id: 'user1', displayName: 'Alice', email: 'alice@example.com' },
+    authoredAt: new Date('2024-01-01'),
+    committedAt: new Date('2024-01-01'),
+    url: 'https://github.com/org/repo/commit/abcdef1234567890',
+};
+
 // ── Server helpers ────────────────────────────────────────────────────────────
 
 let tmpDir: string;
@@ -123,6 +134,7 @@ beforeEach(async () => {
         getPullRequest: vi.fn().mockResolvedValue(mockPr),
         getThreads: vi.fn().mockResolvedValue([mockThread]),
         getReviewers: vi.fn().mockResolvedValue([mockReviewer]),
+        getCommits: vi.fn().mockResolvedValue([mockCommit]),
         getDiff: vi.fn().mockResolvedValue('diff --git a/foo.ts b/foo.ts\n'),
     };
 
@@ -387,6 +399,50 @@ describe('GET /api/repos/:id/pull-requests/:prId/reviewers', () => {
     it('returns 500 on unexpected error', async () => {
         (mockSvc.getReviewers as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network'));
         const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/reviewers`);
+        expect(res.status).toBe(500);
+    });
+});
+
+// ── GET /api/repos/:id/pull-requests/:prId/commits ──────────────────────────
+
+describe('GET /api/repos/:id/pull-requests/:prId/commits', () => {
+    it('returns commits array on success', async () => {
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/commits`);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { commits: unknown[] };
+        expect(Array.isArray(body.commits)).toBe(true);
+        expect(body.commits).toHaveLength(1);
+        expect(mockSvc.getCommits).toHaveBeenCalledWith(REPO_ID, '42');
+    });
+
+    it('returns empty array when getCommits is not implemented', async () => {
+        const svcWithoutCommits = { ...mockSvc };
+        delete (svcWithoutCommits as any).getCommits;
+        (ProviderFactory.createPullRequestsService as ReturnType<typeof vi.fn>).mockResolvedValue(svcWithoutCommits);
+
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/commits`);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { commits: unknown[] };
+        expect(body.commits).toEqual([]);
+    });
+
+    it('returns 404 when repo not found', async () => {
+        mockResolveRepo.mockResolvedValueOnce(null);
+        const res = await fetch(`${baseUrl}/api/repos/unknown/pull-requests/42/commits`);
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 401 when unconfigured', async () => {
+        (ProviderFactory.createPullRequestsService as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/commits`);
+        expect(res.status).toBe(401);
+        const body = await res.json() as { error: string };
+        expect(body.error).toBe('unconfigured');
+    });
+
+    it('returns 500 on unexpected error', async () => {
+        (mockSvc.getCommits as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network'));
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/commits`);
         expect(res.status).toBe(500);
     });
 });

--- a/packages/coc/test/spa/react/repos/pull-requests/PrAiPanels.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PrAiPanels.test.tsx
@@ -19,7 +19,6 @@ import {
     buildAiThreadGroupsFromThreads,
     getMockAiSummary,
     getMockCheckRows,
-    getMockCommitRows,
     getMockMergeReadiness,
     getMockPersonaLenses,
     getMockTimeline,
@@ -96,8 +95,29 @@ describe('PrAiGroupedThreads', () => {
 
 describe('PrCommitTable', () => {
     it('renders one row per commit', () => {
-        render(<PrCommitTable rows={getMockCommitRows()} />);
-        expect(screen.getAllByTestId('pr-commit-row').length).toBeGreaterThanOrEqual(5);
+        render(<PrCommitTable rows={[
+            {
+                sha: 'abcdef1234567890',
+                shortSha: 'abcdef1',
+                title: 'Fix retry handling',
+                author: { displayName: 'Alice' },
+                committedAt: '2024-01-01T00:00:00Z',
+            },
+            {
+                sha: '123456abcdef7890',
+                shortSha: '123456a',
+                title: 'Add retry tests',
+                author: { displayName: 'Bob' },
+                committedAt: '2024-01-02T00:00:00Z',
+            },
+        ]} />);
+        expect(screen.getAllByTestId('pr-commit-row')).toHaveLength(2);
+        expect(screen.getByText('Fix retry handling')).toBeInTheDocument();
+    });
+
+    it('renders an empty state', () => {
+        render(<PrCommitTable rows={[]} />);
+        expect(screen.getByTestId('pr-commits-empty')).toBeInTheDocument();
     });
 });
 

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
@@ -46,6 +46,19 @@ const makeThreads = (overrides: Partial<any>[] = []) =>
         ...o,
     }));
 
+const makeCommits = (overrides: Partial<any>[] = [{}]) =>
+    overrides.map((o, i) => ({
+        sha: `abcdef${i}1234567890`,
+        shortSha: `abcdef${i}`,
+        title: i === 0 ? 'Add retry logic' : `Commit ${i + 1}`,
+        message: i === 0 ? 'Add retry logic\n\nDetailed body' : `Commit ${i + 1}`,
+        author: { displayName: 'Alice', email: 'alice@example.com' },
+        authoredAt: '2024-01-01T00:00:00Z',
+        committedAt: '2024-01-01T01:00:00Z',
+        url: 'https://example.com/commit/abcdef',
+        ...o,
+    }));
+
 /** JSON response shape that satisfies both the SPA's CocApiClient and the
  *  fallback `await response.json()` path. */
 function jsonResponse(payload: unknown, ok = true, status = 200) {
@@ -68,11 +81,12 @@ function textResponse(body: string) {
     } as unknown as Response;
 }
 
-/** Mock the full PR detail fetch trio (pr, threads, diff). */
-function mockFetchDetail(pr: any, threads: any[] = [], diffText = '') {
+/** Mock the full PR detail fetch set (pr, threads, commits, diff). */
+function mockFetchDetail(pr: any, threads: any[] = [], diffText = '', commits: any[] = makeCommits()) {
     global.fetch = vi.fn()
         .mockResolvedValueOnce(jsonResponse(pr))
         .mockResolvedValueOnce(jsonResponse({ threads }))
+        .mockResolvedValueOnce(jsonResponse({ commits }))
         .mockResolvedValueOnce(textResponse(diffText));
 }
 
@@ -80,6 +94,7 @@ function mockFetchPrError(status = 500, message = 'Server error') {
     global.fetch = vi.fn()
         .mockResolvedValueOnce(jsonResponse({ message }, false, status))
         .mockResolvedValueOnce(jsonResponse({ threads: [] }))
+        .mockResolvedValueOnce(jsonResponse({ commits: [] }))
         .mockResolvedValueOnce(textResponse(''));
 }
 
@@ -295,14 +310,15 @@ describe('tabs', () => {
         expect(screen.getByTestId('tab-files').textContent).toContain('2');
     });
 
-    it('switches to the Commits tab and renders the commit intent table behind a preview notice', async () => {
-        mockFetchDetail(makePr());
+    it('switches to the Commits tab and renders real commits', async () => {
+        mockFetchDetail(makePr(), [], '', makeCommits([{ title: 'Wire retry backoff' }]));
         await act(async () => { await renderDetail(); });
         await waitFor(() => expect(screen.getByTestId('tab-commits')).toBeInTheDocument());
         fireEvent.click(screen.getByTestId('tab-commits'));
         expect(screen.getByTestId('commits-tab')).toBeInTheDocument();
         expect(screen.getByTestId('pr-commit-table')).toBeInTheDocument();
-        expect(screen.getByTestId('pr-tab-preview-notice').textContent).toMatch(/Commit list is AI-mocked/i);
+        expect(screen.getByText('Wire retry backoff')).toBeInTheDocument();
+        expect(screen.queryByTestId('pr-tab-preview-notice')).not.toBeInTheDocument();
     });
 
     it('switches to the Checks tab and renders the checks + merge readiness panels with a preview notice', async () => {

--- a/packages/forge/src/ado/ado-pull-requests-adapter.ts
+++ b/packages/forge/src/ado/ado-pull-requests-adapter.ts
@@ -7,6 +7,7 @@ import type {
     CreatePullRequestInput,
     Identity,
     PullRequest,
+    PullRequestCommit,
     PullRequestStatus,
     Reviewer,
     ReviewVote,
@@ -14,6 +15,7 @@ import type {
     UpdatePullRequestInput,
 } from '../providers/types';
 import type { AdoPullRequestsService } from './pull-requests-service';
+import type { GitCommitRef } from './pull-requests-service';
 import { VersionControlChangeType } from './pull-requests-service';
 import { buildUnifiedDiff } from './diff-builder';
 import { getLogger, LogCategory } from '../logger';
@@ -84,6 +86,10 @@ function stripBranchPrefix(ref: string | undefined): string {
     return (ref ?? '').replace(/^refs\/heads\//, '');
 }
 
+function firstLine(message: string | undefined): string {
+    return (message ?? '').split(/\r?\n/, 1)[0] ?? '';
+}
+
 function mapAdoPullRequest(pr: GitPullRequest, repositoryId: string): PullRequest {
     const isDraft = pr.isDraft ?? false;
     const status = isDraft ? 'draft' : mapAdoStatusToPrStatus(pr.status);
@@ -131,6 +137,30 @@ function mapAdoThread(t: GitPullRequestCommentThread): CommentThread {
         comments: (t.comments ?? []).map((c: Parameters<typeof mapAdoComment>[0]) => mapAdoComment(c)),
         status: statusMap[t.status ?? 0] ?? 'unknown',
         createdAt: t.publishedDate ? new Date(t.publishedDate) : new Date(0),
+    };
+}
+
+function mapAdoCommit(commit: GitCommitRef): PullRequestCommit {
+    const extra = commit as GitCommitRef & { commitIdString?: string; objectId?: string };
+    const sha = String(commit.commitId ?? extra.commitIdString ?? extra.objectId ?? '');
+    const author = commit.author ?? {};
+    const committer = commit.committer ?? {};
+    const authoredAt = author.date ? new Date(author.date) : undefined;
+    const committedAt = committer.date ? new Date(committer.date) : authoredAt;
+    return {
+        sha,
+        shortSha: sha.slice(0, 7),
+        title: firstLine(commit.comment),
+        message: commit.comment ?? '',
+        author: {
+            id: author.email ?? author.name ?? '',
+            displayName: author.name ?? author.email ?? '',
+            email: author.email,
+        },
+        authoredAt,
+        committedAt,
+        url: commit.remoteUrl ?? commit.url,
+        raw: commit,
     };
 }
 
@@ -350,5 +380,18 @@ export class AdoPullRequestsAdapter implements IPullRequestsService {
             );
             return '';
         }
+    }
+
+    async getCommits(repositoryId: string, pullRequestId: number | string): Promise<PullRequestCommit[]> {
+        const logger = getLogger();
+        const effectiveRepo = this.repo ?? repositoryId;
+        logger.info(LogCategory.ADO, `getCommits: repo=${effectiveRepo} PR #${pullRequestId} project=${this.project ?? '(default)'}`);
+        const commits = await this.service.getPullRequestCommits(
+            effectiveRepo,
+            Number(pullRequestId),
+            this.project,
+        );
+        logger.info(LogCategory.ADO, `getCommits: mapped ${commits.length} commit(s) for PR #${pullRequestId}`);
+        return commits.map(mapAdoCommit);
     }
 }

--- a/packages/forge/src/ado/index.ts
+++ b/packages/forge/src/ado/index.ts
@@ -23,6 +23,7 @@ export {
     type GitPullRequestIteration,
     type GitPullRequestIterationChanges,
     type GitPullRequestChange,
+    type GitCommitRef,
 } from './pull-requests-service';
 export { AdoPullRequestsAdapter } from './ado-pull-requests-adapter';
 export { AdoWorkItemsAdapter } from './ado-work-items-adapter';

--- a/packages/forge/src/ado/pull-requests-service.ts
+++ b/packages/forge/src/ado/pull-requests-service.ts
@@ -7,6 +7,7 @@ import type {
     GitPullRequestIteration,
     GitPullRequestIterationChanges,
     GitPullRequestChange,
+    GitCommitRef,
     GitVersionDescriptor,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import {
@@ -18,7 +19,7 @@ import { getLogger, LogCategory } from '../logger';
 
 export type { GitPullRequest, GitPullRequestSearchCriteria, GitPullRequestCommentThread };
 export type { IdentityRefWithVote };
-export type { GitPullRequestIteration, GitPullRequestIterationChanges, GitPullRequestChange };
+export type { GitPullRequestIteration, GitPullRequestIterationChanges, GitPullRequestChange, GitCommitRef };
 export { VersionControlChangeType, GitVersionType };
 export { PullRequestStatus } from 'azure-devops-node-api/interfaces/GitInterfaces';
 
@@ -228,6 +229,26 @@ export class AdoPullRequestsService {
             const errMsg = err instanceof Error ? err.message : String(err);
             logger.error(LogCategory.ADO, `getReviewers failed: repo=${repositoryId} PR #${pullRequestId}: ${errMsg}`);
             throw new AdoPullRequestError(`Failed to get reviewers for PR ${pullRequestId}`, err);
+        }
+    }
+
+    async getPullRequestCommits(
+        repositoryId: string,
+        pullRequestId: number,
+        project?: string,
+    ): Promise<GitCommitRef[]> {
+        const logger = getLogger();
+        logger.info(LogCategory.ADO, `getPullRequestCommits: repo=${repositoryId} PR #${pullRequestId} project=${project ?? '(default)'}`);
+        const api = await this.getGitApi();
+        try {
+            const result = await api.getPullRequestCommits(repositoryId, pullRequestId, project);
+            const commits = result ?? [];
+            logger.info(LogCategory.ADO, `getPullRequestCommits: returned ${commits.length} commit(s) for PR #${pullRequestId}`);
+            return commits;
+        } catch (err) {
+            const errMsg = err instanceof Error ? err.message : String(err);
+            logger.error(LogCategory.ADO, `getPullRequestCommits failed: repo=${repositoryId} PR #${pullRequestId}: ${errMsg}`);
+            throw new AdoPullRequestError(`Failed to get commits for PR ${pullRequestId}`, err);
         }
     }
 

--- a/packages/forge/src/github/github-pull-requests-adapter.ts
+++ b/packages/forge/src/github/github-pull-requests-adapter.ts
@@ -6,6 +6,7 @@ import type {
     CreatePullRequestInput,
     Identity,
     PullRequest,
+    PullRequestCommit,
     PullRequestStatus,
     Reviewer,
     ReviewVote,
@@ -73,6 +74,33 @@ function mapGitHubComment(c: GitHubComment): Comment {
         createdAt: new Date(c.created_at),
         updatedAt: new Date(c.updated_at),
         url: c.html_url,
+    };
+}
+
+function firstLine(message: string | null | undefined): string {
+    return (message ?? '').split(/\r?\n/, 1)[0] ?? '';
+}
+
+function mapGitHubCommit(c: any): PullRequestCommit {
+    const sha = String(c.sha ?? '');
+    const author = c.commit?.author;
+    const user = c.author ?? c.committer;
+    const authoredAt = author?.date ? new Date(author.date) : undefined;
+    const committedAt = c.commit?.committer?.date ? new Date(c.commit.committer.date) : authoredAt;
+    return {
+        sha,
+        shortSha: sha.slice(0, 7),
+        title: firstLine(c.commit?.message),
+        message: c.commit?.message ?? '',
+        author: {
+            ...mapGitHubUser(user),
+            displayName: author?.name ?? user?.name ?? user?.login ?? '',
+            email: author?.email,
+        },
+        authoredAt,
+        committedAt,
+        url: c.html_url,
+        raw: c,
     };
 }
 
@@ -232,5 +260,21 @@ export class GitHubPullRequestsAdapter implements IPullRequestsService {
             },
         );
         return String(response.data ?? '');
+    }
+
+    async getCommits(_repositoryId: string, pullRequestId: number | string): Promise<PullRequestCommit[]> {
+        const params = {
+            owner: this.owner,
+            repo: this.repo,
+            pull_number: Number(pullRequestId),
+            per_page: 100,
+        };
+
+        const paginate = (this.octokit as any).paginate;
+        const data = typeof paginate === 'function'
+            ? await paginate(this.octokit.pulls.listCommits, params)
+            : (await this.octokit.pulls.listCommits(params)).data;
+
+        return (data as any[]).map(mapGitHubCommit);
     }
 }

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -859,6 +859,7 @@ export {
     type PullRequestStatus as ProviderPullRequestStatus,
     type ReviewVote,
     type Reviewer,
+    type PullRequestCommit,
     type PullRequest as ProviderPullRequest,
     type WorkItem as ProviderWorkItem,
     type SearchCriteria as ProviderSearchCriteria,

--- a/packages/forge/src/providers/index.ts
+++ b/packages/forge/src/providers/index.ts
@@ -6,6 +6,7 @@ export {
     type PullRequestStatus,
     type ReviewVote,
     type Reviewer,
+    type PullRequestCommit,
     type PullRequest,
     type WorkItem,
     type SearchCriteria,

--- a/packages/forge/src/providers/interfaces.ts
+++ b/packages/forge/src/providers/interfaces.ts
@@ -4,6 +4,7 @@ import type {
     CreatePullRequestInput,
     CreateWorkItemInput,
     PullRequest,
+    PullRequestCommit,
     Reviewer,
     SearchCriteria,
     UpdatePullRequestInput,
@@ -58,6 +59,8 @@ export interface IPullRequestsService {
     ): Promise<Reviewer[]>;
     /** Returns the unified diff for a pull request. Optional — not all providers support this. */
     getDiff?(repositoryId: string, pullRequestId: number | string): Promise<string>;
+    /** Returns commits included in a pull request. Optional — not all providers support this. */
+    getCommits?(repositoryId: string, pullRequestId: number | string): Promise<PullRequestCommit[]>;
 }
 
 export interface IWorkItemsService {

--- a/packages/forge/src/providers/types.ts
+++ b/packages/forge/src/providers/types.ts
@@ -44,6 +44,18 @@ export interface Reviewer {
     isRequired: boolean;
 }
 
+export interface PullRequestCommit {
+    sha: string;
+    shortSha: string;
+    title: string;
+    message: string;
+    author: Identity;
+    authoredAt?: Date;
+    committedAt?: Date;
+    url?: string;
+    raw?: unknown;
+}
+
 // ── Canonical pull-request entity ────────────────────────────
 
 export interface PullRequest {

--- a/packages/forge/test/ado/ado-pull-requests-adapter.test.ts
+++ b/packages/forge/test/ado/ado-pull-requests-adapter.test.ts
@@ -49,6 +49,14 @@ const mockAdoReviewer = {
     isRequired: true,
 };
 
+const mockAdoCommit = {
+    commitId: 'abcdef1234567890',
+    comment: 'Fix bug\n\nDetailed body',
+    author: { name: 'Alice', email: 'alice@example.com', date: new Date('2024-01-04T00:00:00Z') },
+    committer: { name: 'CI', email: 'ci@example.com', date: new Date('2024-01-04T01:00:00Z') },
+    remoteUrl: 'https://dev.azure.com/org/proj/_git/repo/commit/abcdef1234567890',
+};
+
 function makeMockService(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}): AdoPullRequestsService {
     return {
         listPullRequests: vi.fn().mockResolvedValue([mockAdoPr]),
@@ -59,6 +67,7 @@ function makeMockService(overrides: Partial<Record<string, ReturnType<typeof vi.
         createThread: vi.fn().mockResolvedValue(mockAdoThread),
         getReviewers: vi.fn().mockResolvedValue([mockAdoReviewer]),
         addReviewers: vi.fn().mockResolvedValue([mockAdoReviewer]),
+        getPullRequestCommits: vi.fn().mockResolvedValue([mockAdoCommit]),
         getPullRequestIterations: vi.fn().mockResolvedValue([]),
         getPullRequestIterationChanges: vi.fn().mockResolvedValue({ changeEntries: [] }),
         getFileContent: vi.fn().mockResolvedValue(''),
@@ -352,6 +361,26 @@ describe('AdoPullRequestsAdapter', () => {
         });
     });
 
+    // ── getCommits ──────────────────────────────────────────
+
+    describe('getCommits', () => {
+        it('maps ADO PR commits to canonical commits', async () => {
+            const commits = await adapter.getCommits('repo-id', 42);
+            expect(service.getPullRequestCommits).toHaveBeenCalledWith('repo-id', 42, 'my-project');
+            expect(commits).toHaveLength(1);
+            expect(commits[0]).toMatchObject({
+                sha: 'abcdef1234567890',
+                shortSha: 'abcdef1',
+                title: 'Fix bug',
+                message: 'Fix bug\n\nDetailed body',
+                author: { displayName: 'Alice', email: 'alice@example.com' },
+                url: 'https://dev.azure.com/org/proj/_git/repo/commit/abcdef1234567890',
+            });
+            expect(commits[0].authoredAt).toEqual(new Date('2024-01-04T00:00:00Z'));
+            expect(commits[0].committedAt).toEqual(new Date('2024-01-04T01:00:00Z'));
+        });
+    });
+
     // ── addReviewers ─────────────────────────────────────────
 
     describe('addReviewers', () => {
@@ -636,6 +665,9 @@ describe('AdoPullRequestsAdapter', () => {
             await adapterWithRepo.getReviewers('ws-48cyxk', 1);
             expect(svc.getReviewers).toHaveBeenCalledWith('my-repo', 1, 'my-project');
 
+            await adapterWithRepo.getCommits('ws-48cyxk', 1);
+            expect(svc.getPullRequestCommits).toHaveBeenCalledWith('my-repo', 1, 'my-project');
+
             await adapterWithRepo.addReviewers('ws-48cyxk', 1, ['u1']);
             expect(svc.addReviewers).toHaveBeenCalledWith('my-repo', 1, [{ id: 'u1' }], 'my-project');
         });
@@ -646,6 +678,9 @@ describe('AdoPullRequestsAdapter', () => {
 
             await adapterNoRepo.listPullRequests('fallback-repo');
             expect(svc.listPullRequests).toHaveBeenCalledWith('fallback-repo', expect.any(Object), 'my-project', undefined, undefined);
+
+            await adapterNoRepo.getCommits('fallback-repo', 1);
+            expect(svc.getPullRequestCommits).toHaveBeenCalledWith('fallback-repo', 1, 'my-project');
         });
 
         it('preserves repositoryId in mapped PullRequest even when repo override is used', async () => {

--- a/packages/forge/test/ado/pull-requests-service.test.ts
+++ b/packages/forge/test/ado/pull-requests-service.test.ts
@@ -15,6 +15,7 @@ function makeMockGitApi(overrides: Record<string, unknown> = {}) {
         getThreads: vi.fn().mockResolvedValue([]),
         createPullRequestReviewers: vi.fn().mockResolvedValue([]),
         getPullRequestReviewers: vi.fn().mockResolvedValue([]),
+        getPullRequestCommits: vi.fn().mockResolvedValue([]),
         getPullRequestIterations: vi.fn().mockResolvedValue([]),
         getPullRequestIterationChanges: vi.fn().mockResolvedValue({ changeEntries: [] }),
         getItemText: vi.fn().mockResolvedValue(null),
@@ -176,6 +177,33 @@ describe('AdoPullRequestsService', () => {
 
         expect(gitApi.getPullRequestReviewers).toHaveBeenCalledWith('repo-id', 1, 'proj');
         expect(result).toEqual(reviewers);
+    });
+
+    // ── getPullRequestCommits ───────────────────────────────
+
+    it('getPullRequestCommits delegates to gitApi.getPullRequestCommits and returns array', async () => {
+        const commits = [{ commitId: 'abc123', comment: 'Fix bug' }];
+        gitApi.getPullRequestCommits.mockResolvedValue(commits);
+
+        const result = await service.getPullRequestCommits('repo-id', 42, 'proj');
+
+        expect(gitApi.getPullRequestCommits).toHaveBeenCalledWith('repo-id', 42, 'proj');
+        expect(result).toEqual(commits);
+    });
+
+    it('getPullRequestCommits returns [] when API returns undefined', async () => {
+        gitApi.getPullRequestCommits.mockResolvedValue(undefined);
+
+        const result = await service.getPullRequestCommits('repo-id', 42);
+
+        expect(result).toEqual([]);
+    });
+
+    it('getPullRequestCommits throws AdoPullRequestError when the API rejects', async () => {
+        gitApi.getPullRequestCommits.mockRejectedValue(new Error('timeout'));
+
+        await expect(service.getPullRequestCommits('repo-id', 42)).rejects.toThrow(AdoPullRequestError);
+        await expect(service.getPullRequestCommits('repo-id', 42)).rejects.toThrow('Failed to get commits for PR 42');
     });
 
     // ── getGitApi caching ────────────────────────────────────

--- a/packages/forge/test/github/github-pull-requests-adapter.test.ts
+++ b/packages/forge/test/github/github-pull-requests-adapter.test.ts
@@ -39,6 +39,17 @@ const mockGitHubComment = {
     html_url: 'https://github.com/owner/repo/pull/42#issuecomment-300',
 };
 
+const mockGitHubCommit = {
+    sha: 'abcdef1234567890',
+    commit: {
+        message: 'Fix bug\n\nDetailed body',
+        author: { name: 'Alice Smith', email: 'alice@example.com', date: '2024-01-04T00:00:00Z' },
+        committer: { name: 'CI', email: 'ci@example.com', date: '2024-01-04T01:00:00Z' },
+    },
+    author: { id: 100, login: 'alice', name: 'Alice Smith', email: 'alice@example.com', avatar_url: 'https://avatar/alice' },
+    html_url: 'https://github.com/owner/repo/commit/abcdef1234567890',
+};
+
 function makeMockOctokit(overrides: Record<string, unknown> = {}): Octokit {
     return {
         pulls: {
@@ -48,6 +59,7 @@ function makeMockOctokit(overrides: Record<string, unknown> = {}): Octokit {
             update: vi.fn().mockResolvedValue({ data: mockGitHubPr }),
             listReviewComments: vi.fn().mockResolvedValue({ data: [mockGitHubComment] }),
             listReviews: vi.fn().mockResolvedValue({ data: [mockGitHubReview] }),
+            listCommits: vi.fn().mockResolvedValue({ data: [mockGitHubCommit] }),
             requestReviewers: vi.fn().mockResolvedValue({ data: {} }),
         },
         issues: {
@@ -256,6 +268,29 @@ describe('GitHubPullRequestsAdapter', () => {
             (octokit as any).request = vi.fn().mockResolvedValue({ data: null });
             const diff = await adapter.getDiff('repo', 42);
             expect(diff).toBe('');
+        });
+    });
+
+    describe('getCommits', () => {
+        it('maps GitHub PR commits to canonical commits', async () => {
+            const commits = await adapter.getCommits('repo', 42);
+            expect(octokit.pulls.listCommits).toHaveBeenCalledWith({
+                owner: 'owner',
+                repo: 'repo',
+                pull_number: 42,
+                per_page: 100,
+            });
+            expect(commits).toHaveLength(1);
+            expect(commits[0]).toMatchObject({
+                sha: 'abcdef1234567890',
+                shortSha: 'abcdef1',
+                title: 'Fix bug',
+                message: 'Fix bug\n\nDetailed body',
+                author: { displayName: 'Alice Smith', email: 'alice@example.com' },
+                url: 'https://github.com/owner/repo/commit/abcdef1234567890',
+            });
+            expect(commits[0].authoredAt).toEqual(new Date('2024-01-04T00:00:00Z'));
+            expect(commits[0].committedAt).toEqual(new Date('2024-01-04T01:00:00Z'));
         });
     });
 });


### PR DESCRIPTION
## Summary
- Added a provider-neutral PR commit contract and exposed `getCommits` through the forge adapters for GitHub and ADO.
- Added a real `/api/repos/:repoId/pull-requests/:prId/commits` route and client method so the PR detail page can fetch live commit data.
- Replaced the mocked commit-intent table with a real commit table in the PR detail view and updated the related tests/fixtures.

## Testing
- Added and updated unit tests for forge GitHub/ADO commit mapping and ADO commit retrieval.
- Added server route coverage for the new PR commits endpoint.
- Updated SPA and client contract tests, then verified the affected packages with targeted test runs and successful builds for `forge`, `coc-client`, and `coc`.