### PR TITLE
fix(admin): fit admin page to viewport, scroll only the main pane

### DIFF
--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -25,12 +25,14 @@ The `spaHtml` function in `src/server/index.ts` re-reads the config file on ever
 
 The admin route uses a self-contained, Linear-inspired design system that lives in `src/server/spa/client/react/admin/admin-redesign.css`. The stylesheet is imported once at the top of `AdminPanel.tsx` so esbuild bundles it into the SPA's CSS. All selectors are scoped under the `.admin-redesign` root class that wraps the entire admin page — styles never leak to other dashboard surfaces, and light/dark themes are driven by the existing `<html data-theme="…">` attribute.
 
-**Layout (sidebar + main):** The admin page is structured as a two-column shell:
+**Layout (sidebar + main, fit-to-viewport):** The admin page is structured as a two-column shell that fills the available vertical space and never scrolls as a whole. Only the right pane is scrollable.
 
-- `<div className="ar-shell">` is a CSS grid (`var(--ar-sidebar-w)` + `1fr`).
-- `<aside className="ar-sidebar">` (sticky to the dashboard scroll container) hosts the brand, the tab navigation (`.ar-nav-item`s — one per `AdminSubTab`), and a stats footer (`.ar-stats-block` with Processes / Wikis / Disk).
-- `<main className="ar-main">` contains a sticky topbar (`.ar-topbar` with a `.ar-breadcrumb` showing the current tab) and the page body (`.ar-page` with `.ar-page-header` + cards).
-- The tabs live in the sidebar as `.ar-nav-item` buttons (data-testids `admin-tab-{settings|providers|data|server|prompts|database|agents}` are preserved for tests). A `.ar-mobile-tab-select` appears only under the responsive `@media (max-width: 600px)` rule, which hides the sidebar and falls back to a `<select>`.
+- The route mounts inside `<div className="h-full overflow-hidden" data-testid="admin-scroll-container">` (Router) or the AdminDialog body (`flex-1 min-h-0 overflow-y-auto`). Both supply a definite height to the panel.
+- The `.admin-redesign` root (on `#view-admin`) is `height: 100%; min-height: 0` so the panel fills that parent exactly.
+- `<div className="ar-shell">` is a CSS grid (`var(--ar-sidebar-w)` + `1fr`) with `height: 100%; min-height: 0; overflow: hidden`.
+- `<aside className="ar-sidebar">` fills the grid row (`height: 100%; min-height: 0`) and only scrolls internally if its own brand/nav/stats stack ever exceeds the viewport. It is **not** sticky and must not use `100vh` — both would break inside the AdminDialog and any nested pane whose container height differs from the viewport.
+- `<main className="ar-main">` is the **single scroll region** of the admin route: `min-height: 0; height: 100%; overflow-y: auto`. The sticky topbar (`.ar-topbar` with the `.ar-breadcrumb`) pins to the top of this scroller, and the page body (`.ar-page` with `.ar-page-header` + cards) flows underneath.
+- The tabs live in the sidebar as `.ar-nav-item` buttons (data-testids `admin-tab-{settings|providers|data|server|prompts|database|agents}` are preserved for tests). A `.ar-mobile-tab-select` appears only under the responsive `@media (max-width: 600px)` rule, which hides the sidebar and falls back to a `<select>` — the main pane still scrolls internally on mobile.
 
 **Settings sub-tabs (within the Settings top-level tab):** Settings is split into one `SettingsCard` per sub-tab — `ai`, `chat`, `appearance`, `features`, `integrations`, `advanced` — defined in `SETTINGS_SUBTABS` near the top of `AdminPanel.tsx`. A `.ar-subtab-row` with `.ar-subtab` buttons (data-testids `settings-subtab-{ai|chat|appearance|features|integrations|advanced}`) renders above the cards. Selection is kept in local `settingsSubTab` state, defaults to `ai`, and is synced both directions with `#admin/settings/<sub>` (default `ai` collapses to `#admin/settings`). Tests that interact with controls outside of the default `ai` card must first navigate via the `gotoSettingsSubTab(...)` helper.
 

--- a/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
+++ b/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
@@ -60,6 +60,14 @@
   background: transparent;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* Fit to the available vertical space. The route mounts inside a
