### PR TITLE
feat(chat): add /loop hint to slash command dropdown

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -19,7 +19,7 @@ import { useAttachedContext } from './hooks/useAttachedContext';
 import { useSlashCommands } from './hooks/useSlashCommands';
 import { useModelCommand } from './hooks/useModelCommand';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
-import type { SkillItem } from './SlashCommandMenu';
+import { META_SKILL_ITEMS, type SkillItem } from './SlashCommandMenu';
 import { scanTurnsForCreatedFiles } from '../../utils/conversationScan';
 import { toQueueProcessId, isQueueProcessId, toTaskId } from '../../utils/queue-process-id';
 import type { ClientConversationTurn } from '../../types/dashboard';
@@ -170,15 +170,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const { models: availableModels } = useModels();
     const enabledModels = availableModels.filter(m => m.enabled);
     const modelCommand = useModelCommand(enabledModels);
-    // Include synthetic /model entry so useSlashCommands keyboard nav works for it
-    const augmentedSkills = useMemo(
-        () => [
-            ...skills,
-            { name: 'model', description: 'Switch AI model' },
-            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
-        ],
-        [skills],
-    );
+    const augmentedSkills = useMemo(() => [...skills, ...META_SKILL_ITEMS], [skills]);
     const slashCommands = useSlashCommands(augmentedSkills);
 
     // Loop management

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -172,7 +172,11 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const modelCommand = useModelCommand(enabledModels);
     // Include synthetic /model entry so useSlashCommands keyboard nav works for it
     const augmentedSkills = useMemo(
-        () => [...skills, { name: 'model', description: 'Switch AI model' }],
+        () => [
+            ...skills,
+            { name: 'model', description: 'Switch AI model' },
+            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
+        ],
         [skills],
     );
     const slashCommands = useSlashCommands(augmentedSkills);

--- a/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
@@ -60,7 +60,11 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
     const { models: availableModels } = useModels();
     const enabledModels = availableModels.filter(m => m.enabled);
     const augmentedSkills = useMemo(
-        () => [...skills, { name: 'model', description: 'Switch AI model' }],
+        () => [
+            ...skills,
+            { name: 'model', description: 'Switch AI model' },
+            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
+        ],
         [skills],
     );
     const slashCommands = useSlashCommands(augmentedSkills);

--- a/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
@@ -23,8 +23,7 @@ import { useModels } from '../../hooks/useModels';
 import { useDefaultModelForMode } from '../../hooks/useDefaultModelForMode';
 import { useSlashCommands } from './hooks/useSlashCommands';
 import { useModelCommand } from './hooks/useModelCommand';
-import { SlashCommandMenu } from './SlashCommandMenu';
-import type { SkillItem } from './SlashCommandMenu';
+import { SlashCommandMenu, META_SKILL_ITEMS, type SkillItem } from './SlashCommandMenu';
 import { ModelCommandMenu } from './ModelCommandMenu';
 import { ModePillSelector, DEFAULT_MODE_PILL_OPTIONS, RALPH_MODE_PILL_OPTION } from './ModePillSelector';
 import { useOnboardingPreferences } from '../../hooks/useOnboardingPreferences';
@@ -59,14 +58,7 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
     // Model command support
     const { models: availableModels } = useModels();
     const enabledModels = availableModels.filter(m => m.enabled);
-    const augmentedSkills = useMemo(
-        () => [
-            ...skills,
-            { name: 'model', description: 'Switch AI model' },
-            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
-        ],
-        [skills],
-    );
+    const augmentedSkills = useMemo(() => [...skills, ...META_SKILL_ITEMS], [skills]);
     const slashCommands = useSlashCommands(augmentedSkills);
     const modelCommand = useModelCommand(enabledModels);
     const { effectiveModel: defaultModelId, effectiveModelName: defaultModelLabel } = useDefaultModelForMode(workspaceId, selectedMode, availableModels);

