### PR TITLE
Refactor AGENTS.md and enhance documentation for CoC service management

### DIFF
--- a/.github/skills/coc-knowledge/SKILL.md
+++ b/.github/skills/coc-knowledge/SKILL.md
@@ -21,8 +21,14 @@ It consists of three packages (`coc`, `forge`, `deep-wiki`) plus a shared client
 
 | Domain | Reference | Summary |
 |--------|-----------|---------|
+| Monorepo | [monorepo.md](references/monorepo.md) | Cross-package layout, build/test commands, changesets release flow, shared conventions |
 | Server Architecture | [server-architecture.md](references/server-architecture.md) | Module layout, feature domains, route registration, config schema |
-| Ralph | [ralph.md](references/ralph.md) | Iterative execution session journal, writer protocol, size cap |
+| Admin Config | [admin-config.md](references/admin-config.md) | `ADMIN_CONFIG_FIELDS` registry, admin REST surface, admin UI styling (`admin-redesign.css`) |
+| MCP Settings | [mcp-settings.md](references/mcp-settings.md) | Workspace MCP merge (global + workspace), allow-list, secrets boundary |
+| EnDev xDPU | [endev.md](references/endev.md) | Workspace eligibility cache, REST status/revalidate, skill surfacing |
+| CoC Service (Windows) | [coc-service.md](references/coc-service.md) | `Manage-CoCService.ps1` Task Scheduler service, devtunnel integration, logs |
+| Ralph | [ralph.md](references/ralph.md) | Iterative execution session journal, writer protocol, size cap, promote-to-ralph endpoint |
+| Loops | [loops.md](references/loops.md) | Recurring follow-ups, executor, circuit breakers, REST API, dashboard integration |
 | Memory System | [memory-system.md](references/memory-system.md) | Bounded memory, capture mode, candidate ranking, promotion, recall index |
 | LLM Tools | [llm-tools.md](references/llm-tools.md) | Tool registry, per-invocation factories, permissions, web search |
 | SDK Wrapper | [sdk-wrapper.md](references/sdk-wrapper.md) | Session lifecycle, streaming state machine, MCP config, model registry |

--- a/.github/skills/coc-knowledge/references/admin-config.md
+++ b/.github/skills/coc-knowledge/references/admin-config.md
@@ -1,0 +1,53 @@
+# Admin Config & Admin UI Styling
+
+Covers the editable admin config registry in `packages/coc/` and the self-contained styling system for the admin route in the dashboard SPA. Load this when adding or modifying any admin-exposed configuration field or admin UI element.
+
+## Admin Config Field Registry
+
+Editable admin config fields are defined in a single registry: `packages/coc/src/server/admin/admin-config-fields.ts` (`ADMIN_CONFIG_FIELDS`).
+
+Each entry provides a flat key (e.g. `'loops.enabled'`), a `validate()` function, and an `apply()` function. The `PUT /api/admin/config` handler derives `editableKeys`, validation, and merge logic entirely from this registry — **no changes to `admin-handler.ts` are needed when adding a new editable field**.
+
+To expose a new config field via the admin API, add ONE entry to `ADMIN_CONFIG_FIELDS`. Also update:
+
+1. `CLIConfig` / `ResolvedCLIConfig` / `DEFAULT_CONFIG` in `packages/coc/src/config.ts`
+2. `CLIConfigSchema` in `packages/coc/src/config/schema.ts`
+3. Namespace registry in `packages/coc/src/config/namespace-registry.ts` (nested fields)
+4. `AdminResolvedConfig` / `AdminConfigUpdate` in `packages/coc-client/src/contracts/admin.ts`
+5. `AdminPanel.tsx` for the UI control
+
+The `spaHtml` function in `packages/coc/src/server/index.ts` re-reads the config file on every page request, so feature-flag changes (e.g. `terminal.enabled`) take effect on the next browser reload — no server restart required.
+
+## Namespaced Config Merge & Source Tracking
+
+Namespaced config merge/source tracking is registered in `packages/coc/src/config/namespace-registry.ts`; add namespace fields there instead of expanding branch lists in `config.ts`. Default process store backend is SQLite. CLI flags > config file > defaults.
+
+## Admin UI Styling
+
+The admin route uses a self-contained, Linear-inspired design system that lives in `packages/coc/src/server/spa/client/react/admin/admin-redesign.css`. The stylesheet is imported once at the top of `AdminPanel.tsx` so esbuild bundles it into the SPA's CSS. All selectors are scoped under the `.admin-redesign` root class that wraps the entire admin page — styles never leak to other dashboard surfaces, and light/dark themes are driven by the existing `<html data-theme="…">` attribute.
+
+### Layout (sidebar + main, fit-to-viewport)
+
+The admin page is structured as a two-column shell that fills the available vertical space and never scrolls as a whole. Only the right pane is scrollable.
+
+- The route mounts inside `<div className="h-full overflow-hidden" data-testid="admin-scroll-container">` (Router) or the `AdminDialog` body (`flex-1 min-h-0 overflow-y-auto`). Both supply a definite height to the panel.
+- The `.admin-redesign` root (on `#view-admin`) is `height: 100%; min-height: 0` so the panel fills that parent exactly.
+- `<div className="ar-shell">` is a CSS grid (`var(--ar-sidebar-w)` + `1fr`) with `height: 100%; min-height: 0; overflow: hidden`.
+- `<aside className="ar-sidebar">` fills the grid row (`height: 100%; min-height: 0`) and only scrolls internally if its own brand/nav/stats stack ever exceeds the viewport. It is **not** sticky and must not use `100vh` — both would break inside the `AdminDialog` and any nested pane whose container height differs from the viewport.
+- `<main className="ar-main">` is the **single scroll region** of the admin route: `min-height: 0; height: 100%; overflow-y: auto`. The sticky topbar (`.ar-topbar` with the `.ar-breadcrumb`) pins to the top of this scroller, and the page body (`.ar-page` with `.ar-page-header` + cards) flows underneath.
+- The tabs live in the sidebar as `.ar-nav-item` buttons (data-testids `admin-tab-{settings|providers|data|server|prompts|database|agents}` are preserved for tests). A `.ar-mobile-tab-select` appears only under the responsive `@media (max-width: 600px)` rule, which hides the sidebar and falls back to a `<select>` — the main pane still scrolls internally on mobile.
+
+### Settings Sub-Tabs
+
+Settings (the `settings` top-level tab) is split into one `SettingsCard` per sub-tab — `ai`, `chat`, `appearance`, `features`, `integrations`, `advanced` — defined in `SETTINGS_SUBTABS` near the top of `AdminPanel.tsx`. A `.ar-subtab-row` with `.ar-subtab` buttons (data-testids `settings-subtab-{ai|chat|appearance|features|integrations|advanced}`) renders above the cards. Selection is kept in local `settingsSubTab` state, defaults to `ai`, and is synced both directions with `#admin/settings/<sub>` (default `ai` collapses to `#admin/settings`). Tests that interact with controls outside of the default `ai` card must first navigate via the `gotoSettingsSubTab(...)` helper.
+
+### Primitives for New Admin UI
+
+When adding UI to the admin page, prefer the existing primitives:
+
+- **Section cards:** `<SettingsCard title=… description=… badge=… dirty saving onSave onCancel data-testid=…>` (renders `.ar-card` with header/body/footer).
+- **Settings rows:** the local `AdminRow`, `AdminToggle`, `AdminSeg`, `AdminInputSuffix`, and `SourceBadge` helpers defined at the bottom of `AdminPanel.tsx`. They wrap raw inputs in the new visual chrome while preserving `data-testid`s and `id`s used by tests.
+- **Free-form sections** inside a card use `.ar-section`, `.ar-section-head`, and the inline helpers `.ar-input`, `.ar-select`, `.ar-btn`, `.ar-btn-primary` / `-secondary` / `-ghost` / `-danger`(`-outline`), `.ar-pill`, `.ar-badge`, `.ar-pre`, `.ar-code`, `.ar-mono`.
+- **New top-level tabs:** add to `AdminSubTab`, `TAB_LABELS`, `TAB_ICONS`, and `TAB_DESCRIPTIONS` near the top of `AdminPanel.tsx` — the sidebar nav and mobile select pick them up automatically.
+
+Avoid introducing Tailwind utilities or inline `bg-*`/`text-*` classes for admin-only UI — extend `admin-redesign.css` instead so the look stays cohesive.

