### PR TITLE
Refactor admin config validation into a centralized registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@changesets/cli/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -617,6 +629,15 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@changesets/cli/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@changesets/cli/node_modules/universalify": {
       "version": "0.1.2",
@@ -2490,9 +2511,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,9 +2525,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2524,9 +2539,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,9 +2553,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,9 +2567,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2575,9 +2581,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2592,9 +2595,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2609,9 +2609,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2626,9 +2623,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2643,9 +2637,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2660,9 +2651,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2677,9 +2665,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2694,9 +2679,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8990,9 +8972,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9014,9 +8993,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9038,9 +9014,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9062,9 +9035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17115,9 +17085,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17135,9 +17102,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17155,9 +17119,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17175,9 +17136,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17195,9 +17153,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17215,9 +17170,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -5,6 +5,22 @@ root `AGENTS.md` for the cross-package overview, build/test commands, and the
 "repo-scoped data" convention. Deeper architecture references live under
 `.github/skills/coc-knowledge/`.
 
+## Admin Config
+
+Editable admin config fields are defined in a single registry:
+`src/server/admin/admin-config-fields.ts` (`ADMIN_CONFIG_FIELDS`).
+
+Each entry provides a flat key (e.g. `'loops.enabled'`), a `validate()` function, and an `apply()` function. The PUT `/api/admin/config` handler derives `editableKeys`, validation, and merge logic entirely from this registry — **no changes to `admin-handler.ts` are needed when adding a new editable field**.
+
+To expose a new config field via the admin API, add ONE entry to `ADMIN_CONFIG_FIELDS`. Also update:
+1. `CLIConfig` / `ResolvedCLIConfig` / `DEFAULT_CONFIG` in `src/config.ts`
+2. `CLIConfigSchema` in `src/config/schema.ts`
+3. Namespace registry in `src/config/namespace-registry.ts` (nested fields)
+4. `AdminResolvedConfig` / `AdminConfigUpdate` in `packages/coc-client/src/contracts/admin.ts`
+5. `AdminPanel.tsx` for the UI control
+
+The `spaHtml` function in `src/server/index.ts` re-reads the config file on every page request, so feature-flag changes (e.g. `terminal.enabled`) take effect on the next browser reload — no server restart required.
+
 ## Ralph
 
 Ralph sessions live under

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -1,0 +1,190 @@
+/**
+ * Admin Config Field Registry
+ *
+ * Single source of truth for editable admin config fields.
+ * Each entry defines the flat key, a validator, and an apply function.
+ *
+ * To add a new editable admin config field:
+ *   1. Add the field to CLIConfig / ResolvedCLIConfig in config.ts (if structural)
+ *   2. Add a default in DEFAULT_CONFIG in config.ts
+ *   3. Add schema validation in config/schema.ts
+ *   4. Add namespace tracking in config/namespace-registry.ts (for nested fields)
+ *   5. Add ONE entry here — the admin handler picks it up automatically
+ *   6. Update AdminResolvedConfig / AdminConfigUpdate in coc-client/src/contracts/admin.ts
+ *   7. Add UI in AdminPanel.tsx
+ */
+
+import type { CLIConfig } from '../../config';
+
+export interface AdminConfigFieldSpec {
+    /** Flat key used in the PUT /api/admin/config request body, e.g. 'loops.enabled' */
+    key: string;
+    /** Return an error message string if invalid, undefined if valid */
+    validate: (value: unknown) => string | undefined;
+    /** Write the (already-validated) value into the CLIConfig that will be persisted */
+    apply: (config: CLIConfig, value: unknown) => void;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const bool = (key: string, set: (cfg: CLIConfig, v: boolean) => void): AdminConfigFieldSpec => ({
+    key,
+    validate: (v) => typeof v === 'boolean' ? undefined : `${key} must be a boolean`,
+    apply: (cfg, v) => set(cfg, v as boolean),
+});
+
+const VALID_OUTPUT_VALUES = ['table', 'json', 'csv', 'markdown'] as const;
+
+// ── registry ─────────────────────────────────────────────────────────────────
+
+/**
+ * All admin-editable config fields.
+ * The admin handler derives editableKeys, validation, and merge entirely from this list.
+ */
+export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
+    // ── AI execution ──────────────────────────────────────────────────────────
+    {
+        key: 'model',
+        validate: (v) => typeof v === 'string' && v.length > 0 ? undefined : 'model must be a non-empty string',
+        apply: (cfg, v) => { cfg.model = v as string; },
+    },
+    {
+        key: 'parallel',
+        validate: (v) => typeof v === 'number' && v > 0 ? undefined : 'parallel must be a number greater than 0',
+        apply: (cfg, v) => { cfg.parallel = v as number; },
+    },
+    {
+        key: 'timeout',
+        validate: (v) => v === null || (typeof v === 'number' && v > 0)
+            ? undefined
+            : 'timeout must be a number greater than 0, or null to clear',
+        apply: (cfg, v) => {
+            if (v === null) { delete cfg.timeout; } else { cfg.timeout = v as number; }
+        },
+    },
+    {
+        key: 'output',
+        validate: (v) => typeof v === 'string' && (VALID_OUTPUT_VALUES as readonly string[]).includes(v)
+            ? undefined
+            : `output must be one of: ${VALID_OUTPUT_VALUES.join(', ')}`,
+        apply: (cfg, v) => { cfg.output = v as CLIConfig['output']; },
+    },
+
+    // ── display / UI ──────────────────────────────────────────────────────────
+    bool('showReportIntent', (cfg, v) => { cfg.showReportIntent = v; }),
+    {
+        key: 'toolCompactness',
+        validate: (v) =>
+            typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 3
+                ? undefined
+                : 'toolCompactness must be 0, 1, 2, or 3',
+        apply: (cfg, v) => { cfg.toolCompactness = v as CLIConfig['toolCompactness']; },
+    },
+    {
+        key: 'taskCardDensity',
+        validate: (v) => v === 'compact' || v === 'dense'
+            ? undefined
+            : 'taskCardDensity must be "compact" or "dense"',
+        apply: (cfg, v) => { cfg.taskCardDensity = v as CLIConfig['taskCardDensity']; },
+    },
+    bool('groupSingleLineMessages', (cfg, v) => { cfg.groupSingleLineMessages = v; }),
+
+    // ── serve ─────────────────────────────────────────────────────────────────
+    {
+        key: 'serve.serverName',
+        validate: (v) => v === null || v === undefined || (typeof v === 'string' && v.length <= 64)
+            ? undefined
+            : 'serve.serverName must be a string of at most 64 characters, or null to clear',
+        apply: (cfg, v) => {
+            if (v === null || v === '') {
+                if (cfg.serve) { delete cfg.serve.serverName; }
+            } else {
+                if (!cfg.serve) { cfg.serve = {}; }
+                cfg.serve.serverName = v as string;
+            }
+        },
+    },
+
+    // ── chat ─────────────────────────────────────────────────────────────────
+    bool('chat.followUpSuggestions.enabled', (cfg, v) => {
+        if (!cfg.chat) { cfg.chat = {}; }
+        if (!cfg.chat.followUpSuggestions) { cfg.chat.followUpSuggestions = {}; }
+        cfg.chat.followUpSuggestions.enabled = v;
+    }),
+    {
+        key: 'chat.followUpSuggestions.count',
+        validate: (v) =>
+            typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 5
+                ? undefined
+                : 'chat.followUpSuggestions.count must be an integer between 1 and 5',
+        apply: (cfg, v) => {
+            if (!cfg.chat) { cfg.chat = {}; }
+            if (!cfg.chat.followUpSuggestions) { cfg.chat.followUpSuggestions = {}; }
+            cfg.chat.followUpSuggestions.count = v as number;
+        },
+    },
+    bool('chat.askUser.enabled', (cfg, v) => {
+        if (!cfg.chat) { cfg.chat = {}; }
+        if (!cfg.chat.askUser) { cfg.chat.askUser = {}; }
+        cfg.chat.askUser.enabled = v;
+    }),
+
+    // ── feature flags ─────────────────────────────────────────────────────────
+    bool('terminal.enabled', (cfg, v) => {
+        if (!cfg.terminal) { cfg.terminal = {}; }
+        cfg.terminal.enabled = v;
+    }),
+    bool('notes.enabled', (cfg, v) => {
+        if (!cfg.notes) { cfg.notes = {}; }
+        cfg.notes.enabled = v;
+    }),
+    bool('myWork.enabled', (cfg, v) => {
+        if (!cfg.myWork) { cfg.myWork = {}; }
+        cfg.myWork.enabled = v;
+    }),
+    bool('myLife.enabled', (cfg, v) => {
+        if (!cfg.myLife) { cfg.myLife = {}; }
+        cfg.myLife.enabled = v;
+    }),
+    bool('scratchpad.enabled', (cfg, v) => {
+        if (!cfg.scratchpad) { cfg.scratchpad = {}; }
+        cfg.scratchpad.enabled = v;
+    }),
+    {
+        key: 'scratchpad.layout',
+        validate: (v) => v === 'horizontal' || v === 'vertical'
+            ? undefined
+            : 'scratchpad.layout must be "horizontal" or "vertical"',
+        apply: (cfg, v) => {
+            if (!cfg.scratchpad) { cfg.scratchpad = {}; }
+            cfg.scratchpad.layout = v as 'horizontal' | 'vertical';
+        },
+    },
+    bool('workflows.enabled', (cfg, v) => {
+        if (!cfg.workflows) { cfg.workflows = {}; }
+        cfg.workflows.enabled = v;
+    }),
+    bool('pullRequests.enabled', (cfg, v) => {
+        if (!cfg.pullRequests) { cfg.pullRequests = {}; }
+        cfg.pullRequests.enabled = v;
+    }),
+    bool('servers.enabled', (cfg, v) => {
+        if (!cfg.servers) { cfg.servers = {}; }
+        cfg.servers.enabled = v;
+    }),
+    bool('ralph.enabled', (cfg, v) => {
+        if (!cfg.ralph) { cfg.ralph = {}; }
+        cfg.ralph.enabled = v;
+    }),
+    bool('vimNavigation.enabled', (cfg, v) => {
+        if (!cfg.vimNavigation) { cfg.vimNavigation = {}; }
+        cfg.vimNavigation.enabled = v;
+    }),
+    bool('loops.enabled', (cfg, v) => {
+        if (!cfg.loops) { cfg.loops = {}; }
+        cfg.loops.enabled = v;
+    }),
+];
+
+/** Flat keys accepted by PUT /api/admin/config — derived from the registry. */
+export const ADMIN_EDITABLE_KEYS: readonly string[] = ADMIN_CONFIG_FIELDS.map(f => f.key);

