### PR TITLE
fix(forge): infer reasoning effort from model ID suffix when CAPI cap…

### DIFF
--- a/packages/forge/src/copilot-sdk-wrapper/model-reasoning.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/model-reasoning.ts
@@ -117,10 +117,29 @@ export function resolveReasoningSelection(options: ResolveReasoningEffortOptions
         rawCapabilityEfforts,
     });
 
-    return {
-        modelId: baseModelId ?? options.modelId,
-        reasoningEffort,
-    };
+    if (baseModelId) {
+        return { modelId: baseModelId, reasoningEffort };
+    }
+
+    // Fallback: when raw CAPI capability efforts are absent (stale or missing
+    // metadata), the resolved effort may come from outdated contract fields and
+    // be incompatible with the model. If the model ID itself encodes a known
+    // effort suffix (e.g. "claude-opus-4.7-xhigh"), trust that suffix as the
+    // authoritative signal and strip it to derive the base model ID.
+    if (!rawCapabilityEfforts && options.modelId) {
+        const suffixInferred = inferFromModelIdSuffix(options.modelId);
+        if (suffixInferred) {
+            // When the suffix-derived effort differs from the resolved one,
+            // override — the model ID is the most direct signal from CAPI about
+            // which effort this variant was provisioned for.
+            return {
+                modelId: suffixInferred.baseModelId,
+                reasoningEffort: suffixInferred.effort,
+            };
+        }
+    }
+
+    return { modelId: options.modelId, reasoningEffort };
 }
 
 interface DeriveBaseModelOptions {
@@ -145,6 +164,25 @@ interface DeriveBaseModelOptions {
  *
  * Returns undefined when no rewrite applies.
  */
+/**
+ * Infer reasoning effort and base model ID from a model ID suffix.
+ *
+ * For example, "claude-opus-4.7-xhigh" → { baseModelId: "claude-opus-4.7", effort: "xhigh" }.
+ * Returns undefined when the model ID does not end with a known effort suffix.
+ */
+function inferFromModelIdSuffix(modelId: string): { baseModelId: string; effort: ReasoningEffort } | undefined {
+    for (const effort of KNOWN_REASONING_EFFORTS) {
+        const suffix = `-${effort}`;
+        if (modelId.endsWith(suffix)) {
+            const base = modelId.slice(0, -suffix.length);
+            if (base.length > 0) {
+                return { baseModelId: base, effort };
+            }
+        }
+    }
+    return undefined;
+}
+
 function deriveBaseModelId(options: DeriveBaseModelOptions): string | undefined {
     const { modelId, family, reasoningEffort, rawCapabilityEfforts } = options;
 

--- a/packages/forge/test/ai/model-reasoning.test.ts
+++ b/packages/forge/test/ai/model-reasoning.test.ts
@@ -166,4 +166,73 @@ describe('resolveReasoningEffort', () => {
             model: model('plain-model', { supportsReasoning: false }),
         })).toBeUndefined();
     });
+
+    // =========================================================================
+    // Suffix-based fallback (no raw CAPI capabilities)
+    // =========================================================================
+
+    it('infers xhigh effort from model ID suffix when raw capabilities are absent and contract data is stale', () => {
+        // Reproduces: CAPIError 400 reasoning_effort "medium" is not supported
+        // by model claude-opus-4.7-xhigh; supported values: [xhigh]
+        expect(resolveReasoningSelection({
+            modelId: 'claude-opus-4.7-xhigh',
+            model: model('claude-opus-4.7-xhigh', {
+                // No rawEfforts — CAPI capability field missing from metadata
+                supportedEfforts: ['medium'],
+                defaultEffort: 'medium',
+            }),
+        })).toEqual({
+            modelId: 'claude-opus-4.7',
+            reasoningEffort: 'xhigh',
+        });
+    });
+
+    it('infers high effort from model ID suffix when no model metadata is available', () => {
+        expect(resolveReasoningSelection({
+            modelId: 'claude-opus-4.7-high',
+            // No model metadata at all (store not initialized)
+        })).toEqual({
+            modelId: 'claude-opus-4.7',
+            reasoningEffort: 'high',
+        });
+    });
+
+    it('infers effort from suffix when metadata has no reasoning support info', () => {
+        expect(resolveReasoningSelection({
+            modelId: 'some-model-medium',
+            model: model('some-model-medium', { supportsReasoning: false }),
+        })).toEqual({
+            modelId: 'some-model',
+            reasoningEffort: 'medium',
+        });
+    });
+
+    it('does not apply suffix inference when raw CAPI capabilities are present', () => {
+        // Raw capabilities are authoritative — suffix inference should not interfere
+        expect(resolveReasoningSelection({
+            modelId: 'claude-opus-4.7-xhigh',
+            model: model('claude-opus-4.7-xhigh', {
+                family: 'claude-opus-4.7',
+                rawEfforts: ['xhigh'],
+                supportedEfforts: ['medium'],
+                defaultEffort: 'medium',
+            }),
+        })).toEqual({
+            modelId: 'claude-opus-4.7',
+            reasoningEffort: 'xhigh',
+        });
+    });
+
+    it('does not apply suffix inference for model IDs not ending with a known effort', () => {
+        expect(resolveReasoningSelection({
+            modelId: 'claude-opus-4.7-internal',
+            model: model('claude-opus-4.7-internal', {
+                supportedEfforts: ['medium', 'high'],
+                defaultEffort: 'medium',
+            }),
+        })).toEqual({
+            modelId: 'claude-opus-4.7-internal',
+            reasoningEffort: 'medium',
+        });
+    });
 });


### PR DESCRIPTION
…abilities are absent

When model metadata lacks raw CAPI capability efforts but includes stale SDK contract fields (e.g. supportedReasoningEfforts: ['medium']), the resolver trusted that stale data and sent an incompatible effort to CAPI. For variant model IDs like claude-opus-4.7-xhigh, this caused:

  CAPIError: 400 reasoning_effort "medium" is not supported by model
  claude-opus-4.7-xhigh; supported values: [xhigh]

Add suffix-based inference as a last-resort fallback in resolveReasoningSelection: when raw CAPI capabilities are absent and the model ID ends with a known effort suffix (-low/-medium/-high/-xhigh), extract the effort and base model ID from the suffix.

Add 5 regression tests covering stale metadata, missing metadata, no reasoning support, raw capabilities present (no interference), and non-effort suffixes.