### PR TITLE
Highlight active PR row in left-panel list with gray background

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestRow.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestRow.tsx
@@ -88,7 +88,7 @@ export function PullRequestRow({
                 className={cn(
                     'pr-row relative flex w-full cursor-pointer justify-center border-0 bg-white py-[7px] text-left transition-colors dark:bg-gray-900',
                     isSelected
-                        ? "bg-blue-50 before:absolute before:left-0 before:top-0 before:h-full before:w-[3px] before:bg-blue-500 before:content-[''] dark:bg-blue-900/30"
+                        ? "bg-gray-100 before:absolute before:left-0 before:top-0 before:h-full before:w-[3px] before:bg-gray-500 before:content-[''] dark:bg-gray-700/60 dark:before:bg-gray-400"
                         : 'hover:bg-gray-50 dark:hover:bg-gray-800/60',
                 )}
             >
@@ -110,7 +110,7 @@ export function PullRequestRow({
             className={cn(
                 'pr-row grid w-full cursor-pointer items-start gap-[7px] border-b border-l-[3px] border-gray-100 bg-white py-1.5 pl-2.5 pr-2 text-left transition-colors dark:border-gray-800 dark:bg-gray-900',
                 isSelected
-                    ? 'border-l-blue-500 bg-blue-50 dark:bg-blue-900/30'
+                    ? 'border-l-gray-500 bg-gray-100 dark:border-l-gray-400 dark:bg-gray-700/60'
                     : 'border-l-transparent hover:bg-gray-50 dark:hover:bg-gray-800/60',
             )}
             style={{ gridTemplateColumns: '16px minmax(0, 1fr) auto' }}

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestsTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestsTab.tsx
@@ -502,7 +502,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
                                             key={pr.id}
                                             pr={pr}
                                             onClick={() => handleRowClick(pr)}
-                                            isSelected={(pr.number ?? pr.id) === state.selectedPrId}
+                                            isSelected={state.selectedPrId != null && String(pr.number ?? pr.id) === String(state.selectedPrId)}
                                             isChecked={selectedPrIds.has(getPrSelectionId(pr))}
                                             onSelect={(id, checked, shiftKey) =>
                                                 handlePrSelect(id, checked, shiftKey, sectionPrs)

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestRow.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestRow.test.tsx
@@ -129,8 +129,8 @@ describe('PullRequestRow — selection styling', () => {
     it('applies the selected styling when isSelected is true', () => {
         render(<PullRequestRow pr={makePr()} onClick={vi.fn()} isSelected />);
         const row = screen.getByTestId('pr-row');
-        expect(row.className).toContain('bg-blue-50');
-        expect(row.className).toContain('border-l-blue-500');
+        expect(row.className).toContain('bg-gray-100');
+        expect(row.className).toContain('border-l-gray-500');
     });
 
     it('applies the hover styling when isSelected is false', () => {

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestsTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestsTab.test.tsx
@@ -13,8 +13,9 @@ vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
 
 // Mock AppContext to avoid full context setup.
 const mockDispatch = vi.fn();
+let mockSelectedPrId: number | string | null = null;
 vi.mock('../../../../../src/server/spa/client/react/contexts/AppContext', () => ({
-    useApp: () => ({ state: { selectedPrId: null }, dispatch: mockDispatch }),
+    useApp: () => ({ state: { selectedPrId: mockSelectedPrId }, dispatch: mockDispatch }),
 }));
 
 // Default to desktop layout.
@@ -78,6 +79,7 @@ beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
     mockDispatch.mockReset();
+    mockSelectedPrId = null;
 });
 
 // ── Loading state ──────────────────────────────────────────────────────────────
@@ -555,6 +557,44 @@ describe('batch mode toggle', () => {
         fireEvent.click(screen.getByTestId('select-mode-button'));
         fireEvent.click(screen.getByTestId('pr-row-checkbox'));
         await waitFor(() => expect(screen.getByTestId('selection-count-bar')).toHaveTextContent('1 PR selected'));
+    });
+});
+
+// ── Active PR row highlight ────────────────────────────────────────────────────
+
+describe('active PR row highlight', () => {
+    it('marks the matching row isSelected when selectedPrId is a number (click-nav)', async () => {
+        mockSelectedPrId = 42;
+        mockFetchOk([makePr({ id: 1, number: 42, title: 'Active PR' })]);
+        await act(async () => { await renderTab(); });
+        await waitFor(() => expect(screen.getByTestId('pr-row')).toBeInTheDocument());
+
+        const row = screen.getByTestId('pr-row');
+        expect(row.className).toContain('bg-gray-100');
+        expect(row.className).toContain('border-l-gray-500');
+    });
+
+    it('marks the matching row isSelected when selectedPrId is a string (URL deep-link)', async () => {
+        // Router stores the PR id from the hash as a string via decodeURIComponent.
+        mockSelectedPrId = '42';
+        mockFetchOk([makePr({ id: 1, number: 42, title: 'Active PR' })]);
+        await act(async () => { await renderTab(); });
+        await waitFor(() => expect(screen.getByTestId('pr-row')).toBeInTheDocument());
+
+        const row = screen.getByTestId('pr-row');
+        expect(row.className).toContain('bg-gray-100');
+        expect(row.className).toContain('border-l-gray-500');
+    });
+
+    it('does not mark a row selected when the id does not match', async () => {
+        mockSelectedPrId = 99;
+        mockFetchOk([makePr({ id: 1, number: 42, title: 'Other PR' })]);
+        await act(async () => { await renderTab(); });
+        await waitFor(() => expect(screen.getByTestId('pr-row')).toBeInTheDocument());
+
+        const row = screen.getByTestId('pr-row');
+        expect(row.className).not.toContain('bg-gray-100');
+        expect(row.className).toContain('border-l-transparent');
     });
 });
 


### PR DESCRIPTION
## Summary

- **Bug fix**: When navigating to a PR via URL hash (e.g. `#repos/.../pull-requests/42/overview`), the router stores `selectedPrId` as a **string** (`"42"`) via `decodeURIComponent`, while `pr.number` in the list is a **number** (`42`). The strict `===` comparison silently failed, so no row ever got highlighted on URL navigation.
- **Visual fix**: Changed selected-row styling from blue (`bg-blue-50` / `border-l-blue-500`) to gray (`bg-gray-100` / `border-l-gray-500`) — applied to both normal and compact row variants — so the active PR is clearly distinguished in the left-panel list.

## Changes

- `PullRequestRow.tsx` — selected state uses `bg-gray-100 border-l-gray-500` (and dark-mode equivalents) instead of blue
- `PullRequestsTab.tsx` — `isSelected` comparison normalizes both sides with `String()` to handle number/string mismatch
- Tests updated for new gray classes; 3 new regression tests added for the string-vs-number `selectedPrId` comparison

## Test plan

- [ ] Open the PR list tab; click a PR — its row in the left panel gets a gray background + left border
- [ ] Refresh the page (URL keeps the PR hash) — same row is still highlighted
- [ ] Run `npm run test:run -w packages/coc -- pull-requests` — all 315 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01BApvdDhj6VQosjKa3VZY6k)_