### PR TITLE
feat(submit-pr): add --auto-merge and --merge-method flags

### DIFF
--- a/.github/skills/submit-commits-as-pr/SKILL.md
+++ b/.github/skills/submit-commits-as-pr/SKILL.md
@@ -19,6 +19,7 @@ Trigger on requests like:
 - "Submit commits `abc123..def456` as a PR."
 - "PR-ify the last 3 commits on this branch."
 - "Send these commits upstream as a draft PR."
+- "Submit this commit as a PR with auto-merge."
 
 Do **not** use this skill to author new commits — use the `impl` skill for
 that. This skill only republishes commits that already exist.
@@ -58,6 +59,8 @@ Useful options:
 | `--title <t>` / `--body <b>` | PR metadata (otherwise `gh --fill` is used) |
 | `--draft` | Open as draft |
 | `--gh-arg <arg>` | Pass an extra arg through to `gh pr create` (repeat as needed, e.g. `--gh-arg --reviewer --gh-arg alice`) |
+| `--auto-merge` | Enable auto-merge after the PR is created |
+| `--merge-method <method>` | Merge method for auto-merge: `merge` (default), `squash`, or `rebase` |
 
 Examples:
 
@@ -71,6 +74,10 @@ python .github/skills/submit-commits-as-pr/scripts/submit_commits_as_pr.py start
 # Last 3 commits, draft PR with custom title
 python .github/skills/submit-commits-as-pr/scripts/submit_commits_as_pr.py start HEAD~3..HEAD \
     --draft --title "Refactor task queue retry path"
+
+# Single commit with auto-merge enabled
+python .github/skills/submit-commits-as-pr/scripts/submit_commits_as_pr.py start abc1234 \
+    --auto-merge --merge-method merge
 ```
 
 ### Continue (after a conflict)
@@ -106,7 +113,8 @@ switches back to the original branch, and removes the state file.
 6. Rebases onto `<remote>/<base>` (usually a no-op, but guards against races). On conflict → pause as above.
 7. `git push -u <remote> <new-branch>`.
 8. `gh pr create` with the chosen options.
-9. `git checkout <original-branch>` and removes the state file.
+9. If `--auto-merge` is set, run `gh pr merge --auto --<method>` on the new PR.
+10. `git checkout <original-branch>` and removes the state file.
 
 State (remaining commits, current phase, PR metadata, branch names) is
 persisted in `.git/submit_commits_as_pr.state.json` so `--continue` picks up

--- a/.github/skills/submit-commits-as-pr/scripts/submit_commits_as_pr.py
+++ b/.github/skills/submit-commits-as-pr/scripts/submit_commits_as_pr.py
@@ -111,9 +111,11 @@ class State:
     title: str | None = None
     body: str | None = None
     draft: bool = False
+    auto_merge: bool = False
+    merge_method: str = "merge"  # merge | squash | rebase
     pushed: bool = False
     pr_url: str | None = None
-    phase: str = "cherry-pick"  # cherry-pick | rebase | push | pr | done
+    phase: str = "cherry-pick"  # cherry-pick | rebase | push | pr | auto-merge | done
     extra_gh_args: list[str] = field(default_factory=list)
 
     def save(self) -> None:
@@ -326,6 +328,21 @@ def do_pr(state: State) -> None:
 
     url = (result.stdout or "").strip().splitlines()[-1] if result.stdout else None
     state.pr_url = url
+    state.phase = "auto-merge" if state.auto_merge else "done"
+    state.save()
+
+
+def do_auto_merge(state: State) -> None:
+    if not shutil.which("gh"):
+        log("warning: gh not found, skipping auto-merge")
+        state.phase = "done"
+        state.save()
+        return
+
+    cmd = ["gh", "pr", "merge", state.pr_url, "--auto", f"--{state.merge_method}"]
+    result = run(cmd, check=False, capture=True)
+    if result.returncode != 0:
+        log(f"warning: auto-merge failed: {result.stderr.strip()}")
     state.phase = "done"
     state.save()
 
@@ -378,6 +395,8 @@ def cmd_start(args: argparse.Namespace) -> None:
         title=args.title,
         body=args.body,
         draft=args.draft,
+        auto_merge=args.auto_merge,
+        merge_method=args.merge_method,
         extra_gh_args=list(args.gh_arg or []),
     )
     state.save()
@@ -428,6 +447,9 @@ def drive(state: State, *, resume: bool) -> None:
         elif phase == "pr":
             do_pr(state)
             phase = state.phase
+        elif phase == "auto-merge":
+            do_auto_merge(state)
+            phase = state.phase
         elif phase == "done":
             finalize(state)
             return
@@ -463,6 +485,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--gh-arg",
         action="append",
         help="Extra args passed verbatim to `gh pr create` (repeatable)",
+    )
+    start.add_argument(
+        "--auto-merge",
+        action="store_true",
+        help="Enable auto-merge on the PR after creation (requires branch protection rules)",
+    )
+    start.add_argument(
+        "--merge-method",
+        default="merge",
+        choices=["merge", "squash", "rebase"],
+        help="Merge method for auto-merge (default: merge)",
     )
     start.set_defaults(func=cmd_start)
 


### PR DESCRIPTION
Adds native auto-merge support to the submit-commits-as-pr script so
callers no longer need a manual gh pr merge step after PR creation.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
