### PR TITLE
feat(coc): prefix agent name on repo tabs for container mode

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -50,10 +50,10 @@ interface RepoDetailProps {
 
 export const SUB_TABS: { key: RepoSubTab; label: string; shortcut?: string }[] = [
     { key: 'chats', label: 'Chats', shortcut: 'Alt+A' },
-    { key: 'explorer', label: 'Explorer', shortcut: 'Alt+E' },
     { key: 'git', label: 'Git', shortcut: 'Alt+G' },
     { key: 'work-items', label: 'Work Items', shortcut: 'Alt+I' },
     { key: 'schedules', label: 'Schedules', shortcut: 'Alt+S' },
+    { key: 'explorer', label: 'Explorer', shortcut: 'Alt+E' },
     { key: 'workflows', label: 'Workflows', shortcut: 'Alt+W' },
     { key: 'pull-requests', label: 'Pull Requests', shortcut: 'Alt+R' },
     { key: 'tasks', label: 'Tasks (Dep.)', shortcut: 'Alt+T' },

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -8,6 +8,7 @@ import { useQueue } from '../../contexts/QueueContext';
 import { useWorkItems, loadUnseenWorkItemIds } from '../../contexts/WorkItemContext';
 import { useUiLayoutMode } from '../../hooks/preferences/useUiLayoutMode';
 import { Button, cn } from '../../ui';
+import { getRepoDisplayName } from './RepoTabStrip';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
 import { RepoInfoTab } from './RepoInfoTab';
 import { TemplatesTab } from '../templates/TemplatesTab';
@@ -49,10 +50,10 @@ interface RepoDetailProps {
 
 export const SUB_TABS: { key: RepoSubTab; label: string; shortcut?: string }[] = [
     { key: 'chats', label: 'Chats', shortcut: 'Alt+A' },
+    { key: 'explorer', label: 'Explorer', shortcut: 'Alt+E' },
     { key: 'git', label: 'Git', shortcut: 'Alt+G' },
     { key: 'work-items', label: 'Work Items', shortcut: 'Alt+I' },
     { key: 'schedules', label: 'Schedules', shortcut: 'Alt+S' },
-    { key: 'explorer', label: 'Explorer', shortcut: 'Alt+E' },
     { key: 'workflows', label: 'Workflows', shortcut: 'Alt+W' },
     { key: 'pull-requests', label: 'Pull Requests', shortcut: 'Alt+R' },
     { key: 'tasks', label: 'Tasks (Dep.)', shortcut: 'Alt+T' },
@@ -372,7 +373,7 @@ export function RepoDetail({ repo, repos, onRefresh }: RepoDetailProps) {
                 className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
                 style={{ background: color }}
             />
-            <h1 className="text-[10px] font-semibold text-[#1e1e1e] dark:text-[#cccccc] truncate group-active:opacity-70 min-w-0">{ws.name}</h1>
+            <h1 className="text-[10px] font-semibold text-[#1e1e1e] dark:text-[#cccccc] truncate group-active:opacity-70 min-w-0">{getRepoDisplayName(ws)}</h1>
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-3 h-3 flex-shrink-0 text-[#999999] dark:text-[#666666]">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
             </svg>
@@ -394,7 +395,7 @@ export function RepoDetail({ repo, repos, onRefresh }: RepoDetailProps) {
                                 className="inline-block w-3 h-3 md:w-3.5 md:h-3.5 rounded-full flex-shrink-0"
                                 style={{ background: color }}
                             />
-                            <h1 className="text-base font-semibold text-[#1e1e1e] dark:text-[#cccccc] flex-1 truncate">{ws.name}</h1>
+                            <h1 className="text-base font-semibold text-[#1e1e1e] dark:text-[#cccccc] flex-1 truncate">{getRepoDisplayName(ws)}</h1>
                         </div>
                         {/* Sub-tab bar */}
                         <div className="relative flex-1 min-w-0" data-testid="repo-sub-tab-strip-container">

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoTabStrip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoTabStrip.tsx
@@ -111,6 +111,14 @@ function RepoQueueStatusIndicator({
     );
 }
 
+/** Display name for a workspace: prefix agent name for container repos to disambiguate same-named repos across agents. */
+export function getRepoDisplayName(ws: any): string {
+    if (ws.agentName) {
+        return `${ws.agentName}:${ws.name}`;
+    }
+    return ws.name;
+}
+
 export interface RepoTabStripProps {
     repos: RepoData[];
     selectedRepoId: string | null;
@@ -632,8 +640,12 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
             setOverflowHighlight(prev => Math.max(prev - 1, 0));
         } else if (e.key === 'Enter' && overflowHighlight >= 0 && overflowHighlight < flatFilteredRepos.length) {
             e.preventDefault();
-            onSelect(flatFilteredRepos[overflowHighlight].workspace.id);
+            const targetWs = flatFilteredRepos[overflowHighlight].workspace;
+            if (targetWs.agentId) dispatch({ type: 'SET_CURRENT_AGENT', agentId: targetWs.agentId });
+            const sw = targetWs.agentId && appState.currentAgentId !== targetWs.agentId;
+            onSelect(targetWs.id);
             setOverflowOpen(false);
+            if (sw && targetWs.id === selectedRepoId) onRefresh();
         }
     };
 
@@ -641,12 +653,12 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
 
     const renderTab = (repo: RepoData) => {
         const ws = repo.workspace;
-        const isSelected = ws.id === selectedRepoId;
+        const isSelected = ws.id === selectedRepoId && (!ws.agentId || !appState.currentAgentId || ws.agentId === appState.currentAgentId);
         const unseenCount = unseenCounts[ws.id] ?? 0;
         const color = ws.color || '#848484';
         const dotShape = (repo.gitInfoLoading || repo.gitInfo?.isGitRepo !== false) ? 'rounded-full' : 'rounded-sm';
         const queueStatus = repoQueueStatusMap[ws.id] ?? 'idle';
-        const accessibleLabel = getRepoQueueAccessibleLabel(ws.name, queueStatus);
+        const accessibleLabel = getRepoQueueAccessibleLabel(getRepoDisplayName(ws), queueStatus);
         const showBefore = repoDropIndicator?.targetId === ws.id && repoDropIndicator.position === 'before';
         const showAfter = repoDropIndicator?.targetId === ws.id && repoDropIndicator.position === 'after';
         const isDragging = draggedRepoId === ws.id;
@@ -683,7 +695,10 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                             event.preventDefault();
                             return;
                         }
+                        const switchingAgent = ws.agentId && appState.currentAgentId !== ws.agentId;
+                        if (ws.agentId) dispatch({ type: 'SET_CURRENT_AGENT', agentId: ws.agentId });
                         onSelect(ws.id);
+                        if (switchingAgent && ws.id === selectedRepoId) onRefresh();
                     }}
                     onContextMenu={e => {
                         e.preventDefault();
@@ -703,7 +718,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                         isSelected={isSelected}
                         testId="repo-tab-dot"
                     />
-                    <span className="max-w-[100px] truncate">{ws.name}</span>
+                    <span className="max-w-[140px] truncate">{getRepoDisplayName(ws)}</span>
                     {unseenCount > 0 && (
                         <span
                             className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] px-[3px] rounded-full bg-[#d16969] text-white text-[8px] font-semibold flex items-center justify-center leading-none"
@@ -729,7 +744,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                 className="inline-flex items-center gap-1.5 px-2.5 h-7 text-xs whitespace-nowrap shrink-0"
             >
                 <span className="inline-block w-3 h-3" />
-                <span className="max-w-[100px] truncate">{ws.name}</span>
+                <span className="max-w-[140px] truncate">{getRepoDisplayName(ws)}</span>
             </span>
         );
     };
@@ -840,9 +855,14 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                                         onRefresh();
                                                     }
                                                 }}
+                                                onContextMenu={e => {
+                                                    e.preventDefault();
+                                                    dispatch({ type: 'SET_CURRENT_AGENT', agentId });
+                                                    setContextMenu({ repoId: ws.id, x: e.clientX, y: e.clientY });
+                                                }}
                                             >
                                                 <RepoQueueStatusIndicator status={queueStatus} color={color} idleShape="rounded-full" isSelected={isSelected} testId="agent-repo-dot" />
-                                                <span className="truncate">{ws.name}</span>
+                                                <span className="truncate">{getRepoDisplayName(ws)}</span>
                                                 {unseenCount > 0 && (
                                                     <span className="ml-auto min-w-[14px] h-[14px] px-[3px] rounded-full bg-[#d16969] text-white text-[8px] font-semibold flex items-center justify-center leading-none">
                                                         {unseenCount > 99 ? '99+' : unseenCount}
@@ -955,7 +975,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                                         onClick={() => { const sw = appState.currentAgentId !== agentId; dispatch({ type: 'SET_CURRENT_AGENT', agentId }); onSelect(ws.id); setOpenAgentDropdown(null); setAgentOverflowOpen(false); if (sw && ws.id === selectedRepoId) onRefresh(); }}
                                                     >
                                                         <RepoQueueStatusIndicator status={queueStatus} color={color} idleShape="rounded-full" isSelected={isSelected} testId="agent-overflow-repo-dot" />
-                                                        <span className="truncate">{ws.name}</span>
+                                                        <span className="truncate">{getRepoDisplayName(ws)}</span>
                                                     </button>
                                                 );
                                             })}
@@ -1049,12 +1069,12 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                         )}
                                         {groupRepos.map(repo => {
                                             const ws = repo.workspace;
-                                            const isSelected = ws.id === selectedRepoId;
+                                            const isSelected = ws.id === selectedRepoId && (!ws.agentId || !appState.currentAgentId || ws.agentId === appState.currentAgentId);
                                             const unseenCount = unseenCounts[ws.id] ?? 0;
                                             const color = ws.color || '#848484';
                                             const queueStatus = repoQueueStatusMap[ws.id] ?? 'idle';
                                             const dotShape = (repo.gitInfoLoading || repo.gitInfo?.isGitRepo !== false) ? 'rounded-full' : 'rounded-sm';
-                                            const accessibleLabel = getRepoQueueAccessibleLabel(ws.name, queueStatus);
+                                            const accessibleLabel = getRepoQueueAccessibleLabel(getRepoDisplayName(ws), queueStatus);
                                             const flatIdx = flatFilteredRepos.indexOf(repo);
                                             const isHighlighted = flatIdx === overflowHighlight;
                                             const orderIndex = allRepoIds.indexOf(ws.id);
@@ -1079,7 +1099,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                                         idleShape={dotShape}
                                                         testId="overflow-repo-dot"
                                                     />
-                                                    <span className="flex-1 truncate">{ws.name}</span>
+                                                    <span className="flex-1 truncate">{getRepoDisplayName(ws)}</span>
                                                     {isSelected && (
                                                         <span className="text-[#0078d4] dark:text-[#3794ff]" data-testid="overflow-selected-check">✓</span>
                                                     )}
@@ -1127,7 +1147,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                                             <button
                                                                 type="button"
                                                                 data-testid="overflow-move-up"
-                                                                aria-label={`Move ${ws.name} up`}
+                                                                aria-label={`Move ${getRepoDisplayName(ws)} up`}
                                                                 className="text-[10px] text-[#0078d4] dark:text-[#60b4ff] hover:underline disabled:opacity-40"
                                                                 disabled={orderIndex <= 0}
                                                                 onClick={() => moveRepoToIndex(ws.id, orderIndex - 1)}
@@ -1137,7 +1157,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                                             <button
                                                                 type="button"
                                                                 data-testid="overflow-move-down"
-                                                                aria-label={`Move ${ws.name} down`}
+                                                                aria-label={`Move ${getRepoDisplayName(ws)} down`}
                                                                 className="text-[10px] text-[#0078d4] dark:text-[#60b4ff] hover:underline disabled:opacity-40"
                                                                 disabled={orderIndex < 0 || orderIndex >= allRepoIds.length - 1}
                                                                 onClick={() => moveRepoToIndex(ws.id, orderIndex + 1)}
@@ -1158,7 +1178,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                                                     role="menuitem"
                                                     aria-label={accessibleLabel}
                                                     title={accessibleLabel}
-                                                    onClick={() => { onSelect(ws.id); setOverflowOpen(false); }}
+                                                    onClick={() => { if (ws.agentId) dispatch({ type: 'SET_CURRENT_AGENT', agentId: ws.agentId }); const sw = ws.agentId && appState.currentAgentId !== ws.agentId; onSelect(ws.id); setOverflowOpen(false); if (sw && ws.id === selectedRepoId) onRefresh(); }}
                                                     onContextMenu={e => {
                                                         e.preventDefault();
                                                         setContextMenu({ repoId: ws.id, x: e.clientX, y: e.clientY });
@@ -1271,7 +1291,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                 <div
                         ref={contextMenuRef}
                         data-testid="repo-tab-context-menu"
-                        className="fixed z-50 min-w-[160px] bg-white dark:bg-[#252526] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded shadow-lg py-1"
+                        className="fixed z-[10001] min-w-[160px] bg-white dark:bg-[#252526] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded shadow-lg py-1"
                         role="menu"
                         style={{ left: contextMenu.x, top: contextMenu.y }}
                     >
@@ -1362,7 +1382,7 @@ export function RepoTabStrip({ repos, selectedRepoId, onSelect, unseenCounts, on
                             className="w-full text-left px-3 py-1.5 text-xs text-[#1e1e1e] dark:text-[#cccccc] hover:bg-[#0078d4]/10 dark:hover:bg-[#3794ff]/10 cursor-pointer"
                             role="menuitem"
                             onClick={() => {
-                                navigator.clipboard.writeText(`${ws.name}: ${ws.rootPath ?? ''}${ws.description ? '\n' + ws.description : ''}`);
+                                navigator.clipboard.writeText(`${getRepoDisplayName(ws)}: ${ws.rootPath ?? ''}${ws.description ? '\n' + ws.description : ''}`);
                                 setContextMenu(null);
                             }}
                         >

--- a/packages/coc/src/server/spa/client/react/hooks/preferences/useUiLayoutMode.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/preferences/useUiLayoutMode.ts
@@ -13,7 +13,7 @@ import { useEffect, useSyncExternalStore } from 'react';
 import type { UiLayoutMode } from '../../types/dashboard';
 import { getSpaCocClient } from '../../api/cocClient';
 
-const DEFAULT_MODE: UiLayoutMode = 'dev-workflow';
+const DEFAULT_MODE: UiLayoutMode = 'classic';
 
 // ── Module-level shared store ────────────────────────────────────────────────
 let currentMode: UiLayoutMode = DEFAULT_MODE;

--- a/packages/coc/src/server/spa/client/react/hooks/preferences/useUiLayoutMode.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/preferences/useUiLayoutMode.ts
@@ -13,7 +13,7 @@ import { useEffect, useSyncExternalStore } from 'react';
 import type { UiLayoutMode } from '../../types/dashboard';
 import { getSpaCocClient } from '../../api/cocClient';
 
-const DEFAULT_MODE: UiLayoutMode = 'classic';
+const DEFAULT_MODE: UiLayoutMode = 'dev-workflow';
 
 // ── Module-level shared store ────────────────────────────────────────────────
 let currentMode: UiLayoutMode = DEFAULT_MODE;

--- a/packages/coc/src/server/spa/client/react/repos/ReposView.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/ReposView.tsx
@@ -64,7 +64,10 @@ export function ReposView() {
     // My Life virtual workspace — personal goals, journal, life admin
     const isMyLife = myLifeEnabled && state.selectedRepoId === MY_LIFE_WORKSPACE_ID;
 
-    const selectedRepo = repos.find(r => r.workspace.id === state.selectedRepoId) || null;
+    const selectedRepo = repos.find(r =>
+        r.workspace.id === state.selectedRepoId &&
+        (!state.currentAgentId || !r.workspace.agentId || r.workspace.agentId === state.currentAgentId)
+    ) || repos.find(r => r.workspace.id === state.selectedRepoId) || null;
 
     return (
         <div id="view-repos" className={`flex ${heightClass} overflow-hidden`}>
@@ -83,7 +86,7 @@ export function ReposView() {
                 hasSelection && selectedRepo ? (
                     <div className="flex-1 min-w-0 min-h-0 flex flex-col">
                         <main className="flex-1 min-w-0 min-h-0 flex flex-col bg-white dark:bg-[#1e1e1e] overflow-hidden">
-                            <RepoDetail repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
+                            <RepoDetail key={`${selectedRepo.workspace.id}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
                         </main>
                     </div>
                 ) : (
@@ -95,7 +98,7 @@ export function ReposView() {
                 // ── Tablet / Desktop: full-width content, repo selected via top-bar tabs ──
                 <main className="flex-1 min-w-0 min-h-0 flex flex-col bg-white dark:bg-[#1e1e1e] overflow-hidden">
                     {selectedRepo ? (
-                        <RepoDetail repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
+                        <RepoDetail key={`${selectedRepo.workspace.id}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
                     ) : (
                         <div id="repo-detail-empty" data-testid="repo-detail-empty" className="flex-1 flex items-center justify-center text-sm text-[#848484]">
                             Select a repository to view details

--- a/packages/coc/test/spa/react/repos/RepoTabStrip.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoTabStrip.test.tsx
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react';
-import { RepoTabStrip } from '../../../../src/server/spa/client/react/features/repo-detail/RepoTabStrip';
+import { RepoTabStrip, getRepoDisplayName } from '../../../../src/server/spa/client/react/features/repo-detail/RepoTabStrip';
 
 const mockDispatch = vi.fn();
 const mockQueueDispatch = vi.fn();
@@ -907,5 +907,19 @@ describe('RepoTabStrip', () => {
             expect(screen.getByTestId('repo-tab-context-edit')).toBeDefined();
             expect(screen.getByTestId('repo-tab-context-remove')).toBeDefined();
         });
+    });
+});
+
+describe('getRepoDisplayName', () => {
+    it('returns just the repo name when no agentName', () => {
+        expect(getRepoDisplayName({ name: 'my-repo' })).toBe('my-repo');
+    });
+
+    it('returns agentName:name when agentName is present', () => {
+        expect(getRepoDisplayName({ name: 'my-repo', agentName: 'dev2' })).toBe('dev2:my-repo');
+    });
+
+    it('returns just the repo name when agentName is empty string', () => {
+        expect(getRepoDisplayName({ name: 'my-repo', agentName: '' })).toBe('my-repo');
     });
 });


### PR DESCRIPTION
When repos from different agents share the same name, add AgentName:RepoName display format to disambiguate them in the tab strip, overflow dropdown, and management views. Only applies when workspace has agentName (container mode).

Also increases max tab width from 100px to 140px to accommodate the prefix.