--- a/.github/skills/coc-knowledge/references/coc-service.md
+++ b/.github/skills/coc-knowledge/references/coc-service.md
@@ -1,0 +1,46 @@
+# CoC Service Management (Windows)
+
+`scripts/Manage-CoCService.ps1` manages `coc-serve-loop.ps1` as a Windows Task Scheduler task running under the SYSTEM account at startup.
+
+## Usage
+
+```
+.\scripts\Manage-CoCService.ps1 <Command> [options]
+```
+
+| Command      | Description |
+|--------------|-------------|
+| `install`    | Register the startup task (requires elevation). Runs an initial build by default. Use `-TunnelId` to host a configured Microsoft Dev Tunnel alongside the server. |
+| `uninstall`  | Stop and remove the task (requires elevation). |
+| `start`      | Start the task immediately (no reboot required). |
+| `stop`       | Stop the task and kill all CoC-related processes. |
+| `restart`    | `stop` then `start`. |
+| `status`     | Show task state, running PIDs, log file size, and last log line. |
+| `logs`       | Print the last N log lines. Use `-Follow` for continuous tail. |
+
+## Options
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `-Port` | `4000` | Non-tunnel mode only. |
+| `-BindAddress` | `127.0.0.1` | Use `0.0.0.0` to expose on all interfaces. Named `-BindAddress` to avoid PowerShell's `$Host` automatic variable. |
+| `-TunnelId` | — | Host the configured Microsoft Dev Tunnel and use its persisted HTTP port binding. |
+| `-NoBuildSkip` | off | Build on every start, not just install. |
+| `-LogLines` | `50` | Tail size for `logs`. |
+| `-Follow` | off | Follow log output. |
+| `-TaskName` | `CoCServer` | Task Scheduler entry name. |
+
+## Tunnel Setup
+
+Configure the tunnel first with:
+
+```
+.\scripts\config-devtunnel.ps1 [-TunnelId <id>] [-Port <port>]
+```
+
+The service loop reads the configured tunnel port and only starts/stops `devtunnel host`.
+
+## Logs
+
+- **Log file:** `~/.coc/logs/coc-service.log`
+- Rotated automatically at 10 MB.

--- a/.github/skills/coc-knowledge/references/endev.md
+++ b/.github/skills/coc-knowledge/references/endev.md
@@ -1,0 +1,27 @@
+# EnDev xDPU
+
+Workspace-scoped EnDev xDPU support lives in `packages/coc/src/server/endev/`. The EnDev wrapper skill and EnDev plugin skills are only surfaced in eligible workspaces.
+
+## Eligibility Cache
+
+Eligibility is cached under `~/.coc/repos/<workspaceId>/endev/eligibility.json` and requires **all** of the following:
+
+- A native WSL host
+- xDPU workspace markers in the repo
+- EnDev setup files present
+- A successful short-timeout `endev doctor`
+
+## REST API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/workspaces/:id/endev/status` | Read cached eligibility. `?refresh=true` forces revalidation and clears the workspace skill cache. |
+| `POST` | `/api/workspaces/:id/endev/revalidate` | Force revalidation and clear the workspace skill cache. |
+
+## Skill Surfacing
+
+The `EnDev-xDpu` wrapper skill and auto-discovered EnDev plugin skill folders are surfaced **only** when the workspace is eligible — hidden otherwise from skill lists, pickers, and recents.
+
+There is **no separate per-repo toggle**; users disable the wrapper via the standard `disabledSkills` mechanism if needed.
+
+EnDev MCP servers and EnDev plugin skills follow their own settings independently of the wrapper skill.

--- a/.github/skills/coc-knowledge/references/loops.md
+++ b/.github/skills/coc-knowledge/references/loops.md
@@ -169,6 +169,30 @@ Creates a recurring loop. First tick fires after one full interval.
 8. Enqueue follow-up via `TaskQueueManager` with `turnSource: { source: 'loop', loopId }`.
 9. On completion callback (`onTickComplete`): increment `tickCount`, reset failures, schedule next tick. On failure: increment `consecutiveFailures`, auto-pause at threshold.
 
+## Tick Completion Wiring
+
+`ProcessLifecycleRunner` invokes the `onLoopTickComplete(loopId, success)`
+lifecycle option after a loop-originated follow-up (`context.source === 'loop'`
+with string `context.loopId`) finishes. The queue-executor-bridge routes this
+call to `LoopExecutor.onTickComplete()`, which advances `tickCount` /
+`lastTickAt`, clears the in-flight guard, and re-arms the next timer.
+
+Bookkeeping errors are logged but never mask the follow-up's actual
+success/failure result.
+
+## Follow-Up Mode Resolution
+
+`resolveFollowUpMode(store, processId, explicit?)` in
+`executors/follow-up-mode.ts` is the single source of truth for "what mode
+does this follow-up run in?".
+
+- Every programmatic follow-up enqueue site (loop ticks, wakeup timer,
+  requeue) must call it and set `payload.mode`.
+- `validateAndParseTask` only defaults `payload.mode` to `autopilot` for new
+  chats (no `processId`); REST follow-ups must supply mode.
+- `FollowUpExecutor.executeFollowUp` requires `mode` and logs a fail-loud
+  warning + defaults to `'ask'` if missing.
+
 ## REST API
 
 ### Workspace-scoped