--- a/packages/coc/src/server/spa/client/react/features/chat/SlashCommandMenu.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/SlashCommandMenu.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef } from 'react';
 export interface SkillItem {
     name: string;
     description?: string;
+    args?: string;
 }
 
 interface SlashCommandMenuProps {
@@ -100,6 +101,11 @@ export function SlashCommandMenu({
                             <span className="font-mono text-[13px] font-semibold text-[#1e1e1e] dark:text-[#d4d4d4] shrink-0">
                                 /{skill.name}
                             </span>
+                            {skill.args && (
+                                <span className="font-mono text-[12px] text-[#9d9d9d] dark:text-[#6e6e6e] shrink-0">
+                                    {skill.args}
+                                </span>
+                            )}
                             {skill.description && (
                                 <span className="text-xs text-[#616161] dark:text-[#9d9d9d] truncate min-w-0 flex-1">
                                     {skill.description}

--- a/packages/coc/src/server/spa/client/react/features/chat/SlashCommandMenu.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/SlashCommandMenu.tsx
@@ -16,6 +16,11 @@ export interface SkillItem {
     args?: string;
 }
 
+export const META_SKILL_ITEMS: SkillItem[] = [
+    { name: 'model', description: 'Switch AI model' },
+    { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
+];
+
 interface SlashCommandMenuProps {
     skills: SkillItem[];
     filter: string;

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteChatPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteChatPanel.tsx
@@ -9,8 +9,7 @@ import { NoteContextBanner } from './NoteContextBanner';
 import { useModels } from '../../../hooks/useModels';
 import { useSlashCommands } from '../../chat/hooks/useSlashCommands';
 import { useModelCommand } from '../../chat/hooks/useModelCommand';
-import { SlashCommandMenu } from '../../chat/SlashCommandMenu';
-import type { SkillItem } from '../../chat/SlashCommandMenu';
+import { SlashCommandMenu, META_SKILL_ITEMS, type SkillItem } from '../../chat/SlashCommandMenu';
 import { ModelCommandMenu } from '../../chat/ModelCommandMenu';
 import { NoteReferenceChips } from './NoteReferenceChips';
 import { formatNoteReferences } from './useNoteReferences';
@@ -55,14 +54,7 @@ export function NoteChatPanel({ workspaceId, notePath, noteTitle, onClose, onBef
     const { models: availableModels } = useModels();
     const enabledModels = availableModels.filter(m => m.enabled);
     const [skills, setSkills] = useState<SkillItem[]>([]);
-    const augmentedSkills = useMemo(
-        () => [
-            ...skills,
-            { name: 'model', description: 'Switch AI model' },
-            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
-        ],
-        [skills],
-    );
+    const augmentedSkills = useMemo(() => [...skills, ...META_SKILL_ITEMS], [skills]);
     const slashCommands = useSlashCommands(augmentedSkills);
     const modelCommand = useModelCommand(enabledModels);
 

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteChatPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteChatPanel.tsx
@@ -56,7 +56,11 @@ export function NoteChatPanel({ workspaceId, notePath, noteTitle, onClose, onBef
     const enabledModels = availableModels.filter(m => m.enabled);
     const [skills, setSkills] = useState<SkillItem[]>([]);
     const augmentedSkills = useMemo(
-        () => [...skills, { name: 'model', description: 'Switch AI model' }],
+        () => [
+            ...skills,
+            { name: 'model', description: 'Switch AI model' },
+            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
+        ],
         [skills],
     );
     const slashCommands = useSlashCommands(augmentedSkills);

--- a/packages/coc/test/server/spa/client/repos/FollowUpInputArea-attachments.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/FollowUpInputArea-attachments.test.tsx
@@ -62,6 +62,7 @@ vi.mock('../../../../../src/server/spa/client/react/shared/RichTextInput', () =>
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({

--- a/packages/coc/test/server/spa/client/repos/FollowUpInputArea-ralph.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/FollowUpInputArea-ralph.test.tsx
@@ -51,6 +51,7 @@ vi.mock('../../../../../src/server/spa/client/react/shared/RichTextInput', () =>
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({

--- a/packages/coc/test/server/spa/client/repos/FollowUpInputArea-send-label.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/FollowUpInputArea-send-label.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../../../../../src/server/spa/client/react/shared/RichTextInput', () =>
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({

--- a/packages/coc/test/server/spa/client/repos/NewChatArea.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/NewChatArea.test.tsx
@@ -146,6 +146,7 @@ vi.mock('../../../../../src/server/spa/client/react/hooks/useDefaultModelForMode
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({

--- a/packages/coc/test/spa/react/repos/NewChatArea.test.tsx
+++ b/packages/coc/test/spa/react/repos/NewChatArea.test.tsx
@@ -103,6 +103,7 @@ vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useDraftSto
 
 vi.mock('../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 vi.mock('../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({

--- a/packages/coc/test/spa/react/repos/SlashCommandMenu.test.tsx
+++ b/packages/coc/test/spa/react/repos/SlashCommandMenu.test.tsx
@@ -6,7 +6,7 @@
 /* @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { SlashCommandMenu } from '../../../../src/server/spa/client/react/features/chat/SlashCommandMenu';
+import { SlashCommandMenu, META_SKILL_ITEMS } from '../../../../src/server/spa/client/react/features/chat/SlashCommandMenu';
 
 const SKILLS = [
     { name: 'spec', description: 'Ask the agent to draft a Markdown spec instead of code' },
@@ -216,10 +216,13 @@ describe('SlashCommandMenu (redesigned card)', () => {
         expect(row?.textContent).not.toContain('[');
     });
 
-    it('loop meta-command entry has correct shape', () => {
-        const loop = { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' };
-        expect(loop.name).toBe('loop');
-        expect(loop.args).toBe('[interval] <prompt>');
-        expect(loop.description).toBeTruthy();
+    it('META_SKILL_ITEMS includes model and loop with correct shape', () => {
+        const model = META_SKILL_ITEMS.find(s => s.name === 'model');
+        const loop = META_SKILL_ITEMS.find(s => s.name === 'loop');
+        expect(model).toBeDefined();
+        expect(model?.description).toBeTruthy();
+        expect(loop).toBeDefined();
+        expect(loop?.description).toBeTruthy();
+        expect(loop?.args).toBe('[interval] <prompt>');
     });
 });

--- a/packages/coc/test/spa/react/repos/SlashCommandMenu.test.tsx
+++ b/packages/coc/test/spa/react/repos/SlashCommandMenu.test.tsx
@@ -180,4 +180,46 @@ describe('SlashCommandMenu (redesigned card)', () => {
         expect(rows[0].textContent).toContain('Ask the agent to draft a Markdown spec instead of code');
         expect(rows[2].textContent).toContain('Restrict edits to a path or package');
     });
+
+    it('renders args as a dim monospace hint when provided', () => {
+        const skillsWithArgs = [
+            { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
+            { name: 'model', description: 'Switch AI model' },
+        ];
+        render(
+            <SlashCommandMenu
+                skills={skillsWithArgs}
+                filter=""
+                onSelect={() => {}}
+                onDismiss={() => {}}
+                visible={true}
+                highlightIndex={0}
+            />,
+        );
+        const rows = document.querySelectorAll('[data-menu-item]');
+        expect(rows[0].textContent).toContain('[interval] <prompt>');
+        expect(rows[1].textContent).not.toContain('[interval]');
+    });
+
+    it('does not render an args span when args is absent', () => {
+        render(
+            <SlashCommandMenu
+                skills={[{ name: 'spec', description: 'Draft a spec' }]}
+                filter=""
+                onSelect={() => {}}
+                onDismiss={() => {}}
+                visible={true}
+                highlightIndex={0}
+            />,
+        );
+        const row = document.querySelector('[data-menu-item]');
+        expect(row?.textContent).not.toContain('[');
+    });
+
+    it('loop meta-command entry has correct shape', () => {
+        const loop = { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' };
+        expect(loop.name).toBe('loop');
+        expect(loop.args).toBe('[interval] <prompt>');
+        expect(loop.description).toBeTruthy();
+    });
 });

--- a/packages/coc/test/spa/react/repos/compact-input-bar.test.tsx
+++ b/packages/coc/test/spa/react/repos/compact-input-bar.test.tsx
@@ -96,6 +96,7 @@ vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useModelCom
 
 vi.mock('../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 vi.mock('../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({

--- a/packages/coc/test/spa/react/repos/notes/NoteChatPanel.test.ts
+++ b/packages/coc/test/spa/react/repos/notes/NoteChatPanel.test.ts
@@ -232,7 +232,7 @@ describe('NoteChatPanel', () => {
 
     describe('skill slash-command support', () => {
         it('imports SkillItem type from SlashCommandMenu', () => {
-            expect(source).toContain("import type { SkillItem }");
+            expect(source).toContain("SkillItem");
             expect(source).toContain("from '../../chat/SlashCommandMenu'");
         });
 
@@ -250,8 +250,8 @@ describe('NoteChatPanel', () => {
             expect(source).toContain('setSkills(data.merged)');
         });
 
-        it('merges fetched skills into augmentedSkills before model entry', () => {
-            expect(source).toContain('[...skills, { name: \'model\',');
+        it('merges fetched skills with META_SKILL_ITEMS', () => {
+            expect(source).toContain('[...skills, ...META_SKILL_ITEMS]');
         });
 
         it('augmentedSkills depends on skills', () => {

--- a/packages/coc/test/spa/react/shared/ResolveContextDialog.test.tsx
+++ b/packages/coc/test/spa/react/shared/ResolveContextDialog.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useSlashCom
 // Mock SlashCommandMenu
 vi.mock('../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
     SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
 }));
 
 // Mock fetchApi for skills


### PR DESCRIPTION
## Summary

- Adds an `args?: string` field to the `SkillItem` interface in `SlashCommandMenu.tsx`, rendered as a dim monospace hint inline with the command name (e.g. `/loop [interval] <prompt>`)
- Populates `args` for the `/loop` meta-command entry across all three chat surfaces (ChatDetail, NewChatArea, NoteChatPanel)
- Extracts a `META_SKILL_ITEMS` constant to eliminate the previously duplicated `augmentedSkills` inline objects — adding a future meta-command is now a one-line change in one file

## Motivation

The `/loop` command had no hint after selection, unlike Claude Code which shows `[interval] <prompt>` inline. Users had no indication of what to type after `/loop`. The duplication across three components also meant any future meta-command (e.g. `/fast`, `/think`) would need three separate edits.

## Reviewer notes

- `META_SKILL_ITEMS` lives in `SlashCommandMenu.tsx` alongside `SkillItem` — the natural home since the type and the constant are tightly coupled
- The `args` span uses a lighter color (`text-[#9d9d9d]`) and smaller font (`text-[12px]`) to visually distinguish syntax from the description
- 3 new tests cover: args rendering, absent-args case, and the `META_SKILL_ITEMS` shape

## Test plan

- [x] All 12 `SlashCommandMenu` unit tests pass
- [ ] Open the slash command menu in the chat input, type `/loop` — verify `[interval] <prompt>` appears as a dim hint next to the command name
- [ ] Verify `/model` still shows its description without any args hint