### PR TITLE
feat(pr-queue): show last update time on each PR row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -656,6 +656,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@changesets/cli/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -707,6 +719,15 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@changesets/cli/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@changesets/cli/node_modules/universalify": {
       "version": "0.1.2",

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestRow.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestRow.tsx
@@ -9,6 +9,7 @@
  */
 
 import { cn } from '../../ui';
+import { formatRelativeTime } from '../../utils/format';
 import {
     getMockPrFileCount,
     getMockPrReviewMinutes,
@@ -17,6 +18,7 @@ import {
     queueRiskClass,
 } from './pr-mock-data';
 import type { QueueDotState, QueueRiskBadge } from './pr-mock-data';
+import { formatTimestamp } from './pr-utils';
 import type { PullRequest } from './pr-utils';
 
 interface PullRequestRowProps {
@@ -154,6 +156,15 @@ export function PullRequestRow({
                     )}
                     <span>{fileCount} files</span>
                     <span>{minutes} min</span>
+                    {pr.updatedAt && (
+                        <span
+                            className="pr-updated-at"
+                            data-testid="pr-updated-at"
+                            title={formatTimestamp(pr.updatedAt)}
+                        >
+                            {formatRelativeTime(pr.updatedAt)}
+                        </span>
+                    )}
                 </div>
             </div>
             <span

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestRow.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestRow.test.tsx
@@ -47,6 +47,24 @@ describe('PullRequestRow — title and meta', () => {
         expect(document.querySelector('.pr-meta')?.textContent).toMatch(/\d+ min/);
     });
 
+    it('renders the last update time when updatedAt is present', () => {
+        render(<PullRequestRow pr={makePr({ updatedAt: '2026-05-17T10:00:00Z' })} onClick={vi.fn()} />);
+        const el = screen.getByTestId('pr-updated-at');
+        expect(el).toBeTruthy();
+        expect(el.textContent).toBeTruthy();
+    });
+
+    it('shows exact timestamp as tooltip on the updated-at element', () => {
+        render(<PullRequestRow pr={makePr({ updatedAt: '2026-05-17T10:00:00Z' })} onClick={vi.fn()} />);
+        const el = screen.getByTestId('pr-updated-at');
+        expect(el.getAttribute('title')).toContain('2026');
+    });
+
+    it('omits the updated-at element when updatedAt is an empty string', () => {
+        render(<PullRequestRow pr={makePr({ updatedAt: '' })} onClick={vi.fn()} />);
+        expect(screen.queryByTestId('pr-updated-at')).toBeNull();
+    });
+
     it('truncates long titles', () => {
         render(<PullRequestRow pr={makePr({ title: 'A'.repeat(200) })} onClick={vi.fn()} />);
         expect(document.querySelector('.pr-title')?.className).toContain('truncate');


### PR DESCRIPTION
## Summary

- Adds a relative "updated X ago" timestamp to the meta line of every PR queue row
- Sourced from the PR's `updatedAt` field using the existing `formatRelativeTime` utility
- Hovering shows the exact timestamp as a tooltip (via `formatTimestamp`)
- Falls back to a locale date for PRs updated more than 7 days ago
- Compact mode (collapsed rail) is unchanged — only the full row gains the timestamp

## Test plan

- [ ] New unit tests in `PullRequestRow.test.tsx` verify presence, tooltip content, and empty-string edge case
- [ ] All 45 tests pass (42 existing + 3 new)
- [ ] Visual: each PR row in the queue now shows e.g. `#42  3 files  5 min  2h ago`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzxkMA1PCJzN4uumoTxLsr)_