### PR TITLE
pr/d4d5d37b2 featcoc render user messages as plain te

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -720,6 +720,19 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
     const htmlEmbedEnabled = useHtmlEmbedPreference(wsId) && !turn.streaming;
     const assistantRender = !isUser ? buildAssistantRender(turn, wsId, { htmlEmbedEnabled }) : null;
     const userContentText = isUser ? (turn.content || '') : '';
+    const userContentHtml = useMemo(() => {
+        if (!isUser || !userContentText.trim()) return '';
+        // Split on backtick-delimited segments so paths inside inline code are not linkified.
+        // Segments at even indices are normal text; odd indices are code spans.
+        const parts = userContentText.split(/`([^`]*)`/);
+        return parts.map((part, i) => {
+            if (i % 2 === 1) {
+                // Code span — escape only, no linkification
+                return `<code>${escapeHtml(part)}</code>`;
+            }
+            return linkifyFilePaths(escapeHtml(part));
+        }).join('');
+    }, [isUser, userContentText]);
     const [collapsedTaskIds, setCollapsedTaskIds] = useState<Record<string, boolean>>({});
     const [showRaw, setShowRaw] = useState(false);
     const [copied, setCopied] = useState(false);
@@ -1167,9 +1180,9 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
                         </span>
                     )}
                     {isUser && !showRaw && userContentText.trim() && (
-                        <div className="whitespace-pre-wrap break-words text-[13px]" data-testid="user-plain-text">
-                            {userContentText}
-                        </div>
+                        <div className="whitespace-pre-wrap break-words text-[13px]" data-testid="user-plain-text"
+                            dangerouslySetInnerHTML={{ __html: userContentHtml }}
+                        />
                     )}
                     {isUser && showRaw && (
                         <div className="raw-content-view rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-[#ffffff] dark:bg-[#1e1e1e] overflow-auto max-h-[600px]">

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -105,6 +105,24 @@ function createChatMarked(htmlEmbedEnabled: boolean): Marked {
 }
 
 /**
+ * Pre-pass: for every ![alt](url) and [text](url) whose url is a Windows
+ * absolute path, normalize backslashes to forward slashes and, if the url
+ * contains whitespace, wrap it in <…> so CommonMark parses it correctly.
+ * Must run before normalizeWindowsPathsInText and before `marked`.
+ */
+export function normalizeMarkdownLinkUrls(text: string): string {
+    return text.replace(
+        /(!?)\[([^\]]*)\]\(([^)\n]+)\)/g,
+        (match, bang: string, label: string, url: string) => {
+            if (!/^[A-Za-z]:[\\\/]/.test(url)) return match;
+            const fwd = toForwardSlashes(url);
+            const wrapped = /\s/.test(fwd) ? `<${fwd}>` : fwd;
+            return `${bang}[${label}](${wrapped})`;
+        },
+    );
+}
+
+/**
  * Pre-normalize Windows-style paths (backslash) to forward slashes before markdown
  * parsing, so that `marked` does not treat `\.` as an escape sequence (GFM treats
  * backslash-followed-by-ASCII-punctuation as an escape, silently dropping the `\`).
@@ -135,7 +153,10 @@ function rewriteLocalImagePaths(html: string, wsId: string): string {
  */
 export function chatMarkdownToHtml(content: string, wsId?: string, options?: { htmlEmbedEnabled?: boolean }): string {
     if (!content || !content.trim()) return '';
-    const normalized = normalizeWindowsPathsInText(content);
+    // Order matters: normalizeMarkdownLinkUrls fixes link/image URLs first (handles
+    // spaces + backslashes), then normalizeWindowsPathsInText handles bare prose paths.
+    const linkNormalized = normalizeMarkdownLinkUrls(content);
+    const normalized = normalizeWindowsPathsInText(linkNormalized);
     let html = linkifyFilePaths(createChatMarked(options?.htmlEmbedEnabled === true).parse(normalized) as string);
     if (wsId) {
         html = rewriteLocalImagePaths(html, wsId);

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -2,7 +2,7 @@
  * ConversationTurnBubble — role-aware chat bubble for conversation turns.
  */
 import React, { useState, useMemo, useCallback } from 'react';
-import { cn, ImageGallery, Spinner } from '../../../ui';
+import { cn, Spinner } from '../../../ui';
 import type { ClientConversationTurn, ClientTokenUsage } from '../../../types/dashboard';
 import { ContextMenu } from '../../../tasks/comments/ContextMenu';
 import type { ContextMenuItem } from '../../../tasks/comments/ContextMenu';
@@ -15,7 +15,6 @@ import { LoopIcon } from '../icons/LoopIcon';
 import { Marked } from 'marked';
 import { useDisplaySettings } from '../../../hooks/preferences/useDisplaySettings';
 import { useHtmlEmbedPreference } from '../../../hooks/preferences/useHtmlEmbedPreference';
-import { getSpaCocClient } from '../../../api/cocClient';
 import { copyToClipboard, copyHtmlToClipboard, splitMarkdownSections } from '../../../utils/format';
 import { linkifyFilePaths } from '../../../shared/file-path-utils';
 import { toForwardSlashes } from '@plusplusoneplusplus/forge/utils/path-utils';
@@ -699,7 +698,7 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
     const { showReportIntent, toolCompactness, groupSingleLineMessages } = useDisplaySettings();
     const htmlEmbedEnabled = useHtmlEmbedPreference(wsId) && !turn.streaming;
     const assistantRender = !isUser ? buildAssistantRender(turn, wsId, { htmlEmbedEnabled }) : null;
-    const userContentHtml = isUser ? toContentHtml(turn.content || '', wsId, { htmlEmbedEnabled }) : '';
+    const userContentText = isUser ? (turn.content || '') : '';
     const [collapsedTaskIds, setCollapsedTaskIds] = useState<Record<string, boolean>>({});
     const [showRaw, setShowRaw] = useState(false);
     const [copied, setCopied] = useState(false);
@@ -818,25 +817,6 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
         }
         return grouped;
     }, [assistantRender, toolCompactness, groupSingleLineMessages]);
-
-    // Lazy image fetching state
-    const [imageLoadState, setImageLoadState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
-    const [fetchedImages, setFetchedImages] = useState<string[]>([]);
-
-    const hasInlineImages = turn.images && turn.images.length > 0;
-    const needsLazyImages = isUser && !hasInlineImages && !!taskId && (turn.imagesCount ?? 0) > 0;
-
-    const handleLoadImages = async () => {
-        if (!taskId) return;
-        setImageLoadState('loading');
-        try {
-            const data = await getSpaCocClient().queue.images(taskId);
-            setFetchedImages(data.images || []);
-            setImageLoadState('loaded');
-        } catch {
-            setImageLoadState('error');
-        }
-    };
 
     function renderToolTree(toolId: string, depth: number): React.ReactNode {
         if (depth > 20) return null;
@@ -1165,40 +1145,17 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
                             <span>{turn.turnSource.source === 'loop' ? 'loop' : 'wakeup'}</span>
                         </span>
                     )}
-                    {isUser && !showRaw && userContentHtml && <MarkdownView html={userContentHtml} />}
+                    {isUser && !showRaw && userContentText.trim() && (
+                        <div className="whitespace-pre-wrap break-words text-[13px]" data-testid="user-plain-text">
+                            {userContentText}
+                        </div>
+                    )}
                     {isUser && showRaw && (
                         <div className="raw-content-view rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-[#ffffff] dark:bg-[#1e1e1e] overflow-auto max-h-[600px]">
                             <pre className="p-3 font-mono text-xs whitespace-pre-wrap break-words text-[#1e1e1e] dark:text-[#cccccc]">
                                 <code>{turn.content || ''}</code>
                             </pre>
                         </div>
-                    )}
-                    {isUser && turn.images && turn.images.length > 0 && (
-                        <ImageGallery images={turn.images} />
-                    )}
-                    {isUser && needsLazyImages && imageLoadState === 'idle' && (
-                        <button
-                            className="text-[11px] text-[#848484] hover:text-[#005a9e] dark:hover:text-[#7bbef3] cursor-pointer bg-transparent border-none p-0"
-                            data-testid="load-images-btn"
-                            onClick={handleLoadImages}
-                        >
-                            📷 Load {turn.imagesCount} image{(turn.imagesCount ?? 0) > 1 ? 's' : ''}
-                        </button>
-                    )}
-                    {isUser && needsLazyImages && imageLoadState === 'loading' && (
-                        <ImageGallery images={[]} loading={true} imagesCount={turn.imagesCount} />
-                    )}
-                    {isUser && imageLoadState === 'loaded' && fetchedImages.length > 0 && (
-                        <ImageGallery images={fetchedImages} />
-                    )}
-                    {isUser && needsLazyImages && imageLoadState === 'error' && (
-                        <button
-                            className="text-[11px] text-[#f14c4c] hover:text-[#d32f2f] cursor-pointer bg-transparent border-none p-0"
-                            data-testid="retry-images-btn"
-                            onClick={handleLoadImages}
-                        >
-                            ⚠ Failed to load images · Retry
-                        </button>
                     )}
                     {isUser && turn.pasteExternalized && (
                         <div

--- a/packages/coc/src/server/spa/client/react/shared/htmlEmbedMount.ts
+++ b/packages/coc/src/server/spa/client/react/shared/htmlEmbedMount.ts
@@ -85,11 +85,16 @@ function mountOne(placeholder: HTMLElement, wsId: string): void {
     open.textContent = 'Open in new tab';
     open.addEventListener('click', () => window.open(url, '_blank', 'noopener,noreferrer'));
 
+    const maximize = document.createElement('button');
+    maximize.type = 'button';
+    maximize.textContent = 'Maximize';
+    maximize.title = 'Maximize preview to a floating dialog';
+
     const reload = document.createElement('button');
     reload.type = 'button';
     reload.textContent = 'Reload';
 
-    actions.append(open, reload);
+    actions.append(open, maximize, reload);
     toolbar.append(title, actions);
 
     const frameWrap = document.createElement('div');
@@ -128,6 +133,107 @@ function mountOne(placeholder: HTMLElement, wsId: string): void {
         };
         document.addEventListener('mousemove', onMove);
         document.addEventListener('mouseup', onUp);
+    });
+
+    let overlay: HTMLElement | null = null;
+    let escHandler: ((event: KeyboardEvent) => void) | null = null;
+
+    const restoreFromMaximized = () => {
+        if (!overlay) return;
+        if (iframe.parentElement !== frameWrap) {
+            if (resize.isConnected) {
+                frameWrap.insertBefore(iframe, resize);
+            } else {
+                frameWrap.appendChild(iframe);
+            }
+        }
+        iframe.style.height = '';
+        if (escHandler) {
+            document.removeEventListener('keydown', escHandler);
+            escHandler = null;
+        }
+        overlay.remove();
+        overlay = null;
+        maximize.textContent = 'Maximize';
+        maximize.title = 'Maximize preview to a floating dialog';
+    };
+
+    const openMaximized = () => {
+        if (overlay) return;
+        overlay = document.createElement('div');
+        overlay.className = 'md-html-embed-overlay';
+        overlay.setAttribute('role', 'dialog');
+        overlay.setAttribute('aria-modal', 'true');
+        overlay.setAttribute('aria-label', `${basename(href)} preview`);
+
+        const backdrop = document.createElement('div');
+        backdrop.className = 'md-html-embed-overlay-backdrop';
+        backdrop.addEventListener('click', restoreFromMaximized);
+
+        const dialogShell = document.createElement('div');
+        dialogShell.className = 'md-html-embed-overlay-shell';
+
+        const dialogToolbar = document.createElement('div');
+        dialogToolbar.className = 'md-html-embed-overlay-toolbar';
+
+        const dialogTitle = document.createElement('span');
+        dialogTitle.className = 'md-html-embed-title';
+        dialogTitle.title = href;
+        dialogTitle.textContent = basename(href);
+
+        const dialogActions = document.createElement('span');
+        dialogActions.className = 'md-html-embed-actions';
+
+        const dialogOpen = document.createElement('button');
+        dialogOpen.type = 'button';
+        dialogOpen.textContent = 'Open in new tab';
+        dialogOpen.addEventListener('click', () => window.open(url, '_blank', 'noopener,noreferrer'));
+
+        const dialogReload = document.createElement('button');
+        dialogReload.type = 'button';
+        dialogReload.textContent = 'Reload';
+        dialogReload.addEventListener('click', () => {
+            iframe.removeAttribute('src');
+            void loadFrame();
+        });
+
+        const restore = document.createElement('button');
+        restore.type = 'button';
+        restore.textContent = 'Close';
+        restore.title = 'Close (Esc)';
+        restore.addEventListener('click', restoreFromMaximized);
+
+        dialogActions.append(dialogOpen, dialogReload, restore);
+        dialogToolbar.append(dialogTitle, dialogActions);
+
+        const dialogBody = document.createElement('div');
+        dialogBody.className = 'md-html-embed-overlay-body';
+        if (iframe.parentElement) iframe.parentElement.removeChild(iframe);
+        iframe.style.height = '100%';
+        dialogBody.appendChild(iframe);
+
+        dialogShell.append(dialogToolbar, dialogBody);
+        overlay.append(backdrop, dialogShell);
+        document.body.appendChild(overlay);
+
+        escHandler = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                restoreFromMaximized();
+            }
+        };
+        document.addEventListener('keydown', escHandler);
+
+        maximize.textContent = 'Restore';
+        maximize.title = 'Restore preview';
+    };
+
+    maximize.addEventListener('click', () => {
+        if (overlay) {
+            restoreFromMaximized();
+        } else {
+            openMaximized();
+        }
     });
 
     const loadFrame = async () => {

--- a/packages/coc/src/server/spa/client/tailwind.css
+++ b/packages/coc/src/server/spa/client/tailwind.css
@@ -196,6 +196,73 @@
     background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.08));
 }
 
+.md-html-embed-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.md-html-embed-overlay-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.md-html-embed-overlay-shell {
+    position: relative;
+    width: 96vw;
+    height: 96vh;
+    display: flex;
+    flex-direction: column;
+    background: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+}
+
+.dark .md-html-embed-overlay-shell {
+    background: #1e1e1e;
+    border-color: #3c3c3c;
+}
+
+.md-html-embed-overlay-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.45rem 0.6rem;
+    border-bottom: 1px solid #e0e0e0;
+    background: #f3f3f3;
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+.dark .md-html-embed-overlay-toolbar {
+    border-bottom-color: #3c3c3c;
+    background: #252526;
+}
+
+.md-html-embed-overlay-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    background: #ffffff;
+}
+
+.dark .md-html-embed-overlay-body {
+    background: #1e1e1e;
+}
+
+.md-html-embed-overlay-body > iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    display: block;
+}
+
 /* Google Maps previews rendered from allowlisted markdown links */
 .md-map-embed {
     margin-top: 0.5rem;

--- a/packages/coc/src/server/tasks/tasks-read-handler.ts
+++ b/packages/coc/src/server/tasks/tasks-read-handler.ts
@@ -100,6 +100,12 @@ async function resolveAllowedHtmlPath(filePath: string, ws: { id: string; rootPa
         return { path: realCandidate };
     }
 
+    const copilotCliRoot = path.join(os.homedir(), '.copilot');
+    const realCopilotCliRoot = await realpathIfExists(copilotCliRoot);
+    if (realCopilotCliRoot && isWithinDirectory(realCandidate, realCopilotCliRoot)) {
+        return { path: realCandidate };
+    }
+
     return { status: 403, message: 'Access denied: path is outside allowed HTML roots' };
 }
 

--- a/packages/coc/test/server/files-html-handler.test.ts
+++ b/packages/coc/test/server/files-html-handler.test.ts
@@ -229,12 +229,31 @@ describe('GET /api/workspaces/:id/files/html', () => {
         expect(res.body).toContain('workspace file url');
     });
 
+    it('serves HTML from the Copilot CLI session folder (~/.copilot)', async () => {
+        const srv = await startServer();
+        const copilotRoot = path.join(os.homedir(), '.copilot');
+        fs.mkdirSync(copilotRoot, { recursive: true });
+        const sessionDir = fs.mkdtempSync(path.join(copilotRoot, 'files-html-copilot-'));
+        try {
+            const filePath = path.join(sessionDir, 'session-output.html');
+            fs.writeFileSync(filePath, '<html><body>copilot session</body></html>', 'utf-8');
+
+            const res = await request(`${srv.url}/api/workspaces/${wsId}/files/html?path=${encodeURIComponent(filePath)}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toContain('copilot session');
+        } finally {
+            fs.rmSync(sessionDir, { recursive: true, force: true });
+        }
+    });
+
     it('returns 403 for existing absolute HTML files outside allowed roots', async () => {
         const srv = await startServer();
         const outsideDir = mkdtempOutsideAllowedRoots('.files-html-outside-', [
             os.tmpdir(),
             workspaceDir,
             getRepoDataPath(dataDir, wsId, 'outputs'),
+            path.join(os.homedir(), '.copilot'),
         ]);
         if (!outsideDir) {
             return;
@@ -268,6 +287,7 @@ describe('GET /api/workspaces/:id/files/html', () => {
             os.tmpdir(),
             workspaceDir,
             getRepoDataPath(dataDir, wsId, 'outputs'),
+            path.join(os.homedir(), '.copilot'),
         ]);
         if (!outsideDir) {
             return;

--- a/packages/coc/test/spa/react/ConversationTurnBubble-images.test.tsx
+++ b/packages/coc/test/spa/react/ConversationTurnBubble-images.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for ConversationTurnBubble — image rendering in user bubbles.
+ * Tests for ConversationTurnBubble — user turns render as plain text, no images.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -15,12 +15,9 @@ vi.mock('../../../src/server/spa/client/react/shared/MarkdownView', () => ({
     MarkdownView: ({ html }: { html: string }) => <div data-testid="markdown-view" dangerouslySetInnerHTML={{ __html: html }} />,
 }));
 
-vi.mock('../../../src/server/spa/client/diff/markdown-renderer', () => ({
+vi.mock('../../../src/server/spa/client/react/diff/markdown-renderer', () => ({
     renderMarkdownToHtml: (s: string) => `<p>${s}</p>`,
 }));
-
-const IMG_A = 'data:image/png;base64,aaaa';
-const IMG_B = 'data:image/jpeg;base64,bbbb';
 
 function makeTurn(overrides: Partial<ClientConversationTurn> = {}): ClientConversationTurn {
     return {
@@ -33,60 +30,37 @@ function makeTurn(overrides: Partial<ClientConversationTurn> = {}): ClientConver
     };
 }
 
-describe('ConversationTurnBubble — image rendering', () => {
+describe('ConversationTurnBubble — user turns render plain text, no images', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
     });
 
-    it('renders ImageGallery when user turn has images', () => {
-        render(<ConversationTurnBubble turn={makeTurn({ images: [IMG_A, IMG_B] })} />);
-        expect(screen.getByTestId('image-gallery')).toBeTruthy();
-        const imgs = screen.getAllByRole('img');
-        expect(imgs).toHaveLength(2);
-    });
-
-    it('does not render ImageGallery when user turn has no images', () => {
-        render(<ConversationTurnBubble turn={makeTurn()} />);
+    it('does not render ImageGallery for user turns even when images are present', () => {
+        render(<ConversationTurnBubble turn={makeTurn({ images: ['data:image/png;base64,aaaa', 'data:image/jpeg;base64,bbbb'] })} />);
         expect(screen.queryByTestId('image-gallery')).toBeNull();
     });
 
-    it('does not render ImageGallery when user turn has empty images array', () => {
-        render(<ConversationTurnBubble turn={makeTurn({ images: [] })} />);
-        expect(screen.queryByTestId('image-gallery')).toBeNull();
-    });
-
-    it('does not render ImageGallery for assistant turns even with images', () => {
-        render(<ConversationTurnBubble turn={makeTurn({ role: 'assistant', images: [IMG_A] })} />);
-        expect(screen.queryByTestId('image-gallery')).toBeNull();
-    });
-});
-
-describe('ConversationTurnBubble — lazy image loading', () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-    });
-
-    it('renders "Load N images" button when turn has imagesCount but no images', () => {
+    it('does not render "Load N images" button for user turns', () => {
         render(<ConversationTurnBubble turn={makeTurn({ imagesCount: 3, images: undefined })} taskId="task-1" />);
-        const btn = screen.getByTestId('load-images-btn');
-        expect(btn.textContent).toContain('Load 3 images');
-    });
-
-    it('renders inline images directly when images array is present (backward compat)', () => {
-        render(<ConversationTurnBubble turn={makeTurn({ images: [IMG_A], imagesCount: 1 })} taskId="task-1" />);
-        expect(screen.getByTestId('image-gallery')).toBeTruthy();
         expect(screen.queryByTestId('load-images-btn')).toBeNull();
     });
 
-    it('does not render fetch button when taskId is not provided', () => {
-        render(<ConversationTurnBubble turn={makeTurn({ imagesCount: 3, images: undefined })} />);
-        expect(screen.queryByTestId('load-images-btn')).toBeNull();
+    it('renders user content as plain text, not markdown', () => {
+        render(<ConversationTurnBubble turn={makeTurn({ content: 'Hello **world**' })} />);
+        const plainText = screen.getByTestId('user-plain-text');
+        expect(plainText.textContent).toBe('Hello **world**');
+        expect(screen.queryByTestId('markdown-view')).toBeNull();
     });
 
-    it('renders singular "image" for imagesCount of 1', () => {
-        render(<ConversationTurnBubble turn={makeTurn({ imagesCount: 1, images: undefined })} taskId="task-1" />);
-        const btn = screen.getByTestId('load-images-btn');
-        expect(btn.textContent).toContain('Load 1 image');
-        expect(btn.textContent).not.toContain('images');
+    it('preserves newlines in user content via plain text rendering', () => {
+        render(<ConversationTurnBubble turn={makeTurn({ content: 'line1\nline2\nline3' })} />);
+        const plainText = screen.getByTestId('user-plain-text');
+        expect(plainText.textContent).toBe('line1\nline2\nline3');
+    });
+
+    it('does not render markdown-view for user turns with markdown syntax', () => {
+        render(<ConversationTurnBubble turn={makeTurn({ content: '# Heading\n- bullet' })} />);
+        expect(screen.queryByTestId('markdown-view')).toBeNull();
+        expect(screen.getByTestId('user-plain-text').textContent).toBe('# Heading\n- bullet');
     });
 });

--- a/packages/coc/test/spa/react/ConversationTurnBubble-raw-view.test.tsx
+++ b/packages/coc/test/spa/react/ConversationTurnBubble-raw-view.test.tsx
@@ -281,20 +281,20 @@ describe('ConversationTurnBubble — raw view toggle', () => {
 
     // --- User message raw view ---
 
-    it('user message: clicking raw button shows raw content instead of markdown', () => {
+    it('user message: clicking raw button shows raw content instead of plain text', () => {
         const { container } = render(
             <ConversationTurnBubble turn={makeTurn({ role: 'user', content: 'Hello **bold**' })} />
         );
-        // Initially shows markdown, not raw
-        expect(container.querySelector('[data-testid="markdown-view"]')).toBeTruthy();
+        // Initially shows plain text, not raw
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeTruthy();
         expect(container.querySelector('.raw-content-view')).toBeNull();
 
         const btn = container.querySelector('.bubble-raw-btn') as HTMLButtonElement;
         fireEvent.click(btn);
 
-        // Now shows raw content, not markdown
+        // Now shows raw content, not plain text
         expect(container.querySelector('.raw-content-view')).toBeTruthy();
-        expect(container.querySelector('[data-testid="markdown-view"]')).toBeNull();
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeNull();
     });
 
     it('user message: raw view shows turn.content verbatim', () => {
@@ -308,7 +308,7 @@ describe('ConversationTurnBubble — raw view toggle', () => {
         expect(rawView?.textContent).toBe(rawText);
     });
 
-    it('user message: toggling back shows markdown view again', () => {
+    it('user message: toggling back shows plain text view again', () => {
         const { container } = render(
             <ConversationTurnBubble turn={makeTurn({ role: 'user', content: 'Hello' })} />
         );
@@ -317,7 +317,7 @@ describe('ConversationTurnBubble — raw view toggle', () => {
         expect(container.querySelector('.raw-content-view')).toBeTruthy();
         fireEvent.click(btn); // OFF
         expect(container.querySelector('.raw-content-view')).toBeNull();
-        expect(container.querySelector('[data-testid="markdown-view"]')).toBeTruthy();
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeTruthy();
     });
 
     it('user message: copy button copies raw text when in raw mode', () => {

--- a/packages/coc/test/spa/react/ConversationTurnBubble.test.tsx
+++ b/packages/coc/test/spa/react/ConversationTurnBubble.test.tsx
@@ -141,10 +141,17 @@ describe('ConversationTurnBubble — semantic hooks', () => {
         expect(content).toBeTruthy();
     });
 
-    it('nests .markdown-body inside .chat-message-content for border styling', () => {
-        const { container } = render(<ConversationTurnBubble turn={makeTurn()} />);
+    it('nests .markdown-body inside .chat-message-content for assistant turns', () => {
+        const { container } = render(<ConversationTurnBubble turn={makeTurn({ role: 'assistant' })} />);
         const md = container.querySelector('.chat-message-content .markdown-body');
         expect(md).toBeTruthy();
+    });
+
+    it('renders user-plain-text inside .chat-message-content for user turns', () => {
+        const { container } = render(<ConversationTurnBubble turn={makeTurn()} />);
+        const pt = container.querySelector('.chat-message-content [data-testid="user-plain-text"]');
+        expect(pt).toBeTruthy();
+        expect(pt?.textContent).toBe('Hello world');
     });
 
     // --- bubble-copy-btn ---
@@ -201,19 +208,19 @@ describe('ConversationTurnBubble — whitespace-only content suppression', () =>
         vi.restoreAllMocks();
     });
 
-    it('does not render empty markdown-body div for whitespace-only user content', () => {
+    it('does not render plain-text div for whitespace-only user content', () => {
         const { container } = render(<ConversationTurnBubble turn={makeTurn({ role: 'user', content: '   ' })} />);
-        expect(container.querySelector('.markdown-body')).toBeNull();
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeNull();
     });
 
-    it('does not render empty markdown-body div for newline-only user content', () => {
+    it('does not render plain-text div for newline-only user content', () => {
         const { container } = render(<ConversationTurnBubble turn={makeTurn({ role: 'user', content: '\n' })} />);
-        expect(container.querySelector('.markdown-body')).toBeNull();
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeNull();
     });
 
-    it('does not render empty markdown-body div for empty string user content', () => {
+    it('does not render plain-text div for empty string user content', () => {
         const { container } = render(<ConversationTurnBubble turn={makeTurn({ role: 'user', content: '' })} />);
-        expect(container.querySelector('.markdown-body')).toBeNull();
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeNull();
     });
 
     it('does not render markdown-body for whitespace-only timeline content event', () => {
@@ -235,9 +242,10 @@ describe('ConversationTurnBubble — whitespace-only content suppression', () =>
         expect(container.querySelector('.markdown-body')).toBeNull();
     });
 
-    it('still renders markdown-body for non-whitespace content', () => {
+    it('still renders plain text for non-whitespace user content', () => {
         const { container } = render(<ConversationTurnBubble turn={makeTurn({ role: 'user', content: 'Hello' })} />);
-        expect(container.querySelector('.markdown-body')).toBeTruthy();
+        expect(container.querySelector('[data-testid="user-plain-text"]')).toBeTruthy();
+        expect(container.querySelector('[data-testid="user-plain-text"]')?.textContent).toBe('Hello');
     });
 });
 

--- a/packages/coc/test/spa/react/chatMarkdownToHtml.test.ts
+++ b/packages/coc/test/spa/react/chatMarkdownToHtml.test.ts
@@ -6,7 +6,7 @@ import React from 'react';
 import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { MarkdownView } from '../../../src/server/spa/client/react/shared/MarkdownView';
-import { chatMarkdownToHtml, toContentHtml } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
+import { chatMarkdownToHtml, toContentHtml, normalizeMarkdownLinkUrls } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
 
 afterEach(() => {
     cleanup();
@@ -402,6 +402,86 @@ describe('toContentHtml (user prompt renderer)', () => {
         const html = toContentHtml('The type is Map<string, number>');
         expect(html).toContain('&lt;string');
         expect(html).not.toContain('&amp;');
+    });
+});
+
+describe('normalizeMarkdownLinkUrls', () => {
+    it('normalizes backslashes in image syntax with Windows path containing spaces', () => {
+        const input = '![html](C:\\Users\\Yiheng Tao\\.copilot\\foo\\bar.html)';
+        const result = normalizeMarkdownLinkUrls(input);
+        // Backslashes replaced, space causes angle-bracket wrapping
+        expect(result).toBe('![html](<C:/Users/Yiheng Tao/.copilot/foo/bar.html>)');
+    });
+
+    it('normalizes backslashes in image syntax with Windows path without spaces', () => {
+        const input = '![img](C:\\Users\\Bob\\output.png)';
+        const result = normalizeMarkdownLinkUrls(input);
+        expect(result).toBe('![img](C:/Users/Bob/output.png)');
+    });
+
+    it('normalizes backslashes in link syntax with Windows path containing spaces', () => {
+        const input = '[open](C:\\Users\\Yiheng Tao\\notes\\plan.md)';
+        const result = normalizeMarkdownLinkUrls(input);
+        expect(result).toBe('[open](<C:/Users/Yiheng Tao/notes/plan.md>)');
+    });
+
+    it('does not modify non-Windows URLs', () => {
+        const input = '[x](https://example.com/a b)';
+        const result = normalizeMarkdownLinkUrls(input);
+        expect(result).toBe(input);
+    });
+
+    it('does not modify relative paths', () => {
+        const input = '![img](./outputs/chart.html)';
+        const result = normalizeMarkdownLinkUrls(input);
+        expect(result).toBe(input);
+    });
+});
+
+describe('chatMarkdownToHtml — Windows paths with spaces in links', () => {
+    it('renders image with Windows path containing a space as HTML embed', () => {
+        const html = chatMarkdownToHtml(
+            '![html](C:\\Users\\Yiheng Tao\\.copilot\\foo\\bar.html)',
+            'ws1',
+            { htmlEmbedEnabled: true },
+        );
+        expect(html).toContain('class="md-html-embed"');
+        expect(html).toContain('data-html-path="C:/Users/Yiheng Tao/.copilot/foo/bar.html"');
+    });
+
+    it('renders image with Windows path containing a space as proxied img', () => {
+        const html = chatMarkdownToHtml(
+            '![screenshot](C:\\Users\\Yiheng Tao\\.copilot\\screenshot.png)',
+            'ws1',
+        );
+        expect(html).toContain('<img');
+        expect(html).toContain('src="/api/workspaces/ws1/files/image?path=');
+        expect(html).toContain(encodeURIComponent('C:/Users/Yiheng Tao/.copilot/screenshot.png'));
+    });
+
+    it('renders link with Windows path containing a space', () => {
+        const html = chatMarkdownToHtml('[open](C:\\Users\\Yiheng Tao\\notes\\plan.md)');
+        expect(html).toContain('<a');
+        expect(html).toContain('href="C:/Users/Yiheng Tao/notes/plan.md"');
+        expect(html).toContain('open</a>');
+    });
+
+    it('renders image with Windows path without spaces (unchanged behavior)', () => {
+        const html = chatMarkdownToHtml('![img](C:\\Users\\Bob\\file.png)', 'ws1');
+        expect(html).toContain('<img');
+        expect(html).toContain('src="/api/workspaces/ws1/files/image?path=');
+        expect(html).toContain(encodeURIComponent('C:/Users/Bob/file.png'));
+    });
+
+    it('does not alter external image URLs', () => {
+        const html = chatMarkdownToHtml('![x](https://example.com/x.png)');
+        expect(html).toContain('src="https://example.com/x.png"');
+    });
+
+    it('does not alter non-Windows link URLs with spaces', () => {
+        // Non-Windows URLs with spaces are left to marked's native handling
+        const html = chatMarkdownToHtml('[x](https://example.com/a%20b)');
+        expect(html).toContain('href="https://example.com/a%20b"');
     });
 });
 

--- a/packages/coc/test/spa/react/htmlEmbedMount.test.tsx
+++ b/packages/coc/test/spa/react/htmlEmbedMount.test.tsx
@@ -91,4 +91,92 @@ describe('mountHtmlEmbeds', () => {
         });
         expect(document.querySelector('.md-html-embed-error a')?.getAttribute('href')).toContain('/api/workspaces/ws1/files/html');
     });
+
+    it('maximizes the iframe into a floating dialog and restores it on close', async () => {
+        document.body.innerHTML = `
+            <div data-ws-id="ws1">
+                <div class="md-html-embed" data-html-path="outputs/chart.html" data-embed-height="600"></div>
+            </div>
+        `;
+
+        mountHtmlEmbeds(document.body);
+        await waitFor(() => {
+            expect(document.querySelector('iframe')).toBeTruthy();
+        });
+
+        const maximizeBtn = Array.from(
+            document.querySelectorAll<HTMLButtonElement>('.md-html-embed-actions button'),
+        ).find((b) => b.textContent === 'Maximize');
+        expect(maximizeBtn).toBeTruthy();
+
+        const iframe = document.querySelector('iframe')!;
+        const originalParent = iframe.parentElement;
+
+        maximizeBtn!.click();
+
+        const overlay = document.querySelector('.md-html-embed-overlay');
+        expect(overlay).toBeTruthy();
+        expect(overlay?.getAttribute('role')).toBe('dialog');
+        expect(overlay?.getAttribute('aria-modal')).toBe('true');
+        const body = overlay!.querySelector('.md-html-embed-overlay-body');
+        expect(body?.contains(iframe)).toBe(true);
+        expect(maximizeBtn!.textContent).toBe('Restore');
+
+        const closeBtn = Array.from(
+            overlay!.querySelectorAll<HTMLButtonElement>('.md-html-embed-actions button'),
+        ).find((b) => b.textContent === 'Close');
+        expect(closeBtn).toBeTruthy();
+
+        closeBtn!.click();
+
+        expect(document.querySelector('.md-html-embed-overlay')).toBeNull();
+        expect(iframe.parentElement).toBe(originalParent);
+        expect(maximizeBtn!.textContent).toBe('Maximize');
+    });
+
+    it('closes the maximized dialog when Escape is pressed', async () => {
+        document.body.innerHTML = `
+            <div data-ws-id="ws1">
+                <div class="md-html-embed" data-html-path="outputs/chart.html" data-embed-height="600"></div>
+            </div>
+        `;
+
+        mountHtmlEmbeds(document.body);
+        await waitFor(() => {
+            expect(document.querySelector('iframe')).toBeTruthy();
+        });
+
+        const maximizeBtn = Array.from(
+            document.querySelectorAll<HTMLButtonElement>('.md-html-embed-actions button'),
+        ).find((b) => b.textContent === 'Maximize')!;
+        maximizeBtn.click();
+        expect(document.querySelector('.md-html-embed-overlay')).toBeTruthy();
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+        expect(document.querySelector('.md-html-embed-overlay')).toBeNull();
+    });
+
+    it('closes the maximized dialog when the backdrop is clicked', async () => {
+        document.body.innerHTML = `
+            <div data-ws-id="ws1">
+                <div class="md-html-embed" data-html-path="outputs/chart.html" data-embed-height="600"></div>
+            </div>
+        `;
+
+        mountHtmlEmbeds(document.body);
+        await waitFor(() => {
+            expect(document.querySelector('iframe')).toBeTruthy();
+        });
+
+        const maximizeBtn = Array.from(
+            document.querySelectorAll<HTMLButtonElement>('.md-html-embed-actions button'),
+        ).find((b) => b.textContent === 'Maximize')!;
+        maximizeBtn.click();
+
+        const backdrop = document.querySelector<HTMLElement>('.md-html-embed-overlay-backdrop')!;
+        backdrop.click();
+
+        expect(document.querySelector('.md-html-embed-overlay')).toBeNull();
+    });
 });


### PR DESCRIPTION
- **feat(coc): render user messages as plain text, remove image gallery**
- **fix(chat): handle Windows paths with spaces in markdown link/image syntax**
- **feat(coc): allow ~/.copilot as an HTML embed root**
- **feat(coc/spa): add maximize-to-floating-dialog for chat HTML embeds**
