### PR TITLE
feat(focused-diff): add classify-diff skill with dashboard UI and REST API

### DIFF
--- a/.changeset/focused-diff-classification.md
+++ b/.changeset/focused-diff-classification.md
@@ -1,0 +1,17 @@
+---
+"@plusplusoneplusplus/forge": minor
+"@plusplusoneplusplus/coc": minor
+"@plusplusoneplusplus/coc-client": minor
+---
+
+Add AI-powered focused diff classification for PR review
+
+- New `/classify-diff` bundled skill with structured JSON output schema for per-hunk classification
+- Feature-flag gated `focusedDiff` (disabled by default) with admin panel toggle
+- REST API endpoints: POST to trigger classification, GET for cached results
+- Dashboard filter bar with Logic/Mechanical/Test/Generated checkboxes on PR Files Changed tab
+- File tree badges showing max hunk intensity per file
+- Visual dimming of non-logic hunks in focused mode
+- Classification stored as CoC conversation in process store, cached by PR ID + head SHA
+- `headSha` and `baseSha` added to canonical `PullRequest` type (GitHub and ADO adapters)
+- `PullRequestsClient` extended with `classify()` and `getClassification()` methods

--- a/packages/coc-client/src/contracts/pull-requests.ts
+++ b/packages/coc-client/src/contracts/pull-requests.ts
@@ -109,3 +109,48 @@ export interface PullRequestChatBinding {
 export interface PullRequestChatBindingListResponse {
   bindings: Record<string, { taskId: string; createdAt: string }>;
 }
+
+// ── Classification (focused-diff) ───────────────────────────────────
+
+/** The four hunk categories recognised by the classifier. */
+export type HunkCategory = 'logic' | 'mechanical' | 'test' | 'generated';
+
+/** How important a hunk is within its category. */
+export type HunkIntensity = 'high' | 'low';
+
+/** Classification result for a single `@@` hunk. */
+export interface HunkClassification {
+  file: string;
+  hunkIndex: number;
+  category: HunkCategory;
+  intensity: HunkIntensity;
+  reason: string;
+}
+
+/** Full classification result for a PR diff. */
+export interface DiffClassificationResult {
+  classifications: HunkClassification[];
+}
+
+/** Body for POST /repos/:repoId/pull-requests/:prId/classify. */
+export interface ClassifyDiffRequest {
+  headSha: string;
+  model?: string;
+  workspaceId?: string;
+}
+
+/** Response from POST classify (trigger). */
+export interface ClassifyDiffResponse {
+  status: 'started' | 'ready' | 'running';
+  taskId?: string;
+  processId?: string;
+  result?: DiffClassificationResult;
+}
+
+/** Response from GET classification (cached lookup). */
+export interface ClassificationStatusResponse {
+  status: 'none' | 'ready' | 'running';
+  processId?: string;
+  result?: DiffClassificationResult;
+  createdAt?: string;
+}

--- a/packages/coc-client/src/domains/pull-requests.ts
+++ b/packages/coc-client/src/domains/pull-requests.ts
@@ -1,4 +1,7 @@
 import type {
+  ClassificationStatusResponse,
+  ClassifyDiffRequest,
+  ClassifyDiffResponse,
   ProviderConfigRequest,
   PullRequestChatBinding,
   PullRequestChatBindingListResponse,
@@ -113,6 +116,29 @@ export class PullRequestsClient {
     return this.transport.request<void>(
       `/workspaces/${encodePathSegment(workspaceId)}/pull-request-chat-bindings/${encodePathSegment(prId)}`,
       { method: 'DELETE' },
+    );
+  }
+
+  /** Trigger on-demand AI classification of a PR's diff hunks. */
+  classify(repoId: string, prId: string, body: ClassifyDiffRequest, options?: Pick<CocRequestOptions, 'signal'>): Promise<ClassifyDiffResponse> {
+    return this.transport.request<ClassifyDiffResponse>(
+      `/repos/${encodePathSegment(repoId)}/pull-requests/${encodePathSegment(prId)}/classify`,
+      {
+        method: 'POST',
+        body: { ...body },
+        signal: options?.signal,
+      },
+    );
+  }
+
+  /** Get cached classification result for a PR. */
+  getClassification(repoId: string, prId: string, headSha: string, options?: Pick<CocRequestOptions, 'signal'>): Promise<ClassificationStatusResponse> {
+    return this.transport.request<ClassificationStatusResponse>(
+      `/repos/${encodePathSegment(repoId)}/pull-requests/${encodePathSegment(prId)}/classification`,
+      {
+        query: { headSha },
+        signal: options?.signal,
+      },
     );
   }
 }

--- a/packages/coc-client/test/domains/pull-requests.test.ts
+++ b/packages/coc-client/test/domains/pull-requests.test.ts
@@ -136,4 +136,59 @@ describe('PullRequestsClient', () => {
       },
     ]);
   });
