### PR TITLE
feat(notes): redesign notes sidebar with search, meta pills, and richer tree styling

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NotesSidebar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NotesSidebar.tsx
@@ -1,13 +1,12 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import type { NoteTreeNode } from '../notesApi';
 import type { ContextMenuItem } from '../../../tasks/comments/ContextMenu';
 import { ContextMenu } from '../../../tasks/comments/ContextMenu';
-import { Button } from '../../../ui/Button';
 import { Spinner } from '../../../ui/Spinner';
 import { NotesTree } from './NotesTree';
 import { NotesDialogs } from './NotesDialogs';
 import { useNotesTree } from './useNotesTree';
-import { useNotesContextMenu, type NoteDialogAction } from './useNotesContextMenu';
+import { useNotesContextMenu } from './useNotesContextMenu';
 import { useNotesDragDrop, getNotesParentPath, type NoteDragItem, type DropPosition } from '../hooks/useNotesDragDrop';
 import { useNoteSeenState } from '../hooks/useNoteSeenState';
 import { getSpaCocClient } from '../../../api/cocClient';
@@ -24,6 +23,82 @@ function getAncestorPaths(notePath: string): string[] {
         ancestors.push(segments.slice(0, i).join('/'));
     }
     return ancestors;
+}
+
+/** Recursively count `page` nodes inside the subtree (excluding the root node itself). */
+function countDescendantPages(node: NoteTreeNode): number {
+    if (!node.children || node.children.length === 0) return 0;
+    let total = 0;
+    for (const child of node.children) {
+        if (child.type === 'page') total += 1;
+        else total += countDescendantPages(child);
+    }
+    return total;
+}
+
+/** Sum of pages across the entire top-level tree. */
+function countTotalPages(tree: NoteTreeNode[]): number {
+    let total = 0;
+    const walk = (nodes: NoteTreeNode[]) => {
+        for (const n of nodes) {
+            if (n.type === 'page') total += 1;
+            else if (n.children) walk(n.children);
+        }
+    };
+    walk(tree);
+    return total;
+}
+
+/** Count of page nodes that the seen-state hook marks as updated. */
+function countUpdatedPages(tree: NoteTreeNode[], isUpdated: (node: NoteTreeNode) => boolean): number {
+    let total = 0;
+    const walk = (nodes: NoteTreeNode[]) => {
+        for (const n of nodes) {
+            if (n.type === 'page') {
+                if (isUpdated(n)) total += 1;
+            } else if (n.children) walk(n.children);
+        }
+    };
+    walk(tree);
+    return total;
+}
+
+interface VisibilityFilter {
+    visible: Set<string>;
+    expand: Set<string>;
+}
+
+/**
+ * Build a search-driven visibility filter. A node is visible if its name
+ * matches the query or any descendant matches. Ancestors of any match are
+ * expanded so the user can actually see the hits.
+ */
+function buildVisibilityFilter(tree: NoteTreeNode[], query: string): VisibilityFilter | null {
+    const q = query.trim().toLowerCase();
+    if (!q) return null;
+
+    const visible = new Set<string>();
+    const expand = new Set<string>();
+
+    const walk = (nodes: NoteTreeNode[], ancestors: string[]): boolean => {
+        let anyMatch = false;
+        for (const n of nodes) {
+            const nameMatch = n.name.toLowerCase().includes(q);
+            const childMatch = n.children ? walk(n.children, [...ancestors, n.path]) : false;
+            if (nameMatch || childMatch) {
+                visible.add(n.path);
+                if (childMatch) expand.add(n.path);
+                for (const a of ancestors) {
+                    visible.add(a);
+                    expand.add(a);
+                }
+                anyMatch = true;
+            }
+        }
+        return anyMatch;
+    };
+    walk(tree, []);
+    return { visible, expand };
 }
 
 export interface NotesSidebarProps {
@@ -48,6 +123,8 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
     const { isNoteUpdated, markAsSeen, syncSeenState } = useNoteSeenState(workspaceId);
     const { ctxMenu, dialog, openContextMenu, closeContextMenu, openDialog, closeDialog, setSubmitting } = useNotesContextMenu();
     const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+    const [searchQuery, setSearchQuery] = useState('');
+    const [gitInitialized, setGitInitialized] = useState(false);
     const deepLinkAppliedRef = useRef<string | null>(null);
     const dragDrop = useNotesDragDrop();
     const [addDropdownOpen, setAddDropdownOpen] = useState(false);
@@ -112,6 +189,28 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
         };
         return () => { (markSeenRef as React.MutableRefObject<(() => void) | null>).current = null; };
     }, [markSeenRef, selectedPath, markAsSeen]);
+
+    // One-shot fetch of notes git status for the "tracked" meta pill.
+    // Refreshed when the server emits `notes-changed` for this workspace.
+    useEffect(() => {
+        let cancelled = false;
+        const fetchStatus = () => {
+            notesApi.getGitStatus(workspaceId)
+                .then(s => { if (!cancelled) setGitInitialized(Boolean(s?.initialized)); })
+                .catch(() => { /* silently ignore — pill simply stays hidden */ });
+        };
+        fetchStatus();
+        const handler = (e: Event) => {
+            const detail = (e as CustomEvent).detail as { wsId?: string } | undefined;
+            if (detail?.wsId !== workspaceId) return;
+            fetchStatus();
+        };
+        window.addEventListener('notes-changed', handler);
+        return () => {
+            cancelled = true;
+            window.removeEventListener('notes-changed', handler);
+        };
+    }, [workspaceId]);
 
     // Scroll the selected tree item into view after tree renders
     useEffect(() => {
@@ -384,79 +483,173 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
         ];
     };
 
