### PR TITLE
feat(coc): default-enable scratchpad and loops & wakeups

### DIFF
--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -403,7 +403,7 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
         enabled: false,
     },
     scratchpad: {
-        enabled: false,
+        enabled: true,
         layout: 'vertical',
     },
     workflows: {
@@ -419,7 +419,7 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
         enabled: false,
     },
     loops: {
-        enabled: false,
+        enabled: true,
     },
     mcpOauth: {
         enabled: false,

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -59,7 +59,7 @@ describe('Config', () => {
                 askUser: { enabled: false },
             });
             expect(DEFAULT_CONFIG.terminal).toEqual({ enabled: true });
-            expect(DEFAULT_CONFIG.scratchpad).toEqual({ enabled: false, layout: 'vertical' });
+            expect(DEFAULT_CONFIG.scratchpad).toEqual({ enabled: true, layout: 'vertical' });
             expect(DEFAULT_CONFIG.workflows).toEqual({ enabled: false });
         });
 
@@ -444,7 +444,7 @@ timeout: 300
 
         it('should preserve scratchpad.enabled default when not overridden', () => {
             const result = mergeConfig(DEFAULT_CONFIG, { model: 'x' });
-            expect(result.scratchpad.enabled).toBe(false);
+            expect(result.scratchpad.enabled).toBe(true);
         });
 
         it('should override scratchpad.enabled from file', () => {
@@ -503,14 +503,14 @@ timeout: 300
             expect(result.store.backend).toBe('sqlite');
         });
 
-        it('should default loops.enabled to false', () => {
+        it('should default loops.enabled to true', () => {
             const result = mergeConfig(DEFAULT_CONFIG, {});
-            expect(result.loops.enabled).toBe(false);
+            expect(result.loops.enabled).toBe(true);
         });
 
         it('should preserve loops.enabled default when not overridden', () => {
             const result = mergeConfig(DEFAULT_CONFIG, { model: 'x' });
-            expect(result.loops.enabled).toBe(false);
+            expect(result.loops.enabled).toBe(true);
         });
 
         it('should override loops.enabled from file', () => {

--- a/packages/coc/vitest.config.ts
+++ b/packages/coc/vitest.config.ts
@@ -47,6 +47,9 @@ export default defineConfig({
             forks: {
                 // Limit concurrent forks to 2 to avoid OOM on macOS runners
                 // (excalidraw + jsdom forks accumulate ~14 GB peak usage at 3 concurrent).
+                // minForks must be ≤ maxForks; without it tinypool defaults minThreads
+                // to nCPUs-1 which can exceed maxForks and trigger a startup conflict.
+                minForks: 1,
                 maxForks: 2,
             },
         },


### PR DESCRIPTION
## Summary

- `scratchpad.enabled` and `loops.enabled` in `DEFAULT_CONFIG` changed from `false` → `true`, so both features are on out of the box without requiring a manual admin config toggle
- Updated 4 test assertions in `config.test.ts` that hardcoded the old `false` defaults (snapshot check, preserve-default test, and two loops default tests)
- Added `minForks: 1` to the vitest forks pool config to fix a pre-existing tinypool startup crash on machines with >2 logical CPUs (`minThreads > maxForks` conflict)

## What changed

| File | Change |
|------|--------|
| `packages/coc/src/config.ts` | `scratchpad.enabled: false → true`, `loops.enabled: false → true` |
| `packages/coc/test/config.test.ts` | Updated 4 default-value assertions to match new defaults |
| `packages/coc/vitest.config.ts` | Added `minForks: 1` alongside existing `maxForks: 2` |

## Test plan

- [x] All 319 targeted tests pass (`config.test.ts`, `admin-config-fields.test.ts`, `loop-tools.test.ts`, `loop-executor.test.ts`)
- [x] No behavior change for users who have already explicitly set these flags in their config file (file values still override the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)