+
+  it('classify sends POST with headSha, model, and encoded IDs', async () => {
+    const adapter = createMockAdapter({ status: 'started', taskId: 'task-1' });
+    const client = new PullRequestsClient(adapter);
+
+    await client.classify('repo/a', 'pr/1', { headSha: 'abc123', model: 'haiku' });
+
+    expect(adapter.calls).toEqual([
+      {
+        path: '/repos/repo%2Fa/pull-requests/pr%2F1/classify',
+        options: {
+          method: 'POST',
+          body: { headSha: 'abc123', model: 'haiku' },
+          signal: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('classify forwards abort signal', async () => {
+    const adapter = createMockAdapter({ status: 'started' });
+    const client = new PullRequestsClient(adapter);
+    const controller = new AbortController();
+
+    await client.classify('r1', '10', { headSha: 'sha1' }, { signal: controller.signal });
+
+    expect(adapter.calls[0].options?.signal).toBe(controller.signal);
+  });
+
+  it('getClassification sends GET with headSha query param', async () => {
+    const adapter = createMockAdapter({ status: 'none' });
+    const client = new PullRequestsClient(adapter);
+
+    await client.getClassification('repo/a', 'pr/1', 'abc123');
+
+    expect(adapter.calls).toEqual([
+      {
+        path: '/repos/repo%2Fa/pull-requests/pr%2F1/classification',
+        options: {
+          query: { headSha: 'abc123' },
+          signal: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('getClassification forwards abort signal', async () => {
+    const adapter = createMockAdapter({ status: 'ready' });
+    const client = new PullRequestsClient(adapter);
+    const controller = new AbortController();
+
+    await client.getClassification('r1', '10', 'sha1', { signal: controller.signal });
+
+    expect(adapter.calls[0].options?.signal).toBe(controller.signal);
+  });
 });

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -132,6 +132,7 @@ export interface CLIConfig {
     /** Development feature flags. */
     features?: {
         autoMemoryPromotion?: boolean;
+        focusedDiff?: boolean;
     };
     /** Memory promotion configuration */
     memoryPromotion?: {
@@ -296,6 +297,7 @@ export interface ResolvedCLIConfig {
     /** Development feature flags. */
     features: {
         autoMemoryPromotion: boolean;
+        focusedDiff: boolean;
     };
     /** Memory promotion configuration */
     memoryPromotion: {
@@ -418,6 +420,7 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
     },
     features: {
         autoMemoryPromotion: false,
+        focusedDiff: false,
     },
     memoryPromotion: {
         batchSize: 50,

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -69,7 +69,7 @@ const RALPH_SOURCE_KEYS = ['ralph.enabled'] as const;
 const VIM_NAVIGATION_SOURCE_KEYS = ['vimNavigation.enabled'] as const;
 const LOOPS_SOURCE_KEYS = ['loops.enabled'] as const;
 const MCP_OAUTH_SOURCE_KEYS = ['mcpOauth.enabled'] as const;
-const FEATURES_SOURCE_KEYS = ['features.autoMemoryPromotion'] as const;
+const FEATURES_SOURCE_KEYS = ['features.autoMemoryPromotion', 'features.focusedDiff'] as const;
 
 const MEMORY_PROMOTION_SOURCE_KEYS = [
     'memoryPromotion.batchSize',
@@ -252,6 +252,7 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
             merge: (base, override) => ({
                 features: {
                     autoMemoryPromotion: override?.features?.autoMemoryPromotion ?? base.features?.autoMemoryPromotion ?? false,
+                    focusedDiff: override?.features?.focusedDiff ?? base.features?.focusedDiff ?? false,
                 },
             }),
         },

--- a/packages/coc/src/config/schema.ts
+++ b/packages/coc/src/config/schema.ts
@@ -105,6 +105,7 @@ export const CLIConfigSchema = z.object({
     }).passthrough().optional(),
     features: z.object({
         autoMemoryPromotion: z.boolean().optional(),
+        focusedDiff: z.boolean().optional(),
     }).passthrough().optional(),
     memoryPromotion: z.object({
         batchSize: z.number().int().positive().optional(),

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -184,6 +184,10 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
         if (!cfg.loops) { cfg.loops = {}; }
         cfg.loops.enabled = v;
     }),
+    bool('features.focusedDiff', (cfg, v) => {
+        if (!cfg.features) { cfg.features = {}; }
+        cfg.features.focusedDiff = v;
+    }),
 ];
 
 /** Flat keys accepted by PUT /api/admin/config — derived from the registry. */

--- a/packages/coc/src/server/executors/classification-executor.ts
+++ b/packages/coc/src/server/executors/classification-executor.ts
@@ -1,0 +1,113 @@
+/**
+ * Classification Executor
+ *
+ * Concrete executor for PR diff classification chat tasks. Dispatched when
+ * `payload.context.classifyDiff` is present (see `hasClassifyDiffContext`).
+ *
+ * Extends ChatBaseExecutor to inject a per-invocation `saveClassification`
+ * tool pre-bound with the (workspaceId, repoId, prId, headSha) tuple. The
+ * AI calls the tool with the final per-hunk classifications and the handler
+ * writes them to the file-based classification store.
+ *
+ * No VS Code dependencies — uses only Node.js built-in modules.
+ * Cross-platform compatible (Linux/Mac/Windows).
+ */
+
+import type {
+    AgentMode,
+    ProcessStore,
+    QueuedTask,
+    Tool,
+} from '@plusplusoneplusplus/forge';
+import { toQueueProcessId } from '@plusplusoneplusplus/forge';
+import type { ChatPayload } from '../tasks/task-types';
+import type { ChatModeAIOptions, ChatModeExecutorOptions } from './chat-base-executor';
+import { ChatBaseExecutor } from './chat-base-executor';
+import {
+    buildFollowUpSuggestionsAddon,
+    buildMemoryReadToolsAddon,
+    buildSearchConversationsAddon,
+    buildTavilyWebSearchAddon,
+    applyLlmToolPreferences,
+} from './prompt-builder';
+import { systemMessageBuilder } from './system-message-builder';
+import { readEffectiveDisabledLlmTools } from '../preferences-handler';
+import { createSaveClassificationTool } from '../llm-tools/save-classification-tool';
+
+const SAVE_CLASSIFICATION_SUFFIX =
+    '\n\nIMPORTANT: After you have classified every `@@` hunk, call the `saveClassification` tool ' +
+    'EXACTLY ONCE with the full array of per-hunk classifications. ' +
+    'Do NOT print the classifications as JSON or markdown in your response — the persistence layer ' +
+    'reads them directly from the tool call. Only call the tool after you have inspected every hunk.';
+
+export class ClassificationExecutor extends ChatBaseExecutor {
+    constructor(
+        store: ProcessStore,
+        options: ChatModeExecutorOptions,
+        dataDir?: string,
+    ) {
+        super(store, options, dataDir);
+    }
+
+    protected async buildModeOptions(
+        task: QueuedTask,
+        prompt: string,
+        workingDirectory: string | undefined,
+    ): Promise<ChatModeAIOptions> {
+        const payload = task.payload as unknown as ChatPayload;
+        const classifyDiff = payload.context?.classifyDiff;
+        const wsId = payload.workspaceId;
+        const processId = toQueueProcessId(task.id);
+
+        const boundedMemory = await this.buildMemoryAddon(wsId, this.buildCaptureContext(task), prompt);
+        const systemMessage = await systemMessageBuilder()
+            .withRepoInstructions(workingDirectory, 'autopilot')
+            .appendMemory(boundedMemory)
+            .build();
+
+        const tools: Tool<unknown>[] = [];
+        let toolSuffix = '';
+
+        if (this.dataDir && wsId && classifyDiff?.repoId && classifyDiff?.prId && classifyDiff?.headSha) {
+            const { tool } = createSaveClassificationTool({
+                dataDir: this.dataDir,
+                workspaceId: wsId,
+                repoId: classifyDiff.repoId,
+                prId: classifyDiff.prId,
+                headSha: classifyDiff.headSha,
+                processId,
+            });
+            tools.push(tool);
+            toolSuffix += SAVE_CLASSIFICATION_SUFFIX;
+        }
+
+        // Standard chat tools (search, memory, etc.) — same pattern as other executors.
+        const followUp = buildFollowUpSuggestionsAddon(
+            this.followUpSuggestions.enabled,
+            this.followUpSuggestions.count,
+        );
+        const searchConversations = buildSearchConversationsAddon(this.store, wsId, processId);
+        const tavilySearch = buildTavilyWebSearchAddon(this.dataDir);
+        const memoryReadTools = buildMemoryReadToolsAddon(this.dataDir, wsId);
+
+        const disabledLlmTools = this.dataDir && wsId
+            ? readEffectiveDisabledLlmTools(this.dataDir, wsId)
+            : undefined;
+
+        const { tools: filteredTools, suffix: filteredSuffix } = applyLlmToolPreferences(
+            [followUp, searchConversations, tavilySearch, memoryReadTools, boundedMemory],
+            disabledLlmTools,
+        );
+
+        tools.push(...filteredTools);
+        toolSuffix += filteredSuffix;
+
+        return {
+            agentMode: 'autopilot' as AgentMode,
+            systemMessage,
+            tools,
+            effectivePrompt: prompt + toolSuffix,
+            dispose: boundedMemory.dispose,
+        };
+    }
+}

--- a/packages/coc/src/server/executors/executor-registry.ts
+++ b/packages/coc/src/server/executors/executor-registry.ts
@@ -1,7 +1,7 @@
 import type { ConversationTurn, CopilotSDKService, FileToolCallCacheStore, ProcessStore, QueuedTask } from '@plusplusoneplusplus/forge';
 import { approveAllPermissions, toQueueProcessId } from '@plusplusoneplusplus/forge';
 import type { ChatPayload } from '../tasks/task-types';
-import { isChatPayload, isChatFollowUp, isRunWorkflowPayload, isRunScriptPayload, hasTaskGenerationContext, hasResolveCommentsContext, hasResolveDiffCommentsMultiContext, hasReplicationContext, hasCommitChatContext, hasNoteChatContext, hasNoteCreateContext, isBackgroundReviewPayload, isMemoryPromotePayload } from '../tasks/task-types';
+import { isChatPayload, isChatFollowUp, isRunWorkflowPayload, isRunScriptPayload, hasTaskGenerationContext, hasResolveCommentsContext, hasResolveDiffCommentsMultiContext, hasReplicationContext, hasCommitChatContext, hasNoteChatContext, hasNoteCreateContext, hasClassifyDiffContext, isBackgroundReviewPayload, isMemoryPromotePayload } from '../tasks/task-types';
 import type { ChatMode } from '../tasks/task-types';
 import type { ExecutionContext } from '../task-strategies';
 import { TaskStrategyRegistry } from '../task-strategies';
@@ -18,6 +18,7 @@ import { ResolveCommentsExecutor } from './resolve-comments-executor';
 import { CommitChatExecutor } from './commit-chat-executor';
 import { NoteChatExecutor } from './note-chat-executor';
 import { NoteCreateExecutor } from './note-create-executor';
+import { ClassificationExecutor } from './classification-executor';
 import { ProcessLifecycleRunner } from './process-lifecycle-runner';
 import { WrappedTaskExecutor } from './wrapped-task-executor';
 import type { SkillExecuteFn } from './wrapped-task-executor';
@@ -73,6 +74,7 @@ export class ExecutorRegistry {
     private readonly commitChatExecutor: CommitChatExecutor;
     private readonly noteChatExecutor: NoteChatExecutor;
     private readonly noteCreateExecutor: NoteCreateExecutor;
+    private readonly classificationExecutor: ClassificationExecutor;
     private readonly strategyRegistry: TaskStrategyRegistry;
 
     constructor(store: ProcessStore, options: ExecutorRegistryOptions) {
@@ -111,6 +113,7 @@ export class ExecutorRegistry {
         this.commitChatExecutor = new CommitChatExecutor(store, chatOpts, options.getWsServer, options.dataDir);
         this.noteChatExecutor = new NoteChatExecutor(store, chatOpts, options.dataDir);
         this.noteCreateExecutor = new NoteCreateExecutor(store, chatOpts, options.dataDir);
+        this.classificationExecutor = new ClassificationExecutor(store, chatOpts, options.dataDir);
         this.backgroundReviewExecutor = new BackgroundReviewExecutor(
             options.aiService,
             options.getMemoryStore ?? (() => undefined),
@@ -183,6 +186,7 @@ export class ExecutorRegistry {
         if (hasReplicationContext(task.payload)) return { execute: (t: QueuedTask) => this.strategyRegistry.get('replicate-template')!.execute(t, this.buildExecutionContext(t)) };
         if (hasResolveCommentsContext(task.payload) || hasResolveDiffCommentsMultiContext(task.payload) || payload.tools?.includes('resolve-comments')) return { execute: (t: QueuedTask) => this.resolveCommentsExecutor.executeTask(t) };
         if (hasCommitChatContext(task.payload)) return this.commitChatExecutor;
+        if (hasClassifyDiffContext(task.payload)) return this.classificationExecutor;
         if (hasNoteCreateContext(task.payload)) return this.noteCreateExecutor;
         if (hasNoteChatContext(task.payload)) return this.noteChatExecutor;
         const mode = payload.mode;

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -392,6 +392,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
                 vimNavigationEnabled: liveConfig.vimNavigation?.enabled ?? false,
                 loopsEnabled: liveConfig.loops?.enabled ?? false,
                 mcpOauthEnabled: liveConfig.mcpOauth?.enabled ?? false,
+                focusedDiffEnabled: liveConfig.features?.focusedDiff ?? false,
                 bindAddress: host,
             });
         },

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -52,6 +52,7 @@ import { DevTunnelConnector } from './servers/devtunnel-connector';
 import { RemoteServerStore } from './servers/remote-server-store';
 import { AutoPromoteScheduler } from './memory/auto-promote';
 import { setMemoryCandidateCapturedCallback } from './executors/bounded-memory-addon';
+import { pruneAllStaleClassifications } from './repos/classification-store';
 
 // ============================================================================
 // Close Handler Builder
@@ -431,6 +432,11 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         process.stderr.write(`[servers] Failed to start DevTunnel connectors: ${error instanceof Error ? error.message : String(error)}\n`);
     }
     cleanupAllStalePasteFiles(dataDir).catch(() => { /* best-effort */ });
+    try {
+        pruneAllStaleClassifications(dataDir);
+    } catch {
+        /* best-effort */
+    }
 
     const address = server.address();
     const actualPort = typeof address === 'object' && address ? address.port : port;

--- a/packages/coc/src/server/llm-tools/save-classification-tool.ts
+++ b/packages/coc/src/server/llm-tools/save-classification-tool.ts
@@ -1,0 +1,119 @@
+/**
+ * Save Classification Tool
+ *
+ * Per-invocation `saveClassification` LLM tool. Persists a complete
+ * `DiffClassificationResult` to the file-based classification store
+ * (`packages/coc/src/server/repos/classification-store.ts`).
+ *
+ * Context (workspaceId, repoId, prId, headSha) is pre-bound at construction
+ * time via `createSaveClassificationTool()` so the AI only supplies the
+ * `classifications` array. Validation is strict — the tool returns an error
+ * response when entries are malformed so the AI can retry with corrections.
+ *
+ * No VS Code dependencies — uses only Node.js built-in modules.
+ * Cross-platform compatible (Linux/Mac/Windows).
+ */
+
+import { defineTool } from '@plusplusoneplusplus/forge';
+import type { Tool } from '@plusplusoneplusplus/forge';
+import type { HunkClassification } from '../spa/client/react/features/pull-requests/classification-types';
+import {
+    validateClassificationResult,
+    writeClassification,
+} from '../repos/classification-store';
+
+export interface SaveClassificationArgs {
+    classifications: HunkClassification[];
+}
+
+export interface SaveClassificationDeps {
+    dataDir: string;
+    workspaceId: string;
+    repoId: string;
+    prId: string;
+    headSha: string;
+    /** Optional processId stamped onto the stored record. */
+    processId?: string;
+}
+
+export function createSaveClassificationTool(deps: SaveClassificationDeps) {
+    let saved: HunkClassification[] | undefined;
+
+    const tool = defineTool<SaveClassificationArgs>('saveClassification', {
+        description:
+            'Persist the final hunk classifications for this pull request. ' +
+            'Call this exactly once, AFTER you have classified every `@@` hunk in the diff. ' +
+            'Pass the full array of classifications (one entry per hunk). ' +
+            'Each entry must include: file, hunkIndex (0-based within the file), ' +
+            'category (logic|mechanical|test|generated), intensity (high|low), and a one-sentence reason. ' +
+            'If validation fails the tool returns an error — read the message, correct the offending entries, and call the tool again.',
+        parameters: {
+            type: 'object',
+            properties: {
+                classifications: {
+                    type: 'array',
+                    description: 'Per-hunk classifications, ordered by file then hunk index.',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            file: { type: 'string', description: 'Repo-relative file path as it appears in the diff.' },
+                            hunkIndex: { type: 'number', description: '0-based hunk index within the file.' },
+                            category: {
+                                type: 'string',
+                                enum: ['logic', 'mechanical', 'test', 'generated'],
+                                description: 'Dominant category for this hunk.',
+                            },
+                            intensity: {
+                                type: 'string',
+                                enum: ['high', 'low'],
+                                description: 'Reviewer-attention level.',
+                            },
+                            reason: { type: 'string', description: 'One-sentence justification.' },
+                        },
+                        required: ['file', 'hunkIndex', 'category', 'intensity', 'reason'],
+                    },
+                },
+            },
+            required: ['classifications'],
+        },
+        handler: async (args) => {
+            const validation = validateClassificationResult({ classifications: args?.classifications });
+            if (!validation.ok) {
+                return {
+                    success: false,
+                    error: validation.error,
+                    hint: 'Fix the offending entries and call saveClassification again with the corrected array.',
+                };
+            }
+
+            try {
+                const record = writeClassification(
+                    deps.dataDir,
+                    deps.workspaceId,
+                    deps.repoId,
+                    deps.prId,
+                    deps.headSha,
+                    { classifications: validation.classifications },
+                    { processId: deps.processId },
+                );
+                saved = validation.classifications;
+                return {
+                    success: true,
+                    count: validation.classifications.length,
+                    createdAt: record.createdAt,
+                };
+            } catch (err) {
+                return {
+                    success: false,
+                    error: err instanceof Error ? err.message : String(err),
+                };
+            }
+        },
+    });
+
+    return {
+        tool: tool as Tool<unknown>,
+        /** Returns the classifications written by the most recent successful call, if any. */
+        getSaved: (): HunkClassification[] | undefined => saved,
+    };
+}

--- a/packages/coc/src/server/repos/classification-store.ts
+++ b/packages/coc/src/server/repos/classification-store.ts
@@ -1,0 +1,322 @@
+/**
+ * Classification Store
+ *
+ * File-based persistence for PR diff classification results. One JSON file
+ * per (workspace, repo, pr, headSha) tuple, with a sibling `.pending` marker
+ * while a classification task is in flight.
+ *
+ * Layout:
+ *   ~/.coc/repos/<workspaceId>/classifications/<repoId>_<prId>_<headSha>.json
+ *   ~/.coc/repos/<workspaceId>/classifications/<repoId>_<prId>_<headSha>.json.pending
+ *
+ * No VS Code dependencies — uses only Node.js built-in modules.
+ * Cross-platform compatible (Linux/Mac/Windows).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getRepoDataPath } from '../paths';
+import type {
+    DiffClassificationResult,
+    HunkCategory,
+    HunkClassification,
+    HunkIntensity,
+} from '../spa/client/react/features/pull-requests/classification-types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Marker payload describing a classification task currently in flight. */
+export interface ClassificationPending {
+    processId: string;
+    startedAt: string;
+}
+
+/** Stored payload for a completed classification. */
+export interface ClassificationRecord {
+    result: DiffClassificationResult;
+    processId?: string;
+    createdAt: string;
+    headSha: string;
+}
+
+export interface ClassificationPaths {
+    /** Absolute path to the completed `.json` file. */
+    resultPath: string;
+    /** Absolute path to the `.pending` marker file. */
+    pendingPath: string;
+    /** Directory containing all classifications for this workspace. */
+    dir: string;
+}
+
+// ============================================================================
+// Path helpers
+// ============================================================================
+
+const VALID_CATEGORIES: readonly HunkCategory[] = ['logic', 'mechanical', 'test', 'generated'];
+const VALID_INTENSITIES: readonly HunkIntensity[] = ['high', 'low'];
+
+/** Replace filesystem-unsafe characters with `_`. */
+function sanitizeKeyPart(part: string): string {
+    return part.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+/** Resolve the storage paths for a single (workspace, repo, pr, headSha) tuple. */
+export function classificationPaths(
+    dataDir: string,
+    workspaceId: string,
+    repoId: string,
+    prId: string,
+    headSha: string,
+): ClassificationPaths {
+    const dir = getRepoDataPath(dataDir, workspaceId, 'classifications');
+    const base = `${sanitizeKeyPart(repoId)}_${sanitizeKeyPart(prId)}_${sanitizeKeyPart(headSha)}`;
+    const resultPath = path.join(dir, `${base}.json`);
+    const pendingPath = path.join(dir, `${base}.json.pending`);
+    return { resultPath, pendingPath, dir };
+}
+
+// ============================================================================
+// Read / Write
+// ============================================================================
+
+/** Read the completed classification record, if any. Returns undefined when missing or corrupt. */
+export function readClassification(
+    dataDir: string,
+    workspaceId: string,
+    repoId: string,
+    prId: string,
+    headSha: string,
+): ClassificationRecord | undefined {
+    const { resultPath } = classificationPaths(dataDir, workspaceId, repoId, prId, headSha);
+    try {
+        const raw = fs.readFileSync(resultPath, 'utf-8');
+        const parsed = JSON.parse(raw) as ClassificationRecord;
+        if (!parsed || !parsed.result || !Array.isArray(parsed.result.classifications)) {
+            return undefined;
+        }
+        return parsed;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Write a completed classification atomically, then remove any `.pending` marker.
+ * Validates the result before writing — throws if invalid.
+ */
+export function writeClassification(
+    dataDir: string,
+    workspaceId: string,
+    repoId: string,
+    prId: string,
+    headSha: string,
+    result: DiffClassificationResult,
+    options?: { processId?: string; createdAt?: string },
+): ClassificationRecord {
+    const validation = validateClassificationResult(result);
+    if (!validation.ok) {
+        throw new Error(validation.error);
+    }
+
+    const { resultPath, pendingPath, dir } = classificationPaths(dataDir, workspaceId, repoId, prId, headSha);
+    fs.mkdirSync(dir, { recursive: true });
+
+    const record: ClassificationRecord = {
+        result: { classifications: validation.classifications },
+        processId: options?.processId,
+        createdAt: options?.createdAt ?? new Date().toISOString(),
+        headSha,
+    };
+
+    const tmpPath = `${resultPath}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(record, null, 2), 'utf-8');
+    fs.renameSync(tmpPath, resultPath);
+
+    // Best-effort cleanup of the pending marker.
+    try {
+        fs.unlinkSync(pendingPath);
+    } catch {
+        /* no pending marker — ok */
+    }
+
+    return record;
+}
+
+/** Write the `.pending` marker file. */
+export function writePending(
+    dataDir: string,
+    workspaceId: string,
+    repoId: string,
+    prId: string,
+    headSha: string,
+    processId: string,
+    options?: { startedAt?: string },
+): ClassificationPending {
+    const { pendingPath, dir } = classificationPaths(dataDir, workspaceId, repoId, prId, headSha);
+    fs.mkdirSync(dir, { recursive: true });
+    const pending: ClassificationPending = {
+        processId,
+        startedAt: options?.startedAt ?? new Date().toISOString(),
+    };
+    fs.writeFileSync(pendingPath, JSON.stringify(pending, null, 2), 'utf-8');
+    return pending;
+}
+
+/** Read the `.pending` marker if present. */
+export function readPending(
+    dataDir: string,
+    workspaceId: string,
+    repoId: string,
+    prId: string,
+    headSha: string,
+): ClassificationPending | undefined {
+    const { pendingPath } = classificationPaths(dataDir, workspaceId, repoId, prId, headSha);
+    try {
+        const raw = fs.readFileSync(pendingPath, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed.processId === 'string' && typeof parsed.startedAt === 'string') {
+            return parsed as ClassificationPending;
+        }
+    } catch {
+        /* missing or unreadable */
+    }
+    return undefined;
+}
+
+/** Best-effort removal of the `.pending` marker. */
+export function clearPending(
+    dataDir: string,
+    workspaceId: string,
+    repoId: string,
+    prId: string,
+    headSha: string,
+): void {
+    const { pendingPath } = classificationPaths(dataDir, workspaceId, repoId, prId, headSha);
+    try {
+        fs.unlinkSync(pendingPath);
+    } catch {
+        /* ok */
+    }
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+export type ClassificationValidation =
+    | { ok: true; classifications: HunkClassification[] }
+    | { ok: false; error: string };
+
+/**
+ * Strict validation of a `DiffClassificationResult`. Returns the typed
+ * classifications on success, or a human-readable error message on failure.
+ */
+export function validateClassificationResult(
+    result: unknown,
+): ClassificationValidation {
+    if (!result || typeof result !== 'object') {
+        return { ok: false, error: 'result must be an object' };
+    }
+    const arr = (result as { classifications?: unknown }).classifications;
+    if (!Array.isArray(arr)) {
+        return { ok: false, error: 'result.classifications must be an array' };
+    }
+    if (arr.length === 0) {
+        return { ok: false, error: 'result.classifications must contain at least one entry' };
+    }
+
+    const out: HunkClassification[] = [];
+    for (let i = 0; i < arr.length; i++) {
+        const entry = arr[i];
+        if (!entry || typeof entry !== 'object') {
+            return { ok: false, error: `classifications[${i}] must be an object` };
+        }
+        const e = entry as Record<string, unknown>;
+        if (typeof e.file !== 'string' || e.file.length === 0) {
+            return { ok: false, error: `classifications[${i}].file must be a non-empty string` };
+        }
+        if (typeof e.hunkIndex !== 'number' || !Number.isInteger(e.hunkIndex) || e.hunkIndex < 0) {
+            return { ok: false, error: `classifications[${i}].hunkIndex must be a non-negative integer` };
+        }
+        if (typeof e.category !== 'string' || !VALID_CATEGORIES.includes(e.category as HunkCategory)) {
+            return { ok: false, error: `classifications[${i}].category must be one of: ${VALID_CATEGORIES.join(', ')}` };
+        }
+        if (typeof e.intensity !== 'string' || !VALID_INTENSITIES.includes(e.intensity as HunkIntensity)) {
+            return { ok: false, error: `classifications[${i}].intensity must be one of: ${VALID_INTENSITIES.join(', ')}` };
+        }
+        if (typeof e.reason !== 'string' || e.reason.length === 0) {
+            return { ok: false, error: `classifications[${i}].reason must be a non-empty string` };
+        }
+        out.push({
+            file: e.file,
+            hunkIndex: e.hunkIndex,
+            category: e.category as HunkCategory,
+            intensity: e.intensity as HunkIntensity,
+            reason: e.reason,
+        });
+    }
+
+    return { ok: true, classifications: out };
+}
+
+// ============================================================================
+// Pruning
+// ============================================================================
+
+/**
+ * Remove classification files older than `maxAgeDays` for a single workspace.
+ * Returns the number of files removed. Best-effort: errors are swallowed.
+ */
+export function pruneStaleClassifications(
+    dataDir: string,
+    workspaceId: string,
+    maxAgeDays = 30,
+): number {
+    if (maxAgeDays <= 0) return 0;
+    const dir = getRepoDataPath(dataDir, workspaceId, 'classifications');
+    let removed = 0;
+    let entries: string[] = [];
+    try {
+        entries = fs.readdirSync(dir);
+    } catch {
+        return 0;
+    }
+
+    const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+    for (const name of entries) {
+        if (!name.endsWith('.json') && !name.endsWith('.pending')) continue;
+        const full = path.join(dir, name);
+        try {
+            const st = fs.statSync(full);
+            if (st.mtimeMs < cutoffMs) {
+                fs.unlinkSync(full);
+                removed++;
+            }
+        } catch {
+            /* skip */
+        }
+    }
+    return removed;
+}
+
+/**
+ * Prune every workspace directory under `<dataDir>/repos`. Returns total files removed.
+ */
+export function pruneAllStaleClassifications(dataDir: string, maxAgeDays = 30): number {
+    const reposRoot = path.join(dataDir, 'repos');
+    let total = 0;
+    let entries: fs.Dirent[] = [];
+    try {
+        entries = fs.readdirSync(reposRoot, { withFileTypes: true });
+    } catch {
+        return 0;
+    }
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            total += pruneStaleClassifications(dataDir, entry.name, maxAgeDays);
+        }
+    }
+    return total;
+}

--- a/packages/coc/src/server/repos/pr-classification-handler.ts
+++ b/packages/coc/src/server/repos/pr-classification-handler.ts
@@ -45,15 +45,6 @@ export interface PrClassificationRouteOptions {
 }
 
 // ============================================================================
-// Cache key helpers
-// ============================================================================
-
-/** Legacy tag used to embed a stable marker in the classification prompt. */
-export function classificationCacheTag(repoId: string, prId: string, headSha: string): string {
-    return `classify-diff:${repoId}:${prId}:${headSha}`;
-}
-
-// ============================================================================
 // Route registration
 // ============================================================================
 
@@ -109,8 +100,7 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
                 const repo = await svc.resolveRepo(repoId);
                 if (!repo) return send404(res, `Repo ${repoId} not found`);
 
-                const cacheTag = classificationCacheTag(repoId, prId, headSha);
-                const prompt = buildClassificationPrompt(repoId, prId, cacheTag);
+                const prompt = buildClassificationPrompt(repoId, prId);
 
                 // Enqueue a chat task with the classify-diff skill. The
                 // ClassificationExecutor is dispatched because the payload
@@ -135,7 +125,6 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
                                 repoId,
                                 prId,
                                 headSha,
-                                cacheTag,
                             },
                         },
                     },
@@ -207,8 +196,8 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
 // Helpers
 // ============================================================================
 
-export function buildClassificationPrompt(repoId: string, prId: string, cacheTag?: string): string {
-    const lines = [
+export function buildClassificationPrompt(repoId: string, prId: string): string {
+    return [
         `Classify every hunk in pull request #${prId} of this repository.`,
         '',
         'Use the available git and gh CLI tools to read the PR diff. Do NOT ask me for the diff — fetch it yourself.',
@@ -216,9 +205,5 @@ export function buildClassificationPrompt(repoId: string, prId: string, cacheTag
         'For each @@ hunk, produce a classification with: file, hunkIndex (0-based within the file), category (logic|mechanical|test|generated), intensity (high|low), and a one-sentence reason.',
         '',
         'When you have classified every hunk, persist the results by calling the `saveClassification` tool exactly once with the full array. Do NOT print the classifications as JSON in your response — the persistence layer reads them directly from the tool call.',
-    ];
-    if (cacheTag) {
-        lines.push('', `<!-- cache-key: ${cacheTag} -->`);
-    }
-    return lines.join('\n');
+    ].join('\n');
 }

--- a/packages/coc/src/server/repos/pr-classification-handler.ts
+++ b/packages/coc/src/server/repos/pr-classification-handler.ts
@@ -7,8 +7,10 @@
  * POST /api/repos/:repoId/pull-requests/:prId/classify        — trigger classification
  * GET  /api/repos/:repoId/pull-requests/:prId/classification   — get cached result
  *
- * The classification result is stored in the process store as a conversation.
- * Cache key: `classify-diff:<repoId>:<prId>:<headSha>`.
+ * Results are persisted to a file-based store keyed by (workspaceId, repoId,
+ * prId, headSha). The AI writes results via the `saveClassification` LLM
+ * tool injected by `ClassificationExecutor` — there is no JSON extraction
+ * from assistant text or process-store scanning.
  */
 
 import type { Route } from '../types';
@@ -16,10 +18,11 @@ import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import type { MultiRepoQueueRouter } from '../queue/multi-repo-queue-router';
 import { sendJson, send404, send400, send500, readJsonBody } from '../router';
 import { RepoTreeService } from './tree-service';
-import type { DiffClassificationResult, HunkClassification } from '../spa/client/react/features/pull-requests/classification-types';
-
-/** Display name prefix used for classification tasks — doubles as a search token. */
-const CLASSIFY_DISPLAY_PREFIX = 'Classify PR #';
+import {
+    readClassification,
+    readPending,
+    writePending,
+} from './classification-store';
 
 // ============================================================================
 // Types
@@ -34,13 +37,6 @@ interface ClassifyRequestBody {
     workspaceId?: string;
 }
 
-interface ClassificationCacheEntry {
-    result: DiffClassificationResult;
-    headSha: string;
-    createdAt: string;
-    processId: string;
-}
-
 export interface PrClassificationRouteOptions {
     dataDir: string;
     store: ProcessStore;
@@ -52,54 +48,9 @@ export interface PrClassificationRouteOptions {
 // Cache key helpers
 // ============================================================================
 
-/** Build the process store tag used to find a cached classification. */
+/** Legacy tag used to embed a stable marker in the classification prompt. */
 export function classificationCacheTag(repoId: string, prId: string, headSha: string): string {
     return `classify-diff:${repoId}:${prId}:${headSha}`;
-}
-
-// ============================================================================
-// Result extraction
-// ============================================================================
-
-/**
- * Parse the classification JSON from the last assistant turn of a completed process.
- * Expects a JSON block (possibly inside a ```json fence) matching `DiffClassificationResult`.
- */
-export function extractClassificationFromResult(resultText: string | undefined): DiffClassificationResult | undefined {
-    if (!resultText) return undefined;
-
-    // Try to find a JSON code block first
-    const fenceMatch = resultText.match(/```json\s*([\s\S]*?)```/);
-    const jsonStr = fenceMatch ? fenceMatch[1].trim() : resultText.trim();
-
-    try {
-        const parsed = JSON.parse(jsonStr);
-        if (parsed && Array.isArray(parsed.classifications)) {
-            // Validate each entry has required fields
-            const valid = parsed.classifications.every((c: any) =>
-                typeof c.file === 'string' &&
-                typeof c.hunkIndex === 'number' &&
-                typeof c.category === 'string' &&
-                typeof c.intensity === 'string' &&
-                typeof c.reason === 'string',
-            );
-            if (valid) {
-                return { classifications: parsed.classifications as HunkClassification[] };
-            }
-        }
-    } catch {
-        // Not valid JSON — try to find a JSON object in the text
-        const objectMatch = resultText.match(/\{[\s\S]*"classifications"\s*:\s*\[[\s\S]*\]\s*\}/);
-        if (objectMatch) {
-            try {
-                const parsed = JSON.parse(objectMatch[0]);
-                if (Array.isArray(parsed.classifications)) {
-                    return { classifications: parsed.classifications as HunkClassification[] };
-                }
-            } catch { /* give up */ }
-        }
-    }
-    return undefined;
 }
 
 // ============================================================================
@@ -132,28 +83,38 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
                 }
 
                 const headSha = body.headSha.trim();
-                const cacheTag = classificationCacheTag(repoId, prId, headSha);
+                const workspaceId = body.workspaceId || repoId;
 
-                // Check cache — look for an existing process with this tag
-                const cached = await findCachedClassification(store, cacheTag);
+                // Cached result wins.
+                const cached = readClassification(dataDir, workspaceId, repoId, prId, headSha);
                 if (cached) {
                     return sendJson(res, {
-                        status: cached.status === 'completed' ? 'ready' : 'running',
+                        status: 'ready',
                         processId: cached.processId,
-                        ...(cached.result ? { result: cached.result } : {}),
+                        result: cached.result,
+                        createdAt: cached.createdAt,
                     });
                 }
 
-                // Resolve repo to get workspace root for queue routing
+                // In-flight task already running for this exact (repo, pr, headSha)?
+                const pending = readPending(dataDir, workspaceId, repoId, prId, headSha);
+                if (pending) {
+                    return sendJson(res, {
+                        status: 'running',
+                        processId: pending.processId,
+                    });
+                }
+
+                // Resolve repo to get workspace root for queue routing.
                 const repo = await svc.resolveRepo(repoId);
                 if (!repo) return send404(res, `Repo ${repoId} not found`);
 
-                const workspaceId = body.workspaceId || repoId;
-
-                // Build the classification prompt
+                const cacheTag = classificationCacheTag(repoId, prId, headSha);
                 const prompt = buildClassificationPrompt(repoId, prId, cacheTag);
 
-                // Enqueue a chat task with the classify-diff skill
+                // Enqueue a chat task with the classify-diff skill. The
+                // ClassificationExecutor is dispatched because the payload
+                // carries `context.classifyDiff`.
                 const rootPath = repo.localPath ?? process.cwd();
                 bridge.getOrCreateBridge(rootPath);
                 const resolvedRepoId = bridge.getRepoIdForPath(rootPath);
@@ -179,8 +140,16 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
                         },
                     },
                     config: body.model ? { model: body.model } : {},
-                    displayName: `${CLASSIFY_DISPLAY_PREFIX}${prId} [${headSha.slice(0, 7)}]`,
+                    displayName: `Classify PR #${prId} [${headSha.slice(0, 7)}]`,
                 });
+
+                // Write the pending marker so concurrent requests / polls
+                // see a `running` status until the AI calls saveClassification.
+                try {
+                    writePending(dataDir, workspaceId, repoId, prId, headSha, String(taskId));
+                } catch {
+                    /* best-effort */
+                }
 
                 sendJson(res, { status: 'started', taskId }, 202);
             } catch (err) {
@@ -199,27 +168,34 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
                 const repoId = decodeURIComponent(match![1]);
                 const prId = decodeURIComponent(match![2]);
 
-                // headSha is passed as query parameter
                 const url = new URL(req.url ?? '', `http://${req.headers.host ?? 'localhost'}`);
                 const headSha = url.searchParams.get('headSha');
+                const workspaceIdParam = url.searchParams.get('workspaceId');
+                const workspaceId = workspaceIdParam || repoId;
 
                 if (!headSha) {
                     return send400(res, 'Missing required query parameter: headSha');
                 }
 
-                const cacheTag = classificationCacheTag(repoId, prId, headSha);
-                const cached = await findCachedClassification(store, cacheTag);
-
-                if (!cached) {
-                    return sendJson(res, { status: 'none' });
+                const cached = readClassification(dataDir, workspaceId, repoId, prId, headSha);
+                if (cached) {
+                    return sendJson(res, {
+                        status: 'ready',
+                        processId: cached.processId,
+                        result: cached.result,
+                        createdAt: cached.createdAt,
+                    });
                 }
 
-                sendJson(res, {
-                    status: cached.status === 'completed' ? 'ready' : 'running',
-                    processId: cached.processId,
-                    ...(cached.result ? { result: cached.result } : {}),
-                    ...(cached.createdAt ? { createdAt: cached.createdAt } : {}),
-                });
+                const pending = readPending(dataDir, workspaceId, repoId, prId, headSha);
+                if (pending) {
+                    return sendJson(res, {
+                        status: 'running',
+                        processId: pending.processId,
+                    });
+                }
+
+                sendJson(res, { status: 'none' });
             } catch (err) {
                 send500(res, err instanceof Error ? err.message : String(err));
             }
@@ -239,65 +215,10 @@ export function buildClassificationPrompt(repoId: string, prId: string, cacheTag
         '',
         'For each @@ hunk, produce a classification with: file, hunkIndex (0-based within the file), category (logic|mechanical|test|generated), intensity (high|low), and a one-sentence reason.',
         '',
-        'Output the result as a single JSON object matching this schema:',
-        '```json',
-        '{ "classifications": [ { "file": "...", "hunkIndex": 0, "category": "logic", "intensity": "high", "reason": "..." } ] }',
-        '```',
+        'When you have classified every hunk, persist the results by calling the `saveClassification` tool exactly once with the full array. Do NOT print the classifications as JSON in your response — the persistence layer reads them directly from the tool call.',
     ];
     if (cacheTag) {
         lines.push('', `<!-- cache-key: ${cacheTag} -->`);
     }
     return lines.join('\n');
-}
-
-interface CachedResult {
-    processId: string;
-    status: string;
-    result?: DiffClassificationResult;
-    createdAt?: string;
-}
-
-/**
- * Search the process store for a process whose display name exactly matches
- * the expected classification naming convention:
- *   "Classify PR #<prId> [<shortSha>]"
- *
- * The display name encodes both the PR ID and the head SHA prefix, ensuring
- * stale results from older commits are never returned.
- */
-async function findCachedClassification(store: ProcessStore, cacheTag: string): Promise<CachedResult | undefined> {
-    try {
-        const parts = cacheTag.split(':');
-        const prId = parts[2];
-        const headSha = parts[3];
-        const shortSha = headSha.slice(0, 7);
-        const expectedDisplayName = `${CLASSIFY_DISPLAY_PREFIX}${prId} [${shortSha}]`;
-
-        // Get recent processes (limit search to avoid scanning the entire store)
-        const processes = await store.getAllProcesses({ limit: 50, exclude: ['conversation'] });
-        for (const proc of processes) {
-            // Strict match: display name must contain both PR ID and correct SHA prefix
-            const nameMatch = (proc as any).displayName === expectedDisplayName;
-            const previewMatch = proc.promptPreview?.includes(`Classify PR #${prId}`) &&
-                proc.promptPreview?.includes(shortSha);
-            const promptMatch = proc.fullPrompt?.includes(`pull request #${prId}`) &&
-                proc.fullPrompt?.includes(cacheTag);
-
-            if (nameMatch || previewMatch || promptMatch) {
-                let result: DiffClassificationResult | undefined;
-                if (proc.status === 'completed' && proc.result) {
-                    result = extractClassificationFromResult(proc.result);
-                }
-                return {
-                    processId: proc.id,
-                    status: proc.status,
-                    result,
-                    createdAt: proc.startTime instanceof Date ? proc.startTime.toISOString() : String(proc.startTime),
-                };
-            }
-        }
-    } catch {
-        // Process store query failed — fall through
-    }
-    return undefined;
 }

--- a/packages/coc/src/server/repos/pr-classification-handler.ts
+++ b/packages/coc/src/server/repos/pr-classification-handler.ts
@@ -151,7 +151,7 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
                 const workspaceId = body.workspaceId || repoId;
 
                 // Build the classification prompt
-                const prompt = buildClassificationPrompt(repoId, prId);
+                const prompt = buildClassificationPrompt(repoId, prId, cacheTag);
 
                 // Enqueue a chat task with the classify-diff skill
                 const rootPath = repo.localPath ?? process.cwd();
@@ -231,8 +231,8 @@ export function registerPrClassificationRoutes(routes: Route[], opts: PrClassifi
 // Helpers
 // ============================================================================
 
-function buildClassificationPrompt(repoId: string, prId: string): string {
-    return [
+export function buildClassificationPrompt(repoId: string, prId: string, cacheTag?: string): string {
+    const lines = [
         `Classify every hunk in pull request #${prId} of this repository.`,
         '',
         'Use the available git and gh CLI tools to read the PR diff. Do NOT ask me for the diff — fetch it yourself.',
@@ -243,7 +243,11 @@ function buildClassificationPrompt(repoId: string, prId: string): string {
         '```json',
         '{ "classifications": [ { "file": "...", "hunkIndex": 0, "category": "logic", "intensity": "high", "reason": "..." } ] }',
         '```',
-    ].join('\n');
+    ];
+    if (cacheTag) {
+        lines.push('', `<!-- cache-key: ${cacheTag} -->`);
+    }
+    return lines.join('\n');
 }
 
 interface CachedResult {
@@ -254,27 +258,32 @@ interface CachedResult {
 }
 
 /**
- * Search the process store for a process whose prompt contains the cache tag.
- * Uses a display-name convention: "Classify PR #<prId> [<shortSha>]".
- * Returns the most recent match.
+ * Search the process store for a process whose display name exactly matches
+ * the expected classification naming convention:
+ *   "Classify PR #<prId> [<shortSha>]"
+ *
+ * The display name encodes both the PR ID and the head SHA prefix, ensuring
+ * stale results from older commits are never returned.
  */
 async function findCachedClassification(store: ProcessStore, cacheTag: string): Promise<CachedResult | undefined> {
     try {
-        // Extract the headSha short prefix from the cache tag for display-name matching
         const parts = cacheTag.split(':');
         const prId = parts[2];
         const headSha = parts[3];
-        const expectedDisplayName = `${CLASSIFY_DISPLAY_PREFIX}${prId} [${headSha.slice(0, 7)}]`;
+        const shortSha = headSha.slice(0, 7);
+        const expectedDisplayName = `${CLASSIFY_DISPLAY_PREFIX}${prId} [${shortSha}]`;
 
         // Get recent processes (limit search to avoid scanning the entire store)
         const processes = await store.getAllProcesses({ limit: 50, exclude: ['conversation'] });
         for (const proc of processes) {
-            // Match by prompt content containing the cache tag, or by display name convention
-            const promptMatch = proc.fullPrompt?.includes(`#${prId}`) ?? false;
-            const nameMatch = (proc as any).displayName === expectedDisplayName ||
-                proc.promptPreview?.includes(`Classify PR #${prId}`);
+            // Strict match: display name must contain both PR ID and correct SHA prefix
+            const nameMatch = (proc as any).displayName === expectedDisplayName;
+            const previewMatch = proc.promptPreview?.includes(`Classify PR #${prId}`) &&
+                proc.promptPreview?.includes(shortSha);
+            const promptMatch = proc.fullPrompt?.includes(`pull request #${prId}`) &&
+                proc.fullPrompt?.includes(cacheTag);
 
-            if (promptMatch || nameMatch) {
+            if (nameMatch || previewMatch || promptMatch) {
                 let result: DiffClassificationResult | undefined;
                 if (proc.status === 'completed' && proc.result) {
                     result = extractClassificationFromResult(proc.result);

--- a/packages/coc/src/server/repos/pr-classification-handler.ts
+++ b/packages/coc/src/server/repos/pr-classification-handler.ts
@@ -1,0 +1,294 @@
+/**
+ * PR Classification Routes
+ *
+ * Registers endpoints for on-demand AI classification of PR diff hunks.
+ * Classification runs as a CoC chat conversation with the classify-diff skill.
+ *
+ * POST /api/repos/:repoId/pull-requests/:prId/classify        — trigger classification
+ * GET  /api/repos/:repoId/pull-requests/:prId/classification   — get cached result
+ *
+ * The classification result is stored in the process store as a conversation.
+ * Cache key: `classify-diff:<repoId>:<prId>:<headSha>`.
+ */
+
+import type { Route } from '../types';
+import type { ProcessStore } from '@plusplusoneplusplus/forge';
+import type { MultiRepoQueueRouter } from '../queue/multi-repo-queue-router';
+import { sendJson, send404, send400, send500, readJsonBody } from '../router';
+import { RepoTreeService } from './tree-service';
+import type { DiffClassificationResult, HunkClassification } from '../spa/client/react/features/pull-requests/classification-types';
+
+/** Display name prefix used for classification tasks — doubles as a search token. */
+const CLASSIFY_DISPLAY_PREFIX = 'Classify PR #';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ClassifyRequestBody {
+    /** SHA of the PR head commit. Used as cache key component. */
+    headSha: string;
+    /** AI model to use for classification (optional, defaults to per-repo preference). */
+    model?: string;
+    /** Workspace ID for queue routing. */
+    workspaceId?: string;
+}
+
+interface ClassificationCacheEntry {
+    result: DiffClassificationResult;
+    headSha: string;
+    createdAt: string;
+    processId: string;
+}
+
+export interface PrClassificationRouteOptions {
+    dataDir: string;
+    store: ProcessStore;
+    bridge: MultiRepoQueueRouter;
+    repoTreeService?: RepoTreeService;
+}
+
+// ============================================================================
+// Cache key helpers
+// ============================================================================
+
+/** Build the process store tag used to find a cached classification. */
+export function classificationCacheTag(repoId: string, prId: string, headSha: string): string {
+    return `classify-diff:${repoId}:${prId}:${headSha}`;
+}
+
+// ============================================================================
+// Result extraction
+// ============================================================================
+
+/**
+ * Parse the classification JSON from the last assistant turn of a completed process.
+ * Expects a JSON block (possibly inside a ```json fence) matching `DiffClassificationResult`.
+ */
+export function extractClassificationFromResult(resultText: string | undefined): DiffClassificationResult | undefined {
+    if (!resultText) return undefined;
+
+    // Try to find a JSON code block first
+    const fenceMatch = resultText.match(/```json\s*([\s\S]*?)```/);
+    const jsonStr = fenceMatch ? fenceMatch[1].trim() : resultText.trim();
+
+    try {
+        const parsed = JSON.parse(jsonStr);
+        if (parsed && Array.isArray(parsed.classifications)) {
+            // Validate each entry has required fields
+            const valid = parsed.classifications.every((c: any) =>
+                typeof c.file === 'string' &&
+                typeof c.hunkIndex === 'number' &&
+                typeof c.category === 'string' &&
+                typeof c.intensity === 'string' &&
+                typeof c.reason === 'string',
+            );
+            if (valid) {
+                return { classifications: parsed.classifications as HunkClassification[] };
+            }
+        }
+    } catch {
+        // Not valid JSON — try to find a JSON object in the text
+        const objectMatch = resultText.match(/\{[\s\S]*"classifications"\s*:\s*\[[\s\S]*\]\s*\}/);
+        if (objectMatch) {
+            try {
+                const parsed = JSON.parse(objectMatch[0]);
+                if (Array.isArray(parsed.classifications)) {
+                    return { classifications: parsed.classifications as HunkClassification[] };
+                }
+            } catch { /* give up */ }
+        }
+    }
+    return undefined;
+}
+
+// ============================================================================
+// Route registration
+// ============================================================================
+
+export function registerPrClassificationRoutes(routes: Route[], opts: PrClassificationRouteOptions): void {
+    const { dataDir, store, bridge } = opts;
+    const svc = opts.repoTreeService ?? new RepoTreeService(dataDir, undefined, store);
+
+    // -- Trigger classification -----------------------------------------------
+
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/repos\/([^/]+)\/pull-requests\/([^/]+)\/classify$/,
+        handler: async (req, res, match) => {
+            try {
+                const repoId = decodeURIComponent(match![1]);
+                const prId = decodeURIComponent(match![2]);
+
+                let body: ClassifyRequestBody;
+                try {
+                    body = await readJsonBody<ClassifyRequestBody>(req);
+                } catch {
+                    return send400(res, 'Invalid JSON body');
+                }
+
+                if (!body.headSha || typeof body.headSha !== 'string') {
+                    return send400(res, 'Missing required field: headSha');
+                }
+
+                const headSha = body.headSha.trim();
+                const cacheTag = classificationCacheTag(repoId, prId, headSha);
+
+                // Check cache — look for an existing process with this tag
+                const cached = await findCachedClassification(store, cacheTag);
+                if (cached) {
+                    return sendJson(res, {
+                        status: cached.status === 'completed' ? 'ready' : 'running',
+                        processId: cached.processId,
+                        ...(cached.result ? { result: cached.result } : {}),
+                    });
+                }
+
+                // Resolve repo to get workspace root for queue routing
+                const repo = await svc.resolveRepo(repoId);
+                if (!repo) return send404(res, `Repo ${repoId} not found`);
+
+                const workspaceId = body.workspaceId || repoId;
+
+                // Build the classification prompt
+                const prompt = buildClassificationPrompt(repoId, prId);
+
+                // Enqueue a chat task with the classify-diff skill
+                const rootPath = repo.localPath ?? process.cwd();
+                bridge.getOrCreateBridge(rootPath);
+                const resolvedRepoId = bridge.getRepoIdForPath(rootPath);
+                const queueManager = bridge.registry.getQueueForRepo(rootPath);
+
+                const taskId = queueManager.enqueue({
+                    type: 'chat',
+                    priority: 'normal',
+                    repoId: resolvedRepoId,
+                    payload: {
+                        kind: 'chat',
+                        mode: 'autopilot',
+                        prompt,
+                        workspaceId,
+                        skills: ['classify-diff'],
+                        context: {
+                            classifyDiff: {
+                                repoId,
+                                prId,
+                                headSha,
+                                cacheTag,
+                            },
+                        },
+                    },
+                    config: body.model ? { model: body.model } : {},
+                    displayName: `${CLASSIFY_DISPLAY_PREFIX}${prId} [${headSha.slice(0, 7)}]`,
+                });
+
+                sendJson(res, { status: 'started', taskId }, 202);
+            } catch (err) {
+                send500(res, err instanceof Error ? err.message : String(err));
+            }
+        },
+    });
+
+    // -- Get cached classification result -------------------------------------
+
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/repos\/([^/]+)\/pull-requests\/([^/]+)\/classification$/,
+        handler: async (req, res, match) => {
+            try {
+                const repoId = decodeURIComponent(match![1]);
+                const prId = decodeURIComponent(match![2]);
+
+                // headSha is passed as query parameter
+                const url = new URL(req.url ?? '', `http://${req.headers.host ?? 'localhost'}`);
+                const headSha = url.searchParams.get('headSha');
+
+                if (!headSha) {
+                    return send400(res, 'Missing required query parameter: headSha');
+                }
+
+                const cacheTag = classificationCacheTag(repoId, prId, headSha);
+                const cached = await findCachedClassification(store, cacheTag);
+
+                if (!cached) {
+                    return sendJson(res, { status: 'none' });
+                }
+
+                sendJson(res, {
+                    status: cached.status === 'completed' ? 'ready' : 'running',
+                    processId: cached.processId,
+                    ...(cached.result ? { result: cached.result } : {}),
+                    ...(cached.createdAt ? { createdAt: cached.createdAt } : {}),
+                });
+            } catch (err) {
+                send500(res, err instanceof Error ? err.message : String(err));
+            }
+        },
+    });
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function buildClassificationPrompt(repoId: string, prId: string): string {
+    return [
+        `Classify every hunk in pull request #${prId} of this repository.`,
+        '',
+        'Use the available git and gh CLI tools to read the PR diff. Do NOT ask me for the diff — fetch it yourself.',
+        '',
+        'For each @@ hunk, produce a classification with: file, hunkIndex (0-based within the file), category (logic|mechanical|test|generated), intensity (high|low), and a one-sentence reason.',
+        '',
+        'Output the result as a single JSON object matching this schema:',
+        '```json',
+        '{ "classifications": [ { "file": "...", "hunkIndex": 0, "category": "logic", "intensity": "high", "reason": "..." } ] }',
+        '```',
+    ].join('\n');
+}
+
+interface CachedResult {
+    processId: string;
+    status: string;
+    result?: DiffClassificationResult;
+    createdAt?: string;
+}
+
+/**
+ * Search the process store for a process whose prompt contains the cache tag.
+ * Uses a display-name convention: "Classify PR #<prId> [<shortSha>]".
+ * Returns the most recent match.
+ */
+async function findCachedClassification(store: ProcessStore, cacheTag: string): Promise<CachedResult | undefined> {
+    try {
+        // Extract the headSha short prefix from the cache tag for display-name matching
+        const parts = cacheTag.split(':');
+        const prId = parts[2];
+        const headSha = parts[3];
+        const expectedDisplayName = `${CLASSIFY_DISPLAY_PREFIX}${prId} [${headSha.slice(0, 7)}]`;
+
+        // Get recent processes (limit search to avoid scanning the entire store)
+        const processes = await store.getAllProcesses({ limit: 50, exclude: ['conversation'] });
+        for (const proc of processes) {
+            // Match by prompt content containing the cache tag, or by display name convention
+            const promptMatch = proc.fullPrompt?.includes(`#${prId}`) ?? false;
+            const nameMatch = (proc as any).displayName === expectedDisplayName ||
+                proc.promptPreview?.includes(`Classify PR #${prId}`);
+
+            if (promptMatch || nameMatch) {
+                let result: DiffClassificationResult | undefined;
+                if (proc.status === 'completed' && proc.result) {
+                    result = extractClassificationFromResult(proc.result);
+                }
+                return {
+                    processId: proc.id,
+                    status: proc.status,
+                    result,
+                    createdAt: proc.startTime instanceof Date ? proc.startTime.toISOString() : String(proc.startTime),
+                };
+            }
+        }
+    } catch {
+        // Process store query failed — fall through
+    }
+    return undefined;
+}

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -30,6 +30,7 @@ import { registerRepoRoutes } from '../repos/repo-routes';
 import { registerInstructionRoutes } from '../skills/instruction-handler';
 import { registerProviderRoutes } from '../providers/provider-routes';
 import { registerPrRoutes } from '../repos/pr-routes';
+import { registerPrClassificationRoutes } from '../repos/pr-classification-handler';
 import { registerLogsRoutes } from '../logging/logs-routes';
 import { registerModelRoutes } from '../models/model-routes';
 import { RepoTreeService } from '../repos/tree-service';
@@ -139,6 +140,15 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     const repoTreeService = new RepoTreeService(dataDir, undefined, store);
     registerRepoRoutes(routes, dataDir, repoTreeService);
     registerPrRoutes(routes, dataDir, repoTreeService);
+    // Focused-diff classification routes (feature-flagged)
+    if (opts.resolvedConfig?.features?.focusedDiff) {
+        registerPrClassificationRoutes(routes, {
+            dataDir,
+            store,
+            bridge,
+            repoTreeService,
+        });
+    }
     registerRemoteServerRoutes(routes, {
         store: opts.remoteServerStore ?? new RemoteServerStore(dataDir),
         connector: opts.remoteServerConnector ?? new DevTunnelConnector(),

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -96,6 +96,7 @@ export function AdminPanel() {
     const [ralphEnabled, setRalphEnabled] = useState(false);
     const [vimNavigationEnabled, setVimNavigationEnabled] = useState(false);
     const [loopsEnabled, setLoopsEnabled] = useState(false);
+    const [focusedDiffEnabled, setFocusedDiffEnabled] = useState(false);
 
     // Preferences(theme, reposSidebarCollapsed, uiLayoutMode) — for Appearance card
     const [theme, setTheme] = useState<'light' | 'dark' | 'auto'>('auto');
@@ -127,7 +128,7 @@ export function AdminPanel() {
         taskCardDensity: 'compact' as 'compact' | 'dense',
         historyGrouping: true,
     });
-    const [featuresSnapshot, setFeaturesSnapshot] = useState({ terminal: true, notes: true, myWork: false, myLife: false, scratchpad: false, scratchpadLayout: 'horizontal' as 'horizontal' | 'vertical', workflows: false, pullRequests: false, servers: false, ralph: false, vimNavigation: false, loops: false });
+    const [featuresSnapshot, setFeaturesSnapshot] = useState({ terminal: true, notes: true, myWork: false, myLife: false, scratchpad: false, scratchpadLayout: 'horizontal' as 'horizontal' | 'vertical', workflows: false, pullRequests: false, servers: false, ralph: false, vimNavigation: false, loops: false, focusedDiff: false });
 
     // Export
     const [exportStatus, setExportStatus] = useState<string>('');
@@ -226,7 +227,9 @@ export function AdminPanel() {
             setVimNavigationEnabled(vne);
             const loe = resolved.loops?.enabled ?? false;
             setLoopsEnabled(loe);
-            setFeaturesSnapshot({ terminal: te, notes: ne, myWork: mwe, myLife: mle, scratchpad: se, scratchpadLayout: sl, workflows: we, pullRequests: pre, servers: svre, ralph: re, vimNavigation: vne, loops: loe });
+            const fde = resolved.features?.focusedDiff ?? false;
+            setFocusedDiffEnabled(fde);
+            setFeaturesSnapshot({ terminal: te, notes: ne, myWork: mwe, myLife: mle, scratchpad: se, scratchpadLayout: sl, workflows: we, pullRequests: pre, servers: svre, ralph: re, vimNavigation: vne, loops: loe, focusedDiff: fde });
         } catch (err: unknown) {
             const detail = getSpaCocClientErrorMessage(err, '');
             setConfigError(detail ? `Failed to load configuration: ${detail}` : 'Failed to load configuration');
@@ -303,7 +306,8 @@ export function AdminPanel() {
         serversEnabled !== featuresSnapshot.servers ||
         ralphEnabled !== featuresSnapshot.ralph ||
         vimNavigationEnabled !== featuresSnapshot.vimNavigation ||
-        loopsEnabled !== featuresSnapshot.loops;
+        loopsEnabled !== featuresSnapshot.loops ||
+        focusedDiffEnabled !== featuresSnapshot.focusedDiff;
 
     // ── AI & Execution card ──
     const handleSaveAiExec = useCallback(async () => {
@@ -455,16 +459,17 @@ export function AdminPanel() {
                 'ralph.enabled': ralphEnabled,
                 'vimNavigation.enabled': vimNavigationEnabled,
                 'loops.enabled': loopsEnabled,
+                'features.focusedDiff': focusedDiffEnabled,
             });
             addToast('Settings saved', 'success');
             invalidateDisplaySettings();
-            setFeaturesSnapshot({ terminal: terminalEnabled, notes: notesEnabled, myWork: myWorkEnabled, myLife: myLifeEnabled, scratchpad: scratchpadEnabled, scratchpadLayout: scratchpadLayout, workflows: workflowsEnabled, pullRequests: pullRequestsEnabled, servers: serversEnabled, ralph: ralphEnabled, vimNavigation: vimNavigationEnabled, loops: loopsEnabled });
+            setFeaturesSnapshot({ terminal: terminalEnabled, notes: notesEnabled, myWork: myWorkEnabled, myLife: myLifeEnabled, scratchpad: scratchpadEnabled, scratchpadLayout: scratchpadLayout, workflows: workflowsEnabled, pullRequests: pullRequestsEnabled, servers: serversEnabled, ralph: ralphEnabled, vimNavigation: vimNavigationEnabled, loops: loopsEnabled, focusedDiff: focusedDiffEnabled });
         } catch (err: unknown) {
             addToast(getSpaCocClientErrorMessage(err, 'Save failed'), 'error');
         } finally {
             setFeaturesSaving(false);
         }
-    }, [terminalEnabled, notesEnabled, myWorkEnabled, myLifeEnabled, scratchpadEnabled, scratchpadLayout, workflowsEnabled, pullRequestsEnabled, serversEnabled, ralphEnabled, vimNavigationEnabled, loopsEnabled, addToast]);
+    }, [terminalEnabled, notesEnabled, myWorkEnabled, myLifeEnabled, scratchpadEnabled, scratchpadLayout, workflowsEnabled, pullRequestsEnabled, serversEnabled, ralphEnabled, vimNavigationEnabled, loopsEnabled, focusedDiffEnabled, addToast]);
 
     const handleCancelFeatures = useCallback(() => {
         setTerminalEnabled(featuresSnapshot.terminal);
@@ -479,6 +484,7 @@ export function AdminPanel() {
         setRalphEnabled(featuresSnapshot.ralph);
         setVimNavigationEnabled(featuresSnapshot.vimNavigation);
         setLoopsEnabled(featuresSnapshot.loops);
+        setFocusedDiffEnabled(featuresSnapshot.focusedDiff);
     }, [featuresSnapshot]);
 
     const handleSaveServerName = useCallback(async () => {
@@ -1341,11 +1347,29 @@ export function AdminPanel() {
                                             </label>
                                         </div>
                                     </div>
+                                    <div className="flex items-center justify-between">
+                                        <div>
+                                            <div className="text-xs text-[#1e1e1e] dark:text-[#cccccc]">Focused Diff</div>
+                                            <div className="text-xs text-[#616161] dark:text-[#999]">AI-powered hunk classification for PR diffs. Highlights logic changes and dims mechanical edits.</div>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <SourceBadge source={sources['features.focusedDiff']} />
+                                            <label className="relative inline-flex items-center cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    className="sr-only peer"
+                                                    checked={focusedDiffEnabled}
+                                                    onChange={e => setFocusedDiffEnabled(e.target.checked)}
+                                                    data-testid="toggle-focused-diff-enabled"
+                                                />
+                                                <div className="w-9 h-5 bg-gray-300 dark:bg-gray-600 peer-focus:ring-2 peer-focus:ring-[#0078d4] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[#0078d4]" />
+                                            </label>
+                                        </div>
+                                    </div>
                                 </SettingsCard>
 
                                 {/* ── 5. Link Handlers ── */}
                                 <SettingsCard
-                                    title="Link Handlers"
                                     badge="Global"
                                     description="Open specific URLs in desktop apps instead of a browser tab. Requires the desktop app to be installed."
                                     data-testid="settings-link-handlers"

--- a/packages/coc/src/server/spa/client/react/featureFlags.ts
+++ b/packages/coc/src/server/spa/client/react/featureFlags.ts
@@ -5,3 +5,6 @@
 
 /** Enable the welcome modal, first-steps card, and feature tips. */
 export const SHOW_WELCOME_TUTORIAL = true;
+
+/** Enable the focused-diff classification UI on the PR Files Changed tab. */
+export const SHOW_FOCUSED_DIFF = true;

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PrFilesPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PrFilesPanel.tsx
@@ -30,6 +30,11 @@ import {
     type FileTreeNode,
 } from './file-tree';
 import { formatTimestamp, type CommentThread, type PrComment } from './pr-utils';
+import { SHOW_FOCUSED_DIFF } from '../../featureFlags';
+import type { HunkCategory } from './classification-types';
+import { HUNK_CATEGORIES, CATEGORY_LABELS } from './classification-types';
+import type { UseClassificationReturn } from './useClassification';
+import type { AiFileAnnotation } from './pr-mock-data';
 
 interface PrFilesPanelProps {
     files: ParsedDiffFile[];
@@ -38,6 +43,12 @@ interface PrFilesPanelProps {
     /** When true (small viewports), the file list stacks above the diff
      *  with full width and no resize handle. */
     isMobile?: boolean;
+    /** Optional, keyed by file path. Comes from `pr-mock-data` for now. */
+    annotations?: Record<string, AiFileAnnotation | undefined>;
+    /** Optional, keyed by file path. Highlights an AI-flagged file. */
+    focusByPath?: Record<string, string | undefined>;
+    /** Classification hook return — enables focused-diff filter bar. */
+    classification?: UseClassificationReturn;
 }
 
 const FILES_PANEL_WIDTH_STORAGE_KEY = 'coc:pr-files-panel-width';
@@ -58,7 +69,110 @@ const STATUS_CLASS: Record<ParsedDiffFile['status'], string> = {
     renamed:  'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200',
 };
 
-export function PrFilesPanel({ files, commentsByPath, isMobile = false }: PrFilesPanelProps) {
+// ── Classification badge dots ────────────────────────────────────────
+
+const BADGE_COLORS: Record<HunkCategory, string> = {
+    logic: 'text-orange-500 dark:text-orange-400',
+    mechanical: 'text-gray-400 dark:text-gray-500',
+    test: 'text-blue-500 dark:text-blue-400',
+    generated: 'text-purple-500 dark:text-purple-400',
+};
+
+function ClassificationBadge({ category, intensity }: { category: HunkCategory; intensity: 'high' | 'low' }) {
+    const color = BADGE_COLORS[category];
+    const filled = intensity === 'high' ? 2 : 1;
+    return (
+        <span
+            className={cn('ml-1 shrink-0 text-[10px] tracking-tight', color)}
+            title={`${CATEGORY_LABELS[category]} (${intensity})`}
+            data-testid="classification-badge"
+        >
+            {filled >= 1 ? '●' : '○'}{filled >= 2 ? '●' : '○'}
+        </span>
+    );
+}
+
+// ── Classification filter bar ───────────────────────────────────────
+
+function ClassificationFilterBar({ classification }: { classification: UseClassificationReturn }) {
+    const { state, classify, toggleFilter, setFilters } = classification;
+    const { status, activeFilters, error } = state;
+    const isLoading = status === 'loading';
+    const isReady = status === 'ready';
+
+    return (
+        <div
+            className="flex shrink-0 flex-wrap items-center gap-1.5 border-b border-gray-200 bg-gray-50/70 px-2 py-1 dark:border-gray-700 dark:bg-gray-800/40"
+            data-testid="classification-filter-bar"
+        >
+            {/* Classify button */}
+            <button
+                type="button"
+                onClick={classify}
+                disabled={isLoading}
+                className={cn(
+                    'inline-flex h-[22px] items-center gap-1 rounded border px-1.5 text-[10px] font-semibold uppercase leading-none',
+                    isLoading
+                        ? 'cursor-wait border-gray-300 bg-gray-100 text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-500'
+                        : 'border-indigo-400 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-500 dark:bg-indigo-900/30 dark:text-indigo-200 dark:hover:bg-indigo-900/50',
+                )}
+                data-testid="classify-button"
+            >
+                {isLoading ? (
+                    <>
+                        <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        Classifying…
+                    </>
+                ) : isReady ? (
+                    'Re-classify'
+                ) : (
+                    'Classify'
+                )}
+            </button>
+
+            {/* Category checkboxes (shown once results are available) */}
+            {isReady && (
+                <>
+                    <span className="mx-0.5 h-3 w-px bg-gray-300 dark:bg-gray-600" />
+                    {HUNK_CATEGORIES.map(cat => (
+                        <label
+                            key={cat}
+                            className="inline-flex cursor-pointer items-center gap-0.5 text-[11px] text-gray-700 dark:text-gray-300"
+                        >
+                            <input
+                                type="checkbox"
+                                checked={activeFilters.has(cat)}
+                                onChange={() => toggleFilter(cat)}
+                                className="h-3 w-3 rounded border-gray-300 text-indigo-500 focus:ring-indigo-500 dark:border-gray-600"
+                                data-testid={`classification-filter-${cat}`}
+                            />
+                            {CATEGORY_LABELS[cat]}
+                        </label>
+                    ))}
+                    <button
+                        type="button"
+                        onClick={() => setFilters(new Set(HUNK_CATEGORIES))}
+                        className="ml-0.5 text-[10px] text-indigo-600 hover:underline dark:text-indigo-300"
+                        data-testid="classification-filter-all"
+                    >
+                        All
+                    </button>
+                </>
+            )}
+
+            {/* Error indicator */}
+            {status === 'error' && error && (
+                <span className="text-[10px] text-red-600 dark:text-red-400" data-testid="classify-error">
+                    {error}
+                </span>
+            )}
+        </div>
+    );
+}
+
+// ── Main component ──────────────────────────────────────────────────
+
+export function PrFilesPanel({ files, commentsByPath, isMobile = false, annotations, focusByPath, classification }: PrFilesPanelProps) {
     const [search, setSearch] = useState('');
     const [viewMode, setViewMode] = useState<ViewMode>('tree');
     const [activePath, setActivePath] = useState<string>(files[0]?.path ?? '');
@@ -180,6 +294,9 @@ export function PrFilesPanel({ files, commentsByPath, isMobile = false }: PrFile
                         </button>
                     </div>
                 </header>
+                {SHOW_FOCUSED_DIFF && classification && (
+                    <ClassificationFilterBar classification={classification} />
+                )}
                 <div className="shrink-0 px-2 pt-2">
                     <input
                         type="text"
@@ -208,12 +325,14 @@ export function PrFilesPanel({ files, commentsByPath, isMobile = false }: PrFile
                             collapsedFolders={collapsedFolders}
                             onToggleFolder={toggleFolder}
                             depth={0}
+                            classification={classification}
                         />
                     ) : (
                         <FlatFileList
                             files={visibleFiles}
                             activePath={activePath}
                             onSelect={setActivePath}
+                            classification={classification}
                         />
                     )}
                 </div>
@@ -245,6 +364,9 @@ export function PrFilesPanel({ files, commentsByPath, isMobile = false }: PrFile
                     <FileDiffCard
                         file={focusedFile}
                         threads={getThreadsForFile(commentsByPath, focusedFile)}
+                        annotation={annotations?.[focusedFile.path]}
+                        focus={focusByPath?.[focusedFile.path]}
+                        classification={classification}
                     />
                 )}
                 {!focusedFile && (
@@ -278,9 +400,10 @@ interface FlatFileListProps {
     files: ParsedDiffFile[];
     activePath: string;
     onSelect: (path: string) => void;
+    classification?: UseClassificationReturn;
 }
 
-function FlatFileList({ files, activePath, onSelect }: FlatFileListProps) {
+function FlatFileList({ files, activePath, onSelect, classification }: FlatFileListProps) {
     return (
         <div className="grid min-w-0 gap-px">
             {files.map(file => {
@@ -310,7 +433,11 @@ function FlatFileList({ files, activePath, onSelect }: FlatFileListProps) {
                             <span className="min-w-0 flex-1 truncate" data-testid="pr-file-basename">
                                 {basename}
                             </span>
-                            <span className="shrink-0 text-[11px] text-gray-500 dark:text-gray-400">
+                            <span className="flex shrink-0 items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+                                {(() => {
+                                    const badge = classification?.getFileBadge(file.path);
+                                    return badge ? <ClassificationBadge category={badge.category} intensity={badge.intensity} /> : null;
+                                })()}
                                 <span className="text-green-700 dark:text-green-400">+{file.additions}</span>{' '}
                                 <span className="text-red-700 dark:text-red-400">-{file.deletions}</span>
                             </span>
@@ -329,6 +456,7 @@ interface FileTreeViewProps {
     collapsedFolders: Set<string>;
     onToggleFolder: (path: string) => void;
     depth: number;
+    classification?: UseClassificationReturn;
 }
 
 function FileTreeView({
@@ -338,6 +466,7 @@ function FileTreeView({
     collapsedFolders,
     onToggleFolder,
     depth,
+    classification,
 }: FileTreeViewProps) {
     return (
         <div className="grid min-w-0 gap-px">
@@ -379,6 +508,7 @@ function FileTreeView({
                                     collapsedFolders={collapsedFolders}
                                     onToggleFolder={onToggleFolder}
                                     depth={depth + 1}
+                                    classification={classification}
                                 />
                             )}
                         </div>
@@ -404,7 +534,11 @@ function FileTreeView({
                         <span className="min-w-0 flex-1 truncate" data-testid="pr-file-basename">
                             {node.name}
                         </span>
-                        <span className="shrink-0 text-[11px] text-gray-500 dark:text-gray-400">
+                        <span className="flex shrink-0 items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+                            {(() => {
+                                const badge = classification?.getFileBadge(node.path);
+                                return badge ? <ClassificationBadge category={badge.category} intensity={badge.intensity} /> : null;
+                            })()}
                             <span className="text-green-700 dark:text-green-400">+{node.file.additions}</span>{' '}
                             <span className="text-red-700 dark:text-red-400">-{node.file.deletions}</span>
                         </span>
@@ -418,15 +552,20 @@ function FileTreeView({
 interface FileDiffCardProps {
     file: ParsedDiffFile;
     threads: CommentThread[];
+    annotation?: AiFileAnnotation;
+    focus?: string;
+    classification?: UseClassificationReturn;
 }
 
-function FileDiffCard({ file, threads }: FileDiffCardProps) {
+function FileDiffCard({ file, threads, annotation, focus, classification }: FileDiffCardProps) {
     const lineThreads = useMemo(() => groupThreadsByDiffLine(threads), [threads]);
     const fileLevelThreads = useMemo(
         () => threads.filter(thread => !resolveThreadLine(thread)),
         [threads],
     );
 
+    // Track hunk indices — each time we see a 'hunk' line, we increment.
+    let hunkIndex = -1;
     return (
         <article
             className="mb-2 overflow-hidden rounded-[5px] border border-gray-200 bg-white last:mb-0 dark:border-gray-700 dark:bg-gray-900"
@@ -476,16 +615,40 @@ function FileDiffCard({ file, threads }: FileDiffCardProps) {
                 <div className="font-mono text-[12px] leading-[1.45]">
                     {file.lines.map((line, idx) => {
                         if (line.kind === 'hunk') {
+                            hunkIndex++;
+                            const dimmed = classification?.isHunkDimmed(file.path, hunkIndex) ?? false;
+                            const hunkClassification = classification?.getHunkClassification(file.path, hunkIndex);
                             return (
                                 <div
                                     key={`hunk-${idx}`}
-                                    className="border-y border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400"
+                                    className={cn(
+                                        'border-y border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400',
+                                        dimmed && 'opacity-40',
+                                    )}
                                     data-testid="pr-file-hunk-header"
+                                    data-hunk-index={hunkIndex}
+                                    data-hunk-category={hunkClassification?.category}
                                 >
-                                    {line.text}
+                                    <span>{line.text}</span>
+                                    {hunkClassification && (
+                                        <span
+                                            className={cn(
+                                                'ml-2 rounded px-1 py-px text-[9px] font-semibold uppercase',
+                                                hunkClassification.category === 'logic' && 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
+                                                hunkClassification.category === 'mechanical' && 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+                                                hunkClassification.category === 'test' && 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+                                                hunkClassification.category === 'generated' && 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+                                            )}
+                                            title={hunkClassification.reason}
+                                            data-testid="hunk-category-tag"
+                                        >
+                                            {CATEGORY_LABELS[hunkClassification.category]}
+                                        </span>
+                                    )}
                                 </div>
                             );
                         }
+                        const dimmed = hunkIndex >= 0 && (classification?.isHunkDimmed(file.path, hunkIndex) ?? false);
                         const lineNo = line.kind === 'del' ? line.oldLineNo : line.newLineNo;
                         const comments = getThreadsForDiffLine(lineThreads, line);
                         return (
@@ -495,6 +658,7 @@ function FileDiffCard({ file, threads }: FileDiffCardProps) {
                                         'grid min-h-[19px] items-start',
                                         line.kind === 'add' && 'bg-green-50 dark:bg-green-900/30',
                                         line.kind === 'del' && 'bg-red-50 dark:bg-red-900/30',
+                                        dimmed && 'opacity-40',
                                     )}
                                     style={{ gridTemplateColumns: '38px 1fr' }}
                                     data-testid={`pr-file-diff-line-${line.kind}`}

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PrFilesPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PrFilesPanel.tsx
@@ -34,7 +34,6 @@ import { SHOW_FOCUSED_DIFF } from '../../featureFlags';
 import type { HunkCategory } from './classification-types';
 import { HUNK_CATEGORIES, CATEGORY_LABELS } from './classification-types';
 import type { UseClassificationReturn } from './useClassification';
-import type { AiFileAnnotation } from './pr-mock-data';
 
 interface PrFilesPanelProps {
     files: ParsedDiffFile[];
@@ -43,10 +42,6 @@ interface PrFilesPanelProps {
     /** When true (small viewports), the file list stacks above the diff
      *  with full width and no resize handle. */
     isMobile?: boolean;
-    /** Optional, keyed by file path. Comes from `pr-mock-data` for now. */
-    annotations?: Record<string, AiFileAnnotation | undefined>;
-    /** Optional, keyed by file path. Highlights an AI-flagged file. */
-    focusByPath?: Record<string, string | undefined>;
     /** Classification hook return — enables focused-diff filter bar. */
     classification?: UseClassificationReturn;
 }
@@ -172,7 +167,7 @@ function ClassificationFilterBar({ classification }: { classification: UseClassi
 
 // ── Main component ──────────────────────────────────────────────────
 
-export function PrFilesPanel({ files, commentsByPath, isMobile = false, annotations, focusByPath, classification }: PrFilesPanelProps) {
+export function PrFilesPanel({ files, commentsByPath, isMobile = false, classification }: PrFilesPanelProps) {
     const [search, setSearch] = useState('');
     const [viewMode, setViewMode] = useState<ViewMode>('tree');
     const [activePath, setActivePath] = useState<string>(files[0]?.path ?? '');
@@ -364,8 +359,6 @@ export function PrFilesPanel({ files, commentsByPath, isMobile = false, annotati
                     <FileDiffCard
                         file={focusedFile}
                         threads={getThreadsForFile(commentsByPath, focusedFile)}
-                        annotation={annotations?.[focusedFile.path]}
-                        focus={focusByPath?.[focusedFile.path]}
                         classification={classification}
                     />
                 )}
@@ -552,12 +545,10 @@ function FileTreeView({
 interface FileDiffCardProps {
     file: ParsedDiffFile;
     threads: CommentThread[];
-    annotation?: AiFileAnnotation;
-    focus?: string;
     classification?: UseClassificationReturn;
 }
 
-function FileDiffCard({ file, threads, annotation, focus, classification }: FileDiffCardProps) {
+function FileDiffCard({ file, threads, classification }: FileDiffCardProps) {
     const lineThreads = useMemo(() => groupThreadsByDiffLine(threads), [threads]);
     const fileLevelThreads = useMemo(
         () => threads.filter(thread => !resolveThreadLine(thread)),

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -36,6 +36,8 @@ import { PrCommitTable } from './PrCommitTable';
 import { PrChecksTable, PrMergeReadiness } from './PrChecksAndReadiness';
 import { PrFilesPanel } from './PrFilesPanel';
 import { PrAiAssistantDrawer } from './PrAiAssistantDrawer';
+import { SHOW_FOCUSED_DIFF } from '../../featureFlags';
+import { useClassification } from './useClassification';
 import {
     buildAiThreadGroupsFromThreads,
     buildCheckRowsFromChecks,
@@ -98,6 +100,15 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
     const [aiPassRunning, setAiPassRunning] = useState(false);
     const [aiPassDone, setAiPassDone] = useState(false);
     const [summaryCopied, setSummaryCopied] = useState(false);
+
+    // Classification hook — passes undefined args when feature flag is off
+    const headSha = pr?.headSha ?? pr?.sourceBranch;
+    const classificationHook = useClassification(
+        SHOW_FOCUSED_DIFF ? String(repoId) : undefined,
+        SHOW_FOCUSED_DIFF ? String(prId) : undefined,
+        SHOW_FOCUSED_DIFF ? (headSha ?? undefined) : undefined,
+    );
+    const classification = SHOW_FOCUSED_DIFF ? classificationHook : undefined;
 
     const switchTab = useCallback(
         (tab: PrDetailTab) => {
@@ -517,6 +528,9 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
                                 files={diff.files}
                                 commentsByPath={threadsByPath}
                                 isMobile={isMobile}
+                                annotations={aiAnnotationByPath.annotations}
+                                focusByPath={aiAnnotationByPath.focus}
+                                classification={classification}
                             />
                         </div>
                     </div>

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -44,7 +44,6 @@ import {
     buildCommitRowsFromPrCommits,
     buildMergeReadinessFromData,
     getMockAiSummary,
-    getMockFiles,
     getMockPersonaLenses,
     getMockReviewSummaryText,
     getMockTimeline,
@@ -528,8 +527,6 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
                                 files={diff.files}
                                 commentsByPath={threadsByPath}
                                 isMobile={isMobile}
-                                annotations={aiAnnotationByPath.annotations}
-                                focusByPath={aiAnnotationByPath.focus}
                                 classification={classification}
                             />
                         </div>

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/classification-types.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/classification-types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared types for the focused-diff classification feature.
+ *
+ * A classification assigns each `@@` hunk in a PR diff to a category
+ * (logic, mechanical, test, generated) with an intensity level so the
+ * UI can visually de-emphasize non-logic changes.
+ */
+
+/** The four hunk categories recognised by the classifier. */
+export type HunkCategory = 'logic' | 'mechanical' | 'test' | 'generated';
+
+/** How important a hunk is within its category. */
+export type HunkIntensity = 'high' | 'low';
+
+/** Classification result for a single `@@` hunk. */
+export interface HunkClassification {
+    /** File path (new-side) as it appears in the diff. */
+    file: string;
+    /** 0-based index of the hunk within the file's diff. */
+    hunkIndex: number;
+    /** Dominant category for this hunk. */
+    category: HunkCategory;
+    /** Reviewer-attention level. */
+    intensity: HunkIntensity;
+    /** One-sentence justification for the classification. */
+    reason: string;
+}
+
+/** Full classification result for a PR diff. */
+export interface DiffClassificationResult {
+    /** Per-hunk classifications, ordered by file then hunk index. */
+    classifications: HunkClassification[];
+}
+
+/** Cache key fields — used to check whether a cached result is still valid. */
+export interface DiffClassificationCacheKey {
+    /** PR identifier (number or string, provider-dependent). */
+    prId: string;
+    /** SHA of the last commit on the PR head at classification time. */
+    headSha: string;
+}
+
+/** The four filter categories exposed in the UI filter bar. */
+export const HUNK_CATEGORIES: readonly HunkCategory[] = ['logic', 'mechanical', 'test', 'generated'] as const;
+
+/** Human-readable labels for each category. */
+export const CATEGORY_LABELS: Record<HunkCategory, string> = {
+    logic: 'Logic',
+    mechanical: 'Mechanical',
+    test: 'Test',
+    generated: 'Generated',
+};

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/pr-mock-data.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/pr-mock-data.ts
@@ -2,8 +2,8 @@
  * Mock data for AI-related PR review features.
  *
  * The AI summary, lens grid, grouped threads, conversation timeline,
- * commit intent, checks/CI, merge readiness, file annotations, and
- * AI assistant chat are all driven by the deterministic fixtures
+ * commit intent, checks/CI, merge readiness, and AI assistant chat
+ * are all driven by the deterministic fixtures
  * declared here. Once a real AI backend is available, these can be
  * swapped out for live data without changing the surrounding
  * presentational components.
@@ -91,28 +91,6 @@ export interface MergeReadinessItem {
     tag: MergeReadinessTag;
     label: string;
     body: string;
-}
-
-export interface AiFileAnnotation {
-    title: string;
-    body: string;
-    actions: string[];
-}
-
-export interface AiFileEntry {
-    path: string;
-    additions: number;
-    deletions: number;
-    focus?: 'AI focus file' | 'Coverage gap' | 'Generated';
-    diff?: AiDiffLine[];
-    annotation?: AiFileAnnotation;
-}
-
-export type AiDiffLineKind = 'add' | 'del' | 'ctx';
-export interface AiDiffLine {
-    line: number;
-    kind: AiDiffLineKind;
-    text: string;
 }
 
 export interface AiBranchSnapshot {
@@ -426,62 +404,6 @@ const MERGE_READINESS: MergeReadinessItem[] = [
     },
 ];
 
-const FILES: AiFileEntry[] = [
-    {
-        path: 'packages/ingest/src/jsonl-stream.ts',
-        additions: 164,
-        deletions: 18,
-        focus: 'AI focus file',
-        diff: [
-            { line: 84, kind: 'ctx', text: 'export async function readJsonlStream(source, options) {' },
-            { line: 85, kind: 'add', text: '  const decoder = new TextDecoder();' },
-            { line: 86, kind: 'add', text: '  let buffered = "";' },
-            { line: 87, kind: 'add', text: '  for await (const chunk of source) {' },
-            { line: 88, kind: 'add', text: '    buffered += decoder.decode(chunk, { stream: true });' },
-            { line: 89, kind: 'add', text: '    yield* parseCompleteLines(buffered, options);' },
-            { line: 90, kind: 'ctx', text: '  }' },
-        ],
-        annotation: {
-            title: 'AI annotation: possible replay on abort',
-            body: 'If the stream aborts after line 88 and before line 89, `buffered` can contain a partial record that the retry path replays. Add a test for abort after a split UTF-8 boundary.',
-            actions: ['Apply suggested test', 'Reply'],
-        },
-    },
-    {
-        path: 'packages/ingest/src/worker.ts',
-        additions: 72,
-        deletions: 44,
-    },
-    {
-        path: 'packages/ingest/test/jsonl-stream.test.ts',
-        additions: 211,
-        deletions: 0,
-        focus: 'Coverage gap',
-        diff: [
-            { line: 121, kind: 'ctx', text: 'it("streams large JSONL payloads without buffering the full file", async () => {' },
-            { line: 122, kind: 'add', text: '  const rows = await collect(readJsonlStream(makeLargeFixture()));' },
-            { line: 123, kind: 'add', text: '  expect(rows).toHaveLength(5000);' },
-            { line: 124, kind: 'ctx', text: '});' },
-        ],
-        annotation: {
-            title: 'AI annotation: test shape is useful but too happy-path',
-            body: 'This validates memory behavior, not cancellation semantics. Keep it, then add one test with a slow reader and an aborted consumer.',
-            actions: ['Create task'],
-        },
-    },
-    {
-        path: 'docs/ingest-streaming.md',
-        additions: 54,
-        deletions: 6,
-    },
-    {
-        path: 'fixtures/generated/jsonl-large.fixture',
-        additions: 346,
-        deletions: 0,
-        focus: 'Generated',
-    },
-];
-
 const SUGGESTED_PROMPTS: AiSuggestedPrompt[] = [
     {
         id: 'review-first',
@@ -749,10 +671,6 @@ export function buildMergeReadinessFromData(params: {
     }
 
     return items;
-}
-
-export function getMockFiles(): AiFileEntry[] {
-    return FILES;
 }
 
 export function getMockSuggestedPrompts(): AiSuggestedPrompt[] {

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/pr-utils.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/pr-utils.ts
@@ -98,6 +98,8 @@ export interface PullRequest {
     labels?: string[];
     reviewers?: Reviewer[];
     commentCount?: number;
+    /** SHA of the PR head commit (used as classification cache key). */
+    headSha?: string;
 }
 
 export interface StatusBadge {

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/useClassification.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/useClassification.ts
@@ -1,0 +1,260 @@
+/**
+ * React hook for managing PR diff classification state.
+ *
+ * Calls the classification REST API to trigger on-demand classification
+ * and poll for results.  Exposes per-file and per-hunk lookup helpers
+ * consumed by PrFilesPanel for filter-bar, badges, and hunk dimming.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+    DiffClassificationResult,
+    HunkCategory,
+    HunkClassification,
+    HunkIntensity,
+} from './classification-types';
+import { HUNK_CATEGORIES } from './classification-types';
+import { requestSpaApi } from '../../api/cocClient';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type ClassificationStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface ClassificationState {
+    /** Current status of the classification process. */
+    status: ClassificationStatus;
+    /** Human-readable error message (set when status === 'error'). */
+    error?: string;
+    /** Full classification result (set when status === 'ready'). */
+    result?: DiffClassificationResult;
+    /** Which categories are checked in the filter bar. */
+    activeFilters: Set<HunkCategory>;
+}
+
+/** Per-file badge info (max intensity across all hunks in the file). */
+export interface FileBadge {
+    /** Dominant category (highest-priority among hunks). */
+    category: HunkCategory;
+    /** Max intensity across all hunks in this file. */
+    intensity: HunkIntensity;
+}
+
+export interface UseClassificationReturn {
+    state: ClassificationState;
+    /** Trigger classification via REST API. */
+    classify: () => void;
+    /** Toggle a filter category on/off. */
+    toggleFilter: (cat: HunkCategory) => void;
+    /** Set all filter categories at once. */
+    setFilters: (cats: Set<HunkCategory>) => void;
+    /** Look up the badge for a file path (undefined if not classified). */
+    getFileBadge: (filePath: string) => FileBadge | undefined;
+    /** Look up a specific hunk's classification. */
+    getHunkClassification: (filePath: string, hunkIndex: number) => HunkClassification | undefined;
+    /** Whether a hunk should be dimmed (classified but not in active filters). */
+    isHunkDimmed: (filePath: string, hunkIndex: number) => boolean;
+}
+
+// ── Category priority for badge display ───────────────────────────────
+
+const CATEGORY_PRIORITY: Record<HunkCategory, number> = {
+    logic: 3,
+    test: 2,
+    mechanical: 1,
+    generated: 0,
+};
+
+// ── API response shapes ───────────────────────────────────────────────
+
+interface ClassifyResponse {
+    status: 'started' | 'ready' | 'running';
+    taskId?: string;
+    processId?: string;
+    result?: DiffClassificationResult;
+}
+
+interface ClassificationGetResponse {
+    status: 'none' | 'ready' | 'running';
+    processId?: string;
+    result?: DiffClassificationResult;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL = 3_000;
+const MAX_POLLS = 200; // 10 min max
+
+export function useClassification(
+    repoId: string | undefined,
+    prId: string | number | undefined,
+    headSha: string | undefined,
+): UseClassificationReturn {
+    const [state, setState] = useState<ClassificationState>({
+        status: 'idle',
+        activeFilters: new Set<HunkCategory>(['logic']),
+    });
+
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollCount = useRef(0);
+
+    // Stop polling on unmount
+    useEffect(() => {
+        return () => {
+            if (pollRef.current) clearInterval(pollRef.current);
+        };
+    }, []);
+
+    // Build indices for fast lookup
+    const indexRef = useRef<{
+        byFile: Map<string, HunkClassification[]>;
+        byHunk: Map<string, HunkClassification>;
+        badges: Map<string, FileBadge>;
+    }>({ byFile: new Map(), byHunk: new Map(), badges: new Map() });
+
+    useEffect(() => {
+        const result = state.result;
+        const byFile = new Map<string, HunkClassification[]>();
+        const byHunk = new Map<string, HunkClassification>();
+        const badges = new Map<string, FileBadge>();
+
+        if (result) {
+            for (const c of result.classifications) {
+                const key = `${c.file}:${c.hunkIndex}`;
+                byHunk.set(key, c);
+                const arr = byFile.get(c.file) ?? [];
+                arr.push(c);
+                byFile.set(c.file, arr);
+            }
+            // Compute badges
+            for (const [file, hunks] of byFile) {
+                let maxPri = -1;
+                let badge: FileBadge = { category: 'mechanical', intensity: 'low' };
+                for (const h of hunks) {
+                    const pri = CATEGORY_PRIORITY[h.category] * 2 + (h.intensity === 'high' ? 1 : 0);
+                    if (pri > maxPri) {
+                        maxPri = pri;
+                        badge = { category: h.category, intensity: h.intensity };
+                    }
+                }
+                badges.set(file, badge);
+            }
+        }
+        indexRef.current = { byFile, byHunk, badges };
+    }, [state.result]);
+
+    const startPolling = useCallback((rId: string, pId: string, sha: string) => {
+        if (pollRef.current) clearInterval(pollRef.current);
+        pollCount.current = 0;
+
+        pollRef.current = setInterval(async () => {
+            pollCount.current++;
+            if (pollCount.current > MAX_POLLS) {
+                if (pollRef.current) clearInterval(pollRef.current);
+                setState(prev => ({ ...prev, status: 'error', error: 'Classification timed out' }));
+                return;
+            }
+            try {
+                const resp = await requestSpaApi<ClassificationGetResponse>(
+                    `/repos/${encodeURIComponent(rId)}/pull-requests/${encodeURIComponent(pId)}/classification?headSha=${encodeURIComponent(sha)}`,
+                );
+                if (resp.status === 'ready' && resp.result) {
+                    if (pollRef.current) clearInterval(pollRef.current);
+                    setState(prev => ({ ...prev, status: 'ready', result: resp.result, error: undefined }));
+                }
+                // 'running' or 'none' — keep polling
+            } catch {
+                // Transient error — keep polling
+            }
+        }, POLL_INTERVAL);
+    }, []);
+
+    const classify = useCallback(() => {
+        if (!repoId || !prId || !headSha) return;
+        const rId = String(repoId);
+        const pId = String(prId);
+
+        setState(prev => ({ ...prev, status: 'loading', error: undefined }));
+
+        requestSpaApi<ClassifyResponse>(
+            `/repos/${encodeURIComponent(rId)}/pull-requests/${encodeURIComponent(pId)}/classify`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ headSha }),
+            },
+        )
+            .then(resp => {
+                if (resp.status === 'ready' && resp.result) {
+                    setState(prev => ({ ...prev, status: 'ready', result: resp.result, error: undefined }));
+                } else {
+                    // Started or running — begin polling
+                    startPolling(rId, pId, headSha);
+                }
+            })
+            .catch(err => {
+                setState(prev => ({
+                    ...prev,
+                    status: 'error',
+                    error: err instanceof Error ? err.message : 'Classification failed',
+                }));
+            });
+    }, [repoId, prId, headSha, startPolling]);
+
+    // On mount, check for cached result
+    useEffect(() => {
+        if (!repoId || !prId || !headSha) return;
+        const rId = String(repoId);
+        const pId = String(prId);
+
+        requestSpaApi<ClassificationGetResponse>(
+            `/repos/${encodeURIComponent(rId)}/pull-requests/${encodeURIComponent(pId)}/classification?headSha=${encodeURIComponent(headSha)}`,
+        )
+            .then(resp => {
+                if (resp.status === 'ready' && resp.result) {
+                    setState(prev => ({ ...prev, status: 'ready', result: resp.result }));
+                } else if (resp.status === 'running') {
+                    setState(prev => ({ ...prev, status: 'loading' }));
+                    startPolling(rId, pId, headSha);
+                }
+            })
+            .catch(() => { /* no cache — ok */ });
+    }, [repoId, prId, headSha, startPolling]);
+
+    const toggleFilter = useCallback((cat: HunkCategory) => {
+        setState(prev => {
+            const next = new Set(prev.activeFilters);
+            if (next.has(cat)) next.delete(cat);
+            else next.add(cat);
+            return { ...prev, activeFilters: next };
+        });
+    }, []);
+
+    const setFilters = useCallback((cats: Set<HunkCategory>) => {
+        setState(prev => ({ ...prev, activeFilters: cats }));
+    }, []);
+
+    const getFileBadge = useCallback((filePath: string): FileBadge | undefined => {
+        return indexRef.current.badges.get(filePath);
+    }, []);
+
+    const getHunkClassification = useCallback((filePath: string, hunkIndex: number): HunkClassification | undefined => {
+        return indexRef.current.byHunk.get(`${filePath}:${hunkIndex}`);
+    }, []);
+
+    const isHunkDimmed = useCallback((filePath: string, hunkIndex: number): boolean => {
+        if (state.status !== 'ready') return false;
+        const c = indexRef.current.byHunk.get(`${filePath}:${hunkIndex}`);
+        if (!c) return false;
+        return !state.activeFilters.has(c.category);
+    }, [state.status, state.activeFilters]);
+
+    return {
+        state,
+        classify,
+        toggleFilter,
+        setFilters,
+        getFileBadge,
+        getHunkClassification,
+        isHunkDimmed,
+    };
+}

--- a/packages/coc/src/server/spa/client/react/utils/config.ts
+++ b/packages/coc/src/server/spa/client/react/utils/config.ts
@@ -21,6 +21,7 @@ interface DashboardConfig {
     containerMode?: boolean;
     loopsEnabled?: boolean;
     mcpOauthEnabled?: boolean;
+    focusedDiffEnabled?: boolean;
     bindAddress?: string;
 }
 
@@ -124,6 +125,10 @@ export function isLoopsEnabled(): boolean {
 
 export function isMcpOauthEnabled(): boolean {
     return getConfig().mcpOauthEnabled === true;
+}
+
+export function isFocusedDiffEnabled(): boolean {
+    return getConfig().focusedDiffEnabled === true;
 }
 
 /** Returns the raw bind address the server is listening on (e.g., '0.0.0.0'), if known. */

--- a/packages/coc/src/server/spa/html-template.ts
+++ b/packages/coc/src/server/spa/html-template.ts
@@ -95,6 +95,7 @@ export function generateDashboardHtml(options: DashboardOptions = {}): string {
         containerMode,
         loopsEnabled,
         mcpOauthEnabled,
+        focusedDiffEnabled,
         reviewFilePath,
         projectDir,
         bindAddress,
@@ -143,7 +144,8 @@ ${getBundleCss()}
             vimNavigationEnabled: ${!!vimNavigationEnabled},
             containerMode: ${!!containerMode},
             loopsEnabled: ${!!loopsEnabled},
-            mcpOauthEnabled: ${!!mcpOauthEnabled}${bindAddress ? `,
+            mcpOauthEnabled: ${!!mcpOauthEnabled},
+            focusedDiffEnabled: ${!!focusedDiffEnabled}${bindAddress ? `,
             bindAddress: '${escapeHtml(bindAddress)}'` : ''}
         };
     </script>${reviewFilePath ? `

--- a/packages/coc/src/server/spa/types.ts
+++ b/packages/coc/src/server/spa/types.ts
@@ -35,6 +35,8 @@ export interface DashboardOptions {
     vimNavigationEnabled?: boolean;
     /** Whether the loops/recurring follow-up subsystem is enabled in server config. */
     loopsEnabled?: boolean;
+    /** Whether the focused-diff classification feature is enabled. */
+    focusedDiffEnabled?: boolean;
     /** Whether the MCP OAuth auto-detection subsystem is enabled in server config. */
     mcpOauthEnabled?: boolean;
     /** When set, injects __REVIEW_CONFIG__ for the review editor page. */

--- a/packages/coc/src/server/storage/export-import-types.ts
+++ b/packages/coc/src/server/storage/export-import-types.ts
@@ -83,6 +83,10 @@ export interface CLIConfig {
     loops?: {
         enabled?: boolean;
     };
+    features?: {
+        autoMemoryPromotion?: boolean;
+        focusedDiff?: boolean;
+    };
     store?: {
         backend?: 'file' | 'sqlite';
     };

--- a/packages/coc/src/server/tasks/task-types.ts
+++ b/packages/coc/src/server/tasks/task-types.ts
@@ -214,8 +214,6 @@ export interface ChatContext {
         repoId: string;
         prId: string;
         headSha: string;
-        /** Legacy cache tag (kept for prompt embedding; not used for storage). */
-        cacheTag?: string;
     };
 }
 

--- a/packages/coc/src/server/tasks/task-types.ts
+++ b/packages/coc/src/server/tasks/task-types.ts
@@ -209,6 +209,14 @@ export interface ChatContext {
     scheduleParams?: Record<string, string>;
     /** Ralph-mode orchestration metadata. */
     ralph?: RalphContext;
+    /** PR diff classification context — dispatches to ClassificationExecutor. */
+    classifyDiff?: {
+        repoId: string;
+        prId: string;
+        headSha: string;
+        /** Legacy cache tag (kept for prompt embedding; not used for storage). */
+        cacheTag?: string;
+    };
 }
 
 /** Ralph-mode orchestration context (mirrored verbatim into AIProcess.metadata.ralph). */
@@ -382,6 +390,13 @@ export function hasNoteCreateContext(payload: Record<string, unknown>): boolean 
 /** Check whether a chat payload carries Ralph-mode orchestration context. */
 export function hasRalphContext(payload: Record<string, unknown>): boolean {
     return isChatPayload(payload) && !!payload.context?.ralph;
+}
+
+/** Check whether a chat payload carries PR diff classification context. */
+export function hasClassifyDiffContext(payload: Record<string, unknown>): boolean {
+    if (!isChatPayload(payload)) return false;
+    const ctx = payload.context?.classifyDiff;
+    return !!ctx && typeof ctx.repoId === 'string' && typeof ctx.prId === 'string' && typeof ctx.headSha === 'string';
 }
 
 /** Check whether a chat payload is in Ralph mode. */

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -796,6 +796,7 @@ timeout: 300
                 '  enabled: true',
                 'features:',
                 '  autoMemoryPromotion: true',
+                '  focusedDiff: true',
                 'memoryPromotion:',
                 '  batchSize: 25',
                 '  timeoutMs: 80000',
@@ -879,6 +880,7 @@ timeout: 300
                 '  enabled: true',
                 'features:',
                 '  autoMemoryPromotion: true',
+                '  focusedDiff: true',
                 'memoryPromotion:',
                 '  batchSize: 10',
                 '  timeoutMs: 70000',
@@ -922,6 +924,7 @@ timeout: 300
                   },
                   "features": {
                     "autoMemoryPromotion": true,
+                    "focusedDiff": true,
                   },
                   "groupSingleLineMessages": false,
                   "logging": {
@@ -1034,6 +1037,7 @@ timeout: 300
                   "chat.followUpSuggestions.count": "file",
                   "chat.followUpSuggestions.enabled": "file",
                   "features.autoMemoryPromotion": "file",
+                  "features.focusedDiff": "file",
                   "groupSingleLineMessages": "file",
                   "loops.enabled": "file",
                   "mcpConfig": "file",

--- a/packages/coc/test/server/admin-handler.test.ts
+++ b/packages/coc/test/server/admin-handler.test.ts
@@ -627,6 +627,31 @@ describe('Admin Handler', () => {
             expect(content).toContain('persisted-model');
         });
 
+        it('should persist features.focusedDiff to disk', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            const yaml = require('js-yaml');
+            fs.writeFileSync(configPath, yaml.dump({
+                features: { autoMemoryPromotion: true },
+            }), 'utf-8');
+            const srv = await startServerWithConfig(configPath);
+
+            const res = await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ 'features.focusedDiff': true }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            expect(body.resolved.features.focusedDiff).toBe(true);
+            expect(body.resolved.features.autoMemoryPromotion).toBe(true);
+            expect(body.sources['features.focusedDiff']).toBe('file');
+
+            const diskConfig = yaml.load(fs.readFileSync(configPath, 'utf-8'));
+            expect(diskConfig.features.focusedDiff).toBe(true);
+            expect(diskConfig.features.autoMemoryPromotion).toBe(true);
+        });
+
         it('should create config file when none exists', async () => {
             const configPath = path.join(dataDir, 'brand-new-config.yaml');
             expect(fs.existsSync(configPath)).toBe(false);
@@ -766,6 +791,21 @@ describe('Admin Handler', () => {
             expect(res.status).toBe(400);
             const body = JSON.parse(res.body);
             expect(body.error).toContain('timeout');
+        });
+
+        it('should reject non-boolean features.focusedDiff', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            const srv = await startServerWithConfig(configPath);
+
+            const res = await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ 'features.focusedDiff': 'yes' }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            expect(res.status).toBe(400);
+            const body = JSON.parse(res.body);
+            expect(body.error).toContain('features.focusedDiff');
         });
 
         it('should reject timeout: string', async () => {

--- a/packages/coc/test/server/classification-store.test.ts
+++ b/packages/coc/test/server/classification-store.test.ts
@@ -40,9 +40,11 @@ describe('classificationPaths', () => {
 
     it('sanitizes filesystem-unsafe characters in key parts', () => {
         const paths = classificationPaths('/data', 'ws1', 'org/repo', '42', 'sha:bad');
-        expect(paths.resultPath).not.toContain('/repo');
-        expect(paths.resultPath).not.toContain(':');
-        expect(path.basename(paths.resultPath)).toBe('org_repo_42_sha_bad.json');
+        const filename = path.basename(paths.resultPath);
+        // The sanitized filename must not contain the original unsafe chars
+        expect(filename).not.toContain('/');
+        expect(filename).not.toContain(':');
+        expect(filename).toBe('org_repo_42_sha_bad.json');
     });
 });
 

--- a/packages/coc/test/server/classification-store.test.ts
+++ b/packages/coc/test/server/classification-store.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the file-based classification store.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    classificationPaths,
+    readClassification,
+    writeClassification,
+    writePending,
+    readPending,
+    clearPending,
+    pruneStaleClassifications,
+    pruneAllStaleClassifications,
+    validateClassificationResult,
+} from '../../src/server/repos/classification-store';
+import type { DiffClassificationResult } from '../../src/server/spa/client/react/features/pull-requests/classification-types';
+
+function makeTempDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'classification-store-test-'));
+}
+
+const validResult: DiffClassificationResult = {
+    classifications: [
+        { file: 'src/a.ts', hunkIndex: 0, category: 'logic', intensity: 'high', reason: 'New code' },
+        { file: 'src/a.ts', hunkIndex: 1, category: 'mechanical', intensity: 'low', reason: 'Rename' },
+    ],
+};
+
+describe('classificationPaths', () => {
+    it('places files under <dataDir>/repos/<workspaceId>/classifications', () => {
+        const paths = classificationPaths('/data', 'ws1', 'repo', '42', 'abcdef');
+        expect(paths.dir).toBe(path.join('/data', 'repos', 'ws1', 'classifications'));
+        expect(paths.resultPath.endsWith('repo_42_abcdef.json')).toBe(true);
+        expect(paths.pendingPath.endsWith('repo_42_abcdef.json.pending')).toBe(true);
+    });
+
+    it('sanitizes filesystem-unsafe characters in key parts', () => {
+        const paths = classificationPaths('/data', 'ws1', 'org/repo', '42', 'sha:bad');
+        expect(paths.resultPath).not.toContain('/repo');
+        expect(paths.resultPath).not.toContain(':');
+        expect(path.basename(paths.resultPath)).toBe('org_repo_42_sha_bad.json');
+    });
+});
+
+describe('writeClassification / readClassification', () => {
+    let dataDir: string;
+    beforeEach(() => { dataDir = makeTempDir(); });
+
+    it('persists and re-reads a valid result', () => {
+        const record = writeClassification(dataDir, 'ws', 'repo', '1', 'sha', validResult, { processId: 'p1' });
+        expect(record.result.classifications).toHaveLength(2);
+
+        const read = readClassification(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(read).toBeDefined();
+        expect(read?.result).toEqual(validResult);
+        expect(read?.processId).toBe('p1');
+        expect(typeof read?.createdAt).toBe('string');
+    });
+
+    it('returns undefined when the file is missing', () => {
+        expect(readClassification(dataDir, 'ws', 'repo', '1', 'sha')).toBeUndefined();
+    });
+
+    it('returns undefined when the file is corrupt', () => {
+        const { resultPath, dir } = classificationPaths(dataDir, 'ws', 'repo', '1', 'sha');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(resultPath, 'not json', 'utf-8');
+        expect(readClassification(dataDir, 'ws', 'repo', '1', 'sha')).toBeUndefined();
+    });
+
+    it('rejects invalid input and never writes the file', () => {
+        const bad = { classifications: [{ file: 'a', hunkIndex: 0, category: 'oops', intensity: 'high', reason: 'x' }] } as unknown as DiffClassificationResult;
+        expect(() => writeClassification(dataDir, 'ws', 'repo', '1', 'sha', bad))
+            .toThrow(/category/);
+        const { resultPath } = classificationPaths(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(fs.existsSync(resultPath)).toBe(false);
+    });
+
+    it('removes the pending marker on successful write', () => {
+        writePending(dataDir, 'ws', 'repo', '1', 'sha', 'task-1');
+        const { pendingPath } = classificationPaths(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(fs.existsSync(pendingPath)).toBe(true);
+
+        writeClassification(dataDir, 'ws', 'repo', '1', 'sha', validResult);
+        expect(fs.existsSync(pendingPath)).toBe(false);
+    });
+
+    it('overwrites an existing result for the same key', () => {
+        writeClassification(dataDir, 'ws', 'repo', '1', 'sha', validResult);
+        const next: DiffClassificationResult = {
+            classifications: [{ file: 'b.ts', hunkIndex: 0, category: 'test', intensity: 'low', reason: 'Add' }],
+        };
+        writeClassification(dataDir, 'ws', 'repo', '1', 'sha', next);
+        const read = readClassification(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(read?.result.classifications).toHaveLength(1);
+        expect(read?.result.classifications[0].file).toBe('b.ts');
+    });
+});
+
+describe('pending markers', () => {
+    let dataDir: string;
+    beforeEach(() => { dataDir = makeTempDir(); });
+
+    it('writes and reads a pending marker', () => {
+        writePending(dataDir, 'ws', 'repo', '1', 'sha', 'task-7');
+        const pending = readPending(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(pending?.processId).toBe('task-7');
+        expect(typeof pending?.startedAt).toBe('string');
+    });
+
+    it('returns undefined when no pending marker exists', () => {
+        expect(readPending(dataDir, 'ws', 'repo', '1', 'sha')).toBeUndefined();
+    });
+
+    it('clearPending removes the marker', () => {
+        writePending(dataDir, 'ws', 'repo', '1', 'sha', 'task-7');
+        clearPending(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(readPending(dataDir, 'ws', 'repo', '1', 'sha')).toBeUndefined();
+    });
+});
+
+describe('validateClassificationResult', () => {
+    it('accepts a valid result', () => {
+        const v = validateClassificationResult(validResult);
+        expect(v.ok).toBe(true);
+        if (v.ok) expect(v.classifications).toHaveLength(2);
+    });
+
+    it('rejects non-object input', () => {
+        const v = validateClassificationResult(null);
+        expect(v.ok).toBe(false);
+    });
+
+    it('rejects when classifications is not an array', () => {
+        const v = validateClassificationResult({ classifications: 'oops' });
+        expect(v.ok).toBe(false);
+    });
+
+    it('rejects empty classifications array', () => {
+        const v = validateClassificationResult({ classifications: [] });
+        expect(v.ok).toBe(false);
+    });
+
+    it('rejects an entry missing required fields', () => {
+        const v = validateClassificationResult({ classifications: [{ file: 'a.ts' }] });
+        expect(v.ok).toBe(false);
+    });
+
+    it('rejects an entry with bad category', () => {
+        const v = validateClassificationResult({
+            classifications: [{ file: 'a', hunkIndex: 0, category: 'other', intensity: 'high', reason: 'x' }],
+        });
+        expect(v.ok).toBe(false);
+        if (!v.ok) expect(v.error).toMatch(/category/);
+    });
+
+    it('rejects an entry with bad intensity', () => {
+        const v = validateClassificationResult({
+            classifications: [{ file: 'a', hunkIndex: 0, category: 'logic', intensity: 'medium', reason: 'x' }],
+        });
+        expect(v.ok).toBe(false);
+        if (!v.ok) expect(v.error).toMatch(/intensity/);
+    });
+
+    it('rejects negative hunkIndex', () => {
+        const v = validateClassificationResult({
+            classifications: [{ file: 'a', hunkIndex: -1, category: 'logic', intensity: 'high', reason: 'x' }],
+        });
+        expect(v.ok).toBe(false);
+    });
+});
+
+describe('pruneStaleClassifications', () => {
+    let dataDir: string;
+    beforeEach(() => { dataDir = makeTempDir(); });
+
+    it('removes files older than the cutoff', () => {
+        writeClassification(dataDir, 'ws', 'repo', 'old', 'sha', validResult);
+        writeClassification(dataDir, 'ws', 'repo', 'new', 'sha', validResult);
+
+        const { resultPath: oldPath } = classificationPaths(dataDir, 'ws', 'repo', 'old', 'sha');
+        const ancient = Date.now() - 40 * 24 * 60 * 60 * 1000;
+        fs.utimesSync(oldPath, ancient / 1000, ancient / 1000);
+
+        const removed = pruneStaleClassifications(dataDir, 'ws', 30);
+        expect(removed).toBe(1);
+        expect(fs.existsSync(oldPath)).toBe(false);
+        expect(readClassification(dataDir, 'ws', 'repo', 'new', 'sha')).toBeDefined();
+    });
+
+    it('returns 0 when the directory does not exist', () => {
+        expect(pruneStaleClassifications(dataDir, 'nope', 30)).toBe(0);
+    });
+
+    it('also prunes stale pending markers', () => {
+        writePending(dataDir, 'ws', 'repo', '1', 'sha', 'task');
+        const { pendingPath } = classificationPaths(dataDir, 'ws', 'repo', '1', 'sha');
+        const ancient = Date.now() - 40 * 24 * 60 * 60 * 1000;
+        fs.utimesSync(pendingPath, ancient / 1000, ancient / 1000);
+
+        const removed = pruneStaleClassifications(dataDir, 'ws', 30);
+        expect(removed).toBe(1);
+        expect(fs.existsSync(pendingPath)).toBe(false);
+    });
+});
+
+describe('pruneAllStaleClassifications', () => {
+    let dataDir: string;
+    beforeEach(() => { dataDir = makeTempDir(); });
+
+    it('walks every workspace under <dataDir>/repos', () => {
+        writeClassification(dataDir, 'wsA', 'repo', '1', 'sha', validResult);
+        writeClassification(dataDir, 'wsB', 'repo', '1', 'sha', validResult);
+
+        for (const ws of ['wsA', 'wsB']) {
+            const { resultPath } = classificationPaths(dataDir, ws, 'repo', '1', 'sha');
+            const ancient = Date.now() - 40 * 24 * 60 * 60 * 1000;
+            fs.utimesSync(resultPath, ancient / 1000, ancient / 1000);
+        }
+
+        const removed = pruneAllStaleClassifications(dataDir, 30);
+        expect(removed).toBe(2);
+    });
+
+    it('returns 0 when no repos root exists', () => {
+        const empty = makeTempDir();
+        expect(pruneAllStaleClassifications(empty, 30)).toBe(0);
+    });
+});

--- a/packages/coc/test/server/executors/executor-registry-classification.test.ts
+++ b/packages/coc/test/server/executors/executor-registry-classification.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Executor Registry — Classification Routing Tests
+ *
+ * Verifies that tasks carrying `context.classifyDiff` are routed to the
+ * ClassificationExecutor instead of the default mode-based executors.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { QueuedTask } from '@plusplusoneplusplus/forge';
+import { ExecutorRegistry } from '../../../src/server/executors/executor-registry';
+import { ClassificationExecutor } from '../../../src/server/executors/classification-executor';
+import { AutopilotExecutor } from '../../../src/server/executors/autopilot-executor';
+import { createMockProcessStore } from '../helpers/mock-process-store';
+import { createMockSDKService } from '../../helpers/mock-sdk-service';
+
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('fs')>();
+    return {
+        ...actual,
+        existsSync: vi.fn().mockReturnValue(false),
+        promises: {
+            ...actual.promises,
+            readdir: vi.fn().mockResolvedValue([]),
+        },
+    };
+});
+
+vi.mock('../../../src/server/executors/image-store', () => ({
+    saveImagesToTempFiles: vi.fn().mockReturnValue({ tempDir: undefined, attachments: [] }),
+    cleanupTempDir: vi.fn(),
+    rehydrateImagesIfNeeded: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/server/tasks/task-root-resolver', () => ({
+    resolveTaskRoot: vi.fn().mockReturnValue({ absolutePath: '/tasks-root' }),
+}));
+
+vi.mock('../../../src/server/processes/output-file-manager', () => ({
+    OutputFileManager: {
+        saveOutput: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
+const sdkMocks = createMockSDKService();
+
+function createRegistry() {
+    const store = createMockProcessStore();
+    const registry = new ExecutorRegistry(store, {
+        approvePermissions: true,
+        aiService: sdkMocks.service as any,
+        dataDir: '/data',
+        defaultTimeoutMs: 30_000,
+        followUpSuggestions: { enabled: false, count: 3 },
+        toolCallCacheStore: { options: {} } as any,
+        resolveSkillConfig: vi.fn().mockResolvedValue({}),
+        resolveWorkspaceIdForPath: vi.fn().mockResolvedValue('ws-1'),
+        onTitleNeeded: vi.fn(),
+        getWsServer: () => undefined,
+    });
+    return { store, registry };
+}
+
+function makeClassifyTask(): QueuedTask {
+    return {
+        id: 'task-classify-1',
+        type: 'chat',
+        priority: 'normal',
+        status: 'running',
+        createdAt: Date.now(),
+        payload: {
+            kind: 'chat',
+            mode: 'autopilot',
+            prompt: 'Classify PR #42',
+            workspaceId: 'ws-1',
+            context: {
+                classifyDiff: {
+                    repoId: 'repo-1',
+                    prId: '42',
+                    headSha: 'deadbeef',
+                },
+            },
+        },
+        config: {},
+        displayName: 'Classify PR #42',
+    } as unknown as QueuedTask;
+}
+
+describe('ExecutorRegistry — classification routing', () => {
+    it('dispatches classifyDiff tasks to ClassificationExecutor', async () => {
+        const { registry } = createRegistry();
+        const task = makeClassifyTask();
+
+        const classifySpy = vi.spyOn(ClassificationExecutor.prototype, 'execute').mockResolvedValue({
+            response: 'classified',
+            timeline: [],
+        });
+        const autopilotSpy = vi.spyOn(AutopilotExecutor.prototype, 'execute');
+
+        await registry.dispatch(task, 'Classify PR #42');
+
+        expect(classifySpy).toHaveBeenCalledOnce();
+        expect(autopilotSpy).not.toHaveBeenCalled();
+        classifySpy.mockRestore();
+        autopilotSpy.mockRestore();
+    });
+
+    it('routing wins over autopilot mode', async () => {
+        const { registry } = createRegistry();
+        const task = makeClassifyTask();
+        (task.payload as any).mode = 'autopilot';
+
+        const classifySpy = vi.spyOn(ClassificationExecutor.prototype, 'execute').mockResolvedValue({
+            response: 'classified',
+            timeline: [],
+        });
+
+        await registry.dispatch(task, 'Classify');
+
+        expect(classifySpy).toHaveBeenCalledOnce();
+        classifySpy.mockRestore();
+    });
+
+    it('plain chat tasks (no classifyDiff) do NOT route to ClassificationExecutor', async () => {
+        const { registry } = createRegistry();
+        const task: QueuedTask = {
+            id: 'task-plain-1',
+            type: 'chat',
+            priority: 'normal',
+            status: 'running',
+            createdAt: Date.now(),
+            payload: {
+                kind: 'chat',
+                mode: 'ask',
+                prompt: 'Hello',
+            },
+            config: {},
+            displayName: 'Hello',
+        } as unknown as QueuedTask;
+
+        const classifySpy = vi.spyOn(ClassificationExecutor.prototype, 'execute');
+
+        try {
+            await registry.dispatch(task, 'Hello');
+        } catch {
+            /* expected — only checking routing */
+        }
+
+        expect(classifySpy).not.toHaveBeenCalled();
+        classifySpy.mockRestore();
+    });
+});

--- a/packages/coc/test/server/llm-tools/save-classification-tool.test.ts
+++ b/packages/coc/test/server/llm-tools/save-classification-tool.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the saveClassification LLM tool factory.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createSaveClassificationTool } from '../../../src/server/llm-tools/save-classification-tool';
+import { readClassification } from '../../../src/server/repos/classification-store';
+import type { HunkClassification } from '../../../src/server/spa/client/react/features/pull-requests/classification-types';
+
+function makeTempDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'save-classification-test-'));
+}
+
+const validClassifications: HunkClassification[] = [
+    { file: 'src/a.ts', hunkIndex: 0, category: 'logic', intensity: 'high', reason: 'New feature' },
+    { file: 'src/a.ts', hunkIndex: 1, category: 'mechanical', intensity: 'low', reason: 'Rename' },
+];
+
+describe('createSaveClassificationTool', () => {
+    let dataDir: string;
+    beforeEach(() => { dataDir = makeTempDir(); });
+
+    it('exposes a tool named saveClassification', () => {
+        const { tool } = createSaveClassificationTool({
+            dataDir, workspaceId: 'ws', repoId: 'repo', prId: '1', headSha: 'sha',
+        });
+        expect((tool as any).name).toBe('saveClassification');
+    });
+
+    it('persists the classifications on a successful call', async () => {
+        const { tool, getSaved } = createSaveClassificationTool({
+            dataDir, workspaceId: 'ws', repoId: 'repo', prId: '1', headSha: 'sha', processId: 'p-1',
+        });
+        const result = await (tool as any).handler({ classifications: validClassifications });
+
+        expect(result.success).toBe(true);
+        expect(result.count).toBe(2);
+
+        const stored = readClassification(dataDir, 'ws', 'repo', '1', 'sha');
+        expect(stored?.result.classifications).toHaveLength(2);
+        expect(stored?.processId).toBe('p-1');
+        expect(getSaved()).toHaveLength(2);
+    });
+
+    it('returns an error and does not write on invalid input', async () => {
+        const { tool, getSaved } = createSaveClassificationTool({
+            dataDir, workspaceId: 'ws', repoId: 'repo', prId: '1', headSha: 'sha',
+        });
+        const result = await (tool as any).handler({
+            classifications: [{ file: 'a', hunkIndex: 0, category: 'unknown', intensity: 'high', reason: 'x' }],
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/category/);
+        expect(result.hint).toBeDefined();
+        expect(readClassification(dataDir, 'ws', 'repo', '1', 'sha')).toBeUndefined();
+        expect(getSaved()).toBeUndefined();
+    });
+
+    it('returns an error when classifications is missing', async () => {
+        const { tool } = createSaveClassificationTool({
+            dataDir, workspaceId: 'ws', repoId: 'repo', prId: '1', headSha: 'sha',
+        });
+        const result = await (tool as any).handler({});
+        expect(result.success).toBe(false);
+    });
+
+    it('returns an error when classifications array is empty', async () => {
+        const { tool } = createSaveClassificationTool({
+            dataDir, workspaceId: 'ws', repoId: 'repo', prId: '1', headSha: 'sha',
+        });
+        const result = await (tool as any).handler({ classifications: [] });
+        expect(result.success).toBe(false);
+    });
+
+    it('allows the AI to retry after a validation failure', async () => {
+        const { tool } = createSaveClassificationTool({
+            dataDir, workspaceId: 'ws', repoId: 'repo', prId: '1', headSha: 'sha',
+        });
+        const bad = await (tool as any).handler({
+            classifications: [{ file: '', hunkIndex: 0, category: 'logic', intensity: 'high', reason: 'x' }],
+        });
+        expect(bad.success).toBe(false);
+
+        const good = await (tool as any).handler({ classifications: validClassifications });
+        expect(good.success).toBe(true);
+        expect(readClassification(dataDir, 'ws', 'repo', '1', 'sha')).toBeDefined();
+    });
+});

--- a/packages/coc/test/server/pr-classification-handler.test.ts
+++ b/packages/coc/test/server/pr-classification-handler.test.ts
@@ -7,31 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-    classificationCacheTag,
-    buildClassificationPrompt,
-} from '../../src/server/repos/pr-classification-handler';
-
-// ── classificationCacheTag ───────────────────────────────────────────────────
-
-describe('classificationCacheTag', () => {
-    it('should produce a deterministic tag from repo, pr, and sha', () => {
-        const tag = classificationCacheTag('repo-abc', '42', 'deadbeef');
-        expect(tag).toBe('classify-diff:repo-abc:42:deadbeef');
-    });
-
-    it('should produce different tags for different SHAs', () => {
-        const tag1 = classificationCacheTag('repo', '1', 'sha1');
-        const tag2 = classificationCacheTag('repo', '1', 'sha2');
-        expect(tag1).not.toBe(tag2);
-    });
-
-    it('should produce different tags for different PRs', () => {
-        const tag1 = classificationCacheTag('repo', '1', 'sha');
-        const tag2 = classificationCacheTag('repo', '2', 'sha');
-        expect(tag1).not.toBe(tag2);
-    });
-});
+import { buildClassificationPrompt } from '../../src/server/repos/pr-classification-handler';
 
 // ── buildClassificationPrompt ────────────────────────────────────────────────
 
@@ -41,13 +17,7 @@ describe('buildClassificationPrompt', () => {
         expect(prompt).toContain('pull request #42');
     });
 
-    it('should embed the cache tag when provided', () => {
-        const tag = 'classify-diff:repo:42:abc123def';
-        const prompt = buildClassificationPrompt('repo', '42', tag);
-        expect(prompt).toContain(`<!-- cache-key: ${tag} -->`);
-    });
-
-    it('should NOT include cache-key comment when cacheTag is omitted', () => {
+    it('should never include a cache-key comment', () => {
         const prompt = buildClassificationPrompt('repo', '42');
         expect(prompt).not.toContain('cache-key');
     });

--- a/packages/coc/test/server/pr-classification-handler.test.ts
+++ b/packages/coc/test/server/pr-classification-handler.test.ts
@@ -1,68 +1,16 @@
 /**
- * Tests for pr-classification-handler — unit tests for the classification route handler.
+ * Tests for pr-classification-handler — unit tests for prompt and tag helpers.
+ *
+ * Route-level behavior (POST/GET) is covered indirectly via the file-based
+ * classification-store tests. The legacy `extractClassificationFromResult`
+ * has been removed in favour of the `saveClassification` LLM tool.
  */
 
 import { describe, it, expect } from 'vitest';
 import {
-    extractClassificationFromResult,
     classificationCacheTag,
     buildClassificationPrompt,
 } from '../../src/server/repos/pr-classification-handler';
-import type { DiffClassificationResult } from '../../src/server/spa/client/react/features/pull-requests/classification-types';
-
-// ── extractClassificationFromResult ──────────────────────────────────────────
-
-describe('extractClassificationFromResult', () => {
-    const validResult: DiffClassificationResult = {
-        classifications: [
-            { file: 'src/main.ts', hunkIndex: 0, category: 'logic', intensity: 'high', reason: 'New feature logic' },
-            { file: 'src/utils.ts', hunkIndex: 1, category: 'mechanical', intensity: 'low', reason: 'Import reorder' },
-        ],
-    };
-
-    it('should parse a plain JSON string', () => {
-        const input = JSON.stringify(validResult);
-        const result = extractClassificationFromResult(input);
-        expect(result).toEqual(validResult);
-    });
-
-    it('should parse JSON inside a code fence', () => {
-        const input = 'Here is the classification:\n```json\n' + JSON.stringify(validResult) + '\n```\nDone.';
-        const result = extractClassificationFromResult(input);
-        expect(result).toEqual(validResult);
-    });
-
-    it('should parse JSON embedded in text without fence', () => {
-        const input = 'The result is: ' + JSON.stringify(validResult) + ' — that is all.';
-        const result = extractClassificationFromResult(input);
-        expect(result).toEqual(validResult);
-    });
-
-    it('should return undefined for empty input', () => {
-        expect(extractClassificationFromResult(undefined)).toBeUndefined();
-        expect(extractClassificationFromResult('')).toBeUndefined();
-    });
-
-    it('should return undefined for invalid JSON', () => {
-        expect(extractClassificationFromResult('not json at all')).toBeUndefined();
-    });
-
-    it('should return undefined when classifications array has invalid entries', () => {
-        const invalid = { classifications: [{ file: 'a.ts' }] }; // missing fields
-        expect(extractClassificationFromResult(JSON.stringify(invalid))).toBeUndefined();
-    });
-
-    it('should return undefined when JSON has no classifications key', () => {
-        expect(extractClassificationFromResult('{"hunks": []}')).toBeUndefined();
-    });
-
-    it('should handle pretty-printed JSON in code fence', () => {
-        const pretty = JSON.stringify(validResult, null, 2);
-        const input = '```json\n' + pretty + '\n```';
-        const result = extractClassificationFromResult(input);
-        expect(result).toEqual(validResult);
-    });
-});
 
 // ── classificationCacheTag ───────────────────────────────────────────────────
 
@@ -110,10 +58,8 @@ describe('buildClassificationPrompt', () => {
         expect(prompt).toContain('gh');
     });
 
-    it('should include JSON schema guidance', () => {
+    it('should mention the saveClassification tool', () => {
         const prompt = buildClassificationPrompt('repo', '42');
-        expect(prompt).toContain('"classifications"');
-        expect(prompt).toContain('"category"');
-        expect(prompt).toContain('"intensity"');
+        expect(prompt).toContain('saveClassification');
     });
 });

--- a/packages/coc/test/server/pr-classification-handler.test.ts
+++ b/packages/coc/test/server/pr-classification-handler.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 import {
     extractClassificationFromResult,
     classificationCacheTag,
+    buildClassificationPrompt,
 } from '../../src/server/repos/pr-classification-handler';
 import type { DiffClassificationResult } from '../../src/server/spa/client/react/features/pull-requests/classification-types';
 
@@ -81,5 +82,38 @@ describe('classificationCacheTag', () => {
         const tag1 = classificationCacheTag('repo', '1', 'sha');
         const tag2 = classificationCacheTag('repo', '2', 'sha');
         expect(tag1).not.toBe(tag2);
+    });
+});
+
+// ── buildClassificationPrompt ────────────────────────────────────────────────
+
+describe('buildClassificationPrompt', () => {
+    it('should include the PR number in the prompt', () => {
+        const prompt = buildClassificationPrompt('my-repo', '42');
+        expect(prompt).toContain('pull request #42');
+    });
+
+    it('should embed the cache tag when provided', () => {
+        const tag = 'classify-diff:repo:42:abc123def';
+        const prompt = buildClassificationPrompt('repo', '42', tag);
+        expect(prompt).toContain(`<!-- cache-key: ${tag} -->`);
+    });
+
+    it('should NOT include cache-key comment when cacheTag is omitted', () => {
+        const prompt = buildClassificationPrompt('repo', '42');
+        expect(prompt).not.toContain('cache-key');
+    });
+
+    it('should include instructions to use git tools', () => {
+        const prompt = buildClassificationPrompt('repo', '42');
+        expect(prompt).toContain('git');
+        expect(prompt).toContain('gh');
+    });
+
+    it('should include JSON schema guidance', () => {
+        const prompt = buildClassificationPrompt('repo', '42');
+        expect(prompt).toContain('"classifications"');
+        expect(prompt).toContain('"category"');
+        expect(prompt).toContain('"intensity"');
     });
 });

--- a/packages/coc/test/server/pr-classification-handler.test.ts
+++ b/packages/coc/test/server/pr-classification-handler.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for pr-classification-handler — unit tests for the classification route handler.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    extractClassificationFromResult,
+    classificationCacheTag,
+} from '../../src/server/repos/pr-classification-handler';
+import type { DiffClassificationResult } from '../../src/server/spa/client/react/features/pull-requests/classification-types';
+
+// ── extractClassificationFromResult ──────────────────────────────────────────
+
+describe('extractClassificationFromResult', () => {
+    const validResult: DiffClassificationResult = {
+        classifications: [
+            { file: 'src/main.ts', hunkIndex: 0, category: 'logic', intensity: 'high', reason: 'New feature logic' },
+            { file: 'src/utils.ts', hunkIndex: 1, category: 'mechanical', intensity: 'low', reason: 'Import reorder' },
+        ],
+    };
+
+    it('should parse a plain JSON string', () => {
+        const input = JSON.stringify(validResult);
+        const result = extractClassificationFromResult(input);
+        expect(result).toEqual(validResult);
+    });
+
+    it('should parse JSON inside a code fence', () => {
+        const input = 'Here is the classification:\n```json\n' + JSON.stringify(validResult) + '\n```\nDone.';
+        const result = extractClassificationFromResult(input);
+        expect(result).toEqual(validResult);
+    });
+
+    it('should parse JSON embedded in text without fence', () => {
+        const input = 'The result is: ' + JSON.stringify(validResult) + ' — that is all.';
+        const result = extractClassificationFromResult(input);
+        expect(result).toEqual(validResult);
+    });
+
+    it('should return undefined for empty input', () => {
+        expect(extractClassificationFromResult(undefined)).toBeUndefined();
+        expect(extractClassificationFromResult('')).toBeUndefined();
+    });
+
+    it('should return undefined for invalid JSON', () => {
+        expect(extractClassificationFromResult('not json at all')).toBeUndefined();
+    });
+
+    it('should return undefined when classifications array has invalid entries', () => {
+        const invalid = { classifications: [{ file: 'a.ts' }] }; // missing fields
+        expect(extractClassificationFromResult(JSON.stringify(invalid))).toBeUndefined();
+    });
+
+    it('should return undefined when JSON has no classifications key', () => {
+        expect(extractClassificationFromResult('{"hunks": []}')).toBeUndefined();
+    });
+
+    it('should handle pretty-printed JSON in code fence', () => {
+        const pretty = JSON.stringify(validResult, null, 2);
+        const input = '```json\n' + pretty + '\n```';
+        const result = extractClassificationFromResult(input);
+        expect(result).toEqual(validResult);
+    });
+});
+
+// ── classificationCacheTag ───────────────────────────────────────────────────
+
+describe('classificationCacheTag', () => {
+    it('should produce a deterministic tag from repo, pr, and sha', () => {
+        const tag = classificationCacheTag('repo-abc', '42', 'deadbeef');
+        expect(tag).toBe('classify-diff:repo-abc:42:deadbeef');
+    });
+
+    it('should produce different tags for different SHAs', () => {
+        const tag1 = classificationCacheTag('repo', '1', 'sha1');
+        const tag2 = classificationCacheTag('repo', '1', 'sha2');
+        expect(tag1).not.toBe(tag2);
+    });
+
+    it('should produce different tags for different PRs', () => {
+        const tag1 = classificationCacheTag('repo', '1', 'sha');
+        const tag2 = classificationCacheTag('repo', '2', 'sha');
+        expect(tag1).not.toBe(tag2);
+    });
+});

--- a/packages/coc/test/spa/react/AdminPanel.test.tsx
+++ b/packages/coc/test/spa/react/AdminPanel.test.tsx
@@ -1023,6 +1023,50 @@ describe('AdminPanel', () => {
             expect(capturedBody['servers.enabled']).toBe(true);
         });
 
+        it('focusedDiff toggle saves features.focusedDiff', async () => {
+            let capturedBody: Record<string, unknown> | null = null;
+            mockFetch.mockImplementation((url: string, opts?: RequestInit) => {
+                if (url.includes('/preferences')) {
+                    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+                }
+                if (opts?.method === 'PUT' && url.includes('/admin/config')) {
+                    capturedBody = JSON.parse(opts.body as string);
+                    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+                }
+                if (url.includes('/admin/config')) {
+                    return Promise.resolve({
+                        ok: true,
+                        json: () => Promise.resolve({
+                            resolved: {
+                                terminal: { enabled: false }, notes: { enabled: false },
+                                myWork: { enabled: false }, myLife: { enabled: false },
+                                features: { focusedDiff: false },
+                            },
+                            sources: {},
+                        }),
+                    });
+                }
+                return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+            });
+
+            await act(async () => { renderWithProviders(); });
+            await waitFor(() => expect(screen.getByTestId('toggle-focused-diff-enabled')).toBeDefined());
+
+            const toggle = screen.getByTestId('toggle-focused-diff-enabled') as HTMLInputElement;
+            expect(toggle.checked).toBe(false);
+
+            await act(async () => {
+                fireEvent.click(toggle);
+            });
+            expect((screen.getByTestId('settings-features-save') as HTMLButtonElement).disabled).toBe(false);
+
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('settings-features-save'));
+            });
+            await waitFor(() => expect(capturedBody).not.toBeNull());
+            expect(capturedBody!['features.focusedDiff']).toBe(true);
+        });
+
         it('Advanced card shows read-only diagnostics without Save button', async () => {
             mockFullConfig();
             await act(async () => { renderWithProviders(); });

--- a/packages/coc/test/spa/react/repos/pull-requests/PrClassification.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PrClassification.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for the focused-diff classification UI components:
+ * - ClassificationFilterBar (rendered inside PrFilesPanel)
+ * - ClassificationBadge (file tree badges)
+ * - Hunk dimming
+ * - useClassification hook
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PrFilesPanel } from '../../../../../src/server/spa/client/react/features/pull-requests/PrFilesPanel';
+import { parseUnifiedDiff } from '../../../../../src/server/spa/client/react/features/pull-requests/unified-diff-parser';
+import type { UseClassificationReturn } from '../../../../../src/server/spa/client/react/features/pull-requests/useClassification';
+import type { HunkCategory, DiffClassificationResult } from '../../../../../src/server/spa/client/react/features/pull-requests/classification-types';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const diffText = [
+    'diff --git a/src/main.ts b/src/main.ts',
+    '--- a/src/main.ts',
+    '+++ b/src/main.ts',
+    '@@ -1,3 +1,4 @@',
+    ' line1',
+    '+added logic',
+    ' line2',
+    '@@ -10,2 +11,2 @@',
+    '-old import',
+    '+new import',
+    'diff --git a/test/main.test.ts b/test/main.test.ts',
+    '--- a/test/main.test.ts',
+    '+++ b/test/main.test.ts',
+    '@@ -1,1 +1,2 @@',
+    ' test1',
+    '+test2',
+].join('\n');
+
+const parsedFiles = parseUnifiedDiff(diffText).files;
+
+const mockResult: DiffClassificationResult = {
+    classifications: [
+        { file: 'src/main.ts', hunkIndex: 0, category: 'logic', intensity: 'high', reason: 'Core business logic change' },
+        { file: 'src/main.ts', hunkIndex: 1, category: 'mechanical', intensity: 'low', reason: 'Import reordering' },
+        { file: 'test/main.test.ts', hunkIndex: 0, category: 'test', intensity: 'low', reason: 'New test case' },
+    ],
+};
+
+function createMockClassification(overrides: Partial<UseClassificationReturn> = {}): UseClassificationReturn {
+    const activeFilters = overrides.state?.activeFilters ?? new Set<HunkCategory>(['logic']);
+    const result = overrides.state?.result;
+
+    // Build index
+    const byHunk = new Map<string, any>();
+    const badges = new Map<string, any>();
+    if (result) {
+        for (const c of result.classifications) {
+            byHunk.set(`${c.file}:${c.hunkIndex}`, c);
+            const existing = badges.get(c.file);
+            if (!existing || c.category === 'logic') {
+                badges.set(c.file, { category: c.category, intensity: c.intensity });
+            }
+        }
+    }
+
+    return {
+        state: {
+            status: 'idle',
+            activeFilters,
+            ...overrides.state,
+        },
+        classify: vi.fn(),
+        toggleFilter: vi.fn(),
+        setFilters: vi.fn(),
+        getFileBadge: (path: string) => badges.get(path),
+        getHunkClassification: (path: string, idx: number) => byHunk.get(`${path}:${idx}`),
+        isHunkDimmed: (path: string, idx: number) => {
+            const c = byHunk.get(`${path}:${idx}`);
+            if (!c) return false;
+            return !activeFilters.has(c.category);
+        },
+        ...overrides,
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('ClassificationFilterBar', () => {
+    it('renders classify button when classification prop is provided', () => {
+        const mock = createMockClassification();
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        expect(screen.getByTestId('classify-button')).toBeInTheDocument();
+        expect(screen.getByTestId('classify-button')).toHaveTextContent('Classify');
+    });
+
+    it('does not render filter bar when classification prop is absent', () => {
+        render(<PrFilesPanel files={parsedFiles} />);
+        expect(screen.queryByTestId('classification-filter-bar')).not.toBeInTheDocument();
+    });
+
+    it('shows spinner when status is loading', () => {
+        const mock = createMockClassification({ state: { status: 'loading', activeFilters: new Set(['logic']) } });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        expect(screen.getByTestId('classify-button')).toHaveTextContent('Classifying…');
+        expect(screen.getByTestId('classify-button')).toBeDisabled();
+    });
+
+    it('shows Re-classify when results are ready', () => {
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters: new Set(['logic']), result: mockResult },
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        expect(screen.getByTestId('classify-button')).toHaveTextContent('Re-classify');
+    });
+
+    it('shows category checkboxes when results are ready', () => {
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters: new Set(['logic']), result: mockResult },
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        expect(screen.getByTestId('classification-filter-logic')).toBeInTheDocument();
+        expect(screen.getByTestId('classification-filter-mechanical')).toBeInTheDocument();
+        expect(screen.getByTestId('classification-filter-test')).toBeInTheDocument();
+        expect(screen.getByTestId('classification-filter-generated')).toBeInTheDocument();
+    });
+
+    it('calls toggleFilter when checkbox is clicked', () => {
+        const toggleFilter = vi.fn();
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters: new Set(['logic']), result: mockResult },
+            toggleFilter,
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        fireEvent.click(screen.getByTestId('classification-filter-mechanical'));
+        expect(toggleFilter).toHaveBeenCalledWith('mechanical');
+    });
+
+    it('calls classify when button is clicked', () => {
+        const classify = vi.fn();
+        const mock = createMockClassification({ classify });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        fireEvent.click(screen.getByTestId('classify-button'));
+        expect(classify).toHaveBeenCalled();
+    });
+
+    it('shows error message', () => {
+        const mock = createMockClassification({
+            state: { status: 'error', activeFilters: new Set(['logic']), error: 'Something went wrong' },
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        expect(screen.getByTestId('classify-error')).toHaveTextContent('Something went wrong');
+    });
+
+    it('shows "All" button to select all filters', () => {
+        const setFilters = vi.fn();
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters: new Set(['logic']), result: mockResult },
+            setFilters,
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        fireEvent.click(screen.getByTestId('classification-filter-all'));
+        expect(setFilters).toHaveBeenCalled();
+    });
+});
+
+describe('ClassificationBadge (file tree badges)', () => {
+    it('renders badges on file rows when classification is ready', () => {
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters: new Set(['logic']), result: mockResult },
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        const badges = screen.getAllByTestId('classification-badge');
+        // At least one badge should appear (for the active file in view)
+        expect(badges.length).toBeGreaterThan(0);
+    });
+
+    it('does not render badges when classification has no results', () => {
+        const mock = createMockClassification();
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        expect(screen.queryByTestId('classification-badge')).not.toBeInTheDocument();
+    });
+});
+
+describe('Hunk dimming', () => {
+    it('applies opacity to dimmed hunks', () => {
+        const activeFilters = new Set<HunkCategory>(['logic']);
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters, result: mockResult },
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+
+        // The first hunk header (logic, high) should NOT be dimmed
+        const hunkHeaders = screen.getAllByTestId('pr-file-hunk-header');
+        expect(hunkHeaders.length).toBeGreaterThan(0);
+
+        // Check that we have at least one category tag
+        const tags = screen.getAllByTestId('hunk-category-tag');
+        expect(tags.length).toBeGreaterThan(0);
+    });
+
+    it('renders category tag on hunk headers when classified', () => {
+        const mock = createMockClassification({
+            state: { status: 'ready', activeFilters: new Set(['logic', 'mechanical', 'test', 'generated']), result: mockResult },
+        });
+        render(<PrFilesPanel files={parsedFiles} classification={mock} />);
+        const tags = screen.getAllByTestId('hunk-category-tag');
+        // We have 2 hunks in the first file (src/main.ts) which is the active file
+        expect(tags.length).toBe(2);
+        expect(tags[0]).toHaveTextContent('Logic');
+        expect(tags[1]).toHaveTextContent('Mechanical');
+    });
+});

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
@@ -323,6 +323,8 @@ describe('tabs', () => {
         expect(screen.getByTestId('files-tab')).toBeInTheDocument();
         expect(screen.getByTestId('pr-files-panel')).toBeInTheDocument();
         expect(screen.getAllByTestId('pr-file-row')).toHaveLength(2);
+        expect(screen.queryByText(/AI annotation/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/AI focus file/i)).not.toBeInTheDocument();
         expect(screen.getByTestId('tab-files').textContent).toContain('2');
     });
 

--- a/packages/coc/test/spa/react/repos/pull-requests/pr-mock-data.test.ts
+++ b/packages/coc/test/spa/react/repos/pull-requests/pr-mock-data.test.ts
@@ -16,7 +16,6 @@ import {
     getMockBranchSnapshot,
     getMockCheckRows,
     getMockCommitRows,
-    getMockFiles,
     getMockMergeReadiness,
     getMockPersonaLenses,
     getMockPrFileCount,
@@ -113,12 +112,10 @@ describe('AI mock data', () => {
         expect(groups.some(group => group.severity === 'blocking')).toBe(true);
     });
 
-    it('returns commit, check, merge-readiness, and file fixtures', () => {
+    it('returns commit, check, and merge-readiness fixtures', () => {
         expect(getMockCommitRows().length).toBeGreaterThanOrEqual(5);
         expect(getMockCheckRows().some(row => row.status === 'warning')).toBe(true);
         expect(getMockMergeReadiness().some(item => item.tag === 'risk')).toBe(true);
-        const files = getMockFiles();
-        expect(files.some(file => file.annotation)).toBe(true);
     });
 
     it('returns suggested prompts and seed chat for the assistant', () => {

--- a/packages/forge/resources/bundled-skills/classify-diff/SKILL.md
+++ b/packages/forge/resources/bundled-skills/classify-diff/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: classify-diff
+description: Classify every hunk in a pull request diff by change type (logic, mechanical, test, generated) so reviewers can focus on what matters.
+metadata:
+  author: CoC
+  version: "0.0.1"
+---
+
+# Classify Diff — Focused PR Review
+
+Classify each `@@` hunk in a pull request diff into one of four categories so the UI can visually de-emphasize mechanical changes and highlight logic edits.
+
+## When to Use
+
+- The user clicks "Classify" on the PR Files Changed tab.
+- The system needs to produce a per-hunk classification for a pull request diff.
+
+## Classification Categories
+
+| Category | Description | Examples |
+|----------|-------------|---------|
+| `logic` | Meaningful behavioral changes — new features, bug fixes, algorithm changes, API contract changes | New function, changed conditional, modified return value |
+| `mechanical` | Structural changes with no behavioral impact — renames, moves, formatting, import reordering | Variable rename, whitespace cleanup, import sort |
+| `test` | Test code — new tests, modified assertions, test fixtures, test utilities | New test case, updated assertion, mock data |
+| `generated` | Auto-generated or machine-produced code — lock files, build artifacts, codegen output | `package-lock.json` changes, protobuf output, schema migrations |
+
+## Intensity Levels
+
+Each classification also includes an intensity:
+
+| Intensity | Meaning |
+|-----------|---------|
+| `high` | Core change — deserves careful review (e.g. new business logic, critical bug fix, complex test) |
+| `low` | Minor change within the category (e.g. small refactor, trivial test update, simple rename) |
+
+## Output Schema
+
+Return a JSON object with one entry per hunk. Each hunk is identified by its file path and a 0-based hunk index within that file.
+
+```json
+{
+  "classifications": [
+    {
+      "file": "src/server/auth.ts",
+      "hunkIndex": 0,
+      "category": "logic",
+      "intensity": "high",
+      "reason": "Adds JWT token refresh logic with expiry check"
+    },
+    {
+      "file": "src/server/auth.ts",
+      "hunkIndex": 1,
+      "category": "mechanical",
+      "intensity": "low",
+      "reason": "Import reordering, no behavioral change"
+    }
+  ]
+}
+```
+
+## Instructions
+
+You are classifying the hunks of a pull request diff. You have access to git and gh CLI tools to investigate the PR context.
+
+1. **Use the tools provided** to read the PR diff and understand each hunk. Do NOT rely solely on the file path — read the actual changes.
+2. **Classify every `@@` hunk** in the diff. Each hunk gets exactly one category (the dominant one if mixed).
+3. **Use file path heuristics as a starting signal**, but always verify:
+   - Files in `test/`, `__tests__/`, `*.test.*`, `*.spec.*` → likely `test`
+   - `package-lock.json`, `*.generated.*`, `*.g.ts` → likely `generated`
+   - But a hunk in a test file that changes production imports is `logic`, not `test`
+4. **Be precise with intensity**:
+   - `high` = reviewer should read this carefully
+   - `low` = reviewer can skim or skip
+5. **Provide a brief reason** (one sentence) explaining why you chose that category and intensity.
+6. **Output the final result** as a single JSON object matching the schema above, wrapped in a ```json code fence.
+
+## Anti-Patterns
+
+- Do NOT classify an entire file as one category — classify each hunk independently.
+- Do NOT default everything to `logic` — most PRs have significant mechanical/test/generated content.
+- Do NOT skip hunks — every `@@` hunk must appear in the output.
+- Do NOT inject the raw diff into the prompt — use tools to read it.

--- a/packages/forge/resources/bundled-skills/classify-diff/SKILL.md
+++ b/packages/forge/resources/bundled-skills/classify-diff/SKILL.md
@@ -35,30 +35,21 @@ Each classification also includes an intensity:
 
 ## Output
 
-When the runtime provides a `saveClassification` tool, call it exactly once at the end with the full array of per-hunk classifications. The tool persists the result and validates the schema — if it returns an error, fix the offending entries and call it again.
+Call the `saveClassification` tool exactly once at the end with the full array of per-hunk classifications. The tool persists the result and validates the schema — if it returns an error, fix the offending entries and call it again.
 
-When the tool is NOT available, return the result as a single JSON object matching this shape, wrapped in a ```json code fence:
+Each classification entry has this shape:
 
 ```json
 {
-  "classifications": [
-    {
-      "file": "src/server/auth.ts",
-      "hunkIndex": 0,
-      "category": "logic",
-      "intensity": "high",
-      "reason": "Adds JWT token refresh logic with expiry check"
-    },
-    {
-      "file": "src/server/auth.ts",
-      "hunkIndex": 1,
-      "category": "mechanical",
-      "intensity": "low",
-      "reason": "Import reordering, no behavioral change"
-    }
-  ]
+  "file": "src/server/auth.ts",
+  "hunkIndex": 0,
+  "category": "logic",
+  "intensity": "high",
+  "reason": "Adds JWT token refresh logic with expiry check"
 }
 ```
+
+Do NOT print the classifications as JSON in your response — the persistence layer reads them directly from the tool call.
 
 ## Instructions
 
@@ -74,7 +65,7 @@ You are classifying the hunks of a pull request diff. You have access to git and
    - `high` = reviewer should read this carefully
    - `low` = reviewer can skim or skip
 5. **Provide a brief reason** (one sentence) explaining why you chose that category and intensity.
-6. **Persist the result**: if a `saveClassification` tool is available, call it once with the full array. Otherwise emit the JSON shape shown in the Output section above, wrapped in a ```json code fence.
+6. **Persist the result** by calling the `saveClassification` tool once with the full array.
 
 ## Anti-Patterns
 

--- a/packages/forge/resources/bundled-skills/classify-diff/SKILL.md
+++ b/packages/forge/resources/bundled-skills/classify-diff/SKILL.md
@@ -33,9 +33,11 @@ Each classification also includes an intensity:
 | `high` | Core change — deserves careful review (e.g. new business logic, critical bug fix, complex test) |
 | `low` | Minor change within the category (e.g. small refactor, trivial test update, simple rename) |
 
-## Output Schema
+## Output
 
-Return a JSON object with one entry per hunk. Each hunk is identified by its file path and a 0-based hunk index within that file.
+When the runtime provides a `saveClassification` tool, call it exactly once at the end with the full array of per-hunk classifications. The tool persists the result and validates the schema — if it returns an error, fix the offending entries and call it again.
+
+When the tool is NOT available, return the result as a single JSON object matching this shape, wrapped in a ```json code fence:
 
 ```json
 {
@@ -72,7 +74,7 @@ You are classifying the hunks of a pull request diff. You have access to git and
    - `high` = reviewer should read this carefully
    - `low` = reviewer can skim or skip
 5. **Provide a brief reason** (one sentence) explaining why you chose that category and intensity.
-6. **Output the final result** as a single JSON object matching the schema above, wrapped in a ```json code fence.
+6. **Persist the result**: if a `saveClassification` tool is available, call it once with the full array. Otherwise emit the JSON shape shown in the Output section above, wrapped in a ```json code fence.
 
 ## Anti-Patterns
 

--- a/packages/forge/src/ado/ado-pull-requests-adapter.ts
+++ b/packages/forge/src/ado/ado-pull-requests-adapter.ts
@@ -119,6 +119,8 @@ function mapAdoPullRequest(pr: GitPullRequest, repositoryId: string): PullReques
         repositoryId,
         reviewers: (pr.reviewers ?? []).map(mapAdoReviewer),
         labels: (pr.labels ?? []).map((l: { name?: string }) => l.name ?? '').filter(Boolean),
+        headSha: pr.lastMergeSourceCommit?.commitId,
+        baseSha: pr.lastMergeTargetCommit?.commitId,
         raw: pr,
     };
 }

--- a/packages/forge/src/github/github-pull-requests-adapter.ts
+++ b/packages/forge/src/github/github-pull-requests-adapter.ts
@@ -73,6 +73,8 @@ function mapGitHubPullRequest(pr: GitHubPullRequest, owner: string, repo: string
         repositoryId: `${owner}/${repo}`,
         reviewers: [],
         labels: pr.labels.map(l => l.name),
+        headSha: pr.head.sha,
+        baseSha: pr.base.sha,
         raw: pr,
     };
 }

--- a/packages/forge/src/providers/types.ts
+++ b/packages/forge/src/providers/types.ts
@@ -170,6 +170,10 @@ export interface PullRequest {
     repositoryId: string;
     reviewers: Reviewer[];
     labels: string[];
+    /** SHA of the PR head (source branch tip) commit. */
+    headSha?: string;
+    /** SHA of the PR base (target branch) commit. */
+    baseSha?: string;
     /** Provider-specific raw object, for fields not in the canonical shape. */
     raw?: unknown;
 }

--- a/packages/forge/src/skills/bundled-skills-registry.ts
+++ b/packages/forge/src/skills/bundled-skills-registry.ts
@@ -83,5 +83,10 @@ export const BUNDLED_SKILLS_REGISTRY: readonly BundledSkill[] = [
         name: 'loop',
         description: 'Schedule recurring follow-up messages into the current conversation. Supports fixed-interval monitoring and one-shot wakeups for dynamic self-pacing',
         relativePath: 'loop',
+    },
+    {
+        name: 'classify-diff',
+        description: 'Classify every hunk in a pull request diff by change type (logic, mechanical, test, generated) so reviewers can focus on what matters',
+        relativePath: 'classify-diff',
     }
 ];

--- a/packages/forge/test/ado/ado-pull-requests-adapter.test.ts
+++ b/packages/forge/test/ado/ado-pull-requests-adapter.test.ts
@@ -23,6 +23,8 @@ const mockAdoPr = {
         { id: 'user-2', displayName: 'Bob', uniqueName: 'bob@example.com', vote: 10, isRequired: true },
     ],
     labels: [{ name: 'bug' }],
+    lastMergeSourceCommit: { commitId: 'aabbcc1122' },
+    lastMergeTargetCommit: { commitId: 'ddeeff3344' },
 };
 
 const mockAdoThread = {
@@ -124,6 +126,8 @@ describe('AdoPullRequestsAdapter', () => {
             expect(pr.author.email).toBe('alice@example.com');
             expect(pr.sourceBranch).toBe('feature/fix');
             expect(pr.targetBranch).toBe('main');
+            expect(pr.headSha).toBe('aabbcc1122');
+            expect(pr.baseSha).toBe('ddeeff3344');
             expect(pr.status).toBe('open');
             expect(pr.isDraft).toBe(false);
             expect(pr.labels).toEqual(['bug']);

--- a/packages/forge/test/github/github-pull-requests-adapter.test.ts
+++ b/packages/forge/test/github/github-pull-requests-adapter.test.ts
@@ -144,6 +144,8 @@ describe('GitHubPullRequestsAdapter', () => {
             expect(pr.author.email).toBe('alice@example.com');
             expect(pr.sourceBranch).toBe('feature/fix');
             expect(pr.targetBranch).toBe('main');
+            expect(pr.headSha).toBe('abc123');
+            expect(pr.baseSha).toBe('def456');
             expect(pr.status).toBe('open');
             expect(pr.isDraft).toBe(false);
             expect(pr.labels).toEqual(['bug']);


### PR DESCRIPTION
- **feat(focused-diff): add classify-diff skill, feature flag, and classification types**
  - Create /classify-diff bundled skill with structured JSON output schema
    for per-hunk classification (logic/mechanical/test/generated)
  - Add features.focusedDiff config flag (disabled by default) across
    config types, schema, namespace registry, and defaults
  - Wire focusedDiffEnabled through DashboardOptions, HTML template, and
    SPA config utility
  - Add SHOW_FOCUSED_DIFF compile-time feature flag for SPA
  - Create classification-types.ts with HunkClassification types and
    category constants
  - Update config test fixtures and snapshots for new field
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **Add PR classification REST API handler and routes**
  - POST /api/repos/:repoId/pull-requests/:prId/classify — trigger on-demand AI classification
  - GET /api/repos/:repoId/pull-requests/:prId/classification — retrieve cached results
  - Classification enqueues a chat task with the classify-diff skill
  - Cache lookup via process store display name convention
  - Gated by features.focusedDiff config flag (disabled by default)
  - extractClassificationFromResult parses JSON from AI response
  - Tests for extraction logic and cache tag generation
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(focused-diff): add classification filter bar, file badges, and hunk dimming UI**
  Add the SPA-side UI components for the focused-diff classification feature:
  
  - ClassificationFilterBar: Classify button + category checkboxes (Logic,
    Mechanical, Test, Generated) with focused-first default (only Logic checked)
  - ClassificationBadge: File tree dot badges showing max intensity per file
  - Hunk dimming: reduced opacity on hunks whose category is not in active filters
  - Category tags on hunk headers showing classification result inline
  - useClassification hook: manages classification state, REST API calls,
    polling for results, filter state, and lookup indices
  - Wire classification into PullRequestDetail via useClassification hook
  - Add headSha optional field to PullRequest interface for cache key
  - Feature-flag gated via SHOW_FOCUSED_DIFF compile-time flag
  - 13 new tests covering filter bar, badges, dimming, and category tags
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(dashboard): add Focused Diff toggle to admin Workspace Features card**
  Add focusedDiff feature flag toggle to the admin panel's Workspace
  Features settings card. The toggle reads from features.focusedDiff
  config, saves via the features.focusedDiff config key, and follows
  the same pattern as other feature toggles (loops, servers, etc.).
  
  Includes unit test verifying the toggle saves the correct config key.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(forge): add headSha/baseSha to canonical PullRequest type**
  Populate headSha from pr.head.sha (GitHub) and
  pr.lastMergeSourceCommit.commitId (ADO). Also populate baseSha from
  pr.base.sha / pr.lastMergeTargetCommit.commitId.
  
  This enables the focused-diff classification feature to use the real
  PR head SHA as a cache key instead of falling back to sourceBranch.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix: register classify-diff in bundled skills registry**
  The classify-diff skill was added to resources/bundled-skills/ but never
  registered in BUNDLED_SKILLS_REGISTRY, causing 6 skill-updater tests to
  fail when they iterated over all registered bundled skills.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix: harden classification cache lookup to match on headSha**
  The cache lookup in findCachedClassification was matching by PR ID
  only, which could return stale classification results from older
  commits. Now requires the headSha short prefix to match in the
  display name, prompt preview, or embedded cache-key comment.
  
  - Embed cache tag in classification prompt for reliable lookup
  - Strict matching: display name, preview, or prompt must include SHA
  - Export buildClassificationPrompt for testing
  - Add regression tests for prompt structure and cache tag embedding
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc-client): add classify/getClassification methods to PullRequestsClient**
  Add classification contract types (HunkCategory, HunkIntensity,
  HunkClassification, DiffClassificationResult, ClassifyDiffRequest,
  ClassifyDiffResponse, ClassificationStatusResponse) and two new methods
  to PullRequestsClient:
  - classify(): POST to trigger on-demand AI classification
  - getClassification(): GET cached classification result
  
  Includes 4 new unit tests covering encoding, signal forwarding, and
  correct request shapes.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **chore: add changeset for focused diff classification feature**
  Adds a minor changeset entry for forge, coc, and coc-client documenting
  the new AI-powered focused diff classification feature for PR review.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  