+    // ── Derived values for the redesigned header / meta row ────────────────
+
+    const totalPages = useMemo(() => (tree ? countTotalPages(tree) : 0), [tree]);
+    const updatedCount = useMemo(
+        () => (tree ? countUpdatedPages(tree, isNoteUpdated) : 0),
+        [tree, isNoteUpdated],
+    );
+
+    const filter = useMemo(
+        () => (tree ? buildVisibilityFilter(tree, searchQuery) : null),
+        [tree, searchQuery],
+    );
+
+    /** Combined expansion set: user-controlled plus search-driven expansion. */
+    const effectiveExpanded = useMemo(() => {
+        if (!filter) return expandedPaths;
+        const combined = new Set(expandedPaths);
+        for (const p of filter.expand) combined.add(p);
+        return combined;
+    }, [filter, expandedPaths]);
+
     return (
-        <div className="flex flex-col h-full" data-testid="notes-sidebar">
-            {/* Toolbar */}
-            <div className="h-10 flex items-center gap-1 px-3 border-b border-[#e0e0e0] dark:border-[#3c3c3c]">
-                <Button
-                    variant="ghost"
-                    size="sm"
+        <div className="flex flex-col h-full bg-[#f6f8fa] dark:bg-[#252526]" data-testid="notes-sidebar">
+            {/* Panel header — back / title / refresh / primary "New" button */}
+            <div className="flex items-center min-h-[36px] px-2 py-1 gap-1.5 border-b border-[#d0d7de] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e]">
+                <button
+                    type="button"
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-transparent text-[#1f2328] dark:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2d2e] disabled:opacity-40 disabled:cursor-not-allowed"
                     onClick={onGoBack}
                     disabled={!canGoBack}
+                    aria-label="Previous note"
+                    title="Previous note"
                     data-testid="notes-back-btn"
-                    aria-label="Go to previous note"
-                    title="Go to previous note"
-                    className={!canGoBack ? 'opacity-40 cursor-not-allowed' : ''}
                 >
-                    ←
-                </Button>
-                <span className="text-xs font-semibold text-[#1e1e1e] dark:text-[#cccccc] flex-1">Notes</span>
-                <Button
-                    variant="ghost"
-                    size="sm"
+                    <svg className="w-4 h-4" viewBox="0 0 16 16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M10 12L6 8l4-4" />
+                    </svg>
+                </button>
+                <span className="flex-1 min-w-0 text-[13px] font-semibold text-[#1f2328] dark:text-[#cccccc] truncate">
+                    Notes
+                </span>
+                <button
+                    type="button"
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-transparent text-[#1f2328] dark:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2d2e] disabled:opacity-40 disabled:cursor-not-allowed"
                     onClick={refresh}
                     disabled={loading}
-                    data-testid="refresh-notes-btn"
                     aria-label="Refresh Notes"
                     title="Refresh Notes"
+                    data-testid="refresh-notes-btn"
                 >
-                    ↻
-                </Button>
+                    <svg className="w-4 h-4" viewBox="0 0 16 16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M13 8a5 5 0 1 1-1.46-3.54" />
+                        <path d="M13 3.5V7h-3.5" />
+                    </svg>
+                </button>
                 <div className="relative" ref={addDropdownRef}>
-                    <Button
-                        variant="ghost"
-                        size="sm"
+                    <button
+                        type="button"
+                        className="inline-flex items-center justify-center gap-1.5 min-h-[28px] px-2.5 rounded-md border border-black/15 bg-[#1f883d] text-white text-[13px] font-semibold leading-none shadow-[0_1px_0_rgba(31,35,40,0.1)] hover:bg-[#1a7f37] disabled:opacity-50 disabled:cursor-not-allowed"
                         onClick={() => setAddDropdownOpen(prev => !prev)}
                         data-testid="add-note-btn"
-                        aria-label="Add"
-                        title="Add"
+                        aria-label="New"
+                        aria-haspopup="menu"
+                        aria-expanded={addDropdownOpen}
+                        title="New"
                     >
-                        + ▾
-                    </Button>
+                        <svg className="w-4 h-4" viewBox="0 0 16 16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M3 8h10M8 3v10" />
+                        </svg>
+                        <span>New</span>
+                    </button>
                     {addDropdownOpen && (
                         <div
-                            className="absolute right-0 top-full mt-1 z-30 min-w-[180px] bg-white dark:bg-[#252526] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded shadow-lg py-1"
+                            className="absolute right-0 top-full mt-1 z-30 min-w-[200px] bg-white dark:bg-[#252526] border border-[#d0d7de] dark:border-[#3c3c3c] rounded-md shadow-[0_8px_24px_rgba(140,149,159,0.2)] py-1"
                             data-testid="add-note-dropdown"
+                            role="menu"
                         >
                             <button
-                                className="w-full text-left px-3 py-1.5 text-xs text-[#1e1e1e] dark:text-[#cccccc] hover:bg-[#e8e8e8] dark:hover:bg-[#2a2d2e]"
+                                className="w-full text-left px-3 py-1.5 text-xs text-[#1f2328] dark:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2d2e]"
                                 onClick={handleNewNotebook}
                                 data-testid="add-note-new-notebook"
+                                role="menuitem"
                             >
                                 📓 New Notebook
                             </button>
                             <button
                                 className={`w-full text-left px-3 py-1.5 text-xs ${
                                     findCurrentNotebook()
-                                        ? 'text-[#1e1e1e] dark:text-[#cccccc] hover:bg-[#e8e8e8] dark:hover:bg-[#2a2d2e]'
-                                        : 'text-[#999] dark:text-[#555] cursor-not-allowed'
+                                        ? 'text-[#1f2328] dark:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2d2e]'
+                                        : 'text-[#8c959f] dark:text-[#555] cursor-not-allowed'
                                 }`}
                                 onClick={handleNewPage}
                                 disabled={!findCurrentNotebook()}
                                 data-testid="add-note-new-page"
+                                role="menuitem"
                             >
                                 📄 New Page
                             </button>
                             <button
-                                className="w-full text-left px-3 py-1.5 text-xs text-[#1e1e1e] dark:text-[#cccccc] hover:bg-[#e8e8e8] dark:hover:bg-[#2a2d2e]"
+                                className="w-full text-left px-3 py-1.5 text-xs text-[#1f2328] dark:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2d2e]"
                                 onClick={handleNewPageWithAI}
                                 data-testid="add-note-ai-create"
+                                role="menuitem"
                             >
                                 🤖 New Page with AI…
                             </button>
                         </div>
                     )}
                 </div>
+            </div>
+
+            {/* Search */}
+            <div className="px-2 py-1.5 border-b border-[#d8dee4] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e]">
+                <div className="relative flex items-center">
+                    <svg
+                        className="pointer-events-none absolute left-2 w-3.5 h-3.5 text-[#656d76] dark:text-[#9d9d9d]"
+                        viewBox="0 0 16 16"
+                        aria-hidden="true"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <circle cx="7" cy="7" r="4.25" />
+                        <path d="M10.3 10.3L13 13" />
+                    </svg>
+                    <input
+                        type="search"
+                        placeholder="Search notes"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className="w-full h-7 pl-7 pr-2 rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e] text-[13px] text-[#1f2328] dark:text-[#cccccc] outline-none focus:border-[#0969da] dark:focus:border-[#3794ff] focus:shadow-[0_0_0_3px_rgba(9,105,218,0.18)]"
+                        aria-label="Search notes"
+                        data-testid="notes-search-input"
+                    />
+                </div>
+            </div>
+
+            {/* Meta row — counts + tracked status */}
+            <div
+                className="flex items-center gap-1 px-2 py-1.5 border-b border-[#eaeef2] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#252526]"
+                data-testid="notes-tree-meta"
+            >
+                {updatedCount > 0 && (
+                    <span
+                        className="inline-flex items-center gap-1 min-h-[18px] px-1.5 rounded-full border border-[#b6e3ff] dark:border-[#3a567e] bg-[#ddf4ff] dark:bg-[#0a3b66]/40 text-[#0969da] dark:text-[#79c0ff] text-[12px] whitespace-nowrap"
+                        data-testid="notes-updated-pill"
+                    >
+                        {updatedCount} updated
+                    </span>
+                )}
+                <span
+                    className="inline-flex items-center gap-1 min-h-[18px] px-1.5 rounded-full border border-[#d8dee4] dark:border-[#3c3c3c] bg-white dark:bg-transparent text-[#656d76] dark:text-[#9d9d9d] text-[12px] whitespace-nowrap"
+                    data-testid="notes-pages-pill"
+                >
+                    {totalPages} {totalPages === 1 ? 'page' : 'pages'}
+                </span>
+                {gitInitialized && (
+                    <span
+                        className="inline-flex items-center gap-1 min-h-[18px] px-1.5 rounded-full border border-[#aceebb] dark:border-[#2ea043]/40 bg-[#dafbe1] dark:bg-[#0f5132]/30 text-[#1a7f37] dark:text-[#56d364] text-[12px] whitespace-nowrap"
+                        data-testid="notes-tracked-pill"
+                        title="Notes are tracked by git"
+                    >
+                        tracked
+                    </span>
+                )}
             </div>
 
             {/* Tree area */}
@@ -474,7 +667,7 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
                 )}
 
                 {!loading && !error && tree && tree.length === 0 && (
-                    <div className="py-6 px-4 text-center text-xs text-[#848484] dark:text-[#666] italic" data-testid="notes-empty">
+                    <div className="py-6 px-4 text-center text-xs text-[#656d76] dark:text-[#666] italic" data-testid="notes-empty">
                         No notebooks yet
                     </div>
                 )}
@@ -483,12 +676,14 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
                     <NotesTree
                         nodes={tree}
                         selectedPath={selectedPath}
-                        expandedPaths={expandedPaths}
+                        expandedPaths={effectiveExpanded}
                         systemFolders={systemFolders}
                         onToggleExpand={handleToggleExpand}
                         onSelectPage={onSelectPage}
                         onContextMenu={handleContextMenu}
                         isNoteUpdated={isNoteUpdated}
+                        visiblePaths={filter?.visible ?? null}
+                        countDescendantPages={countDescendantPages}
                         dragDrop={{
                             createDragStartHandler: dragDrop.createDragStartHandler,
                             createDragEndHandler: dragDrop.createDragEndHandler,
@@ -501,6 +696,12 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
                             onDrop: handleNoteDrop,
                         }}
                     />
+                )}
+
+                {!loading && !error && tree && tree.length > 0 && filter && filter.visible.size === 0 && (
+                    <div className="py-6 px-4 text-center text-xs text-[#656d76] dark:text-[#9d9d9d] italic" data-testid="notes-search-empty">
+                        No notes match “{searchQuery.trim()}”
+                    </div>
                 )}
             </div>
 

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NotesTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NotesTree.tsx
@@ -27,6 +27,13 @@ export interface NotesTreeProps {
     onSelectPage: (path: string) => void;
     onContextMenu: (node: NoteTreeNode, x: number, y: number) => void;
     isNoteUpdated?: (node: NoteTreeNode) => boolean;
+    /**
+     * When non-null, only nodes whose path is in this set are rendered.
+     * Used by the sidebar search filter; `null` means "no filter".
+     */
+    visiblePaths?: Set<string> | null;
+    /** Helper used to compute the recursive page count badge for folder rows. */
+    countDescendantPages?: (node: NoteTreeNode) => number;
     dragDrop?: NotesDragDropHandlers;
 }
 