+     parent that supplies a definite height (`h-full overflow-hidden` in
+     Router, or the AdminDialog body with `min-h-0`). Filling that
+     parent — rather than growing past it — is what guarantees the
+     whole admin page never scrolls. */
+  height: 100%;
+  min-height: 0;
 }
 
 [data-theme="light"] .admin-redesign {
@@ -105,17 +113,27 @@
 }
 
 /* ── App shell (sidebar + main) ───────────────────────────────── */
+/*
+ * The admin route is mounted inside a parent that provides a definite
+ * height (Router wraps it in `h-full overflow-hidden`, AdminDialog wraps
+ * it in a flex body with `min-h-0`). The shell fills that parent exactly
+ * and never grows beyond it — only the main pane is allowed to scroll
+ * internally if its content overflows. The sidebar stays put.
+ */
 .admin-redesign {
   --ar-sidebar-w: 248px;
 }
 .admin-redesign .ar-shell {
   display: grid;
   grid-template-columns: var(--ar-sidebar-w) 1fr;
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
   background: var(--ar-bg);
 }
 
-/* Sidebar — sticky to the scroll-container, scrolls internally */
+/* Sidebar — fills the grid row, scrolls internally only if its own
+   content is too tall for the viewport. */
 .admin-redesign .ar-sidebar {
   background: var(--ar-bg-1);
   border-right: 1px solid var(--ar-border);
@@ -123,10 +141,8 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  position: sticky;
-  top: 0;
-  align-self: start;
-  height: 100vh;
+  height: 100%;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
 }
@@ -312,10 +328,15 @@
 }
 
 /* ── Main content area ──────────────────────────────────────── */