--- a/.github/skills/coc-knowledge/references/mcp-settings.md
+++ b/.github/skills/coc-knowledge/references/mcp-settings.md
@@ -1,0 +1,25 @@
+# MCP Settings (Workspace-Scoped)
+
+Workspace MCP servers in CoC are a merge of two sources: global servers from `~/.copilot/mcp-config.json` and workspace servers from `<repo>/.vscode/mcp.json`. Workspace entries override global entries with the same name. CoC's REST API surfaces both the effective merge and the source-separated views, and persists a name-based allow-list per workspace.
+
+## REST API
+
+### `GET /api/workspaces/:id/mcp-config`
+
+Returns both the effective `availableServers` list and source-separated `sources.global` / `sources.workspace` sections.
+
+- Global servers come from `~/.copilot/mcp-config.json`.
+- Workspace servers come from `<repo>/.vscode/mcp.json` via Forge MCP loader helpers.
+- Workspace entries override global entries with the same name.
+- The endpoint only exposes safe row metadata (`name`, `type`, optional `url`/`command`, source/effective flags) and must **not** return secrets such as `env`, headers, or full argument arrays.
+- `?forceReload=true` bypasses the path-keyed MCP config cache for manual dashboard refreshes; no file watcher is used.
+
+### `PUT /api/workspaces/:id/mcp-config`
+
+Stores only the name-based `enabledMcpServers` allow-list. Workflow run filtering must resolve that list against the same effective global-plus-workspace MCP merge used at runtime.
+
+## Invariants
+
+- Never expose secrets (`env`, headers, full `args`) through the REST surface.
+- Allow-list is name-only — the effective server set is always re-resolved at run time.
+- File watching is intentionally avoided; clients drive cache invalidation via `?forceReload=true`.

--- a/.github/skills/coc-knowledge/references/monorepo.md
+++ b/.github/skills/coc-knowledge/references/monorepo.md
@@ -1,0 +1,78 @@
+# Monorepo Layout, Build, and Release
+
+All four published packages plus a frozen VS Code extension live in one npm workspaces monorepo. This file documents the cross-package contract, build/test commands, package management, and conventions enforced across the whole tree. Load it when planning multi-package changes, debugging build/release issues, or wiring new conventions.
+
+## Products & Shared Packages
+
+| Product | Location | Runtime | Description |
+|---------|----------|---------|-------------|
+| **VS Code Extension** | `packages/vscode-extension/` | VS Code | Markdown review, git diff review, code review, shortcut groups, global notes, tasks viewer, YAML workflows — **FROZEN: do not modify** |
+| **CoC CLI** | `packages/coc/` | Node.js | CLI for executing YAML-based AI workflows (`coc run|validate|list|serve|wipe-data`) |
+| **CoC Client** | `packages/coc-client/` | Node.js/browser | Framework-free TypeScript client for CoC REST and realtime APIs |
+| **Deep Wiki** | `packages/deep-wiki/` | Node.js | CLI that auto-generates comprehensive wikis for codebases (`deep-wiki seeds|discover|generate|theme|init`) |
+
+| Shared Package | Location | Description |
+|----------------|----------|-------------|
+| **forge** | `packages/forge/` | Core AI/pipeline engine: AI SDK (CopilotSDKService, session-per-request), DAG workflow engine (`executeWorkflow`, `compileToWorkflow`), task queue, runtime policies, process store, git CLI, utilities |
+| **whatsapp-bot** | `packages/whatsapp-bot/` | Standalone WhatsApp bot via Baileys — no CoC/forge deps. Used by `coccontainer` when `messaging.whatsapp.enabled` is true |
+
+**Architectural boundary:** Pure Node.js logic lives in packages (no VS Code deps). VS Code-specific wrappers live in `packages/vscode-extension/src/shortcuts/`. Example: `forge/src/ai/` = pure AI SDK; `packages/vscode-extension/src/shortcuts/ai-service/` = VS Code UI wrapper. **`packages/vscode-extension/` is frozen — do not read, edit, or reason about its code.**
+
+## Package Management & Publishing
+
+All published packages (`forge`, `coc`, `coc-client`, `deep-wiki`) are published to npm under the `@plusplusoneplusplus` scope with public access. Versioning and publishing are coordinated via **`@changesets/cli`** with an independent versioning strategy.
+
+**How forge is consumed:** `coc` and `deep-wiki` depend on the published `@plusplusoneplusplus/forge` package via a caret range (`^1.0.0`). During local development, npm workspaces symlink forge automatically. There is no bundling or copying of forge into consumer packages — forge is resolved from `node_modules` at runtime.
+
+**Versioning workflow:**
+1. Add a changeset: `npm run changeset` (interactive prompt for affected packages and semver bump)
+2. Version packages: `npm run version-packages` (applies changesets, updates `package.json` versions and changelogs)
+3. Publish: `npm run publish-packages` (builds all packages then runs `changeset publish`)
+
+**CI release:** `.github/workflows/release.yml` runs on pushes to `main`. When pending changesets exist, `changesets/action` opens a "Version Packages" PR. When the PR is merged (no pending changesets), it publishes changed packages to npm.
+
+**Changesets config:** `.changeset/config.json` — independent versioning, public access, `main` as base branch, `updateInternalDependencies: "patch"`.
+
+**Minimum Node.js:** All packages require Node.js ≥ 24 (`engines.node`). CI runs on `24.x`.
+
+## Build & Test
+
+- **Build packages:** `npm run build:packages`
+- **Build extension:** `npm run compile`
+- **Watch:** `npm run watch`
+- **Test all:** `npm run test` (extension Mocha tests, 6900+)
+- **Test packages:** `npm run test:run` in any package directory (Vitest)
+- **Lint:** `npm run lint`
+- **Package:** `npm run vsce:package`
+- **Publish:** `npm run vsce:publish`
+- **Debug CoC:** `cd packages/coc && npm run build && npm link && cd ../..` then `coc run <path>` or `coc serve --no-open`
+- **Debug Deep Wiki:** `cd packages/deep-wiki && npm run build && npm link && cd ../..` then `deep-wiki generate <repo>`
+- **Run CoC as a service:** see [coc-service.md](coc-service.md)
+
+## Cross-Package Conventions
+
+**Repo-scoped data:** All runtime data specific to a single repository must live under `~/.coc/repos/<workspaceId>/`. Use `getRepoDataPath(dataDir, workspaceId, filename)` from `packages/coc/src/server/` to resolve the path. Do **NOT** add new top-level directories under `~/.coc/` for per-repo data.
+
+**Creating work items:** Work items are stored as JSON files in `~/.coc/repos/<workspaceId>/work-items/` (NOT as `.plan.md` files in `tasks/`).
+
+- **ALWAYS use the REST API** to create/update work items when the CoC server is running:
+  ```
+  POST http://localhost:4000/api/workspaces/<workspaceId>/work-items
+  Body: { title, description, priority, tags, source }
+  ```
+- **Never write work-item JSON files directly** — the server uses an atomic write-queue.
+
+**Model resolution:** `task.config.model` > `PerRepoPreferences.defaultModels[mode]` > `defaultModel` > CLI default.
+
+## VS Code Extension (FROZEN)
+
+> ⚠️ `packages/vscode-extension/` is frozen and no longer actively developed. AI agents must NOT read, edit, or reason about code in `packages/vscode-extension/`. It is not an npm workspace.
+
+Historical reference (do not modify): entry point `packages/vscode-extension/src/extension.ts`. Feature modules under `packages/vscode-extension/src/shortcuts/` covered markdown comments, git diff comments, code review, YAML pipelines, tasks viewer, AI service, git layer, skills, and shared base classes. Configuration lived in `.vscode/shortcuts.yaml` with a versioned migration system (v1→v4). MCP/Permissions were handled via `SendMessageOptions`.
+
+## Development Notes
+
+- TypeScript, webpack bundling, VS Code API ≥ 1.95.0, Node.js ≥ 24
+- Format on save and import organization enabled
+- Cross-platform: Linux, macOS, Windows
+- (Extension only, frozen) Tree data providers extend `BaseTreeDataProvider` or `FilterableTreeDataProvider`; commands are registered centrally in `src/shortcuts/commands.ts`