--- a/packages/coc/src/server/admin/admin-handler.ts
+++ b/packages/coc/src/server/admin/admin-handler.ts
@@ -28,6 +28,7 @@ import { StorageMigrationEngine } from '../storage/storage-migration';
 import type { ProcessWebSocketServer } from '../streaming/websocket';
 import type { Route } from '../types';
 import { sendSSE } from '../wiki/ask-handler';
+import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS } from './admin-config-fields';
 
 // ============================================================================
 // Token Management
@@ -141,9 +142,6 @@ export interface AdminRouteOptions {
  * Register admin API routes on the given route table.
  * Mutates the `routes` array in-place.
  */
-/** Allowed output values for PUT validation. */
-const VALID_OUTPUT_VALUES = ['table', 'json', 'csv', 'markdown'] as const;
-
 export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions): void {
     const { store, dataDir, getWsServer, configPath, configFunctions } = options;
     const wiper = new DataWiper(dataDir, store);
@@ -216,268 +214,29 @@ export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions)
             }
 
             // Reject empty body (no editable keys)
-            const editableKeys = ['model', 'parallel', 'timeout', 'output', 'showReportIntent', 'toolCompactness', 'taskCardDensity', 'groupSingleLineMessages', 'chat.followUpSuggestions.enabled', 'chat.followUpSuggestions.count', 'chat.askUser.enabled', 'serve.serverName', 'terminal.enabled', 'notes.enabled', 'myWork.enabled', 'myLife.enabled', 'scratchpad.enabled', 'scratchpad.layout', 'workflows.enabled', 'pullRequests.enabled', 'servers.enabled', 'ralph.enabled', 'vimNavigation.enabled', 'loops.enabled'];
-            const hasEditableKey = editableKeys.some(k => k in body);
+            const hasEditableKey = ADMIN_EDITABLE_KEYS.some(k => k in body);
             if (!hasEditableKey) {
                 return handleAPIError(res, badRequest('Request body must contain at least one editable field'));
             }
 