+/* The main pane is the only scrolling region in the admin route. The
+   sticky topbar stays pinned to the top of this scroll container. */
 .admin-redesign .ar-main {
   min-width: 0;
+  min-height: 0;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 .admin-redesign .ar-topbar {
   display: flex;

--- a/packages/coc/src/server/spa/client/react/layout/Router.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/Router.tsx
@@ -759,7 +759,7 @@ export function Router() {
         case 'admin':
             return (
                 <Suspense fallback={<div className="flex items-center justify-center h-full text-[#888]">Loading…</div>}>
-                    <div className="h-full overflow-y-auto" data-testid="admin-scroll-container">
+                    <div className="h-full overflow-hidden" data-testid="admin-scroll-container">
                         <AdminPanel />
                     </div>
                 </Suspense>

--- a/packages/coc/test/e2e/admin-scroll-regression.spec.ts
+++ b/packages/coc/test/e2e/admin-scroll-regression.spec.ts
@@ -1,13 +1,19 @@
 /**
  * Admin page scroll regression E2E test.
  *
- * Regression: after ProviderTokensSection was added to AdminPanel (commit
- * 1c4b9b1e), the admin page became unscrollable because the page renders
- * AdminPanel inline inside <main class="overflow-hidden">, but AdminPanel
- * had no scroll container of its own.
+ * Layout invariants the admin page must preserve:
+ *   - The whole admin route must never scroll as a single page. The outer
+ *     `admin-scroll-container` is bounded by the viewport and uses
+ *     `overflow: hidden` so the page chrome (sidebar + topbar) always
+ *     stays in place.
+ *   - The right pane (`.ar-main`) is the only scroll region. When card
+ *     content overflows, only that pane scrolls; the left sidebar and
+ *     topbar remain pinned.
  *
- * Fix: Router.tsx wraps AdminPanel in <div class="h-full overflow-y-auto">
- * so the admin page can scroll within the bounded main area.
+ * Historical context: a much earlier regression (commit 1c4b9b1e) had the
+ * admin page completely unscrollable. Today the layout is fit-to-viewport
+ * with the main pane providing the single internal scroller — this test
+ * locks that contract in.
  */
 
 import { test, expect } from './fixtures/server-fixture';
@@ -24,13 +30,13 @@ async function navigateToAdmin(page: import('@playwright/test').Page, serverUrl:
 test.describe('Admin page scrollability regression', () => {
     test.use({ viewport: VIEWPORTS.desktop });
 
-    test('admin scroll container has overflow-y:auto and scrollable content', async ({ page, serverUrl }) => {
+    test('outer admin scroll container is bounded and does not scroll itself', async ({ page, serverUrl }) => {
         await navigateToAdmin(page, serverUrl);
 
-        const scrollContainer = page.locator('[data-testid="admin-scroll-container"]');
-        await expect(scrollContainer).toBeVisible();
+        const outer = page.locator('[data-testid="admin-scroll-container"]');
+        await expect(outer).toBeVisible();
 
-        const metrics = await scrollContainer.evaluate((el) => {
+        const metrics = await outer.evaluate((el) => {
             const style = getComputedStyle(el);
             return {
                 overflowY: style.overflowY,
@@ -39,59 +45,100 @@ test.describe('Admin page scrollability regression', () => {
             };
         });
 
-        // Must be scrollable
+        // The outer container is no longer a scroller — it must clip overflow.
+        expect(['hidden', 'clip']).toContain(metrics.overflowY);
+        // Its own scrollHeight should match its clientHeight (no internal scroll).
+        expect(metrics.scrollHeight).toBe(metrics.clientHeight);
+
+        const box = await outer.boundingBox();
+        expect(box).not.toBeNull();
+        const viewportHeight = page.viewportSize()?.height ?? 800;
+        // The outer container must fit within the viewport.
+        expect(box!.height).toBeLessThanOrEqual(viewportHeight);
+    });
+
+    test('right main pane is the scroll container with scrollable content', async ({ page, serverUrl }) => {
+        await navigateToAdmin(page, serverUrl);
+
+        const main = page.locator('#view-admin .ar-main');
+        await expect(main).toBeVisible();
+
+        const metrics = await main.evaluate((el) => {
+            const style = getComputedStyle(el);
+            return {
+                overflowY: style.overflowY,
+                scrollHeight: el.scrollHeight,
+                clientHeight: el.clientHeight,
+            };
+        });
+
+        // .ar-main must be the scroll region.
         expect(['auto', 'scroll']).toContain(metrics.overflowY);
-        // Admin panel has enough content to require scrolling
+        // It should be bounded (clientHeight <= viewport).
+        const box = await main.boundingBox();
+        expect(box).not.toBeNull();
+        const viewportHeight = page.viewportSize()?.height ?? 800;
+        expect(box!.height).toBeLessThanOrEqual(viewportHeight);
+        // The Settings tab has enough cards to force overflow on a desktop viewport.
         expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
     });
 
-    test('admin scroll container is bounded by viewport height (not taller)', async ({ page, serverUrl }) => {
+    test('mouse wheel scrolls the main pane, not the document', async ({ page, serverUrl }) => {
         await navigateToAdmin(page, serverUrl);
 
-        const scrollContainer = page.locator('[data-testid="admin-scroll-container"]');
-        const box = await scrollContainer.boundingBox();
-        expect(box).not.toBeNull();
+        const main = page.locator('#view-admin .ar-main');
+        await expect(main).toBeVisible();
 
-        const viewportHeight = page.viewportSize()?.height ?? 800;
-        // The scroll container should fill the viewport area (not exceed it)
-        expect(box!.height).toBeLessThanOrEqual(viewportHeight);
-
-        // But content should exceed the visible area (otherwise there's nothing to scroll)
-        const scrollHeight = await scrollContainer.evaluate((el) => el.scrollHeight);
-        expect(scrollHeight).toBeGreaterThan(box!.height);
-    });
-
-    test('admin page scrolls with mouse wheel', async ({ page, serverUrl }) => {
-        await navigateToAdmin(page, serverUrl);
-
-        const scrollContainer = page.locator('[data-testid="admin-scroll-container"]');
-        await expect(scrollContainer).toBeVisible();
-
-        const before = await scrollContainer.evaluate((el) => (el as HTMLElement).scrollTop);
-        const box = await scrollContainer.boundingBox();
+        const before = await main.evaluate((el) => (el as HTMLElement).scrollTop);
+        const box = await main.boundingBox();
         expect(box).not.toBeNull();
 
         await page.mouse.move(box!.x + box!.width / 2, box!.y + Math.min(200, box!.height / 2));
         await page.mouse.wheel(0, 1200);
         await page.waitForTimeout(200);
 
-        const after = await scrollContainer.evaluate((el) => (el as HTMLElement).scrollTop);
+        const after = await main.evaluate((el) => (el as HTMLElement).scrollTop);
         expect(after).toBeGreaterThan(before);
+
+        // The outer container must remain unscrolled.
+        const outerScrollTop = await page
+            .locator('[data-testid="admin-scroll-container"]')
+            .evaluate((el) => (el as HTMLElement).scrollTop);
+        expect(outerScrollTop).toBe(0);
     });
 
-    test('admin page bottom content (Danger Zone) is reachable by scroll', async ({ page, serverUrl }) => {
+    test('sidebar stays pinned while the main pane scrolls', async ({ page, serverUrl }) => {
         await navigateToAdmin(page, serverUrl);
-        await page.click('[data-testid="admin-tab-data"]');
 
-        // Scroll to the bottom
-        await page.locator('#view-admin').evaluate((el) => {
-            (el.parentElement!).scrollTop = el.parentElement!.scrollHeight;
+        const sidebar = page.locator('#view-admin .ar-sidebar');
+        await expect(sidebar).toBeVisible();
+        const beforeBox = await sidebar.boundingBox();
+        expect(beforeBox).not.toBeNull();
+
+        // Force the main pane to scroll to the bottom.
+        await page.locator('#view-admin .ar-main').evaluate((el) => {
+            (el as HTMLElement).scrollTop = (el as HTMLElement).scrollHeight;
         });
         await page.waitForTimeout(100);
 
-        // "Danger Zone" card should be in the DOM and reachable
+        const afterBox = await sidebar.boundingBox();
+        expect(afterBox).not.toBeNull();
+        // The sidebar must still be visible at the same top offset.
+        expect(Math.round(afterBox!.y)).toBe(Math.round(beforeBox!.y));
+        expect(Math.round(afterBox!.height)).toBe(Math.round(beforeBox!.height));
+    });
+
+    test('admin page bottom content (Danger Zone) is reachable by scrolling the main pane', async ({ page, serverUrl }) => {
+        await navigateToAdmin(page, serverUrl);
+        await page.click('[data-testid="admin-tab-data"]');
+
+        // Scroll the main pane to the bottom.
+        await page.locator('#view-admin .ar-main').evaluate((el) => {
+            (el as HTMLElement).scrollTop = (el as HTMLElement).scrollHeight;
+        });
+        await page.waitForTimeout(100);
+
         const dangerZone = page.getByText('Danger Zone');
         await expect(dangerZone).toBeVisible({ timeout: 3000 });
     });
 });
-

--- a/packages/coc/test/spa/react/admin/AdminPanel-fit-viewport.test.ts
+++ b/packages/coc/test/spa/react/admin/AdminPanel-fit-viewport.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Layout invariants for the admin route: the page must fit the available
+ * vertical space, never grow into a single big scrollable page, and only
+ * the right pane (`.ar-main`) is allowed to scroll internally when its
+ * content overflows.
+ *
+ * These checks are static (string-level) but lock the contract between
+ * `Router.tsx` (the outer wrapper) and `admin-redesign.css` (the shell
+ * sizing) so that any regression to the previous "whole page scrolls"
+ * behaviour shows up here, not in production.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const css = readFileSync(
+    resolve(__dirname, '../../../../src/server/spa/client/react/admin/admin-redesign.css'),
+    'utf-8',
+);
+const routerSource = readFileSync(
+    resolve(__dirname, '../../../../src/server/spa/client/react/layout/Router.tsx'),
+    'utf-8',
+);
+
+function block(selector: string): string {
+    const re = new RegExp(`\\.admin-redesign\\s+${selector.replace(/\./g, '\\.')}\\s*\\{([^}]*)\\}`);
+    const match = css.match(re);
+    if (!match) throw new Error(`Selector not found in admin-redesign.css: .admin-redesign ${selector}`);
+    return match[1];
+}
+
+function rootBlock(): string {
+    // The root `.admin-redesign { ... }` rule (no descendant selector after the class).
+    const re = /\.admin-redesign\s*\{([^}]*)\}/;
+    const match = css.match(re);
+    if (!match) throw new Error('Root .admin-redesign rule not found');
+    return match[1];
+}
+
+describe('AdminPanel — fit-to-viewport layout invariants', () => {
+    it('Router wraps the admin route in an overflow-hidden container, not a scroller', () => {
+        // Find the admin route branch.
+        const adminCase = routerSource.match(/case 'admin':[\s\S]*?return\s*\([\s\S]*?\);/);
+        expect(adminCase, 'admin case in Router.tsx not found').not.toBeNull();
+        const branch = adminCase![0];
+        expect(branch).toMatch(/data-testid="admin-scroll-container"/);
+        // The outer wrapper must clip overflow (so the whole page can't scroll).
+        expect(branch).toMatch(/overflow-hidden/);
+        // It must NOT mark itself as a scroll container any longer.
+        expect(branch).not.toMatch(/overflow-y-auto/);
+    });
+
+    it('root .admin-redesign fills its parent so children can size against it', () => {
+        const root = rootBlock();
+        expect(root).toMatch(/height:\s*100%/);
+        // min-height: 0 is required so the root can shrink inside a flex parent
+        // (e.g. the AdminDialog body) instead of forcing the whole dialog to grow.
+        expect(root).toMatch(/min-height:\s*0/);
+    });
+
+    it('.ar-shell pins itself to 100% height and never overflows', () => {
+        const shell = block('.ar-shell');
+        expect(shell).toMatch(/height:\s*100%/);
+        expect(shell).toMatch(/min-height:\s*0/);
+        expect(shell).toMatch(/overflow:\s*hidden/);
+        // Must NOT use `min-height: 100%` which was the source of full-page scroll.
+        expect(shell).not.toMatch(/min-height:\s*100%/);
+    });
+
+    it('.ar-sidebar fills the grid row, scrolls only its own overflow, and is NOT sticky', () => {
+        const sidebar = block('.ar-sidebar');
+        expect(sidebar).toMatch(/height:\s*100%/);
+        expect(sidebar).toMatch(/min-height:\s*0/);
+        expect(sidebar).toMatch(/overflow-y:\s*auto/);
+        // The previous design used sticky + 100vh to keep the sidebar in view
+        // while the whole page scrolled. With fit-to-viewport, both are
+        // unnecessary and would be wrong (100vh != container height in a
+        // dialog or nested pane).
+        expect(sidebar).not.toMatch(/position:\s*sticky/);
+        expect(sidebar).not.toMatch(/height:\s*100vh/);
+    });
+
+    it('.ar-main is the single internal scroller', () => {
+        const main = block('.ar-main');
+        expect(main).toMatch(/height:\s*100%/);
+        expect(main).toMatch(/min-height:\s*0/);
+        expect(main).toMatch(/overflow-y:\s*auto/);
+    });
+
+    it('.ar-topbar stays pinned via sticky positioning inside the main scroller', () => {
+        const topbar = block('.ar-topbar');
+        // The topbar must remain visible while .ar-main scrolls. CSS sticky
+        // works inside any overflow container, so this is still the right tool.
+        expect(topbar).toMatch(/position:\s*sticky/);
+        expect(topbar).toMatch(/top:\s*0/);
+    });
+});


### PR DESCRIPTION
The admin route was rendered inside a single overflow-y:auto wrapper, so
the whole page (sidebar + topbar + content) scrolled together once the
cards stacked taller than the viewport. The sidebar held its place only
because it was position:sticky + height:100vh, which also broke down
inside AdminDialog where 100vh != container height.

Rework the shell to fit-to-viewport:
 - Router wraps the admin route in h-full overflow-hidden (no outer
   scroll).
 - .admin-redesign / .ar-shell fill that parent exactly (height:100%,
   min-height:0, overflow:hidden on the shell).
 - .ar-sidebar fills its grid row, drops sticky/100vh, and only scrolls
   internally if its own content overflows.
 - .ar-main becomes the single scroll region (height:100%, min-height:0,
   overflow-y:auto). The sticky topbar pins to the top of this scroller.

Lock the contract in with a vitest layout-invariant test
(AdminPanel-fit-viewport.test.ts) and rewrite the e2e regression spec to
assert the new behavior (outer container clipped, .ar-main scrolls,
sidebar stays pinned during scroll).

Co-authored-by: Cursor <cursoragent@cursor.com>