--- a/.github/skills/coc-knowledge/references/ralph.md
+++ b/.github/skills/coc-knowledge/references/ralph.md
@@ -75,3 +75,21 @@ repository-specific implementation skills, set `context.skills`, or begin with
 `<available_skills>`, `<additional_tool_instructions>`, or `<skill-context`,
 since the retriever skips messages with those prefixes when locating the user
 query.
+
+## Promote Ask-Mode Chat to Ralph
+
+A completed ask-mode chat can be promoted to a Ralph session in place via
+`POST /api/processes/:id/promote-to-ralph`
+(`packages/coc/src/server/routes/ralph-promote-routes.ts`).
+
+The endpoint:
+
+1. Attaches a `grilling`-phase Ralph context to the existing process.
+2. Enqueues a synthesis follow-up turn with `mode=ask`,
+   `context.skills=['grill-me']`, `context.ralph.phase='grilling'`, carrying
+   the prompt produced by `buildRalphSynthesisPrompt`
+   (`packages/coc/src/server/ralph/synthesis-prompt.ts`).
+
+The SPA shows a **"Promote to Ralph"** pill in the follow-up area for eligible
+chats and calls this endpoint via `coc-client`'s `processes.promoteToRalph`
+helper.

--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -36,6 +36,7 @@ CoC server exposes HTTP endpoints organized by domain. All routes are registered
 | DELETE | `/api/processes/:id` | Delete process |
 | POST | `/api/processes/:id/message` | Follow-up message |
 | POST | `/api/processes/:id/cancel` | Cancel running process |
+| POST | `/api/processes/:id/promote-to-ralph` | Promote completed ask-mode chat to Ralph session (see [ralph.md](ralph.md)) |
 | PATCH | `/api/processes/:id/pin` | Pin/unpin process |
 | PATCH | `/api/processes/:id/archive` | Archive/unarchive |
 | GET | `/api/processes/:id/turns/pinned` | Get pinned turns |
@@ -119,6 +120,37 @@ CoC server exposes HTTP endpoints organized by domain. All routes are registered
 | PUT | `/api/memory/bounded/:level` | Write bounded memory |
 | DELETE | `/api/repos/:repoId/memory` | Wipe repo memory |
 | GET | `/api/repos/:repoId/memory/entries` | List memory entries |
