### PR TITLE
feat(chat): Layer 2 — ghost text hint after /loop selection

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
@@ -68,6 +68,7 @@ export interface FollowUpInputAreaProps {
         menuFilter: string;
         filteredSkills: SkillItem[];
         highlightIndex: number;
+        activeCommandHint?: string | null;
     };
     /** Model command state for the /model meta-command */
     modelCommand?: {
@@ -454,7 +455,7 @@ export function FollowUpInputArea({
                             ref={richTextRef}
                             disabled={inputDisabled}
                             value={followUpInput}
-                            ghostText={autocomplete.completion}
+                            ghostText={slashCommands.activeCommandHint ?? autocomplete.completion}
                             placeholder={inputDisabled && !isActiveGeneration ? 'Session expired.' : 'Send a message... (type / for commands)'}
                             className={cn(
                                 'w-full min-h-[34px] max-h-28 overflow-y-auto rounded border bg-white dark:bg-[#1f1f1f] px-2 py-1.5 text-sm text-[#1e1e1e] dark:text-[#cccccc] focus:outline-none focus:ring-2 disabled:opacity-60',
@@ -548,7 +549,7 @@ export function FollowUpInputArea({
                             ref={richTextRef}
                             disabled={inputDisabled}
                             value={followUpInput}
-                            ghostText={autocomplete.completion}
+                            ghostText={slashCommands.activeCommandHint ?? autocomplete.completion}
                             placeholder={inputDisabled && !isActiveGeneration ? 'Session expired.' : 'Reply to CoC, or type / for commands...'}
                             // border-transparent + focus:ring-transparent neutralize the
                             // base RichTextInput's 1px gray border and default blue

--- a/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
@@ -285,7 +285,7 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
                         ref={richTextRef}
                         disabled={sending}
                         value={input}
-                        ghostText={autocomplete.completion}
+                        ghostText={slashCommands.activeCommandHint ?? autocomplete.completion}
                         placeholder="Reply to CoC, or type / for commands..."
                         // border-transparent + focus:ring-transparent neutralize the
                         // base RichTextInput's 1px gray border and default blue

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useSlashCommands.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useSlashCommands.ts
@@ -5,7 +5,7 @@
  * filtering, keyboard navigation, and skill selection/extraction.
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useMemo } from 'react';
 import { parseSlashCommands, getSlashCommandContext, getActiveMetaCommands } from '../slash-command-parser';
 import { isLoopsEnabled } from '../../../utils/config';
 import type { SkillItem } from '../SlashCommandMenu';
@@ -31,12 +31,15 @@ export interface UseSlashCommandsResult {
     parseAndExtract: (text: string) => { skills: string[]; prompt: string };
     /** Dismiss the menu */
     dismissMenu: () => void;
+    /** Ghost text hint shown after a meta-command with no argument yet (e.g. "[interval] <prompt>" after /loop) */
+    activeCommandHint: string | null;
 }
 
 export function useSlashCommands(skills: SkillItem[]): UseSlashCommandsResult {
     const [menuVisible, setMenuVisible] = useState(false);
     const [menuFilter, setMenuFilter] = useState('');
     const [highlightIndex, setHighlightIndex] = useState(0);
+    const [currentText, setCurrentText] = useState('');
     const slashStartRef = useRef<number>(-1);
 
     const skillNames = skills.map(s => s.name);
@@ -45,7 +48,13 @@ export function useSlashCommands(skills: SkillItem[]): UseSlashCommandsResult {
         ? skills.filter(s => s.name.toLowerCase().startsWith(menuFilter.toLowerCase()))
         : [];
 
+    const activeCommandHint = useMemo((): string | null => {
+        if (!/\/loop(\s*)$/.test(currentText)) return null;
+        return skills.find(s => s.name === 'loop')?.args ?? null;
+    }, [currentText, skills]);
+
     const handleInputChange = useCallback((text: string, cursorPos: number) => {
+        setCurrentText(text);
         const ctx = getSlashCommandContext(text, cursorPos);
         if (ctx?.active) {
             slashStartRef.current = ctx.startIndex;
@@ -141,5 +150,6 @@ export function useSlashCommands(skills: SkillItem[]): UseSlashCommandsResult {
         selectSkill,
         parseAndExtract,
         dismissMenu,
+        activeCommandHint,
     };
 }

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteChatPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteChatPanel.tsx
@@ -155,6 +155,7 @@ export function NoteChatPanel({ workspaceId, notePath, noteTitle, onClose, onBef
                                         <RichTextInput
                                             ref={richTextRef}
                                             placeholder="Ask about your notes..."
+                                            ghostText={slashCommands.activeCommandHint ?? undefined}
                                             className="w-full min-h-[34px] max-h-28 overflow-y-auto rounded border bg-white dark:bg-[#1f1f1f] px-2 py-1.5 text-sm"
                                             onChange={(val, cursorPos) => {
                                                 setInput(val);

--- a/packages/coc/test/spa/react/repos/useSlashCommands.test.ts
+++ b/packages/coc/test/spa/react/repos/useSlashCommands.test.ts
@@ -17,6 +17,12 @@ const skills: SkillItem[] = [
     { name: 'go-deep', description: 'Advanced research and verification' },
 ];
 
+const skillsWithMeta: SkillItem[] = [
+    ...skills,
+    { name: 'loop', description: 'Run a prompt on a recurring interval', args: '[interval] <prompt>' },
+    { name: 'model', description: 'Switch AI model' },
+];
+
 /** Trigger the menu by simulating typing "/im" at position 3 */
 function openMenu(result: ReturnType<typeof useSlashCommands>) {
     act(() => {
@@ -152,6 +158,52 @@ describe('useSlashCommands', () => {
 
         // cursor = 0 + 1 + 7 + 1 = 9
         expect(setValue).toHaveBeenCalledWith('/go-deep ', 9);
+    });
+
+    // activeCommandHint tests
+    describe('activeCommandHint', () => {
+        it('is null when input is empty', () => {
+            const { result } = renderHook(() => useSlashCommands(skillsWithMeta));
+            expect(result.current.activeCommandHint).toBeNull();
+        });
+
+        it('returns args when input is exactly /loop', () => {
+            const { result } = renderHook(() => useSlashCommands(skillsWithMeta));
+            act(() => { result.current.handleInputChange('/loop', 5); });
+            expect(result.current.activeCommandHint).toBe('[interval] <prompt>');
+        });
+
+        it('returns args when input is /loop with trailing space (separator)', () => {
+            const { result } = renderHook(() => useSlashCommands(skillsWithMeta));
+            act(() => { result.current.handleInputChange('/loop ', 6); });
+            expect(result.current.activeCommandHint).toBe('[interval] <prompt>');
+        });
+
+        it('is null when user has typed an argument after /loop', () => {
+            const { result } = renderHook(() => useSlashCommands(skillsWithMeta));
+            act(() => { result.current.handleInputChange('/loop 5m', 8); });
+            expect(result.current.activeCommandHint).toBeNull();
+        });
+
+        it('is null for /model (no args defined)', () => {
+            const { result } = renderHook(() => useSlashCommands(skillsWithMeta));
+            act(() => { result.current.handleInputChange('/model', 6); });
+            expect(result.current.activeCommandHint).toBeNull();
+        });
+
+        it('is null when skills list has no loop entry', () => {
+            const { result } = renderHook(() => useSlashCommands(skills));
+            act(() => { result.current.handleInputChange('/loop', 5); });
+            expect(result.current.activeCommandHint).toBeNull();
+        });
+
+        it('clears after typing a real argument', () => {
+            const { result } = renderHook(() => useSlashCommands(skillsWithMeta));
+            act(() => { result.current.handleInputChange('/loop ', 6); });
+            expect(result.current.activeCommandHint).toBe('[interval] <prompt>');
+            act(() => { result.current.handleInputChange('/loop 5m', 8); });
+            expect(result.current.activeCommandHint).toBeNull();
+        });
     });
 
     // T8: cursor accounts for text before the slash


### PR DESCRIPTION
## Summary

- Adds `activeCommandHint: string | null` to `useSlashCommands` — returns `'[interval] <prompt>'` when the input is `/loop` with no real argument yet, `null` otherwise
- Wires it as `ghostText` on `RichTextInput` across all three chat surfaces (NewChatArea, FollowUpInputArea, NoteChatPanel), taking priority over autocomplete completion
- The hint self-dismisses the moment the user types any non-whitespace content after `/loop`

## Motivation

Layer 1 (merged in #124) added the args hint to the slash command dropdown — visible before selection. Layer 2 adds the post-selection hint: after the user picks `/loop`, greyed-out text `[interval] <prompt>` appears inline in the input, matching the UX Claude Code shows in the terminal.

## Implementation notes

- No new components or positioning math needed — `RichTextInput` already has a `ghostText` prop that renders an absolute overlay with transparent user text + opaque grey suffix
- Detection is a single regex: `/\/loop(\s*)$/` — active when input ends with `/loop` plus optional whitespace (the command separator), inactive once the user types a real argument
- Priority: command hint wins over autocomplete completion (`slashCommands.activeCommandHint ?? autocomplete.completion`)

## Reviewer notes

- `FollowUpInputArea` receives `slashCommands` as a prop with an inline interface — added `activeCommandHint?: string | null` there
- `NoteChatPanel` had no `ghostText` previously; `null` is coerced to `undefined` via `?? undefined` to satisfy the optional prop type

## Test plan

- [x] 7 new unit tests for `activeCommandHint` in `useSlashCommands.test.ts` (null on empty, returns hint on `/loop`, returns hint on `/loop `, null on `/loop 5m`, null on `/model`, null when no loop skill, clears after typing argument)
- [x] All 163 tests across affected files pass locally
- [ ] Type `/loop` in the chat input → verify greyed-out `[interval] <prompt>` appears after cursor
- [ ] Type a character after `/loop ` → verify hint disappears
- [ ] Verify autocomplete ghost text still works for non-`/loop` inputs