### PR TITLE
feat(pr): add collapsible "PR queue" header to the left rail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,18 +566,6 @@
         }
       }
     },
-    "node_modules/@changesets/cli/node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
     "node_modules/@changesets/cli/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -629,15 +617,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@changesets/cli/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@changesets/cli/node_modules/universalify": {
       "version": "0.1.2",

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PrQueueFilters.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PrQueueFilters.tsx
@@ -36,7 +36,7 @@ export function PrQueueFilters({ active, counts, onChange }: PrQueueFiltersProps
                         onClick={() => onChange(filter.id)}
                         aria-pressed={isActive}
                         className={cn(
-                            'inline-flex min-h-[22px] items-center gap-1 rounded-full border px-[7px] py-px text-xs font-semibold transition-colors',
+                            'inline-flex min-h-[22px] items-center rounded-full border px-[7px] py-px text-xs font-semibold transition-colors',
                             isActive
                                 ? 'border-gray-900 bg-gray-900 text-white dark:border-gray-200 dark:bg-gray-100 dark:text-gray-900'
                                 : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/60',
@@ -44,8 +44,7 @@ export function PrQueueFilters({ active, counts, onChange }: PrQueueFiltersProps
                         data-testid={`pr-queue-filter-${filter.id}`}
                         data-active={isActive}
                     >
-                        {filter.label}
-                        <span className="font-mono tabular-nums">{count}</span>
+                        {filter.label} {count}
                     </button>
                 );
             })}

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PrQueueGroupSection.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PrQueueGroupSection.tsx
@@ -10,13 +10,15 @@ import type { QueueSection } from './pr-attention-groups';
 interface PrQueueGroupSectionProps {
     section: QueueSection;
     label: string;
+    /** When true, the section label is hidden (used by the collapsed rail). */
+    compact?: boolean;
     /** Pre-rendered PR rows (keep row rendering in the parent so it can
      *  pass batch-mode props consistently). */
     children: ReactNode;
 }
 
 export const PrQueueGroupSection = forwardRef<HTMLElement, PrQueueGroupSectionProps>(
-    function PrQueueGroupSection({ section, label, children }, ref) {
+    function PrQueueGroupSection({ section, label, compact, children }, ref) {
         return (
             <section
                 ref={ref}
@@ -24,9 +26,11 @@ export const PrQueueGroupSection = forwardRef<HTMLElement, PrQueueGroupSectionPr
                 data-testid="pr-queue-group"
                 data-queue-section={section}
             >
-                <div className="px-2.5 pb-[3px] pt-[5px] text-[11px] font-semibold uppercase tracking-normal text-gray-500 dark:text-gray-400">
-                    {label}
-                </div>
+                {!compact && (
+                    <div className="px-2.5 pb-[3px] pt-[5px] text-[11px] font-semibold uppercase tracking-normal text-gray-500 dark:text-gray-400">
+                        {label}
+                    </div>
+                )}
                 <div data-testid="pr-queue-group-rows">{children}</div>
             </section>
         );

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestRow.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestRow.tsx
@@ -28,6 +28,11 @@ interface PullRequestRowProps {
     /** When true, the selection checkbox is rendered. Hidden by default. */
     batchMode?: boolean;
     /**
+     * When true, the row collapses to a centered state-dot only.
+     * Used by the collapsed PR queue rail.
+     */
+    compact?: boolean;
+    /**
      * Optional override for the state dot. When omitted, the dot is
      * derived from the PR status and the AI-flagged risk level.
      */
@@ -59,6 +64,7 @@ export function PullRequestRow({
     onSelect,
     isChecked,
     batchMode,
+    compact,
     dotState,
     risk,
 }: PullRequestRowProps) {
@@ -66,6 +72,36 @@ export function PullRequestRow({
     const effectiveDot: QueueDotState = dotState ?? deriveDotState(pr, effectiveRisk);
     const fileCount = getMockPrFileCount(pr);
     const minutes = getMockPrReviewMinutes(pr);
+
+    if (compact) {
+        return (
+            <button
+                type="button"
+                title={pr.title}
+                aria-label={pr.title}
+                onClick={onClick}
+                data-testid="pr-row"
+                data-pr-status={pr.status}
+                data-compact="true"
+                className={cn(
+                    'pr-row relative flex w-full cursor-pointer justify-center border-0 bg-white py-[7px] text-left transition-colors dark:bg-gray-900',
+                    isSelected
+                        ? "bg-blue-50 before:absolute before:left-0 before:top-0 before:h-full before:w-[3px] before:bg-blue-500 before:content-[''] dark:bg-blue-900/30"
+                        : 'hover:bg-gray-50 dark:hover:bg-gray-800/60',
+                )}
+            >
+                <span
+                    aria-hidden="true"
+                    className={cn(
+                        'pr-state-dot h-[13px] w-[13px] shrink-0 rounded-full border-[2.5px]',
+                        queueDotClass(effectiveDot),
+                    )}
+                    data-testid="pr-state-dot"
+                    data-state={effectiveDot}
+                />
+            </button>
+        );
+    }
 
     return (
         <div

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestsTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestsTab.tsx
@@ -67,6 +67,22 @@ function formatFetchedAt(ts: number): string {
 }
 
 const STATUS_FILTER: PrStatus = 'open';
+const QUEUE_COLLAPSED_KEY = 'pr-queue-collapsed';
+const QUEUE_COLLAPSED_WIDTH = 44;
+
+function loadQueueCollapsed(): boolean {
+    try {
+        return localStorage.getItem(QUEUE_COLLAPSED_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+function persistQueueCollapsed(value: boolean): void {
+    try {
+        localStorage.setItem(QUEUE_COLLAPSED_KEY, String(value));
+    } catch { /* ignore */ }
+}
 
 /** Map a queue filter pill to the server scope it requires. */
 function scopeForFilter(filter: QueueFilter): 'mine' | 'all' {
@@ -105,6 +121,20 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
     const [selectedPrIds, setSelectedPrIds] = useState<Set<string>>(new Set());
     const [anchorPrId, setAnchorPrId] = useState<string | null>(null);
     const [batchMode, setBatchMode] = useState(false);
+    const [queueCollapsed, setQueueCollapsed] = useState<boolean>(() => loadQueueCollapsed());
+
+    const toggleQueueCollapsed = useCallback(() => {
+        setQueueCollapsed(prev => {
+            const next = !prev;
+            persistQueueCollapsed(next);
+            if (next) {
+                setBatchMode(false);
+                setSelectedPrIds(new Set());
+                setAnchorPrId(null);
+            }
+            return next;
+        });
+    }, []);
 
     const skipRef = useRef(0);
     const abortRef = useRef<AbortController | null>(null);
@@ -315,169 +345,207 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         }
     }
 
+    const queueHeader = (
+        <div
+            className={cn(
+                'flex shrink-0 items-center border-b border-gray-200 dark:border-gray-700',
+                queueCollapsed
+                    ? 'justify-center gap-0 px-1 py-1'
+                    : 'justify-between gap-1.5 px-2.5 py-1',
+            )}
+            data-testid="pr-queue-header"
+            data-collapsed={queueCollapsed}
+        >
+            {!queueCollapsed && (
+                <span className="min-w-0 truncate text-xs font-semibold text-gray-900 dark:text-gray-100">
+                    PR queue
+                </span>
+            )}
+            <button
+                type="button"
+                onClick={toggleQueueCollapsed}
+                aria-expanded={!queueCollapsed}
+                aria-label={queueCollapsed ? 'Expand PR queue' : 'Collapse PR queue'}
+                aria-controls="pr-queue-content"
+                title={queueCollapsed ? 'Expand PR queue' : 'Collapse PR queue'}
+                data-testid="pr-queue-toggle"
+                className="inline-grid h-6 w-6 shrink-0 place-items-center rounded-md border border-gray-300 bg-white text-xs font-semibold text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+                {queueCollapsed ? '>' : '<'}
+            </button>
+        </div>
+    );
+
     const queuePanel = (
         <>
-            <div
-                className="flex items-center gap-1.5 border-b border-gray-200 px-2.5 py-1.5 dark:border-gray-700"
-                data-testid="pr-queue-toolbar"
-            >
-                <input
-                    className="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-1.5 py-0.5 text-xs text-gray-900 outline-none placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-                    placeholder="Search PRs…"
-                    value={searchText}
-                    onChange={e => setSearchText(e.target.value)}
-                    data-testid="search-input"
-                />
-                <button
-                    type="button"
-                    onClick={() => fetchPrs(true, true)}
-                    disabled={loading}
-                    title="Refresh pull requests"
-                    data-testid="refresh-button"
-                    className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            {queueHeader}
+            {!queueCollapsed && (
+                <div
+                    className="flex shrink-0 items-center gap-1.5 border-b border-gray-200 px-2.5 py-1.5 dark:border-gray-700"
+                    data-testid="pr-queue-toolbar"
                 >
-                    <svg
-                        className={loading ? 'animate-spin' : ''}
-                        width="12" height="12" viewBox="0 0 24 24"
-                        fill="none" stroke="currentColor" strokeWidth="2"
-                        strokeLinecap="round" strokeLinejoin="round"
+                    <input
+                        className="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-1.5 py-0.5 text-xs text-gray-900 outline-none placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                        placeholder="Search PRs…"
+                        value={searchText}
+                        onChange={e => setSearchText(e.target.value)}
+                        data-testid="search-input"
+                    />
+                    <button
+                        type="button"
+                        onClick={() => fetchPrs(true, true)}
+                        disabled={loading}
+                        title="Refresh pull requests"
+                        data-testid="refresh-button"
+                        className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                     >
-                        <path d="M21 2v6h-6" />
-                        <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-                        <path d="M3 22v-6h6" />
-                        <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-                    </svg>
-                </button>
-                <button
-                    type="button"
-                    onClick={handleToggleBatchMode}
-                    aria-pressed={batchMode}
-                    data-testid="select-mode-button"
-                    className={cn(
-                        'inline-flex h-[22px] shrink-0 items-center rounded-md border px-1.5 text-[11px] font-semibold transition-colors',
-                        batchMode
-                            ? 'border-blue-500 bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300'
-                            : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
+                        <svg
+                            className={loading ? 'animate-spin' : ''}
+                            width="12" height="12" viewBox="0 0 24 24"
+                            fill="none" stroke="currentColor" strokeWidth="2"
+                            strokeLinecap="round" strokeLinejoin="round"
+                        >
+                            <path d="M21 2v6h-6" />
+                            <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                            <path d="M3 22v-6h6" />
+                            <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+                        </svg>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleToggleBatchMode}
+                        aria-pressed={batchMode}
+                        data-testid="select-mode-button"
+                        className={cn(
+                            'inline-flex h-[22px] shrink-0 items-center rounded-md border px-1.5 text-[11px] font-semibold transition-colors',
+                            batchMode
+                                ? 'border-blue-500 bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300'
+                                : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
+                        )}
+                    >
+                        {batchMode ? 'Cancel' : 'Select'}
+                    </button>
+                </div>
+            )}
+
+            <div id="pr-queue-content" className="flex min-h-0 flex-1 flex-col">
+                {!queueCollapsed && (
+                    <PrQueueFilters
+                        active={activeFilter}
+                        counts={filterCounts}
+                        onChange={handleFilterChange}
+                    />
+                )}
+
+                {!queueCollapsed && batchMode && selectedPrIds.size > 0 && (
+                    <div
+                        className="flex items-center justify-between border-b border-blue-100 bg-blue-50 px-2.5 py-0.5 text-[11px] font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
+                        data-testid="selection-count-bar"
+                    >
+                        <span>{selectedPrIds.size} PR{selectedPrIds.size !== 1 ? 's' : ''} selected</span>
+                        <button
+                            className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                            onClick={() => {
+                                setSelectedPrIds(new Set());
+                                setAnchorPrId(null);
+                            }}
+                            data-testid="clear-selection"
+                        >
+                            Clear
+                        </button>
+                    </div>
+                )}
+
+                {!queueCollapsed && fetchedAt != null && !loading && !error && !unconfigured && (
+                    <div
+                        className="border-b border-gray-200 px-2.5 py-0.5 text-[11px] text-gray-500 dark:border-gray-700 dark:text-gray-400"
+                        data-testid="fetched-at"
+                    >
+                        {formatFetchedAt(fetchedAt)}
+                    </div>
+                )}
+
+                {!queueCollapsed && unconfigured && (
+                    <ProviderConfigPanel
+                        detected={unconfigured.detected}
+                        remoteUrl={unconfigured.remoteUrl}
+                        noCredentials={unconfigured.noCredentials}
+                        onConfigured={() => fetchPrs(true)}
+                    />
+                )}
+
+                {!queueCollapsed && error && (
+                    <div className="px-4 py-2 text-sm text-red-500 dark:text-red-400" data-testid="error-message">
+                        {error}
+                    </div>
+                )}
+
+                {!queueCollapsed && loading && prs.length === 0 && (
+                    <div className="flex items-center justify-center py-8" data-testid="loading-spinner">
+                        <span className="text-sm text-gray-500">Loading pull requests…</span>
+                    </div>
+                )}
+
+                <div className="flex-1 overflow-y-auto" data-testid="pr-list">
+                    {!error && !unconfigured && !(loading && prs.length === 0) && filteredByPill.length > 0 && (
+                        groupedPrs
+                            .filter(({ prs: sectionPrs }) => sectionPrs.length > 0)
+                            .map(({ config, prs: sectionPrs }) => (
+                                <PrQueueGroupSection
+                                    key={config.section}
+                                    section={config.section}
+                                    label={config.label}
+                                    compact={queueCollapsed}
+                                >
+                                    {sectionPrs.map(pr => (
+                                        <PullRequestRow
+                                            key={pr.id}
+                                            pr={pr}
+                                            onClick={() => handleRowClick(pr)}
+                                            isSelected={(pr.number ?? pr.id) === state.selectedPrId}
+                                            isChecked={selectedPrIds.has(getPrSelectionId(pr))}
+                                            onSelect={(id, checked, shiftKey) =>
+                                                handlePrSelect(id, checked, shiftKey, sectionPrs)
+                                            }
+                                            batchMode={batchMode && !queueCollapsed}
+                                            compact={queueCollapsed}
+                                        />
+                                    ))}
+                                </PrQueueGroupSection>
+                            ))
                     )}
-                >
-                    {batchMode ? 'Cancel' : 'Select'}
-                </button>
-            </div>
-
-            <PrQueueFilters
-                active={activeFilter}
-                counts={filterCounts}
-                onChange={handleFilterChange}
-            />
-
-            {batchMode && selectedPrIds.size > 0 && (
-                <div
-                    className="flex items-center justify-between border-b border-blue-100 bg-blue-50 px-2.5 py-0.5 text-[11px] font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
-                    data-testid="selection-count-bar"
-                >
-                    <span>{selectedPrIds.size} PR{selectedPrIds.size !== 1 ? 's' : ''} selected</span>
-                    <button
-                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-                        onClick={() => {
-                            setSelectedPrIds(new Set());
-                            setAnchorPrId(null);
-                        }}
-                        data-testid="clear-selection"
-                    >
-                        Clear
-                    </button>
+                    {!queueCollapsed && !loading && !error && !unconfigured && prs.length > 0 && filteredByPill.length === 0 && (
+                        <div className="px-4 py-6 text-center text-sm text-gray-500" data-testid="no-results">
+                            No pull requests match your filters.
+                        </div>
+                    )}
+                    {!queueCollapsed && !loading && !error && !unconfigured && prs.length === 0 && (
+                        <div className="pr-empty-state px-4 py-6 text-center text-sm text-gray-500" data-testid="empty-state">
+                            No pull requests found.
+                        </div>
+                    )}
                 </div>
-            )}
 
-            {fetchedAt != null && !loading && !error && !unconfigured && (
-                <div
-                    className="border-b border-gray-200 px-2.5 py-0.5 text-[11px] text-gray-500 dark:border-gray-700 dark:text-gray-400"
-                    data-testid="fetched-at"
-                >
-                    {formatFetchedAt(fetchedAt)}
-                </div>
-            )}
-
-            {/* Loading / unconfigured / error states share the same scroll body */}
-            {unconfigured && (
-                <ProviderConfigPanel
-                    detected={unconfigured.detected}
-                    remoteUrl={unconfigured.remoteUrl}
-                    noCredentials={unconfigured.noCredentials}
-                    onConfigured={() => fetchPrs(true)}
-                />
-            )}
-
-            {error && (
-                <div className="px-4 py-2 text-sm text-red-500 dark:text-red-400" data-testid="error-message">
-                    {error}
-                </div>
-            )}
-
-            {loading && prs.length === 0 && (
-                <div className="flex items-center justify-center py-8" data-testid="loading-spinner">
-                    <span className="text-sm text-gray-500">Loading pull requests…</span>
-                </div>
-            )}
-
-            {/* Queue rows */}
-            <div className="flex-1 overflow-y-auto" data-testid="pr-list">
-                {!error && !unconfigured && !(loading && prs.length === 0) && filteredByPill.length > 0 && (
-                    groupedPrs
-                        .filter(({ prs: sectionPrs }) => sectionPrs.length > 0)
-                        .map(({ config, prs: sectionPrs }) => (
-                            <PrQueueGroupSection
-                                key={config.section}
-                                section={config.section}
-                                label={config.label}
-                            >
-                                {sectionPrs.map(pr => (
-                                    <PullRequestRow
-                                        key={pr.id}
-                                        pr={pr}
-                                        onClick={() => handleRowClick(pr)}
-                                        isSelected={(pr.number ?? pr.id) === state.selectedPrId}
-                                        isChecked={selectedPrIds.has(getPrSelectionId(pr))}
-                                        onSelect={(id, checked, shiftKey) =>
-                                            handlePrSelect(id, checked, shiftKey, sectionPrs)
-                                        }
-                                        batchMode={batchMode}
-                                    />
-                                ))}
-                            </PrQueueGroupSection>
-                        ))
-                )}
-                {!loading && !error && !unconfigured && prs.length > 0 && filteredByPill.length === 0 && (
-                    <div className="px-4 py-6 text-center text-sm text-gray-500" data-testid="no-results">
-                        No pull requests match your filters.
+                {!queueCollapsed && hasMore && !loading && (
+                    <div className="border-t border-gray-200 px-2.5 py-1.5 dark:border-gray-700">
+                        <button
+                            className="w-full py-0.5 text-xs text-blue-600 hover:underline dark:text-blue-400"
+                            onClick={() => fetchPrs(false)}
+                            data-testid="load-more"
+                        >
+                            Load more
+                        </button>
                     </div>
                 )}
-                {!loading && !error && !unconfigured && prs.length === 0 && (
-                    <div className="pr-empty-state px-4 py-6 text-center text-sm text-gray-500" data-testid="empty-state">
-                        No pull requests found.
+
+                {!queueCollapsed && loading && prs.length > 0 && (
+                    <div className="px-2.5 py-1.5 text-center text-xs text-gray-500" data-testid="loading-more">
+                        Loading…
                     </div>
                 )}
+
+                {!queueCollapsed && <PrQueueFooter />}
             </div>
-
-            {hasMore && !loading && (
-                <div className="border-t border-gray-200 px-2.5 py-1.5 dark:border-gray-700">
-                    <button
-                        className="w-full py-0.5 text-xs text-blue-600 hover:underline dark:text-blue-400"
-                        onClick={() => fetchPrs(false)}
-                        data-testid="load-more"
-                    >
-                        Load more
-                    </button>
-                </div>
-            )}
-
-            {loading && prs.length > 0 && (
-                <div className="px-2.5 py-1.5 text-center text-xs text-gray-500" data-testid="loading-more">
-                    Loading…
-                </div>
-            )}
-
-            <PrQueueFooter />
         </>
     );
 
@@ -528,26 +596,31 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
     // Suppress unused-warning when mock helper is only re-exported for tests.
     void getMockQueueRisk;
 
+    const effectiveLeftPanelWidth = queueCollapsed ? QUEUE_COLLAPSED_WIDTH : leftPanelWidth;
+
     return (
         <div className={cn('flex h-full overflow-hidden', isDragging && 'select-none')} data-testid="pr-split-panel">
             <div
                 className="flex-shrink-0 border-r border-gray-200 flex flex-col overflow-hidden bg-white dark:border-gray-700 dark:bg-gray-900"
-                style={{ width: leftPanelWidth }}
+                style={{ width: effectiveLeftPanelWidth }}
                 data-testid="pr-list-panel"
+                data-collapsed={queueCollapsed}
             >
                 {queuePanel}
             </div>
 
-            <div
-                className="flex items-center justify-center w-1 cursor-col-resize hover:bg-blue-400/30 active:bg-blue-400/50 transition-colors flex-shrink-0"
-                onMouseDown={handleMouseDown}
-                onTouchStart={handleTouchStart}
-                data-testid="pr-resize-handle"
-                role="separator"
-                aria-orientation="vertical"
-                aria-label="Resize pull requests panel"
-                tabIndex={0}
-            />
+            {!queueCollapsed && (
+                <div
+                    className="flex items-center justify-center w-1 cursor-col-resize hover:bg-blue-400/30 active:bg-blue-400/50 transition-colors flex-shrink-0"
+                    onMouseDown={handleMouseDown}
+                    onTouchStart={handleTouchStart}
+                    data-testid="pr-resize-handle"
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label="Resize pull requests panel"
+                    tabIndex={0}
+                />
+            )}
 
             <div className="flex-1 min-w-0 overflow-y-auto" data-testid="pr-detail-panel">
                 {detailContent}

--- a/packages/coc/test/spa/react/repos/pull-requests/PrQueueChrome.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PrQueueChrome.test.tsx
@@ -68,6 +68,17 @@ describe('PrQueueGroupSection', () => {
         expect(screen.getByTestId('pr-queue-group-rows').textContent).toContain('row content');
     });
 
+    it('hides the section label when compact', () => {
+        render(
+            <PrQueueGroupSection section="needs-review" label="Needs review" compact>
+                <div data-testid="row-stub">row content</div>
+            </PrQueueGroupSection>,
+        );
+        const section = screen.getByTestId('pr-queue-group');
+        expect(section.textContent).not.toContain('Needs review');
+        expect(screen.getByTestId('pr-queue-group-rows').textContent).toContain('row content');
+    });
+
     it('exposes both queue sections distinctly', () => {
         render(
             <>

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestRow.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestRow.test.tsx
@@ -130,6 +130,31 @@ describe('PullRequestRow — click handling', () => {
     });
 });
 
+describe('PullRequestRow — compact mode', () => {
+    it('renders only the state dot when compact', () => {
+        render(<PullRequestRow pr={makePr({ title: 'Hidden title' })} onClick={vi.fn()} compact risk="med" />);
+        expect(screen.getByTestId('pr-state-dot')).toBeInTheDocument();
+        expect(screen.getByTestId('pr-row').getAttribute('data-compact')).toBe('true');
+        expect(screen.queryByText('Hidden title')).toBeNull();
+        expect(screen.queryByText(/#\d+/)).toBeNull();
+        expect(screen.queryByTestId('pr-risk-pill')).toBeNull();
+    });
+
+    it('still calls onClick when the compact dot is clicked', () => {
+        const onClick = vi.fn();
+        render(<PullRequestRow pr={makePr()} onClick={onClick} compact />);
+        fireEvent.click(screen.getByTestId('pr-row'));
+        expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('exposes the PR title via title and aria-label for tooltips', () => {
+        render(<PullRequestRow pr={makePr({ title: 'Tooltip PR' })} onClick={vi.fn()} compact />);
+        const row = screen.getByTestId('pr-row');
+        expect(row.getAttribute('title')).toBe('Tooltip PR');
+        expect(row.getAttribute('aria-label')).toBe('Tooltip PR');
+    });
+});
+
 describe('PullRequestRow — batch mode checkbox', () => {
     it('hides the checkbox by default', () => {
         render(<PullRequestRow pr={makePr()} onClick={vi.fn()} />);

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestsTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestsTab.test.tsx
@@ -101,10 +101,18 @@ describe('successful fetch', () => {
         expect(screen.getByText('PR Two')).toBeInTheDocument();
     });
 
+    it('renders the PR queue header with title and collapse toggle', async () => {
+        mockFetchOk([]);
+        await act(async () => { await renderTab(); });
+        const header = screen.getByTestId('pr-queue-header');
+        expect(header).toBeInTheDocument();
+        expect(header.textContent).toContain('PR queue');
+        expect(screen.getByTestId('pr-queue-toggle')).toBeInTheDocument();
+    });
+
     it('renders the search input, refresh, and select controls', async () => {
         mockFetchOk([]);
         await act(async () => { await renderTab(); });
-        expect(screen.queryByTestId('pr-queue-header')).not.toBeInTheDocument();
         expect(screen.getByTestId('search-input')).toBeInTheDocument();
         expect(screen.getByTestId('refresh-button')).toBeInTheDocument();
         expect(screen.getByTestId('select-mode-button')).toBeInTheDocument();
@@ -405,6 +413,88 @@ describe('split-panel layout', () => {
         // List panel must still be in the DOM
         expect(screen.getByTestId('pr-list-panel')).toBeInTheDocument();
         expect(screen.getByTestId('pr-list')).toBeInTheDocument();
+    });
+});
+
+// ── Queue collapse toggle ─────────────────────────────────────────────────────
+
+describe('queue collapse toggle', () => {
+    beforeEach(() => {
+        try { localStorage.removeItem('pr-queue-collapsed'); } catch { /* ignore */ }
+    });
+
+    it('starts expanded by default', async () => {
+        mockFetchOk([]);
+        await act(async () => { await renderTab(); });
+        const header = screen.getByTestId('pr-queue-header');
+        expect(header.getAttribute('data-collapsed')).toBe('false');
+        expect(screen.getByTestId('pr-queue-toggle').getAttribute('aria-expanded')).toBe('true');
+        expect(screen.getByTestId('pr-queue-toggle').textContent).toContain('<');
+    });
+
+    it('collapses queue when toggle is clicked, hiding toolbar and filters', async () => {
+        mockFetchOk([makePr({ id: 1, title: 'Hidden Title' })]);
+        await act(async () => { await renderTab(); });
+        await waitFor(() => expect(screen.getByTestId('pr-row')).toBeInTheDocument());
+
+        await act(async () => { fireEvent.click(screen.getByTestId('pr-queue-toggle')); });
+
+        const header = screen.getByTestId('pr-queue-header');
+        expect(header.getAttribute('data-collapsed')).toBe('true');
+        expect(screen.getByTestId('pr-queue-toggle').textContent).toContain('>');
+        expect(screen.queryByTestId('search-input')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('refresh-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('select-mode-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pr-queue-filter-all')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pr-queue-footer')).not.toBeInTheDocument();
+        expect(screen.queryByText('Hidden Title')).not.toBeInTheDocument();
+    });
+
+    it('renders compact PR rows that show only the state dot when collapsed', async () => {
+        mockFetchOk([makePr({ id: 1, title: 'Compact PR' })]);
+        await act(async () => { await renderTab(); });
+        await waitFor(() => expect(screen.getByTestId('pr-row')).toBeInTheDocument());
+
+        await act(async () => { fireEvent.click(screen.getByTestId('pr-queue-toggle')); });
+
+        const row = screen.getByTestId('pr-row');
+        expect(row.getAttribute('data-compact')).toBe('true');
+        expect(screen.getByTestId('pr-state-dot')).toBeInTheDocument();
+        expect(screen.queryByText('Compact PR')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pr-risk-pill')).not.toBeInTheDocument();
+    });
+
+    it('hides the resize handle when collapsed', async () => {
+        mockFetchOk([]);
+        await act(async () => { await renderTab(); });
+        expect(screen.getByTestId('pr-resize-handle')).toBeInTheDocument();
+
+        await act(async () => { fireEvent.click(screen.getByTestId('pr-queue-toggle')); });
+        expect(screen.queryByTestId('pr-resize-handle')).not.toBeInTheDocument();
+    });
+
+    it('persists collapsed state across remounts via localStorage', async () => {
+        mockFetchOk([]);
+        const { unmount } = await renderTab();
+        await act(async () => { fireEvent.click(screen.getByTestId('pr-queue-toggle')); });
+        expect(screen.getByTestId('pr-queue-header').getAttribute('data-collapsed')).toBe('true');
+        unmount();
+
+        await act(async () => { await renderTab(); });
+        expect(screen.getByTestId('pr-queue-header').getAttribute('data-collapsed')).toBe('true');
+    });
+
+    it('restores expanded state when toggle is clicked again', async () => {
+        mockFetchOk([makePr({ id: 1, title: 'Toggle PR' })]);
+        await act(async () => { await renderTab(); });
+        await act(async () => { fireEvent.click(screen.getByTestId('pr-queue-toggle')); });
+        expect(screen.getByTestId('pr-queue-header').getAttribute('data-collapsed')).toBe('true');
+
+        await act(async () => { fireEvent.click(screen.getByTestId('pr-queue-toggle')); });
+        expect(screen.getByTestId('pr-queue-header').getAttribute('data-collapsed')).toBe('false');
+        expect(screen.getByTestId('search-input')).toBeInTheDocument();
+        expect(screen.getByTestId('pr-queue-filter-all')).toBeInTheDocument();
+        expect(screen.getByText('Toggle PR')).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
Match the redesigned PR review command center: the queue rail now opens
with a "PR queue" title and a collapse toggle. When collapsed the rail
shrinks to a 44px gutter that shows only the per-row state dots, with
a left-edge accent on the active PR; the toolbar, filter chips, group
labels, and footer are hidden so the right pane gets more room. The
collapsed state is persisted in localStorage.

Filter chips render the count inline ("All 18") instead of a separate
monospaced span, matching the design's single-text pill format.

PullRequestRow grows a `compact` prop and PrQueueGroupSection grows a
`compact` prop for the collapsed rail. The resize handle is suppressed
while collapsed since the width is fixed.

Tests cover the new header, collapse/expand toggling, localStorage
persistence, hidden chrome, compact row rendering, and resize-handle
gating.

Co-authored-by: Cursor <cursoragent@cursor.com>