+
+## Loops
+
+See [loops.md](loops.md) for the full subsystem. Gated by `loops.enabled` (default `false`).
+
+### Workspace-scoped
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/workspaces/:id/loops` | List loops for workspace |
+| GET | `/api/workspaces/:id/loops/:loopId` | Get single loop |
+| PATCH | `/api/workspaces/:id/loops/:loopId` | Update loop fields (description, prompt, intervalMs, model) |
+| DELETE | `/api/workspaces/:id/loops/:loopId` | Cancel & soft-delete loop |
+| POST | `/api/workspaces/:id/loops/:loopId/pause` | Pause loop (body: `{ reason? }`) |
+| POST | `/api/workspaces/:id/loops/:loopId/resume` | Resume paused loop |
+
+### Server-wide
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/loops` | List all loops server-wide |
+| GET | `/api/loops/:loopId` | Get a loop by ID |
+
+## MCP Settings
+
+See [mcp-settings.md](mcp-settings.md).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/workspaces/:id/mcp-config` | Effective + source-separated MCP servers. `?forceReload=true` bypasses cache |
+| PUT | `/api/workspaces/:id/mcp-config` | Store name-based `enabledMcpServers` allow-list |
 
 ## Work Items
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,167 +3,39 @@
 Guidance for AI agents working in this repository. NEVER create document files unless explicitly asked.
 
 ## Key Design Choice (Maintained manually, AI should NEVER update this section)
+
 - CoC:
-    - multi-repo support is required. Never design or implement a feature that would break multi-repo scenario. 
+    - multi-repo support is required. Never design or implement a feature that would break multi-repo scenario.
     - copilot-sdk wrapper should NEVER add a sendFollowUp method or something similar. copilot-sdk-wrapper layer or above should NEVER try to add keep-alive/session-object cache.
     - Prefer use file path in the prompt instead of expanding the prompt with file's content.
 
-## Monorepo Overview
+## Repo Layout (one-liner)
 
-Three products plus shared infrastructure, all in one npm workspaces monorepo:
+npm workspaces monorepo with one frozen VS Code extension and four published Node packages (`forge`, `coc`, `coc-client`, `deep-wiki`). `packages/vscode-extension/` is **FROZEN — do not read, edit, or reason about its code.**
 
-| Product | Location | Runtime | Description |
-|---------|----------|---------|-------------|
-| **VS Code Extension** | `packages/vscode-extension/` | VS Code | Markdown review, git diff review, code review, shortcut groups, global notes, tasks viewer, YAML workflows — **FROZEN: do not modify** |
-| **CoC CLI** | `packages/coc/` | Node.js | CLI for executing YAML-based AI workflows (`coc run\|validate\|list\|serve\|wipe-data`) |
-| **CoC Client** | `packages/coc-client/` | Node.js/browser | Framework-free TypeScript client for CoC REST and realtime APIs |
-| **Deep Wiki** | `packages/deep-wiki/` | Node.js | CLI that auto-generates comprehensive wikis for codebases (`deep-wiki seeds\|discover\|generate\|theme\|init`) |
+## Load the CoC Knowledge Skill
 
-| Shared Package | Location | Description |
-|----------------|----------|-------------|
-| **forge** | `packages/forge/` | Core AI/pipeline engine: AI SDK (CopilotSDKService, session-per-request), DAG workflow engine (executeWorkflow, compileToWorkflow), task queue, runtime policies, process store, git CLI, utilities |
-| **whatsapp-bot** | `packages/whatsapp-bot/` | Standalone WhatsApp bot via Baileys — no CoC/forge deps. Used by coccontainer when `messaging.whatsapp.enabled` is true |
+For anything touching CoC, forge, deep-wiki, coc-client, the dashboard SPA, REST API, workflow engine, memory system, LLM tools, process store, admin config, MCP settings, Ralph, loops, EnDev, the Windows service, monorepo layout, build/test/release flow, or repo conventions — **load `.github/skills/coc-knowledge/SKILL.md` and read the relevant `references/*.md` files** before responding or editing.
 
-**Key architectural boundary:** Pure Node.js logic lives in packages (no VS Code deps). VS Code-specific wrappers live in `packages/vscode-extension/src/shortcuts/`. Example: `forge/src/ai/` = pure AI SDK; `packages/vscode-extension/src/shortcuts/ai-service/` = VS Code UI wrapper. **`packages/vscode-extension/` is frozen — do not read, edit, or reason about its code.**
+Quick-start pointers (full detail lives in the skill):
 
-## Package Management & Publishing
+- **Monorepo, build, test, changesets release** → [monorepo.md](.github/skills/coc-knowledge/references/monorepo.md)
+- **CoC server module layout / executors / startup** → [server-architecture.md](.github/skills/coc-knowledge/references/server-architecture.md)
+- **Admin config field registry + admin UI styling** → [admin-config.md](.github/skills/coc-knowledge/references/admin-config.md)
+- **Workspace MCP merge & allow-list** → [mcp-settings.md](.github/skills/coc-knowledge/references/mcp-settings.md)
+- **EnDev xDPU eligibility & skill surfacing** → [endev.md](.github/skills/coc-knowledge/references/endev.md)
+- **Windows service (`Manage-CoCService.ps1`)** → [coc-service.md](.github/skills/coc-knowledge/references/coc-service.md)
+- **Ralph iterative sessions + promote endpoint** → [ralph.md](.github/skills/coc-knowledge/references/ralph.md)
+- **Recurring loops + wakeups + circuit breakers** → [loops.md](.github/skills/coc-knowledge/references/loops.md)
+- **Deep Wiki six-phase pipeline** → [deep-wiki.md](.github/skills/coc-knowledge/references/deep-wiki.md)
+- **REST API catalog** → [rest-api.md](.github/skills/coc-knowledge/references/rest-api.md)
 
-All published packages (`forge`, `coc`, `coc-client`, `deep-wiki`) are published to npm under the `@plusplusoneplusplus` scope with public access. Versioning and publishing are coordinated via **`@changesets/cli`** with an independent versioning strategy.
+## Hard Invariants (apply even before reading the skill)
 
-**How forge is consumed:** `coc` and `deep-wiki` depend on the published `@plusplusoneplusplus/forge` package via a caret range (`^1.0.0`). During local development, npm workspaces symlink forge automatically. There is no bundling or copying of forge into consumer packages — forge is resolved from `node_modules` at runtime.
-
-**Versioning workflow:**
-1. Add a changeset: `npm run changeset` (interactive prompt for affected packages and semver bump)
-2. Version packages: `npm run version-packages` (applies changesets, updates `package.json` versions and changelogs)
-3. Publish: `npm run publish-packages` (builds all packages then runs `changeset publish`)
-
-**CI release:** `.github/workflows/release.yml` runs on pushes to `main`. When pending changesets exist, `changesets/action` opens a "Version Packages" PR. When the PR is merged (no pending changesets), it publishes changed packages to npm.
-
-**Changesets config:** `.changeset/config.json` — independent versioning, public access, `main` as base branch, `updateInternalDependencies: "patch"`.
-
-**Minimum Node.js:** All packages require Node.js ≥ 24 (`engines.node`). CI runs on `24.x`.
-
-## Build & Test
-
-- **Build packages:** `npm run build:packages` · **Build extension:** `npm run compile` · **Watch:** `npm run watch`
-- **Test all:** `npm run test` (extension Mocha tests, 6900+)
-- **Test packages:** `npm run test:run` in any package directory (Vitest)
-- **Lint:** `npm run lint` · **Package:** `npm run vsce:package` · **Publish:** `npm run vsce:publish`
-- **Debug CoC:** `cd packages/coc && npm run build && npm link && cd ../..` then `coc run <path>` or `coc serve --no-open`
-- **Debug Deep Wiki:** `cd packages/deep-wiki && npm run build && npm link && cd ../..` then `deep-wiki generate <repo>`
-- **Run CoC as a service:** `.\scripts\Manage-CoCService.ps1 install` (see section below)
-
-## CoC Service Management (`scripts/Manage-CoCService.ps1`)
-
-Manages `coc-serve-loop.ps1` as a Windows Task Scheduler task running under the SYSTEM account at startup.
-
-```
-.\scripts\Manage-CoCService.ps1 <Command> [options]
-```
-
-| Command      | Description |
-|--------------|-------------|
-| `install`    | Register the startup task (requires elevation). Runs an initial build by default. Use `-TunnelId` to host a configured Microsoft Dev Tunnel alongside the server. |
-| `uninstall`  | Stop and remove the task (requires elevation). |
-| `start`      | Start the task immediately (no reboot required). |
-| `stop`       | Stop the task and kill all CoC-related processes. |
-| `restart`    | `stop` then `start`. |
-| `status`     | Show task state, running PIDs, log file size, and last log line. |
-| `logs`       | Print the last N log lines. Use `-Follow` for continuous tail. |
-
-Key options: `-Port` (default 4000, non-tunnel mode only), `-BindAddress` (default `127.0.0.1`; use `0.0.0.0` to expose on all interfaces — named `-BindAddress` to avoid PowerShell's `$Host` automatic variable), `-TunnelId` (host the configured Microsoft Dev Tunnel and use its persisted HTTP port binding), `-NoBuildSkip` (build on every start, not just install), `-LogLines` (default 50), `-Follow`, `-TaskName` (default `CoCServer`). Configure the tunnel first with `.\scripts\config-devtunnel.ps1 [-TunnelId <id>] [-Port <port>]`; the service loop reads the configured tunnel port and only starts/stops `devtunnel host`.
-
-**Log file:** `~/.coc/logs/coc-service.log` — rotated automatically at 10 MB.
-
-## VS Code Extension(`packages/vscode-extension/`) — FROZEN
-
-> ⚠️ **This folder is frozen and no longer actively developed. AI agents must NOT read, edit, or reason about code in `packages/vscode-extension/`. It is not an npm workspace.**
-
-Entry point: `packages/vscode-extension/src/extension.ts`. Feature modules under `packages/vscode-extension/src/shortcuts/`:
-
-- **markdown-comments** — Custom Editor API for inline markdown review. Comments in `.vscode/comments/<hash>.json`.
-- **git-diff-comments** — Git diff review with comment categories and resolve/reopen workflow.
-- **code-review** — Review commits against rules in `.github/cr-rules/*.md`.
-- **yaml-pipeline** — Workflows management UI. Workflows are directories with `pipeline.yaml` under `.vscode/workflows/`.
-- **tasks-viewer** — Hierarchical task management in `.vscode/tasks/`. Recursive scanning, document grouping by suffix (plan/spec/test/notes/todo/design/impl/review/checklist/requirements/analysis).
-- **ai-service** — VS Code AI wrapper: `AIProcessManager` (Memento persistence), `AIQueueService`, `CopilotCLIInvoker`. Working dir defaults to `{workspace}/src` if exists.
-- **git** — VS Code git layer wrapping `forge/src/git/`.
-- **skills** — Install skills from GitHub repos or local dirs to `.github/skills`.
-- **shared** — Base classes: `BaseTreeDataProvider`, `FilterableTreeDataProvider`, icon/filter/error utilities.
-
-**Configuration:** `.vscode/shortcuts.yaml` with `basePaths` (aliases like `@frontend`), `logicalGroups` (nested, items of type file/folder/command/task/note), `globalNotes`. Versioned migration system (v1→v4) in `config-migrations.ts`.
-
-**MCP/Permissions:** `SendMessageOptions` supports `availableTools` (whitelist), `excludedTools` (blacklist), `mcpServers`, `onPermissionRequest`. MCP config auto-loaded from `~/.copilot/mcp-config.json` for every session (opt out with `loadDefaultMcpConfig: false` or `mcpServers: {}`). Without `onPermissionRequest`, operations are denied by default.
-
-## CoC CLI (`packages/coc/`)
-
-Standalone CLI for YAML AI workflows. Consumes `forge`. Server functionality (HTTP/WebSocket, REST API, SSE streaming, SPA dashboard, wiki serving) is integrated directly into `packages/coc/src/server/`.
-
-**Commands:** `coc run <path>`, `coc validate <path>`, `coc list [dir]`, `coc serve`, `coc skills`, `coc wipe-data`.
-
-**Configuration:** `~/.coc/config.yaml` (legacy: `~/.coc.yaml`). CLI flags > config file > defaults. Default process store backend is SQLite. Namespaced config merge/source tracking is registered in `packages/coc/src/config/namespace-registry.ts`; add namespace fields there instead of expanding branch lists in `config.ts`.
-
-**Loop subsystem (`src/server/loops/`):** Recurring follow-up messages within a conversation. **Gated by `loops.enabled` config flag (default `false`).** When disabled, infrastructure is not constructed, REST routes are not registered, `scheduleWakeup`/`createLoop` LLM tools are filtered out, the `/loop` skill is not auto-installed, and dashboard UI (badge, panel, slash-command) is hidden. Separate from schedules — own `LoopEntry` type, own SQLite persistence (`loops` table in `processes.db`), own executor. Uses `ScheduleTimerRegistry` for timing and `TaskQueueManager` for follow-up execution.
-
-- **Types:** `LoopEntry`, `LoopStatus` (`active`/`paused`/`cancelled`/`expired`) in `loop-types.ts`.
-- **Persistence:** `LoopStore` — SQLite CRUD with `ensureTable()`, max 50 active loops per server.
-- **Executor:** `LoopExecutor` — arms timers, handles tick execution with circuit breakers (3 consecutive failures → auto-pause, 100 wakeups/process limit, 3-day TTL default). Per-process concurrency guard prevents double-firing.
-- **LLM tools:** `createLoop`, `cancelLoop`, `listLoops` (skill-gated via `/loop` skill); `scheduleWakeup` (always available, registered in `LLM_TOOL_REGISTRY`). Defined in `llm-tools/loop-tools.ts`.
-- **Bundled skill:** `/loop` in `forge/resources/bundled-skills/loop/SKILL.md` — teaches interval parsing, mode selection, user confirmation, stop-condition recognition.
-- **REST API:** Workspace-scoped at `/api/workspaces/:id/loops`, server-wide at `/api/loops`. CRUD + pause/resume. Handler in `loops/loop-handler.ts`.
-- **Infrastructure:** `loop-infrastructure.ts` factory creates LoopStore + LoopExecutor + ScheduleTimerRegistry. Wired into `createExecutionServer`. On shutdown, active loops are paused with `pausedReason: 'server-restart'` (no auto-resume).
-- **Dashboard UI:** `LoopBadge` (header badge with active count), `LoopManagementPanel` (list/pause/resume/cancel), turn source badge on `ConversationTurnBubble` for loop/wakeup turns.
-- **Turn metadata:** `turnSource` field on `ConversationTurn` (`{ source: 'loop'|'wakeup', loopId/wakeupId }`) propagated through follow-up executor pipeline.
-- **Follow-up mode resolution:** `resolveFollowUpMode(store, processId, explicit?)` in `executors/follow-up-mode.ts` is the single source of truth for "what mode does this follow-up run in?". Every programmatic follow-up enqueue site (loop ticks, wakeup timer, requeue) must call it and set `payload.mode`. `validateAndParseTask` only defaults `payload.mode` to `autopilot` for new chats (no `processId`); REST follow-ups must supply mode. `FollowUpExecutor.executeFollowUp` requires `mode` and logs a fail-loud warning + defaults to `'ask'` if missing.
-
-**Testing:** 627+ Vitest test files under `packages/coc/test/server/`.
-
-> **Deep reference:** See `.github/skills/coc-knowledge/` for detailed architecture, module layout, REST API catalog, memory system, LLM tools, and dashboard SPA documentation.
-
-## CoC Client (`packages/coc-client/`)
-
-Framework-free TypeScript client for CoC REST and realtime APIs. Exposes domain clients for all server endpoints plus WebSocket events and per-process SSE streaming helpers. Includes `LoopsClient` domain for loop CRUD + pause/resume.
-
-## Deep Wiki (`packages/deep-wiki/`)
-
-CLI that generates comprehensive wikis via a six-phase AI pipeline (Seeds → Discovery → Consolidation → Analysis → Writing → Website). Consumes `forge`.
-
-**Commands:** `deep-wiki seeds`, `deep-wiki discover`, `deep-wiki generate`, `deep-wiki theme`, `deep-wiki init`.
-
-**Testing:** 64 Vitest test files.
-
-> **Deep reference:** See `.github/skills/coc-knowledge/references/deep-wiki.md`.
-
-## forge (`packages/forge/`)
-
-Pure Node.js AI engine — no VS Code deps. Published as `@plusplusoneplusplus/forge`.
-
-**Key modules:** Logger, Errors, Runtime policies, Task queue, AI SDK (CopilotSDKService, session-per-request), Workflow engine (DAG), Map-Reduce, Process store (SQLite default), Git CLI, Diff providers (`src/diff/` — unified `IDiffProvider` for commit, range, working-tree, PR, and PR-iteration diffs), Memory system, Skills, Utilities. `ConversationTurn` includes optional `turnSource` field for loop/wakeup attribution. Bundled skills include `/loop` in `resources/bundled-skills/loop/`.
-
-**Workflow execution:** `compileToWorkflow(yamlContent)` → `executeWorkflow(config, options)` → `flattenWorkflowResult(result)`.
-
-**Testing:** 156 Vitest test files.
-
-> **Deep reference:** See `.github/skills/coc-knowledge/` for SDK wrapper, workflow engine, memory system, and process store details.
-
-## Key Conventions
-
-**Convention — repo-scoped data:** All runtime data specific to a single repository must live under `~/.coc/repos/<workspaceId>/`. Use `getRepoDataPath(dataDir, workspaceId, filename)` from `packages/coc/src/server/` to resolve the path. Do **NOT** add new top-level directories under `~/.coc/` for per-repo data.
-
-**Convention — creating work items:** Work items are stored as JSON files in `~/.coc/repos/<workspaceId>/work-items/` (NOT as `.plan.md` files in `tasks/`).
-- **ALWAYS use the REST API** to create/update work items when the CoC server is running:
-  ```
-  POST http://localhost:4000/api/workspaces/<workspaceId>/work-items
-  Body: { title, description, priority, tags, source }
-  ```
-- **Never write work-item JSON files directly** — the server uses an atomic write-queue.
-
-**Convention — model resolution:** `task.config.model` > `PerRepoPreferences.defaultModels[mode]` > `defaultModel` > CLI default.
-
-## Development Notes
-
-- TypeScript, webpack bundling, VS Code API ≥ 1.95.0, Node.js ≥ 24
-- Format on save and import organization enabled
-- Tree data providers: extend `BaseTreeDataProvider` or `FilterableTreeDataProvider`
-- Commands registered centrally in `src/shortcuts/commands.ts`
-- Cross-platform: Linux, macOS, Windows
+- **Multi-repo:** every feature must support multiple workspaces.
+- **Repo-scoped data:** all per-repo runtime data lives under `~/.coc/repos/<workspaceId>/`; resolve paths with `getRepoDataPath(dataDir, workspaceId, filename)`. Never add new top-level dirs under `~/.coc/` for per-repo data.
+- **Work items:** create/update via `POST http://localhost:4000/api/workspaces/<workspaceId>/work-items` — never write `work-items/*.json` files directly.
+- **VS Code extension is frozen:** do not read, edit, or reason about `packages/vscode-extension/`. It is not an npm workspace.
+- **No SDK session caching:** `copilot-sdk-wrapper` and above must never add `sendFollowUp` or keep-alive/session caches.
+- **Model resolution order:** `task.config.model` > `PerRepoPreferences.defaultModels[mode]` > `defaultModel` > CLI default.
+- **Node.js ≥ 24** for every package (`engines.node`).

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -1,109 +1,43 @@
 # packages/coc
 
-CoC CLI and integrated server. Consumes `@plusplusoneplusplus/forge`. See the
-root `AGENTS.md` for the cross-package overview, build/test commands, and the
-"repo-scoped data" convention. Deeper architecture references live under
-`.github/skills/coc-knowledge/`.
+CoC CLI and integrated server. Consumes `@plusplusoneplusplus/forge`.
 
-## Admin Config
+See the root `AGENTS.md` for cross-package conventions and **always load
+`.github/skills/coc-knowledge/SKILL.md`** before working on this package —
+detailed architecture lives in its `references/*.md` files.
 
-Editable admin config fields are defined in a single registry:
-`src/server/admin/admin-config-fields.ts` (`ADMIN_CONFIG_FIELDS`).
+## Where to Read Before Editing
 
-Each entry provides a flat key (e.g. `'loops.enabled'`), a `validate()` function, and an `apply()` function. The PUT `/api/admin/config` handler derives `editableKeys`, validation, and merge logic entirely from this registry — **no changes to `admin-handler.ts` are needed when adding a new editable field**.
+| If you are touching… | Read first |
+|----------------------|------------|
+| CLI commands, source layout, executors, server startup, storage layout | [server-architecture.md](../../.github/skills/coc-knowledge/references/server-architecture.md) |
+| Admin REST handler, editable config fields, admin UI | [admin-config.md](../../.github/skills/coc-knowledge/references/admin-config.md) |
+| `~/.copilot/mcp-config.json` + `.vscode/mcp.json` merge, allow-list | [mcp-settings.md](../../.github/skills/coc-knowledge/references/mcp-settings.md) |
+| `src/server/endev/`, `EnDev-xDpu` skill visibility | [endev.md](../../.github/skills/coc-knowledge/references/endev.md) |
+| Ralph sessions, iteration prompt, promote-to-ralph endpoint | [ralph.md](../../.github/skills/coc-knowledge/references/ralph.md) |
+| `src/server/loops/`, loop tools, tick lifecycle | [loops.md](../../.github/skills/coc-knowledge/references/loops.md) |
+| Process store / SQLite schema / FTS5 / pin / archive | [process-store.md](../../.github/skills/coc-knowledge/references/process-store.md) |
+| Dashboard SPA (`src/server/spa/`) | [dashboard-spa.md](../../.github/skills/coc-knowledge/references/dashboard-spa.md) |
+| REST endpoints | [rest-api.md](../../.github/skills/coc-knowledge/references/rest-api.md) |
 
-To expose a new config field via the admin API, add ONE entry to `ADMIN_CONFIG_FIELDS`. Also update:
-1. `CLIConfig` / `ResolvedCLIConfig` / `DEFAULT_CONFIG` in `src/config.ts`
-2. `CLIConfigSchema` in `src/config/schema.ts`
-3. Namespace registry in `src/config/namespace-registry.ts` (nested fields)
-4. `AdminResolvedConfig` / `AdminConfigUpdate` in `packages/coc-client/src/contracts/admin.ts`
-5. `AdminPanel.tsx` for the UI control
+Other domains (memory, workflow engine, prompt autocomplete, wiki serving,
+remote servers, task comments, llm-tools, sdk-wrapper, chat-prompt-history)
+all have their own `references/*.md`.
 
-The `spaHtml` function in `src/server/index.ts` re-reads the config file on every page request, so feature-flag changes (e.g. `terminal.enabled`) take effect on the next browser reload — no server restart required.
+## Local Invariants
 
-### Admin UI styling
-
-The admin route uses a self-contained, Linear-inspired design system that lives in `src/server/spa/client/react/admin/admin-redesign.css`. The stylesheet is imported once at the top of `AdminPanel.tsx` so esbuild bundles it into the SPA's CSS. All selectors are scoped under the `.admin-redesign` root class that wraps the entire admin page — styles never leak to other dashboard surfaces, and light/dark themes are driven by the existing `<html data-theme="…">` attribute.
-
-**Layout (sidebar + main, fit-to-viewport):** The admin page is structured as a two-column shell that fills the available vertical space and never scrolls as a whole. Only the right pane is scrollable.
-
-- The route mounts inside `<div className="h-full overflow-hidden" data-testid="admin-scroll-container">` (Router) or the AdminDialog body (`flex-1 min-h-0 overflow-y-auto`). Both supply a definite height to the panel.
-- The `.admin-redesign` root (on `#view-admin`) is `height: 100%; min-height: 0` so the panel fills that parent exactly.
-- `<div className="ar-shell">` is a CSS grid (`var(--ar-sidebar-w)` + `1fr`) with `height: 100%; min-height: 0; overflow: hidden`.
-- `<aside className="ar-sidebar">` fills the grid row (`height: 100%; min-height: 0`) and only scrolls internally if its own brand/nav/stats stack ever exceeds the viewport. It is **not** sticky and must not use `100vh` — both would break inside the AdminDialog and any nested pane whose container height differs from the viewport.
-- `<main className="ar-main">` is the **single scroll region** of the admin route: `min-height: 0; height: 100%; overflow-y: auto`. The sticky topbar (`.ar-topbar` with the `.ar-breadcrumb`) pins to the top of this scroller, and the page body (`.ar-page` with `.ar-page-header` + cards) flows underneath.
-- The tabs live in the sidebar as `.ar-nav-item` buttons (data-testids `admin-tab-{settings|providers|data|server|prompts|database|agents}` are preserved for tests). A `.ar-mobile-tab-select` appears only under the responsive `@media (max-width: 600px)` rule, which hides the sidebar and falls back to a `<select>` — the main pane still scrolls internally on mobile.
-
-**Settings sub-tabs (within the Settings top-level tab):** Settings is split into one `SettingsCard` per sub-tab — `ai`, `chat`, `appearance`, `features`, `integrations`, `advanced` — defined in `SETTINGS_SUBTABS` near the top of `AdminPanel.tsx`. A `.ar-subtab-row` with `.ar-subtab` buttons (data-testids `settings-subtab-{ai|chat|appearance|features|integrations|advanced}`) renders above the cards. Selection is kept in local `settingsSubTab` state, defaults to `ai`, and is synced both directions with `#admin/settings/<sub>` (default `ai` collapses to `#admin/settings`). Tests that interact with controls outside of the default `ai` card must first navigate via the `gotoSettingsSubTab(...)` helper.
-
-When adding UI to the admin page, prefer the existing primitives:
-
-- Section cards: `<SettingsCard title=… description=… badge=… dirty saving onSave onCancel data-testid=…>` (renders `.ar-card` with header/body/footer).
-- Settings rows: the local `AdminRow`, `AdminToggle`, `AdminSeg`, `AdminInputSuffix`, and `SourceBadge` helpers defined at the bottom of `AdminPanel.tsx`. They wrap raw inputs in the new visual chrome while preserving `data-testid`s and `id`s used by tests.
-- Free-form sections inside a card use `.ar-section`, `.ar-section-head`, and the inline helpers `.ar-input`, `.ar-select`, `.ar-btn`, `.ar-btn-primary` / `-secondary` / `-ghost` / `-danger`(`-outline`), `.ar-pill`, `.ar-badge`, `.ar-pre`, `.ar-code`, `.ar-mono`.
-- New top-level tabs: add to `AdminSubTab`, `TAB_LABELS`, `TAB_ICONS`, and `TAB_DESCRIPTIONS` near the top of `AdminPanel.tsx` — the sidebar nav and mobile select pick them up automatically.
-
-Avoid introducing Tailwind utilities or inline `bg-*`/`text-*` classes for admin-only UI — extend `admin-redesign.css` instead so the look stays cohesive.
-
-## Ralph
-
-Ralph sessions live under
-`~/.coc/repos/<workspaceId>/ralph-sessions/<sessionId>/`. Keep the durable
-architecture details in `.github/skills/coc-knowledge/references/ralph.md`;
-this local file should only carry package-specific pointers and invariants.
-Execution iteration prompts include a generic `<work_intent>` block before
-`<goal>` and must not hard-code implementation skill names or set
-`context.skills`.
-
-A completed ask-mode chat can be promoted to a Ralph session in place via
-`POST /api/processes/:id/promote-to-ralph`
-(`src/server/routes/ralph-promote-routes.ts`). The endpoint attaches a
-`grilling`-phase ralph context to the existing process and enqueues a
-synthesis follow-up turn (mode=ask, `context.skills=['grill-me']`,
-`context.ralph.phase='grilling'`) carrying the prompt produced by
-`buildRalphSynthesisPrompt` (`src/server/ralph/synthesis-prompt.ts`). The SPA
-shows a "Promote to Ralph" pill in the follow-up area for eligible chats and
-calls this endpoint via `coc-client`'s `processes.promoteToRalph` helper.
-
-## MCP Settings
-
-`GET /api/workspaces/:id/mcp-config` returns both the effective
-`availableServers` list and source-separated `sources.global` /
-`sources.workspace` sections. Global servers come from
-`~/.copilot/mcp-config.json`; workspace servers come from
-`<repo>/.vscode/mcp.json` via Forge MCP loader helpers. Workspace entries
-override global entries with the same name. The endpoint only exposes safe row
-metadata (`name`, `type`, optional `url`/`command`, source/effective flags) and
-must not return secrets such as `env`, headers, or full argument arrays.
-`?forceReload=true` bypasses the path-keyed MCP config cache for manual dashboard
-refreshes; no file watcher is used.
-
-`PUT /api/workspaces/:id/mcp-config` stores only the name-based
-`enabledMcpServers` allow-list. Workflow run filtering must resolve that list
-against the same effective global-plus-workspace MCP merge used at runtime.
-
-## EnDev xDPU
-
-Workspace-scoped EnDev support lives in `src/server/endev/`. Eligibility is
-cached under `~/.coc/repos/<workspaceId>/endev/eligibility.json` and requires a
-native WSL host, xDPU workspace markers, EnDev setup files, and a successful
-short-timeout `endev doctor`. `GET /api/workspaces/:id/endev/status` reads the
-cache by default; `?refresh=true` or `POST /api/workspaces/:id/endev/revalidate`
-forces revalidation and clears the workspace skill cache. The `EnDev-xDpu`
-wrapper skill and auto-discovered EnDev plugin skill folders are surfaced only
-when the workspace is eligible — hidden otherwise from skill lists, pickers,
-and recents. There is no separate per-repo toggle; users disable the wrapper
-via the standard `disabledSkills` mechanism if needed. EnDev MCP servers and
-EnDev plugin skills follow their own settings independently.
-
-## Loops
-
-Recurring follow-up subsystem in `src/server/loops/`. Separate from schedules.
-
-- **Types/Store/Executor:** `loop-types.ts`, `loop-store.ts`, `loop-executor.ts`
-- **REST routes:** `loop-handler.ts` → `/api/workspaces/:id/loops` + `/api/loops`
-- **Infrastructure:** `infrastructure/loop-infrastructure.ts` wires store + executor + timer registry
-- **LLM tools:** `llm-tools/loop-tools.ts` — `createLoop`/`cancelLoop`/`listLoops` (skill-gated), `scheduleWakeup` (always available)
-- **Dashboard:** `LoopBadge`, `LoopManagementPanel`, turn source badges in `ConversationTurnBubble`
-- **Restart behavior:** active loops stay persisted as `active` on shutdown and are re-armed from `nextTickAt` on startup; manually paused/cancelled/expired loops stay inactive.
-- **Tick completion wiring:** `ProcessLifecycleRunner` invokes the `onLoopTickComplete(loopId, success)` lifecycle option after a loop-originated follow-up (`context.source === 'loop'` with string `context.loopId`) finishes. The queue-executor-bridge routes this to `LoopExecutor.onTickComplete()`, which advances `tickCount`/`lastTickAt`, clears the in-flight guard, and re-arms the next timer. Bookkeeping errors are logged but never mask the follow-up's actual success/failure result.
+- **627+ Vitest test files** live under `packages/coc/test/server/`. Any
+  server change should add or update tests there.
+- **Adding an editable config field** is a single registry entry — do not
+  modify `admin-handler.ts` (see [admin-config.md](../../.github/skills/coc-knowledge/references/admin-config.md)).
+- **Adding a namespaced config field** must update
+  `src/config/namespace-registry.ts`; do not expand branch lists in `config.ts`.
+- **MCP REST surface** must never expose secrets (`env`, headers, full `args`).
+- **Ralph iteration prompts** must not hard-code implementation skill names
+  or set `context.skills`; the `<work_intent>` block must stay generic.
+- **Loop ticks** must route completion through
+  `ProcessLifecycleRunner → onLoopTickComplete → LoopExecutor.onTickComplete`;
+  bookkeeping errors must never mask the follow-up's actual result.
+- **Follow-up enqueue sites** must call `resolveFollowUpMode(...)` and set
+  `payload.mode`. `FollowUpExecutor.executeFollowUp` fail-loud warns + defaults
+  to `'ask'` if missing.


### PR DESCRIPTION
- Consolidated and streamlined the content in AGENTS.md, removing outdated sections and focusing on essential information.
- Added detailed documentation for the new `admin-config.md`, `coc-service.md`, `endev.md`, `mcp-settings.md`, and `loops.md` files, covering admin configuration, CoC service management, EnDev xDPU support, and workspace MCP settings.
- Improved clarity and organization of the monorepo layout and build processes in `monorepo.md`.
- Updated references to ensure consistency across documentation, particularly regarding the CoC service and its management scripts.

This update aims to enhance the usability and maintainability of the documentation for developers working with the CoC framework.