-            // Validate editable fields
+            // Validate all present editable fields via registry
             const errors: string[] = [];
-
-            if ('model' in body) {
-                if (typeof body.model !== 'string' || body.model.length === 0) {
-                    errors.push('model must be a non-empty string');
+            for (const field of ADMIN_CONFIG_FIELDS) {
+                if (field.key in body) {
+                    const err = field.validate(body[field.key]);
+                    if (err) { errors.push(err); }
                 }
             }
-            if ('parallel' in body) {
-                if (typeof body.parallel !== 'number' || body.parallel <= 0) {
-                    errors.push('parallel must be a number greater than 0');
-                }
-            }
-            if ('timeout' in body) {
-                if (body.timeout !== null && (typeof body.timeout !== 'number' || body.timeout <= 0)) {
-                    errors.push('timeout must be a number greater than 0, or null to clear');
-                }
-            }
-            if ('output' in body) {
-                if (typeof body.output !== 'string' || !(VALID_OUTPUT_VALUES as readonly string[]).includes(body.output)) {
-                    errors.push(`output must be one of: ${VALID_OUTPUT_VALUES.join(', ')}`);
-                }
-            }
-            if ('showReportIntent' in body) {
-                if (typeof body.showReportIntent !== 'boolean') {
-                    errors.push('showReportIntent must be a boolean');
-                }
-            }
-            if ('toolCompactness' in body) {
-                if (
-                    typeof body.toolCompactness !== 'number' ||
-                    !Number.isInteger(body.toolCompactness) ||
-                    body.toolCompactness < 0 ||
-                    body.toolCompactness > 3
-                ) {
-                    errors.push('toolCompactness must be 0, 1, 2, or 3');
-                }
-            }
-            if ('taskCardDensity' in body) {
-                if (body.taskCardDensity !== 'compact' && body.taskCardDensity !== 'dense') {
-                    errors.push('taskCardDensity must be "compact" or "dense"');
-                }
-            }
-            if ('groupSingleLineMessages' in body) {
-                if (typeof body.groupSingleLineMessages !== 'boolean') {
-                    errors.push('groupSingleLineMessages must be a boolean');
-                }
-            }
-            if ('serve.serverName' in body) {
-                const val = body['serve.serverName'];
-                if (val !== null && val !== undefined && (typeof val !== 'string' || val.length > 64)) {
-                    errors.push('serve.serverName must be a string of at most 64 characters, or null to clear');
-                }
-            }
-            if ('terminal.enabled' in body) {
-                if (typeof body['terminal.enabled'] !== 'boolean') {
-                    errors.push('terminal.enabled must be a boolean');
-                }
-            }
-            if ('notes.enabled' in body) {
-                if (typeof body['notes.enabled'] !== 'boolean') {
-                    errors.push('notes.enabled must be a boolean');
-                }
-            }
-            if ('myWork.enabled' in body) {
-                if (typeof body['myWork.enabled'] !== 'boolean') {
-                    errors.push('myWork.enabled must be a boolean');
-                }
-            }
-            if ('myLife.enabled' in body) {
-                if (typeof body['myLife.enabled'] !== 'boolean') {
-                    errors.push('myLife.enabled must be a boolean');
-                }
-            }
-            if ('scratchpad.enabled' in body) {
-                if (typeof body['scratchpad.enabled'] !== 'boolean') {
-                    errors.push('scratchpad.enabled must be a boolean');
-                }
-            }
-            if ('scratchpad.layout' in body) {
-                if (body['scratchpad.layout'] !== 'horizontal' && body['scratchpad.layout'] !== 'vertical') {
-                    errors.push('scratchpad.layout must be "horizontal" or "vertical"');
-                }
-            }
-            if ('workflows.enabled' in body) {
-                if (typeof body['workflows.enabled'] !== 'boolean') {
-                    errors.push('workflows.enabled must be a boolean');
-                }
-            }
-            if ('pullRequests.enabled' in body) {
-                if (typeof body['pullRequests.enabled'] !== 'boolean') {
-                    errors.push('pullRequests.enabled must be a boolean');
-                }
-            }
-            if ('servers.enabled' in body) {
-                if (typeof body['servers.enabled'] !== 'boolean') {
-                    errors.push('servers.enabled must be a boolean');
-                }
-            }
-            if ('ralph.enabled' in body) {
-                if (typeof body['ralph.enabled'] !== 'boolean') {
-                    errors.push('ralph.enabled must be a boolean');
-                }
-            }
-            if ('vimNavigation.enabled' in body) {
-                if (typeof body['vimNavigation.enabled'] !== 'boolean') {
-                    errors.push('vimNavigation.enabled must be a boolean');
-                }
-            }
-            if ('loops.enabled' in body) {
-                if (typeof body['loops.enabled'] !== 'boolean') {
-                    errors.push('loops.enabled must be a boolean');
-                }
-            }
-
-            // Validate nested chat.followUpSuggestions fields
-            const chatBody = body['chat.followUpSuggestions.enabled'] !== undefined || body['chat.followUpSuggestions.count'] !== undefined
-                ? body : null;
-            if (chatBody && 'chat.followUpSuggestions.enabled' in chatBody) {
-                if (typeof chatBody['chat.followUpSuggestions.enabled'] !== 'boolean') {
-                    errors.push('chat.followUpSuggestions.enabled must be a boolean');
-                }
-            }
-            if (chatBody && 'chat.followUpSuggestions.count' in chatBody) {
-                const count = chatBody['chat.followUpSuggestions.count'];
-                if (typeof count !== 'number' || !Number.isInteger(count) || count < 1 || count > 5) {
-                    errors.push('chat.followUpSuggestions.count must be an integer between 1 and 5');
-                }
-            }
-
-            // Validate nested chat.askUser fields
-            if ('chat.askUser.enabled' in body) {
-                if (typeof body['chat.askUser.enabled'] !== 'boolean') {
-                    errors.push('chat.askUser.enabled must be a boolean');
-                }
-            }
-
             if (errors.length > 0) {
                 return handleAPIError(res, badRequest(errors.join('; ')));
             }
 
-            // Merge with existing config
+            // Merge with existing config via registry
             const existing: CLIConfig = configFunctions?.loadConfigFile?.(configPath) ?? {};
-            if ('model' in body) { existing.model = body.model as string; }
-            if ('parallel' in body) { existing.parallel = body.parallel as number; }
-            if ('timeout' in body) {
-                if (body.timeout === null) {
-                    delete existing.timeout;
-                } else {
-                    existing.timeout = body.timeout as number;
+            for (const field of ADMIN_CONFIG_FIELDS) {
+                if (field.key in body) {
+                    field.apply(existing, body[field.key]);
                 }
-            }
-            if ('output' in body) { existing.output = body.output as CLIConfig['output']; }
-            if ('showReportIntent' in body) { existing.showReportIntent = body.showReportIntent as boolean; }
-            if ('toolCompactness' in body) { existing.toolCompactness = body.toolCompactness as CLIConfig['toolCompactness']; }
-            if ('taskCardDensity' in body) { existing.taskCardDensity = body.taskCardDensity as CLIConfig['taskCardDensity']; }
-            if ('groupSingleLineMessages' in body) { existing.groupSingleLineMessages = body.groupSingleLineMessages as boolean; }
-
-            // Handle serve.serverName (cosmetic override for dashboard title)
-            if ('serve.serverName' in body) {
-                const val = body['serve.serverName'];
-                if (val === null || val === '') {
-                    if (existing.serve) { delete existing.serve.serverName; }
-                } else {
-                    if (!existing.serve) { existing.serve = {}; }
-                    existing.serve.serverName = val as string;
-                }
-            }
-
-            // Handle nested chat.followUpSuggestions fields
-            if ('chat.followUpSuggestions.enabled' in body) {
-                if (!existing.chat) { existing.chat = {}; }
-                if (!existing.chat.followUpSuggestions) { existing.chat.followUpSuggestions = {}; }
-                existing.chat.followUpSuggestions.enabled = body['chat.followUpSuggestions.enabled'] as boolean;
-            }
-            if ('chat.followUpSuggestions.count' in body) {
-                if (!existing.chat) { existing.chat = {}; }
-                if (!existing.chat.followUpSuggestions) { existing.chat.followUpSuggestions = {}; }
-                existing.chat.followUpSuggestions.count = body['chat.followUpSuggestions.count'] as number;
-            }
-
-            // Handle nested chat.askUser fields
-            if ('chat.askUser.enabled' in body) {
-                if (!existing.chat) { existing.chat = {}; }
-                if (!existing.chat.askUser) { existing.chat.askUser = {}; }
-                existing.chat.askUser.enabled = body['chat.askUser.enabled'] as boolean;
-            }
-
-            // Handle nested terminal.enabled field
-            if ('terminal.enabled' in body) {
-                if (!existing.terminal) { existing.terminal = {}; }
-                existing.terminal.enabled = body['terminal.enabled'] as boolean;
-            }
-
-            // Handle nested notes.enabled field
-            if ('notes.enabled' in body) {
-                if (!existing.notes) { existing.notes = {}; }
-                existing.notes.enabled = body['notes.enabled'] as boolean;
-            }
-
-            // Handle nested myWork.enabled field
-            if ('myWork.enabled' in body) {
-                if (!existing.myWork) { existing.myWork = {}; }
-                existing.myWork.enabled = body['myWork.enabled'] as boolean;
-            }
-
-            // Handle nested myLife.enabled field
-            if ('myLife.enabled' in body) {
-                if (!existing.myLife) { existing.myLife = {}; }
-                existing.myLife.enabled = body['myLife.enabled'] as boolean;
-            }
-
-            // Handle nested scratchpad fields
-            if ('scratchpad.enabled' in body) {
-                if (!existing.scratchpad) { existing.scratchpad = {}; }
-                existing.scratchpad.enabled = body['scratchpad.enabled'] as boolean;
-            }
-            if ('scratchpad.layout' in body) {
-                if (!existing.scratchpad) { existing.scratchpad = {}; }
-                existing.scratchpad.layout = body['scratchpad.layout'] as 'horizontal' | 'vertical';
-            }
-
-            // Handle nested workflows.enabled field
-            if ('workflows.enabled' in body) {
-                if (!existing.workflows) { existing.workflows = {}; }
-                existing.workflows.enabled = body['workflows.enabled'] as boolean;
-            }
-
-            // Handle nested pullRequests.enabled field
-            if ('pullRequests.enabled' in body) {
-                if (!existing.pullRequests) { existing.pullRequests = {}; }
-                existing.pullRequests.enabled = body['pullRequests.enabled'] as boolean;
-            }
-
-            // Handle nested servers.enabled field
-            if ('servers.enabled' in body) {
-                if (!existing.servers) { existing.servers = {}; }
-                existing.servers.enabled = body['servers.enabled'] as boolean;
-            }
-
-            // Handle nested ralph.enabled field
-            if ('ralph.enabled' in body) {
-                if (!existing.ralph) { existing.ralph = {}; }
-                existing.ralph.enabled = body['ralph.enabled'] as boolean;
-            }
-
-            // Handle nested vimNavigation.enabled field
-            if ('vimNavigation.enabled' in body) {
-                if (!existing.vimNavigation) { existing.vimNavigation = {}; }
-                existing.vimNavigation.enabled = body['vimNavigation.enabled'] as boolean;
-            }
-
-            // Handle nested loops.enabled field
-            if ('loops.enabled' in body) {
-                if (!existing.loops) { existing.loops = {}; }
-                existing.loops.enabled = body['loops.enabled'] as boolean;
             }
 
             configFunctions?.writeConfigFile?.(resolvedConfigPath, existing);

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -371,9 +371,30 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     notesGitTimerManager.startAll(store, dataDir).catch(() => { /* best-effort */ });
 
     const rawHostname = os.hostname();
-    const displayHostname = resolvedConfig.serve?.serverName || shortenHostname(rawHostname);
     const handler = createRequestHandler({
-        routes, spaHtml: () => generateDashboardHtml({ enableWiki: true, hostname: displayHostname, terminalEnabled: resolvedConfig.terminal?.enabled ?? true, notesEnabled: resolvedConfig.notes?.enabled ?? true, myWorkEnabled: resolvedConfig.myWork?.enabled ?? false, myLifeEnabled: resolvedConfig.myLife?.enabled ?? false, scratchpadEnabled: resolvedConfig.scratchpad?.enabled ?? false, scratchpadLayout: resolvedConfig.scratchpad?.layout ?? 'horizontal', workflowsEnabled: resolvedConfig.workflows?.enabled ?? false, pullRequestsEnabled: resolvedConfig.pullRequests?.enabled ?? false, serversEnabled: resolvedConfig.servers?.enabled ?? false, ralphEnabled: resolvedConfig.ralph?.enabled ?? false, vimNavigationEnabled: resolvedConfig.vimNavigation?.enabled ?? false, loopsEnabled, mcpOauthEnabled, bindAddress: host }),
+        routes, spaHtml: () => {
+            // Re-read config on each page load so that feature-flag changes made via the
+            // admin UI take effect on the next browser refresh — no server restart needed.
+            const liveConfig = resolveConfig(options.configPath);
+            return generateDashboardHtml({
+                enableWiki: true,
+                hostname: liveConfig.serve?.serverName || shortenHostname(rawHostname),
+                terminalEnabled: liveConfig.terminal?.enabled ?? true,
+                notesEnabled: liveConfig.notes?.enabled ?? true,
+                myWorkEnabled: liveConfig.myWork?.enabled ?? false,
+                myLifeEnabled: liveConfig.myLife?.enabled ?? false,
+                scratchpadEnabled: liveConfig.scratchpad?.enabled ?? false,
+                scratchpadLayout: liveConfig.scratchpad?.layout ?? 'horizontal',
+                workflowsEnabled: liveConfig.workflows?.enabled ?? false,
+                pullRequestsEnabled: liveConfig.pullRequests?.enabled ?? false,
+                serversEnabled: liveConfig.servers?.enabled ?? false,
+                ralphEnabled: liveConfig.ralph?.enabled ?? false,
+                vimNavigationEnabled: liveConfig.vimNavigation?.enabled ?? false,
+                loopsEnabled: liveConfig.loops?.enabled ?? false,
+                mcpOauthEnabled: liveConfig.mcpOauth?.enabled ?? false,
+                bindAddress: host,
+            });
+        },
         store, spaETag: getBundleETag,
         staticDir: path.join(__dirname, 'spa', 'client', 'dist'),
         getIconSvg: () => generateIconSvg(rawHostname),

--- a/packages/coc/test/server/admin-config-fields.test.ts
+++ b/packages/coc/test/server/admin-config-fields.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Admin Config Field Registry Tests
+ *
+ * Verifies that ADMIN_CONFIG_FIELDS covers every expected key, that validators
+ * accept valid values and reject invalid ones, and that apply() correctly
+ * mutates a CLIConfig object.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS } from '../../src/server/admin/admin-config-fields';
+import type { AdminConfigFieldSpec } from '../../src/server/admin/admin-config-fields';
+import type { CLIConfig } from '../../src/config';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function fieldFor(key: string): AdminConfigFieldSpec {
+    const f = ADMIN_CONFIG_FIELDS.find(f => f.key === key);
+    if (!f) throw new Error(`No field registered for key: ${key}`);
+    return f;
+}
+
+// ── registry shape ────────────────────────────────────────────────────────────
+
+describe('ADMIN_EDITABLE_KEYS', () => {
+    it('contains no duplicate keys', () => {
+        const seen = new Set<string>();
+        for (const k of ADMIN_EDITABLE_KEYS) {
+            expect(seen.has(k), `duplicate key: ${k}`).toBe(false);
+            seen.add(k);
+        }
+    });
+
+    it('contains all expected keys', () => {
+        const expected = [
+            'model', 'parallel', 'timeout', 'output',
+            'showReportIntent', 'toolCompactness', 'taskCardDensity', 'groupSingleLineMessages',
+            'serve.serverName',
+            'chat.followUpSuggestions.enabled', 'chat.followUpSuggestions.count',
+            'chat.askUser.enabled',
+            'terminal.enabled', 'notes.enabled', 'myWork.enabled', 'myLife.enabled',
+            'scratchpad.enabled', 'scratchpad.layout',
+            'workflows.enabled', 'pullRequests.enabled', 'servers.enabled',
+            'ralph.enabled', 'vimNavigation.enabled', 'loops.enabled',
+        ];
+        for (const k of expected) {
+            expect(ADMIN_EDITABLE_KEYS).toContain(k);
+        }
+    });
+});
+
+// ── validate() ────────────────────────────────────────────────────────────────
+
+describe('validate()', () => {
+    describe('model', () => {
+        it('accepts non-empty string', () => {
+            expect(fieldFor('model').validate('claude-opus')).toBeUndefined();
+        });
+        it('rejects empty string', () => {
+            expect(fieldFor('model').validate('')).toMatch(/non-empty/);
+        });
+        it('rejects non-string', () => {
+            expect(fieldFor('model').validate(42)).toMatch(/non-empty/);
+        });
+    });
+
+    describe('parallel', () => {
+        it('accepts positive number', () => {
+            expect(fieldFor('parallel').validate(4)).toBeUndefined();
+        });
+        it('rejects zero', () => {
+            expect(fieldFor('parallel').validate(0)).toMatch(/greater than 0/);
+        });
+        it('rejects negative', () => {
+            expect(fieldFor('parallel').validate(-1)).toMatch(/greater than 0/);
+        });
+        it('rejects string', () => {
+            expect(fieldFor('parallel').validate('4')).toMatch(/greater than 0/);
+        });
+    });
+
+    describe('timeout', () => {
+        it('accepts positive number', () => {
+            expect(fieldFor('timeout').validate(30)).toBeUndefined();
+        });
+        it('accepts null (to clear)', () => {
+            expect(fieldFor('timeout').validate(null)).toBeUndefined();
+        });
+        it('rejects zero', () => {
+            expect(fieldFor('timeout').validate(0)).toMatch(/greater than 0/);
+        });
+        it('rejects string', () => {
+            expect(fieldFor('timeout').validate('30')).toMatch(/greater than 0/);
+        });
+    });
+
+    describe('output', () => {
+        const valid = ['table', 'json', 'csv', 'markdown'];
+        for (const v of valid) {
+            it(`accepts "${v}"`, () => {
+                expect(fieldFor('output').validate(v)).toBeUndefined();
+            });
+        }
+        it('rejects unknown value', () => {
+            expect(fieldFor('output').validate('xml')).toMatch(/one of/);
+        });
+    });
+
+    describe('toolCompactness', () => {
+        for (const v of [0, 1, 2, 3]) {
+            it(`accepts ${v}`, () => {
+                expect(fieldFor('toolCompactness').validate(v)).toBeUndefined();
+            });
+        }
+        it('rejects 4', () => {
+            expect(fieldFor('toolCompactness').validate(4)).toMatch(/0, 1, 2, or 3/);
+        });
+        it('rejects float', () => {
+            expect(fieldFor('toolCompactness').validate(1.5)).toMatch(/0, 1, 2, or 3/);
+        });
+    });
+
+    describe('taskCardDensity', () => {
+        it('accepts "compact"', () => {
+            expect(fieldFor('taskCardDensity').validate('compact')).toBeUndefined();
+        });
+        it('accepts "dense"', () => {
+            expect(fieldFor('taskCardDensity').validate('dense')).toBeUndefined();
+        });
+        it('rejects other strings', () => {
+            expect(fieldFor('taskCardDensity').validate('sparse')).toMatch(/compact.*dense/);
+        });
+    });
+
+    describe('serve.serverName', () => {
+        it('accepts short string', () => {
+            expect(fieldFor('serve.serverName').validate('my-server')).toBeUndefined();
+        });
+        it('accepts null', () => {
+            expect(fieldFor('serve.serverName').validate(null)).toBeUndefined();
+        });
+        it('accepts string of exactly 64 chars', () => {
+            expect(fieldFor('serve.serverName').validate('a'.repeat(64))).toBeUndefined();
+        });
+        it('rejects string of 65 chars', () => {
+            expect(fieldFor('serve.serverName').validate('a'.repeat(65))).toMatch(/64 characters/);
+        });
+    });
+
+    describe('chat.followUpSuggestions.count', () => {
+        it('accepts 1', () => {
+            expect(fieldFor('chat.followUpSuggestions.count').validate(1)).toBeUndefined();
+        });
+        it('accepts 5', () => {
+            expect(fieldFor('chat.followUpSuggestions.count').validate(5)).toBeUndefined();
+        });
+        it('rejects 0', () => {
+            expect(fieldFor('chat.followUpSuggestions.count').validate(0)).toMatch(/1 and 5/);
+        });
+        it('rejects 6', () => {
+            expect(fieldFor('chat.followUpSuggestions.count').validate(6)).toMatch(/1 and 5/);
+        });
+        it('rejects float', () => {
+            expect(fieldFor('chat.followUpSuggestions.count').validate(2.5)).toMatch(/1 and 5/);
+        });
+    });
+
+    describe('scratchpad.layout', () => {
+        it('accepts "horizontal"', () => {
+            expect(fieldFor('scratchpad.layout').validate('horizontal')).toBeUndefined();
+        });
+        it('accepts "vertical"', () => {
+            expect(fieldFor('scratchpad.layout').validate('vertical')).toBeUndefined();
+        });
+        it('rejects other strings', () => {
+            expect(fieldFor('scratchpad.layout').validate('diagonal')).toMatch(/horizontal.*vertical/);
+        });
+    });
+
+    // All plain boolean fields
+    const booleanFields = [
+        'showReportIntent', 'groupSingleLineMessages',
+        'chat.followUpSuggestions.enabled', 'chat.askUser.enabled',
+        'terminal.enabled', 'notes.enabled', 'myWork.enabled', 'myLife.enabled',
+        'scratchpad.enabled', 'workflows.enabled', 'pullRequests.enabled',
+        'servers.enabled', 'ralph.enabled', 'vimNavigation.enabled', 'loops.enabled',
+    ];
+
+    for (const key of booleanFields) {
+        describe(key, () => {
+            it('accepts true', () => {
+                expect(fieldFor(key).validate(true)).toBeUndefined();
+            });
+            it('accepts false', () => {
+                expect(fieldFor(key).validate(false)).toBeUndefined();
+            });
+            it('rejects non-boolean', () => {
+                expect(fieldFor(key).validate('true')).toMatch(/boolean/);
+            });
+        });
+    }
+});
+
+// ── apply() ───────────────────────────────────────────────────────────────────
+
+describe('apply()', () => {
+    it('sets model on CLIConfig', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('model').apply(cfg, 'claude-3');
+        expect(cfg.model).toBe('claude-3');
+    });
+
+    it('sets parallel on CLIConfig', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('parallel').apply(cfg, 8);
+        expect(cfg.parallel).toBe(8);
+    });
+
+    it('sets timeout on CLIConfig', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('timeout').apply(cfg, 60);
+        expect(cfg.timeout).toBe(60);
+    });
+
+    it('deletes timeout when null', () => {
+        const cfg: CLIConfig = { timeout: 30 };
+        fieldFor('timeout').apply(cfg, null);
+        expect(cfg.timeout).toBeUndefined();
+    });
+
+    it('sets output on CLIConfig', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('output').apply(cfg, 'json');
+        expect(cfg.output).toBe('json');
+    });
+
+    it('sets showReportIntent', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('showReportIntent').apply(cfg, true);
+        expect(cfg.showReportIntent).toBe(true);
+    });
+
+    it('sets toolCompactness', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('toolCompactness').apply(cfg, 2);
+        expect(cfg.toolCompactness).toBe(2);
+    });
+
+    it('sets taskCardDensity', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('taskCardDensity').apply(cfg, 'compact');
+        expect(cfg.taskCardDensity).toBe('compact');
+    });
+
+    it('sets groupSingleLineMessages', () => {
+        const cfg: CLIConfig = {};
+        fieldFor('groupSingleLineMessages').apply(cfg, false);
+        expect(cfg.groupSingleLineMessages).toBe(false);
+    });
+
+    describe('serve.serverName', () => {
+        it('sets serverName', () => {
+            const cfg: CLIConfig = {};
+            fieldFor('serve.serverName').apply(cfg, 'prod-server');
+            expect(cfg.serve?.serverName).toBe('prod-server');
+        });
+        it('deletes serverName when null', () => {
+            const cfg: CLIConfig = { serve: { serverName: 'old' } };
+            fieldFor('serve.serverName').apply(cfg, null);
+            expect(cfg.serve?.serverName).toBeUndefined();
+        });
+        it('deletes serverName when empty string', () => {
+            const cfg: CLIConfig = { serve: { serverName: 'old' } };
+            fieldFor('serve.serverName').apply(cfg, '');
+            expect(cfg.serve?.serverName).toBeUndefined();
+        });
+    });
+
+    describe('chat.followUpSuggestions.enabled', () => {
+        it('initializes nested path and sets value', () => {
+            const cfg: CLIConfig = {};
+            fieldFor('chat.followUpSuggestions.enabled').apply(cfg, false);
+            expect(cfg.chat?.followUpSuggestions?.enabled).toBe(false);
+        });
+        it('updates existing nested value', () => {
+            const cfg: CLIConfig = { chat: { followUpSuggestions: { enabled: true } } };
+            fieldFor('chat.followUpSuggestions.enabled').apply(cfg, false);
+            expect(cfg.chat?.followUpSuggestions?.enabled).toBe(false);
+        });
+    });
+
+    describe('chat.followUpSuggestions.count', () => {
+        it('sets count, initializing nested path', () => {
+            const cfg: CLIConfig = {};
+            fieldFor('chat.followUpSuggestions.count').apply(cfg, 4);
+            expect(cfg.chat?.followUpSuggestions?.count).toBe(4);
+        });
+    });
+
+    describe('chat.askUser.enabled', () => {
+        it('sets value, initializing nested path', () => {
+            const cfg: CLIConfig = {};
+            fieldFor('chat.askUser.enabled').apply(cfg, true);
+            expect(cfg.chat?.askUser?.enabled).toBe(true);
+        });
+    });
+
+    // Feature flag nested fields
+    const nestedBoolFields: Array<[string, (cfg: CLIConfig) => boolean | undefined]> = [
+        ['terminal.enabled', (c) => c.terminal?.enabled],
+        ['notes.enabled', (c) => c.notes?.enabled],
+        ['myWork.enabled', (c) => c.myWork?.enabled],
+        ['myLife.enabled', (c) => c.myLife?.enabled],
+        ['scratchpad.enabled', (c) => c.scratchpad?.enabled],
+        ['workflows.enabled', (c) => c.workflows?.enabled],
+        ['pullRequests.enabled', (c) => c.pullRequests?.enabled],
+        ['servers.enabled', (c) => c.servers?.enabled],
+        ['ralph.enabled', (c) => c.ralph?.enabled],
+        ['vimNavigation.enabled', (c) => c.vimNavigation?.enabled],
+        ['loops.enabled', (c) => c.loops?.enabled],
+    ];
+
+    for (const [key, getter] of nestedBoolFields) {
+        describe(key, () => {
+            it('sets true, initializing namespace', () => {
+                const cfg: CLIConfig = {};
+                fieldFor(key).apply(cfg, true);
+                expect(getter(cfg)).toBe(true);
+            });
+            it('sets false, initializing namespace', () => {
+                const cfg: CLIConfig = {};
+                fieldFor(key).apply(cfg, false);
+                expect(getter(cfg)).toBe(false);
+            });
+        });
+    }
+
+    describe('scratchpad.layout', () => {
+        it('sets layout', () => {
+            const cfg: CLIConfig = {};
+            fieldFor('scratchpad.layout').apply(cfg, 'vertical');
+            expect(cfg.scratchpad?.layout).toBe('vertical');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Extracted admin config field validation and application logic into a centralized registry (`ADMIN_CONFIG_FIELDS`), eliminating duplication and making it easier to add new editable fields without modifying the admin handler.

## Key Changes

- **New file: `admin-config-fields.ts`** — Defines `ADMIN_CONFIG_FIELDS` registry with entries for all 24 editable config fields. Each entry specifies:
  - A flat key (e.g., `'loops.enabled'`)
  - A `validate()` function that returns an error message or `undefined`
  - An `apply()` function that mutates a `CLIConfig` object
  - Automatically derives `ADMIN_EDITABLE_KEYS` from the registry

- **Refactored `admin-handler.ts`** — Replaced ~240 lines of inline validation and merge logic with two loops:
  - Validation loop: iterates `ADMIN_CONFIG_FIELDS` and collects errors
  - Apply loop: iterates `ADMIN_CONFIG_FIELDS` and applies changes to the config
  - Removed hardcoded `VALID_OUTPUT_VALUES` constant (now in registry)
  - Removed hardcoded `editableKeys` array (now derived from registry)

- **Updated `index.ts`** — Modified dashboard HTML generation to re-read config on each page load, allowing feature-flag changes made via the admin UI to take effect without a server restart

- **Added comprehensive test suite** (`admin-config-fields.test.ts`) — 344 lines covering:
  - Registry shape validation (no duplicates, all expected keys present)
  - Validator acceptance/rejection for all 24 fields
  - Apply function correctness for flat and nested config paths

- **Updated `AGENTS.md`** — Documented the new registry pattern and the steps to add a new editable field

## Implementation Details

- The registry uses a helper function `bool()` to reduce boilerplate for simple boolean fields
- Nested field application (e.g., `chat.followUpSuggestions.enabled`) initializes parent objects as needed
- Special handling for nullable fields like `timeout` and `serve.serverName` (delete when null/empty)
- All validation logic is co-located with its corresponding field definition, improving maintainability

https://claude.ai/code/session_01XT2DzUBCcqYuqmDGqgPPSp