### PR TITLE
fix(forge): default MCP server tools to ["*"] when not specified

### DIFF
--- a/packages/forge/src/copilot-sdk-wrapper/mcp-config-loader.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/mcp-config-loader.ts
@@ -149,8 +149,9 @@ function normalizeVSCodeServer(server: Record<string, unknown>): MCPServerConfig
         const env = stringRecord(server.env);
         if (env) config.env = env;
         if (typeof server.cwd === 'string') config.cwd = server.cwd;
-        const tools = stringArray(server.tools);
-        if (tools) config.tools = tools;
+        // The SDK requires `tools: string[]`; missing/empty means "no tools".
+        // Default to ["*"] (all tools) when not specified, matching VS Code behavior.
+        config.tools = stringArray(server.tools) ?? ['*'];
         const timeout = optionalNumber(server.timeout);
         if (timeout !== undefined) config.timeout = timeout;
         const enabled = optionalBoolean(server.enabled);
@@ -162,8 +163,7 @@ function normalizeVSCodeServer(server: Record<string, unknown>): MCPServerConfig
         const config: MCPRemoteServerConfig = { type: server.type, url: server.url };
         const headers = stringRecord(server.headers);
         if (headers) config.headers = headers;
-        const tools = stringArray(server.tools);
-        if (tools) config.tools = tools;
+        config.tools = stringArray(server.tools) ?? ['*'];
         const timeout = optionalNumber(server.timeout);
         if (timeout !== undefined) config.timeout = timeout;
         const enabled = optionalBoolean(server.enabled);
@@ -199,7 +199,18 @@ function selectGlobalMcpServers(config: unknown): Record<string, MCPServerConfig
         return {};
     }
 
-    return config.mcpServers as Record<string, MCPServerConfig>;
+    // Default `tools` to ["*"] for global servers that don't specify it,
+    // matching the SDK expectation (missing tools = no tools exposed).
+    const servers = config.mcpServers as Record<string, MCPServerConfig>;
+    const result: Record<string, MCPServerConfig> = {};
+    for (const [name, server] of Object.entries(servers)) {
+        if (!server.tools || server.tools.length === 0) {
+            result[name] = { ...server, tools: ['*'] };
+        } else {
+            result[name] = server;
+        }
+    }
+    return result;
 }
 
 function loadMcpConfigFromPath(

--- a/packages/forge/test/ai/mcp-config-loader.test.ts
+++ b/packages/forge/test/ai/mcp-config-loader.test.ts
@@ -196,6 +196,24 @@ describe('MCP Config Loader', () => {
                 expect(Object.keys(result.mcpServers)).toHaveLength(2);
             });
 
+            it('defaults tools to ["*"] for global servers missing the field', () => {
+                const config = {
+                    mcpServers: {
+                        'no-tools': { type: 'local', command: 'server-a' },
+                        'with-tools': { type: 'sse', url: 'http://localhost:8000/sse', tools: ['specific-tool'] },
+                    },
+                };
+
+                fs.mkdirSync(mockCopilotDir, { recursive: true });
+                fs.writeFileSync(mockConfigPath, JSON.stringify(config));
+
+                const result = loadDefaultMcpConfig();
+
+                expect(result.success).toBe(true);
+                expect(result.mcpServers['no-tools']).toHaveProperty('tools', ['*']);
+                expect(result.mcpServers['with-tools']).toHaveProperty('tools', ['specific-tool']);
+            });
+
             it('handles config with empty mcpServers', () => {
                 const config: MCPConfigFile = {
                     mcpServers: {}
@@ -375,7 +393,27 @@ describe('MCP Config Loader', () => {
                 command: 'server',
                 args: ['--stdio'],
                 env: { KEY: 'value' },
+                tools: ['*'],
             });
+        });
+
+        it('defaults tools to ["*"] for workspace servers missing the field', () => {
+            const config = {
+                servers: {
+                    'stdio-no-tools': { command: 'mcp-server', args: ['--port', '8080'] },
+                    'http-no-tools': { type: 'http', url: 'https://example.com/mcp' },
+                    'with-tools': { command: 'mcp-server', tools: ['tool-a', 'tool-b'] },
+                },
+            };
+
+            fs.mkdirSync(path.dirname(workspaceConfigPath), { recursive: true });
+            fs.writeFileSync(workspaceConfigPath, JSON.stringify(config));
+
+            const result = loadWorkspaceMcpConfig(workspaceDir);
+
+            expect(result.mcpServers['stdio-no-tools']).toHaveProperty('tools', ['*']);
+            expect(result.mcpServers['http-no-tools']).toHaveProperty('tools', ['*']);
+            expect(result.mcpServers['with-tools']).toHaveProperty('tools', ['tool-a', 'tool-b']);
         });
 
         it('returns an error for invalid JSON', () => {
@@ -595,8 +633,8 @@ describe('MCP Config Loader', () => {
             });
 
             expect(result.success).toBe(true);
-            expect(result.mcpServers['globalOnly']).toEqual({ type: 'local', command: 'global-only' });
-            expect(result.mcpServers['workspaceOnly']).toEqual({ type: 'local', command: 'workspace-only' });
+            expect(result.mcpServers['globalOnly']).toEqual({ type: 'local', command: 'global-only', tools: ['*'] });
+            expect(result.mcpServers['workspaceOnly']).toEqual({ type: 'local', command: 'workspace-only', tools: ['*'] });
             expect(result.mcpServers['shared']).toEqual({ type: 'local', command: 'explicit-shared' });
         });
 


### PR DESCRIPTION
The Copilot SDK requires 'tools: string[]' on MCP server configs, where [] means no tools and ["*"] means all tools. When .vscode/mcp.json or global mcp-config.json entries omit the tools field, the SDK interprets the missing value as no tools, silently disabling all MCP tools for those servers.

Fix normalizeVSCodeServer to always set tools (defaulting to ["*"]), and fix selectGlobalMcpServers to backfill missing tools on global configs. Servers that explicitly specify tools keep their value.

Add regression tests for both workspace and global tools defaulting.