@@ -46,11 +53,15 @@ export function NotesTree({
     onSelectPage,
     onContextMenu,
     isNoteUpdated,
+    visiblePaths,
+    countDescendantPages,
     dragDrop,
 }: NotesTreeProps) {
     return (
         <div role="tree" data-testid={depth === 0 ? 'notes-tree' : undefined}>
             {nodes.map(node => {
+                if (visiblePaths && !visiblePaths.has(node.path)) return null;
+
                 const isFolder = node.type === 'notebook' || node.type === 'section';
                 const isExpanded = expandedPaths.has(node.path);
                 const isSysFolder = !!(systemFolders && systemFolders.includes(node.name) && node.type === 'notebook' && depth === 0);
@@ -60,6 +71,7 @@ export function NotesTree({
                     : undefined;
 
                 const isDragOver = dragDrop ? dragDrop.dropTargetPath === node.path : false;
+                const folderCount = isFolder && countDescendantPages ? countDescendantPages(node) : undefined;
 
                 return (
                     <div key={node.path}>
@@ -70,6 +82,7 @@ export function NotesTree({
                             depth={depth}
                             isSystemFolder={isSysFolder}
                             hasUpdate={hasNodeUpdate(node, isNoteUpdated)}
+                            pageCount={folderCount}
                             onToggleExpand={onToggleExpand}
                             onSelectPage={onSelectPage}
                             onContextMenu={onContextMenu}
@@ -96,6 +109,8 @@ export function NotesTree({
                                 onSelectPage={onSelectPage}
                                 onContextMenu={onContextMenu}
                                 isNoteUpdated={isNoteUpdated}
+                                visiblePaths={visiblePaths}
+                                countDescendantPages={countDescendantPages}
                                 dragDrop={dragDrop}
                             />
                         )}

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NotesTreeItem.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NotesTreeItem.tsx
@@ -9,6 +9,8 @@ export interface NotesTreeItemProps {
     depth: number;
     isSystemFolder?: boolean;
     hasUpdate?: boolean;
+    /** Recursive page count rendered as a muted badge on folder rows. */
+    pageCount?: number;
     onToggleExpand: (path: string) => void;
     onSelectPage: (path: string) => void;
     onContextMenu: (node: NoteTreeNode, x: number, y: number) => void;
@@ -24,12 +26,6 @@ export interface NotesTreeItemProps {
     onDrop?: (e: React.DragEvent) => void;
 }
 
-const ICON_MAP: Record<NoteTreeNode['type'], string> = {
-    notebook: '📓',
-    section: '📁',
-    page: '📄',
-};
-
 const isFolder = (type: NoteTreeNode['type']): boolean => type === 'notebook' || type === 'section';
 
 export function NotesTreeItem({
@@ -39,6 +35,7 @@ export function NotesTreeItem({
     depth,
     isSystemFolder,
     hasUpdate,
+    pageCount,
     onToggleExpand,
     onSelectPage,
     onContextMenu,
@@ -83,24 +80,30 @@ export function NotesTreeItem({
     const showBeforeIndicator = isDragOver && dropPosition === 'before';
     const showAfterIndicator = isDragOver && dropPosition === 'after';
 
+    // Indent base: 10px so the first column lines up with the search/meta padding.
+    const paddingLeft = 10 + depth * 16;
+
     return (
         <div className="relative">
             {/* Drop indicator line — before */}
             {showBeforeIndicator && (
                 <div
-                    className="absolute left-0 right-0 top-0 h-0.5 bg-[#007acc] z-10 pointer-events-none"
+                    className="absolute left-0 right-0 top-0 h-0.5 bg-[#0969da] z-10 pointer-events-none"
                     data-testid="drop-indicator-before"
                 />
             )}
             <div
                 className={cn(
-                    'flex items-center gap-2 px-2 py-1.5 cursor-pointer text-xs transition-colors',
-                    'hover:bg-black/[0.04] dark:hover:bg-white/[0.04]',
-                    selected && 'bg-[#0078d4]/10 dark:bg-[#3794ff]/10',
-                    showInsideFolderHighlight && 'ring-1 ring-inset ring-[#007acc] bg-[#007acc]/10',
+                    'relative grid items-center gap-1.5 pr-2 py-[3px] min-h-[26px] cursor-pointer text-[13px] transition-colors',
+                    'grid-cols-[14px_minmax(0,1fr)_auto]',
+                    'hover:bg-[#d0d7de]/[0.34] dark:hover:bg-white/[0.06]',
+                    selected && 'bg-[#ddf4ff] dark:bg-[#0078d4]/20 text-[#1f2328] dark:text-[#cccccc]',
+                    selected && 'shadow-[inset_3px_0_0_#0969da] dark:shadow-[inset_3px_0_0_#3794ff]',
+                    showInsideFolderHighlight && 'ring-1 ring-inset ring-[#0969da] bg-[#0969da]/10',
+                    folder && 'font-semibold',
                     draggable && 'select-none',
                 )}
-                style={{ paddingLeft: depth * 16 }}
+                style={{ paddingLeft }}
                 data-testid={`notes-tree-item-${node.name}`}
                 data-node-path={node.path}
                 onClick={handleClick}
@@ -117,43 +120,63 @@ export function NotesTreeItem({
                 onDragLeave={onDragLeave}
                 onDrop={onDrop}
             >
-                {/* Chevron */}
+                {/* Chevron column — folders show ▾/▸, pages get a blank spacer */}
                 {folder ? (
-                    <span className="flex-shrink-0 text-xs text-[#848484] w-3.5 inline-block" data-testid="chevron">
+                    <span
+                        className="flex-shrink-0 text-[11px] leading-none text-[#656d76] dark:text-[#9d9d9d] inline-flex justify-center"
+                        data-testid="chevron"
+                        aria-hidden="true"
+                    >
                         {isExpanded ? '▾' : '▸'}
                     </span>
                 ) : (
-                    <span className="flex-shrink-0 w-3 inline-block" />
+                    <span className="flex-shrink-0 inline-block" aria-hidden="true" />
                 )}
-                {/* Icon */}
-                <span className="flex-shrink-0 text-[11px]" data-testid="node-icon">{ICON_MAP[node.type]}</span>
                 {/* Name */}
-                <span className={cn('flex-1 truncate text-[#1e1e1e] dark:text-[#cccccc]', isSystemFolder && 'italic opacity-80')}>{displayName}</span>
-                {hasUpdate && (
-                    <span
-                        className="flex-shrink-0 h-2 w-2 rounded-full bg-[#0078d4] dark:bg-[#3794ff]"
-                        data-testid="note-update-indicator"
-                        title="Updated since last viewed"
-                        aria-label="Updated since last viewed"
-                    />
-                )}
-                {/* System folder lock badge */}
-                {isSystemFolder && (
-                    <span
-                        className="flex-shrink-0 ml-1 text-[#848484] dark:text-[#666] opacity-60"
-                        title="System folder — cannot be renamed or deleted"
-                        aria-label="System folder"
-                    >
-                        <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 inline-block">
-                            <path d="M10 7V5a2 2 0 0 0-4 0v2H4.5A1.5 1.5 0 0 0 3 8.5v4A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5v-4A1.5 1.5 0 0 0 11.5 7H10zM7 5a1 1 0 1 1 2 0v2H7V5zm1 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2z" />
-                        </svg>
-                    </span>
-                )}
+                <span
+                    className={cn(
+                        'truncate text-[#1f2328] dark:text-[#cccccc]',
+                        isSystemFolder && 'italic opacity-80',
+                    )}
+                >
+                    {displayName}
+                </span>
+                {/* Trailing badge column: folder page-count, page update-dot, or system lock */}
+                <span className="flex items-center justify-end gap-1 flex-shrink-0">
+                    {folder && typeof pageCount === 'number' && pageCount > 0 && (
+                        <span
+                            className="text-[12px] tabular-nums text-[#656d76] dark:text-[#9d9d9d] font-mono"
+                            data-testid="folder-page-count"
+                            aria-label={`${pageCount} pages`}
+                        >
+                            {pageCount}
+                        </span>
+                    )}
+                    {hasUpdate && (
+                        <span
+                            className="h-2 w-2 rounded-full bg-[#0969da] dark:bg-[#3794ff]"
+                            data-testid="note-update-indicator"
+                            title="Updated since last viewed"
+                            aria-label="Updated since last viewed"
+                        />
+                    )}
+                    {isSystemFolder && (
+                        <span
+                            className="text-[#656d76] dark:text-[#9d9d9d] opacity-60"
+                            title="System folder — cannot be renamed or deleted"
+                            aria-label="System folder"
+                        >
+                            <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 inline-block">
+                                <path d="M10 7V5a2 2 0 0 0-4 0v2H4.5A1.5 1.5 0 0 0 3 8.5v4A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5v-4A1.5 1.5 0 0 0 11.5 7H10zM7 5a1 1 0 1 1 2 0v2H7V5zm1 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2z" />
+                            </svg>
+                        </span>
+                    )}
+                </span>
             </div>
             {/* Drop indicator line — after */}
             {showAfterIndicator && (
                 <div
-                    className="absolute left-0 right-0 bottom-0 h-0.5 bg-[#007acc] z-10 pointer-events-none"
+                    className="absolute left-0 right-0 bottom-0 h-0.5 bg-[#0969da] z-10 pointer-events-none"
                     data-testid="drop-indicator-after"
                 />
             )}

--- a/packages/coc/test/spa/react/notes-sidebar.test.tsx
+++ b/packages/coc/test/spa/react/notes-sidebar.test.tsx
@@ -26,6 +26,7 @@ const mockCreateNode = vi.fn();
 const mockRenameNode = vi.fn();
 const mockDeleteNode = vi.fn();
 const mockCreateWithAI = vi.fn();
+const mockGetGitStatus = vi.fn().mockResolvedValue({ initialized: false });
 const mockClipboardWriteText = vi.fn();
 
 vi.mock('../../../src/server/spa/client/react/features/notes/notesApi', () => ({
@@ -35,6 +36,7 @@ vi.mock('../../../src/server/spa/client/react/features/notes/notesApi', () => ({
         renameNode: (...args: any[]) => mockRenameNode(...args),
         deleteNode: (...args: any[]) => mockDeleteNode(...args),
         createWithAI: (...args: any[]) => mockCreateWithAI(...args),
+        getGitStatus: (...args: any[]) => mockGetGitStatus(...args),
     },
 }));
 
@@ -85,6 +87,7 @@ describe('NotesSidebar', () => {
         mockCreateNode.mockResolvedValue({ path: 'new', type: 'page' });
         mockRenameNode.mockResolvedValue({ oldPath: 'x', newPath: 'y' });
         mockDeleteNode.mockResolvedValue(undefined);
+        mockGetGitStatus.mockResolvedValue({ initialized: false });
     });
 
     afterEach(() => {
@@ -109,22 +112,23 @@ describe('NotesSidebar', () => {
         expect(empty.className).toContain('italic');
     });
 
-    it('renders notebooks, sections, and pages with correct icons', async () => {
+    it('renders notebooks, sections, and pages with folder chevrons', async () => {
         const { findByTestId } = renderSidebar();
         const nb1 = await findByTestId('notes-tree-item-Notebook1');
         expect(nb1).toBeTruthy();
+
+        // Folders show a chevron; pages do not
+        expect(nb1.querySelector('[data-testid="chevron"]')).toBeTruthy();
 
         // Expand notebook to see children
         fireEvent.click(nb1);
 
         const section = await findByTestId('notes-tree-item-Section1');
         expect(section).toBeTruthy();
+        expect(section.querySelector('[data-testid="chevron"]')).toBeTruthy();
 
-        // Check icon texts — notebook has 📓, section has 📁, page has 📄
-        const allIcons = document.querySelectorAll('[data-testid="node-icon"]');
-        const iconTexts = Array.from(allIcons).map(el => el.textContent);
-        expect(iconTexts).toContain('📓');
-        expect(iconTexts).toContain('📁');
+        const page = await findByTestId('notes-tree-item-TopPage');
+        expect(page.querySelector('[data-testid="chevron"]')).toBeNull();
     });
 
     it('expands and collapses folders on click', async () => {
@@ -160,19 +164,19 @@ describe('NotesSidebar', () => {
     it('indents nested items by depth', async () => {
         const { findByTestId } = renderSidebar();
 
-        // Depth 0 — notebook
+        // Depth 0 — notebook (base 10px indent + depth * 16px)
         const nb1 = await findByTestId('notes-tree-item-Notebook1');
-        expect(nb1.style.paddingLeft).toBe('0px');
+        expect(nb1.style.paddingLeft).toBe('10px');
 
         // Expand to depth 1
         fireEvent.click(nb1);
         const section = await findByTestId('notes-tree-item-Section1');
-        expect(section.style.paddingLeft).toBe('16px');
+        expect(section.style.paddingLeft).toBe('26px');
 
         // Expand section to depth 2
         fireEvent.click(section);
         const page = await findByTestId('notes-tree-item-Page1');
-        expect(page.style.paddingLeft).toBe('32px');
+        expect(page.style.paddingLeft).toBe('42px');
     });
 
     it('shows context menu on right-click', async () => {
@@ -878,5 +882,123 @@ describe('NotesSidebar', () => {
 
         // Verify no call with wrong prefix (queue- hyphen)
         expect(processIds.includes('queue-abc-123')).toBe(false);
+    });
+
+    // ── Redesigned header / meta / search ─────────────────────────────────
+
+    it('renders the redesigned panel header with Notes title and "New" button', async () => {
+        const { findByTestId } = renderSidebar();
+        await findByTestId('notes-tree');
+
+        const sidebar = await findByTestId('notes-sidebar');
+        expect(sidebar.textContent).toContain('Notes');
+
+        const newBtn = await findByTestId('add-note-btn');
+        expect(newBtn.textContent).toContain('New');
+    });
+
+    it('renders the pages count pill reflecting total pages in the tree', async () => {
+        const { findByTestId } = renderSidebar();
+        // SAMPLE_TREE has 2 pages: TopPage and Section1/Page1
+        const pill = await findByTestId('notes-pages-pill');
+        expect(pill.textContent).toBe('2 pages');
+    });
+
+    it('shows the updated pill only when at least one page is unseen', async () => {
+        window.localStorage.setItem('coc-notes-seen-ws1', JSON.stringify({
+            'Notebook1/TopPage': '2024-01-01T00:00:00.000Z',
+        }));
+        mockGetTree.mockResolvedValue({
+            tree: [
+                {
+                    ...SAMPLE_TREE[0],
+                    children: [
+                        SAMPLE_TREE[0].children![0],
+                        {
+                            ...SAMPLE_TREE[0].children![1],
+                            lastModifiedAt: '2024-01-02T00:00:00.000Z',
+                        },
+                    ],
+                },
+                SAMPLE_TREE[1],
+            ],
+            notesRoot: '/mock/notes',
+        });
+
+        const { findByTestId } = renderSidebar();
+        const pill = await findByTestId('notes-updated-pill');
+        expect(pill.textContent).toContain('1 updated');
+    });
+
+    it('hides the updated pill when nothing is new', async () => {
+        const { findByTestId, queryByTestId } = renderSidebar();
+        await findByTestId('notes-tree');
+        expect(queryByTestId('notes-updated-pill')).toBeNull();
+    });
+
+    it('shows the tracked pill when notes git reports initialized', async () => {
+        mockGetGitStatus.mockResolvedValue({ initialized: true });
+        const { findByTestId } = renderSidebar();
+        await findByTestId('notes-tree');
+
+        await waitFor(() => {
+            expect(document.querySelector('[data-testid="notes-tracked-pill"]')).toBeTruthy();
+        });
+    });
+
+    it('omits the tracked pill when notes git is not initialized', async () => {
+        const { findByTestId, queryByTestId } = renderSidebar();
+        await findByTestId('notes-tree');
+        // Allow the getGitStatus promise to resolve
+        await waitFor(() => {
+            expect(mockGetGitStatus).toHaveBeenCalled();
+        });
+        expect(queryByTestId('notes-tracked-pill')).toBeNull();
+    });
+
+    it('renders a search input that filters tree rows by name', async () => {
+        const { findByTestId, queryByTestId } = renderSidebar();
+        await findByTestId('notes-tree');
+
+        const input = await findByTestId('notes-search-input') as HTMLInputElement;
+        expect(input).toBeTruthy();
+
+        // Type a query that matches only TopPage — Section1/Page1 should disappear
+        fireEvent.change(input, { target: { value: 'TopPage' } });
+
+        await waitFor(() => {
+            expect(queryByTestId('notes-tree-item-TopPage')).toBeTruthy();
+            expect(queryByTestId('notes-tree-item-Page1')).toBeNull();
+        });
+    });
+
+    it('renders an empty-state message when no notes match the search query', async () => {
+        const { findByTestId } = renderSidebar();
+        await findByTestId('notes-tree');
+
+        const input = await findByTestId('notes-search-input') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'no-such-page' } });
+
+        await waitFor(() => {
+            const empty = document.querySelector('[data-testid="notes-search-empty"]');
+            expect(empty).toBeTruthy();
+            expect(empty!.textContent).toContain('no-such-page');
+        });
+    });
+
+    it('renders a recursive page-count badge on folder rows', async () => {
+        const { findByTestId } = renderSidebar();
+        const nb1 = await findByTestId('notes-tree-item-Notebook1');
+
+        // Notebook1 contains 2 descendant pages (Section1/Page1 and TopPage)
+        const badge = nb1.querySelector('[data-testid="folder-page-count"]');
+        expect(badge).toBeTruthy();
+        expect(badge!.textContent).toBe('2');
+    });
+
+    it('does not render a page-count badge on empty folders', async () => {
+        const { findByTestId } = renderSidebar();
+        const nb2 = await findByTestId('notes-tree-item-Notebook2');
+        expect(nb2.querySelector('[data-testid="folder-page-count"]')).toBeNull();
     });
 });

--- a/packages/coc/test/spa/react/notes-tree-item-drag.test.tsx
+++ b/packages/coc/test/spa/react/notes-tree-item-drag.test.tsx
@@ -138,7 +138,7 @@ describe('NotesTreeItem — drag and drop props', () => {
             />,
         );
         const el = getByTestId('notes-tree-item-NB');
-        expect(el.className).toContain('ring-[#007acc]');
+        expect(el.className).toContain('ring-[#0969da]');
     });
 
     it('does not render drop indicators when isDragOver is false', () => {

--- a/packages/coc/test/spa/react/notes-tree-item.test.tsx
+++ b/packages/coc/test/spa/react/notes-tree-item.test.tsx
@@ -17,28 +17,45 @@ function makeNode(overrides: Partial<NoteTreeNode> = {}): NoteTreeNode {
 }
 
 describe('NotesTreeItem', () => {
-    it('renders notebook icon for type notebook', () => {
+    it('renders folder rows in bold weight', () => {
         const { getByTestId } = render(
             <NotesTreeItem node={makeNode({ type: 'notebook', name: 'NB' })} selectedPath={null} isExpanded={false} depth={0}
                 onToggleExpand={vi.fn()} onSelectPage={vi.fn()} onContextMenu={vi.fn()} />,
         );
-        expect(getByTestId('node-icon').textContent).toBe('📓');
+        expect(getByTestId('notes-tree-item-NB').className).toContain('font-semibold');
     });
 
-    it('renders section icon for type section', () => {
+    it('renders a recursive page-count badge on folder rows when pageCount > 0', () => {
         const { getByTestId } = render(
-            <NotesTreeItem node={makeNode({ type: 'section', name: 'Sec' })} selectedPath={null} isExpanded={false} depth={0}
-                onToggleExpand={vi.fn()} onSelectPage={vi.fn()} onContextMenu={vi.fn()} />,
+            <NotesTreeItem
+                node={makeNode({ type: 'section', name: 'Sec' })}
+                selectedPath={null}
+                isExpanded={false}
+                depth={0}
+                pageCount={5}
+                onToggleExpand={vi.fn()}
+                onSelectPage={vi.fn()}
+                onContextMenu={vi.fn()}
+            />,
         );
-        expect(getByTestId('node-icon').textContent).toBe('📁');
+        const badge = getByTestId('folder-page-count');
+        expect(badge.textContent).toBe('5');
     });
 
-    it('renders page icon for type page', () => {
-        const { getByTestId } = render(
-            <NotesTreeItem node={makeNode({ type: 'page', name: 'Pg' })} selectedPath={null} isExpanded={false} depth={0}
-                onToggleExpand={vi.fn()} onSelectPage={vi.fn()} onContextMenu={vi.fn()} />,
+    it('does not render a page-count badge on page rows', () => {
+        const { queryByTestId } = render(
+            <NotesTreeItem
+                node={makeNode({ type: 'page', name: 'Pg' })}
+                selectedPath={null}
+                isExpanded={false}
+                depth={0}
+                pageCount={3}
+                onToggleExpand={vi.fn()}
+                onSelectPage={vi.fn()}
+                onContextMenu={vi.fn()}
+            />,
         );
-        expect(getByTestId('node-icon').textContent).toBe('📄');
+        expect(queryByTestId('folder-page-count')).toBeNull();
     });
 
     it('shows expand chevron for folder types', () => {
@@ -67,14 +84,16 @@ describe('NotesTreeItem', () => {
         expect(queryByTestId('chevron')).toBeNull();
     });
 
-    it('applies selected class when selectedPath matches', () => {
+    it('applies selected class with accent stripe when selectedPath matches', () => {
         const node = makeNode({ path: 'nb/page1', name: 'page1' });
         const { getByTestId } = render(
             <NotesTreeItem node={node} selectedPath="nb/page1" isExpanded={false} depth={0}
                 onToggleExpand={vi.fn()} onSelectPage={vi.fn()} onContextMenu={vi.fn()} />,
         );
         const el = getByTestId('notes-tree-item-page1');
-        expect(el.className).toContain('bg-[#0078d4]/10');
+        expect(el.className).toContain('bg-[#ddf4ff]');
+        expect(el.className).toContain('shadow-[inset_3px_0_0_#0969da]');
+        expect(el.getAttribute('aria-selected')).toBe('true');
     });
 
     it('does not apply selected class when selectedPath does not match', () => {
@@ -84,7 +103,9 @@ describe('NotesTreeItem', () => {
                 onToggleExpand={vi.fn()} onSelectPage={vi.fn()} onContextMenu={vi.fn()} />,
         );
         const el = getByTestId('notes-tree-item-page1');
-        expect(el.className).not.toContain('bg-[#0078d4]/10');
+        expect(el.className).not.toContain('bg-[#ddf4ff]');
+        expect(el.className).not.toContain('shadow-[inset_3px_0_0_#0969da]');
+        expect(el.getAttribute('aria-selected')).toBe('false');
     });
 
     it('fires onContextMenu with node and coordinates on right-click', () => {
@@ -142,13 +163,13 @@ describe('NotesTreeItem', () => {
         expect(onToggle).toHaveBeenCalledWith('mynotebook');
     });
 
-    it('applies correct paddingLeft based on depth', () => {
+    it('applies correct paddingLeft based on depth (10px base + 16px per depth)', () => {
         const node = makeNode({ name: 'deep', path: 'a/b/deep' });
         const { getByTestId } = render(
             <NotesTreeItem node={node} selectedPath={null} isExpanded={false} depth={2}
                 onToggleExpand={vi.fn()} onSelectPage={vi.fn()} onContextMenu={vi.fn()} />,
         );
-        expect(getByTestId('notes-tree-item-deep').style.paddingLeft).toBe('32px');
+        expect(getByTestId('notes-tree-item-deep').style.paddingLeft).toBe('42px');
     });
 
     it('renders a subtle update indicator when hasUpdate is true', () => {


### PR DESCRIPTION
Refresh the Notes / My Work / My Life left panel to a knowledge-base-style
sidebar: a compact header with back / refresh and a primary green "New" button,
a client-side search filter, a meta row showing updated count, total pages,
and a "tracked" pill when notes git is initialized, and tree rows that show
recursive page counts on folders plus a 3px accent stripe on the selected row.

Co-authored-by: Cursor <cursoragent@cursor.com>
