### PR TITLE
Show note absolute path in Settings → Notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -656,6 +656,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@changesets/cli/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -707,6 +719,15 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@changesets/cli/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@changesets/cli/node_modules/universalify": {
       "version": "0.1.2",

--- a/packages/coc/src/server/spa/client/react/features/repo-settings/NotesSettingsSection.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-settings/NotesSettingsSection.tsx
@@ -53,6 +53,7 @@ export function NotesSettingsSection({ workspaceId }: NotesSettingsSectionProps)
 
     const [gitInitialized, setGitInitialized] = useState<boolean | null>(null);
     const [gitStatusLoading, setGitStatusLoading] = useState(true);
+    const [notesRoot, setNotesRoot] = useState<string | null>(null);
     const [initBusy, setInitBusy] = useState(false);
     const [deinitBusy, setDeinitBusy] = useState(false);
     const [confirmingDeinit, setConfirmingDeinit] = useState(false);
@@ -60,11 +61,16 @@ export function NotesSettingsSection({ workspaceId }: NotesSettingsSectionProps)
     useEffect(() => {
         let cancelled = false;
         setGitStatusLoading(true);
-        notesApi
-            .getGitStatus(workspaceId)
-            .then(s => { if (!cancelled) setGitInitialized(s.initialized); })
-            .catch(() => { if (!cancelled) setGitInitialized(false); })
-            .finally(() => { if (!cancelled) setGitStatusLoading(false); });
+        Promise.all([
+            notesApi
+                .getGitStatus(workspaceId)
+                .then(s => { if (!cancelled) setGitInitialized(s.initialized); })
+                .catch(() => { if (!cancelled) setGitInitialized(false); }),
+            notesApi
+                .getTree(workspaceId)
+                .then(t => { if (!cancelled) setNotesRoot(t.notesRoot); })
+                .catch(() => {}),
+        ]).finally(() => { if (!cancelled) setGitStatusLoading(false); });
         return () => { cancelled = true; };
     }, [workspaceId]);
 
@@ -122,6 +128,20 @@ export function NotesSettingsSection({ workspaceId }: NotesSettingsSectionProps)
 
     return (
         <div data-testid="notes-settings-section">
+            {/* Notes location */}
+            {notesRoot && (
+                <div className="flex flex-col md:flex-row items-start md:items-center gap-1 md:gap-2 mb-3">
+                    <label className={labelClass}>Location</label>
+                    <span
+                        className="text-xs text-[#616161] dark:text-[#999] font-mono break-all"
+                        data-testid="notes-absolute-path"
+                        title={notesRoot}
+                    >
+                        {notesRoot}
+                    </span>
+                </div>
+            )}
+
             {/* Git Version Tracking */}
             <div className={sectionHeadClass} data-testid="section-git-tracking">
                 Git Version Tracking

--- a/packages/coc/test/spa/react/repos/NotesSettingsSection.test.tsx
+++ b/packages/coc/test/spa/react/repos/NotesSettingsSection.test.tsx
@@ -46,12 +46,14 @@ async function renderSection(opts: {
     autoCommit?: AutoCommitState;
     initializeGit?: ReturnType<typeof vi.fn>;
     deinitGit?: ReturnType<typeof vi.fn>;
+    notesRoot?: string | null;
 }) {
     const {
         gitInitialized = true,
         autoCommit = { enabled: false },
         initializeGit = vi.fn().mockResolvedValue({ initialized: true }),
         deinitGit = vi.fn().mockResolvedValue({ deinitialized: true }),
+        notesRoot = '/home/user/notes',
     } = opts;
 
     const mockHook = mockAutoCommitHook(autoCommit);
@@ -63,6 +65,7 @@ async function renderSection(opts: {
     vi.doMock('../../../../src/server/spa/client/react/features/notes/notesApi', () => ({
         notesApi: {
             getGitStatus: vi.fn().mockResolvedValue({ initialized: gitInitialized }),
+            getTree: vi.fn().mockResolvedValue({ tree: [], notesRoot: notesRoot ?? '/home/user/notes' }),
             initializeGit,
             deinitGit,
         },
@@ -107,6 +110,7 @@ describe('NotesSettingsSection', () => {
         vi.doMock('../../../../src/server/spa/client/react/features/notes/notesApi', () => ({
             notesApi: {
                 getGitStatus: vi.fn().mockResolvedValue({ initialized: true }),
+                getTree: vi.fn().mockResolvedValue({ tree: [], notesRoot: '/home/user/notes' }),
             },
         }));
         const { NotesSettingsSection } = await import(
@@ -360,6 +364,36 @@ describe('NotesSettingsSection', () => {
         await waitFor(() => {
             expect(mockAddToast).toHaveBeenCalledWith('boom-init', 'error');
         });
+    });
+
+    it('shows absolute path from notesRoot', async () => {
+        await renderSection({ gitInitialized: true, notesRoot: '/var/data/my-notes' });
+
+        const el = screen.getByTestId('notes-absolute-path');
+        expect(el.textContent).toBe('/var/data/my-notes');
+        expect(el.getAttribute('title')).toBe('/var/data/my-notes');
+    });
+
+    it('hides path when notesRoot is unavailable', async () => {
+        vi.doMock('../../../../src/server/spa/client/react/features/notes/hooks/useNotesAutoCommit', () => ({
+            useNotesAutoCommit: () => mockAutoCommitHook({ enabled: false }),
+        }));
+        vi.doMock('../../../../src/server/spa/client/react/features/notes/notesApi', () => ({
+            notesApi: {
+                getGitStatus: vi.fn().mockResolvedValue({ initialized: true }),
+                getTree: vi.fn().mockRejectedValue(new Error('not found')),
+                initializeGit: vi.fn(),
+                deinitGit: vi.fn(),
+            },
+        }));
+        const { NotesSettingsSection } = await import(
+            '../../../../src/server/spa/client/react/features/repo-settings/NotesSettingsSection'
+        );
+        render(<NotesSettingsSection workspaceId="ws-1" />);
+        await waitFor(() => {
+            expect(screen.queryByTestId('notes-settings-loading')).toBeNull();
+        });
+        expect(screen.queryByTestId('notes-absolute-path')).toBeNull();
     });
 
     it('shows error toast when deinit fails', async () => {


### PR DESCRIPTION
## Summary

- Fetches `notesRoot` from `notesApi.getTree` in parallel with the git status check in `NotesSettingsSection`
- Displays the notes directory absolute path as a **Location** row at the top of the Notes settings panel (monospace, with hover title)
- Falls back gracefully (row hidden) when `getTree` fails

## Test plan

- [ ] Open Settings → Notes for a workspace — "Location" row appears at the top showing the absolute path
- [ ] Verify path renders in monospace and shows full path on hover
- [ ] Verify row is absent if the tree fetch fails
- [ ] All 26 unit tests pass (`NotesSettingsSection.test.tsx`)

https://claude.ai/code/session_0141Szi23ceWNwKTLhLob4eS

---
_Generated by [Claude Code](https://claude.ai/code/session_0141Szi23ceWNwKTLhLob4eS)_