### PR TITLE
coc: route LLM tool guidance into systemMessage (not per-turn user prompt)

### DIFF
--- a/packages/coc/src/server/executors/autopilot-executor.ts
+++ b/packages/coc/src/server/executors/autopilot-executor.ts
@@ -51,7 +51,7 @@ export class AutopilotExecutor extends ChatBaseExecutor {
         const boundedMemory = await this.buildMemoryAddon(payload.workspaceId, this.buildCaptureContext(task), prompt);
         const processId = toQueueProcessId(task.id);
         const loopDeps = this.buildLoopToolDeps(processId);
-        const { tools, suffix } = buildChatToolBundle({
+        const { tools, toolGuidance } = buildChatToolBundle({
             dataDir: this.dataDir,
             store: this.store,
             workspaceId: payload.workspaceId,
@@ -65,11 +65,16 @@ export class AutopilotExecutor extends ChatBaseExecutor {
             loopTools: loopDeps.loopTools,
         });
 
+        const systemMessage = await systemMessageBuilder()
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolGuidance)
+            .build();
+
         return {
             agentMode: 'autopilot' as AgentMode,
-            systemMessage: await systemMessageBuilder().appendMemory(boundedMemory).build(),
+            systemMessage,
             tools,
-            effectivePrompt: prompt + suffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -279,48 +279,6 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
 
         const boundedMemory = await this.buildMemoryAddon(payload.workspaceId, this.buildCaptureContext(task), prompt);
         const notePath = payload.context?.noteChat?.notePath;
-        const systemMessage = await systemMessageBuilder()
-            .append(buildModeSystemMessage(mode)?.content)
-            .withRepoInstructions(workingDirectory, mode)
-            .appendMemory(boundedMemory)
-            .appendAutoFolder(autoFolderContext)
-            .appendNoteFile(notePath)
-            .build();
-
-        // When this is a Ralph grilling session, append the goal-spec instruction.
-        if (payload.context?.ralph?.phase === 'grilling' && systemMessage) {
-            const ralphGrillSuffix = [
-                '## Ralph Grilling Phase — Clarification Protocol',
-                '',
-                'You are in the Ralph grilling phase. Your job right now is to interactively interview the user to nail down a precise goal spec before any coding begins.',
-                '',
-                'Rules for this phase (these OVERRIDE any earlier guidance about ask_user):',
-                '- Use the `ask_user` tool for EVERY clarification, confirmation, or choice question. Do NOT write clarification questions as plain assistant text.',
-                '- Batch related questions into a SINGLE `ask_user` call by passing multiple entries in `questions[]`. Do not call the tool repeatedly for one round of clarification.',
-                '- Yes/no clarifications ARE in scope here — ignore the earlier "Do NOT use ask_user for simple yes/no" guidance during grilling. In this phase, simple yes/no clarifications MUST also go through `ask_user`.',
-                '- Keep questions concrete and answerable. Prefer choice questions with explicit options when there are a few obvious paths.',
-                '- Only after the user explicitly signals they are done (e.g. "enough", "go", "that\'s it") OR you have gathered enough answers to write a precise spec, emit the final goal-spec block as plain assistant text using the template below. Do not emit the goal spec while still asking questions.',
-                '',
-                'Final goal-spec template (emit ONLY at the end, as plain assistant text — not via ask_user):',
-                '',
-                '## Goal',
-                '<one-sentence goal>',
-                '',
-                '## Acceptance Criteria',
-                '<bullet list>',
-                '',
-                '## Constraints / Tech Context',
-                '<bullet list>',
-                '',
-                '## Out of Scope',
-                '<bullet list>',
-                '',
-                'This spec will be used to drive an automated coding loop. Be precise and concrete.',
-            ].join('\n');
-            systemMessage.content = systemMessage.content
-                ? systemMessage.content + '\n\n' + ralphGrillSuffix
-                : ralphGrillSuffix;
-        }
 
         const processId = toQueueProcessId(task.id);
         const loopDeps = this.buildLoopToolDeps(processId);
@@ -360,11 +318,55 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
             hasPending: toolBundle.askUser!.hasPending,
         };
 
+        const systemMessage = await systemMessageBuilder()
+            .append(buildModeSystemMessage(mode)?.content)
+            .withRepoInstructions(workingDirectory, mode)
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolBundle.toolGuidance)
+            .appendAutoFolder(autoFolderContext)
+            .appendNoteFile(notePath)
+            .build();
+
+        // When this is a Ralph grilling session, append the goal-spec instruction.
+        if (payload.context?.ralph?.phase === 'grilling' && systemMessage) {
+            const ralphGrillSuffix = [
+                '## Ralph Grilling Phase — Clarification Protocol',
+                '',
+                'You are in the Ralph grilling phase. Your job right now is to interactively interview the user to nail down a precise goal spec before any coding begins.',
+                '',
+                'Rules for this phase (these OVERRIDE any earlier guidance about ask_user):',
+                '- Use the `ask_user` tool for EVERY clarification, confirmation, or choice question. Do NOT write clarification questions as plain assistant text.',
+                '- Batch related questions into a SINGLE `ask_user` call by passing multiple entries in `questions[]`. Do not call the tool repeatedly for one round of clarification.',
+                '- Yes/no clarifications ARE in scope here — ignore the earlier "Do NOT use ask_user for simple yes/no" guidance during grilling. In this phase, simple yes/no clarifications MUST also go through `ask_user`.',
+                '- Keep questions concrete and answerable. Prefer choice questions with explicit options when there are a few obvious paths.',
+                '- Only after the user explicitly signals they are done (e.g. "enough", "go", "that\'s it") OR you have gathered enough answers to write a precise spec, emit the final goal-spec block as plain assistant text using the template below. Do not emit the goal spec while still asking questions.',
+                '',
+                'Final goal-spec template (emit ONLY at the end, as plain assistant text — not via ask_user):',
+                '',
+                '## Goal',
+                '<one-sentence goal>',
+                '',
+                '## Acceptance Criteria',
+                '<bullet list>',
+                '',
+                '## Constraints / Tech Context',
+                '<bullet list>',
+                '',
+                '## Out of Scope',
+                '<bullet list>',
+                '',
+                'This spec will be used to drive an automated coding loop. Be precise and concrete.',
+            ].join('\n');
+            systemMessage.content = systemMessage.content
+                ? systemMessage.content + '\n\n' + ralphGrillSuffix
+                : ralphGrillSuffix;
+        }
+
         return {
             agentMode: mode === 'plan' ? 'plan' as AgentMode : 'interactive' as AgentMode,
             systemMessage,
             tools: toolBundle.tools,
-            effectivePrompt: prompt + toolBundle.suffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/chat-tool-builder.ts
+++ b/packages/coc/src/server/executors/chat-tool-builder.ts
@@ -47,7 +47,12 @@ export interface ChatToolBundleOptions {
 
 export interface ChatToolBundle {
     tools: Tool<any>[];
-    suffix: string;
+    /**
+     * Aggregated LLM-tool-guidance prose. Callers route this into the
+     * system message via `systemMessageBuilder().appendToolGuidance(...)`
+     * rather than appending it to the user prompt.
+     */
+    toolGuidance: string;
     askUser?: AskUserAddon;
 }
 
@@ -112,9 +117,9 @@ export function buildChatToolBundle(options: ChatToolBundleOptions): ChatToolBun
         ? readEffectiveDisabledLlmTools(options.dataDir, options.workspaceId)
         : undefined;
     const disabledWithContextExclusions = mergeDisabledTools(disabledLlmTools, options.excludeTools);
-    const { tools, suffix } = applyLlmToolPreferences(addons, disabledWithContextExclusions);
+    const { tools, toolGuidance } = applyLlmToolPreferences(addons, disabledWithContextExclusions);
 
-    return { tools, suffix, askUser };
+    return { tools, toolGuidance, askUser };
 }
 
 function mergeDisabledTools(

--- a/packages/coc/src/server/executors/classification-executor.ts
+++ b/packages/coc/src/server/executors/classification-executor.ts
@@ -61,13 +61,9 @@ export class ClassificationExecutor extends ChatBaseExecutor {
         const processId = toQueueProcessId(task.id);
 
         const boundedMemory = await this.buildMemoryAddon(wsId, this.buildCaptureContext(task), prompt);
-        const systemMessage = await systemMessageBuilder()
-            .withRepoInstructions(workingDirectory, 'autopilot')
-            .appendMemory(boundedMemory)
-            .build();
 
         const tools: Tool<unknown>[] = [];
-        let toolSuffix = '';
+        let toolGuidance = '';
 
         if (this.dataDir && wsId && ctx.repoId && ctx.prId && ctx.headSha) {
             const { tool } = createSaveClassificationTool({
@@ -79,7 +75,7 @@ export class ClassificationExecutor extends ChatBaseExecutor {
                 processId,
             });
             tools.push(tool);
-            toolSuffix += SAVE_CLASSIFICATION_SUFFIX;
+            toolGuidance += SAVE_CLASSIFICATION_SUFFIX;
         }
 
         // Standard chat tools (search, memory, etc.) — same pattern as other executors.
@@ -95,19 +91,25 @@ export class ClassificationExecutor extends ChatBaseExecutor {
             ? readEffectiveDisabledLlmTools(this.dataDir, wsId)
             : undefined;
 
-        const { tools: filteredTools, suffix: filteredSuffix } = applyLlmToolPreferences(
+        const { tools: filteredTools, toolGuidance: filteredGuidance } = applyLlmToolPreferences(
             [followUp, searchConversations, tavilySearch, memoryReadTools, boundedMemory],
             disabledLlmTools,
         );
 
         tools.push(...filteredTools);
-        toolSuffix += filteredSuffix;
+        toolGuidance += filteredGuidance;
+
+        const systemMessage = await systemMessageBuilder()
+            .withRepoInstructions(workingDirectory, 'autopilot')
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolGuidance)
+            .build();
 
         return {
             agentMode: 'autopilot' as AgentMode,
             systemMessage,
             tools,
-            effectivePrompt: prompt + toolSuffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/commit-chat-executor.ts
+++ b/packages/coc/src/server/executors/commit-chat-executor.ts
@@ -68,7 +68,7 @@ export class CommitChatExecutor extends ChatBaseExecutor {
         // Resolve parent hash
         const parentHash = resolveParentHash(commitHash, workingDirectory);
 
-        // Build system message (same pattern as ChatExecutor)
+        // Build auto-folder context (same pattern as ChatExecutor)
         let autoFolderContext = undefined;
         if (workingDirectory) {
             autoFolderContext = await this.buildAutoFolderContext(
@@ -78,16 +78,11 @@ export class CommitChatExecutor extends ChatBaseExecutor {
         }
 
         const boundedMemory = await this.buildMemoryAddon(wsId, this.buildCaptureContext(task), prompt);
-        const systemMessage = await systemMessageBuilder()
-            .append(buildModeSystemMessage('ask')?.content)
-            .withRepoInstructions(workingDirectory, 'ask')
-            .appendMemory(boundedMemory)
-            .appendAutoFolder(autoFolderContext)
-            .build();
 
-        // Build tools
+        // Build tools first so we can route the aggregated tool-guidance prose
+        // into the system message via `.appendToolGuidance()`.
         const tools: Tool<unknown>[] = [];
-        let toolSuffix = '';
+        let toolGuidance = '';
 
         // Inject add_diff_comment tool when we have enough context
         if (this.dataDir && wsId && commitHash && workingDirectory) {
@@ -101,11 +96,10 @@ export class CommitChatExecutor extends ChatBaseExecutor {
                 getWsServer: this.getWsServer,
             });
             tools.push(tool);
-            toolSuffix += ADD_DIFF_COMMENT_SUFFIX;
+            toolGuidance += ADD_DIFF_COMMENT_SUFFIX;
         }
 
         // Standard chat tools
-        const hasPlanFile = (payload.context?.files?.length ?? 0) > 1;
         const followUp = buildFollowUpSuggestionsAddon(
             this.followUpSuggestions.enabled,
             this.followUpSuggestions.count,
@@ -118,19 +112,27 @@ export class CommitChatExecutor extends ChatBaseExecutor {
             ? readEffectiveDisabledLlmTools(this.dataDir, wsId)
             : undefined;
 
-        const { tools: filteredTools, suffix: filteredSuffix } = applyLlmToolPreferences(
+        const { tools: filteredTools, toolGuidance: filteredGuidance } = applyLlmToolPreferences(
             [followUp, searchConversations, tavilySearch, memoryReadTools, boundedMemory],
             disabledLlmTools,
         );
 
         tools.push(...filteredTools);
-        toolSuffix += filteredSuffix;
+        toolGuidance += filteredGuidance;
+
+        const systemMessage = await systemMessageBuilder()
+            .append(buildModeSystemMessage('ask')?.content)
+            .withRepoInstructions(workingDirectory, 'ask')
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolGuidance)
+            .appendAutoFolder(autoFolderContext)
+            .build();
 
         return {
             agentMode: 'interactive' as AgentMode,
             systemMessage,
             tools,
-            effectivePrompt: prompt + toolSuffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/follow-up-executor.ts
+++ b/packages/coc/src/server/executors/follow-up-executor.ts
@@ -192,15 +192,6 @@ export class FollowUpExecutor extends ChatBaseExecutor {
             turnIndex: process.conversationTurns?.length ?? 0,
         }, message);
         const notePath = process.metadata?.notePath as string | undefined;
-        let systemMessage = await systemMessageBuilder()
-            .append(buildModeSystemMessage(currentMode)?.content)
-            .withRepoInstructions(workingDirectory, currentMode)
-            .appendMemory(boundedMemory)
-            .appendAutoFolder(autoFolderContextForFollowUp)
-            .appendNoteFile(notePath)
-            .build();
-
-        this.persistSystemPromptAsync(processId, 'chat', systemMessage?.content);
 
         // Capture pre-edit note content for snapshot (note-chat follow-ups only)
         let preEditContent: string | undefined;
@@ -297,7 +288,7 @@ export class FollowUpExecutor extends ChatBaseExecutor {
                     },
                 },
             });
-            const { tools: filteredTools, suffix: combinedSuffix } = toolBundle;
+            const filteredTools = toolBundle.tools;
             const session = this.getOrCreateSession(processId);
             session.pendingAskUser = {
                 answerQuestion: toolBundle.askUser!.answerQuestion,
@@ -306,10 +297,23 @@ export class FollowUpExecutor extends ChatBaseExecutor {
                 cancelAll: toolBundle.askUser!.cancelAll,
                 hasPending: toolBundle.askUser!.hasPending,
             };
-            const followUpMessage = prependSelectedSkillsDirective(
-                combinedSuffix ? `${message}${combinedSuffix}` : message,
-                selectedSkillNames,
-            );
+
+            // Build the system message AFTER the tool bundle so the
+            // tool-guidance prose lives in `systemMessage` (sent once at
+            // session creation) rather than being stapled to every user
+            // turn.
+            const systemMessage = await systemMessageBuilder()
+                .append(buildModeSystemMessage(currentMode)?.content)
+                .withRepoInstructions(workingDirectory, currentMode)
+                .appendMemory(boundedMemory)
+                .appendToolGuidance(toolBundle.toolGuidance)
+                .appendAutoFolder(autoFolderContextForFollowUp)
+                .appendNoteFile(notePath)
+                .build();
+
+            this.persistSystemPromptAsync(processId, 'chat', systemMessage?.content);
+
+            const followUpMessage = prependSelectedSkillsDirective(message, selectedSkillNames);
             const agentMode = toAgentMode(currentMode);
 
             const historySystemMessage: SystemMessageConfig | undefined = historyContext

--- a/packages/coc/src/server/executors/note-chat-executor.ts
+++ b/packages/coc/src/server/executors/note-chat-executor.ts
@@ -112,7 +112,7 @@ export class NoteChatExecutor extends ChatBaseExecutor {
         const payload = task.payload as unknown as ChatPayload;
         const wsId = payload.workspaceId;
 
-        // Build system message (same pattern as ChatExecutor)
+        // Build auto-folder context (same pattern as ChatExecutor)
         let autoFolderContext = undefined;
         if (workingDirectory) {
             autoFolderContext = await this.buildAutoFolderContext(
@@ -122,10 +122,6 @@ export class NoteChatExecutor extends ChatBaseExecutor {
         }
 
         const boundedMemory = await this.buildMemoryAddon(wsId, this.buildCaptureContext(task), prompt);
-        const systemMessage = await systemMessageBuilder()
-            .appendMemory(boundedMemory)
-            .appendAutoFolder(autoFolderContext)
-            .build();
 
         // Standard chat tools
         const followUp = buildFollowUpSuggestionsAddon(
@@ -140,10 +136,16 @@ export class NoteChatExecutor extends ChatBaseExecutor {
             ? readEffectiveDisabledLlmTools(this.dataDir, wsId)
             : undefined;
 
-        const { tools, suffix: toolSuffix } = applyLlmToolPreferences(
+        const { tools, toolGuidance } = applyLlmToolPreferences(
             [followUp, searchConversations, tavilySearch, memoryReadTools, boundedMemory],
             disabledLlmTools,
         );
+
+        const systemMessage = await systemMessageBuilder()
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolGuidance)
+            .appendAutoFolder(autoFolderContext)
+            .build();
 
         const payloadMode = payload.mode;
         const agentMode: AgentMode =
@@ -155,7 +157,7 @@ export class NoteChatExecutor extends ChatBaseExecutor {
             agentMode,
             systemMessage,
             tools,
-            effectivePrompt: prompt + toolSuffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/note-create-executor.ts
+++ b/packages/coc/src/server/executors/note-create-executor.ts
@@ -294,9 +294,6 @@ export class NoteCreateExecutor extends ChatBaseExecutor {
         const wsId = payload.workspaceId;
 
         const boundedMemory = await this.buildMemoryAddon(wsId, this.buildCaptureContext(task), prompt);
-        const systemMessage = await systemMessageBuilder()
-            .appendMemory(boundedMemory)
-            .build();
 
         const followUp = buildFollowUpSuggestionsAddon(false, 0);
         const searchConversations = buildSearchConversationsAddon(this.store, wsId, toQueueProcessId(task.id));
@@ -307,16 +304,21 @@ export class NoteCreateExecutor extends ChatBaseExecutor {
             ? readEffectiveDisabledLlmTools(this.dataDir, wsId)
             : undefined;
 
-        const { tools, suffix: toolSuffix } = applyLlmToolPreferences(
+        const { tools, toolGuidance } = applyLlmToolPreferences(
             [followUp, searchConversations, tavilySearch, memoryReadTools, boundedMemory],
             disabledLlmTools,
         );
+
+        const systemMessage = await systemMessageBuilder()
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolGuidance)
+            .build();
 
         return {
             agentMode: 'interactive' as AgentMode,
             systemMessage,
             tools,
-            effectivePrompt: prompt + toolSuffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -642,29 +642,35 @@ export function buildExcalidrawToolsAddon(
 // ============================================================================
 
 /**
- * Filters the assembled tools + suffixes by the per-repo disabled LLM tools list.
- * Call this as the final step before returning from `buildModeOptions`.
+ * Filters the assembled tools + per-addon prose by the per-repo disabled
+ * LLM tools list, and returns the surviving tools alongside the
+ * aggregated `toolGuidance` block.
  *
- * Each entry in `toolsWithSuffix` is a named tool paired with the prompt suffix
- * that describes it. When a tool is disabled, both the tool and its suffix are
- * removed from the output.
+ * Each entry in `toolsWithSuffix` is a named tool paired with the prose
+ * that describes it. When a tool is disabled, both the tool and its prose
+ * are removed from the output.
+ *
+ * The aggregated prose is exposed as `toolGuidance` (not `suffix`) because
+ * callers route it into the system message via
+ * `systemMessageBuilder().appendToolGuidance(...)` rather than appending
+ * it to the user prompt.
  */
 export function applyLlmToolPreferences(
     toolsWithSuffix: Array<{ tools: Tool<any>[]; suffix: string }>,
     disabledLlmTools: string[] | undefined,
-): { tools: Tool<any>[]; suffix: string } {
+): { tools: Tool<any>[]; toolGuidance: string } {
     const allTools: Tool<any>[] = [];
-    let combinedSuffix = '';
+    let toolGuidance = '';
 
     for (const entry of toolsWithSuffix) {
         const filtered = filterDisabledLlmTools(entry.tools, disabledLlmTools);
         if (filtered.length > 0) {
             allTools.push(...filtered);
-            combinedSuffix += entry.suffix;
+            toolGuidance += entry.suffix;
         }
     }
 
-    return { tools: allTools, suffix: combinedSuffix };
+    return { tools: allTools, toolGuidance };
 }
 
 // Re-export for convenience

--- a/packages/coc/src/server/executors/ralph-executor.ts
+++ b/packages/coc/src/server/executors/ralph-executor.ts
@@ -137,15 +137,9 @@ export class RalphExecutor extends ChatBaseExecutor {
 
         const boundedMemory = await this.buildMemoryAddon(payload.workspaceId, this.buildCaptureContext(task), prompt);
 
-        const systemMessage = await systemMessageBuilder()
-            .append(ralphSystemPrompt)
-            .withRepoInstructions(workingDirectory, 'ralph')
-            .appendMemory(boundedMemory)
-            .build();
-
         const processId = toQueueProcessId(task.id);
         const loopDeps = this.buildLoopToolDeps(processId);
-        const { tools, suffix } = buildChatToolBundle({
+        const { tools, toolGuidance } = buildChatToolBundle({
             dataDir: this.dataDir,
             store: this.store,
             workspaceId: payload.workspaceId,
@@ -159,11 +153,18 @@ export class RalphExecutor extends ChatBaseExecutor {
             loopTools: loopDeps.loopTools,
         });
 
+        const systemMessage = await systemMessageBuilder()
+            .append(ralphSystemPrompt)
+            .withRepoInstructions(workingDirectory, 'ralph')
+            .appendMemory(boundedMemory)
+            .appendToolGuidance(toolGuidance)
+            .build();
+
         return {
             agentMode: 'autopilot' as AgentMode,
             systemMessage,
             tools,
-            effectivePrompt: prompt + suffix,
+            effectivePrompt: prompt,
             dispose: boundedMemory.dispose,
         };
     }

--- a/packages/coc/src/server/executors/system-message-builder.ts
+++ b/packages/coc/src/server/executors/system-message-builder.ts
@@ -70,6 +70,24 @@ class SystemMessageBuilder {
     }
 
     /**
+     * Append the aggregated LLM-tool-guidance block (concatenated `suffix`
+     * strings from each enabled addon, as produced by
+     * `applyLlmToolPreferences` / `buildChatToolBundle`).
+     *
+     * Lives in the system message rather than appended to the user prompt
+     * so the prose is sent exactly once at session creation instead of
+     * being repeated on every turn.
+     *
+     * No-op when `block` is empty, undefined, or only whitespace.
+     */
+    appendToolGuidance(block: string | undefined): this {
+        if (block && block.trim().length > 0) {
+            this.steps.push({ kind: 'eager', block });
+        }
+        return this;
+    }
+
+    /**
      * Defer loading per-repo `.github/coc/` instructions.
      * No-op when `workingDir` or `mode` is `undefined`.
      */

--- a/packages/coc/test/server/executors-prompt-builder.test.ts
+++ b/packages/coc/test/server/executors-prompt-builder.test.ts
@@ -712,6 +712,63 @@ describe('systemMessageBuilder', () => {
     });
 
     // -------------------------------------------------------------------------
+    // .appendToolGuidance()
+    // -------------------------------------------------------------------------
+
+    it('appends a tool-guidance block as eager content', async () => {
+        const result = await systemMessageBuilder()
+            .appendToolGuidance('Use the foo_tool for X.')
+            .build();
+        expect(result!.content).toBe('Use the foo_tool for X.');
+    });
+
+    it('joins tool guidance after prior content', async () => {
+        const result = await systemMessageBuilder()
+            .append('base instructions')
+            .appendToolGuidance('Use the foo_tool for X.')
+            .build();
+        expect(result!.content).toBe('base instructions\n\nUse the foo_tool for X.');
+    });
+
+    it('is a no-op when tool-guidance block is undefined', async () => {
+        const result = await systemMessageBuilder()
+            .append('base')
+            .appendToolGuidance(undefined)
+            .build();
+        expect(result!.content).toBe('base');
+    });
+
+    it('is a no-op when tool-guidance block is empty string', async () => {
+        const result = await systemMessageBuilder()
+            .append('base')
+            .appendToolGuidance('')
+            .build();
+        expect(result!.content).toBe('base');
+    });
+
+    it('is a no-op when tool-guidance block is whitespace-only', async () => {
+        const result = await systemMessageBuilder()
+            .append('base')
+            .appendToolGuidance('   \n\n  ')
+            .build();
+        expect(result!.content).toBe('base');
+    });
+
+    it('places tool guidance after memory and before auto-folder in the canonical chain', async () => {
+        const addon = { systemMessageSuffix: 'memory block', tools: [], suffix: '', dispose: () => {} };
+        const ctx = { tasksRoot: '/tasks', existingFolders: ['feat1'] };
+        const result = await systemMessageBuilder()
+            .append('base')
+            .appendMemory(addon)
+            .appendToolGuidance('Use foo_tool.')
+            .appendAutoFolder(ctx)
+            .build();
+        const content = result!.content;
+        expect(content.indexOf('memory block')).toBeLessThan(content.indexOf('Use foo_tool.'));
+        expect(content.indexOf('Use foo_tool.')).toBeLessThan(content.indexOf('auto-folder-block'));
+    });
+
+    // -------------------------------------------------------------------------
     // .appendAutoFolder()
     // -------------------------------------------------------------------------
 

--- a/packages/coc/test/server/executors/chat-mode-executors.test.ts
+++ b/packages/coc/test/server/executors/chat-mode-executors.test.ts
@@ -409,7 +409,7 @@ describe('ChatExecutor ask_user enabled', () => {
         expect(toolNames).toContain('ask_user');
     });
 
-    it('does not include ask_user prompt suffix', async () => {
+    it('routes ask_user tool guidance into systemMessage (not user prompt)', async () => {
         const executor = new ChatExecutor(store, makeOptions(store, {
             askUser: { enabled: true },
         } as any));
@@ -418,8 +418,11 @@ describe('ChatExecutor ask_user enabled', () => {
         await executor.execute(task, 'Hello');
 
         const call = sdkMocks.mockSendMessage.mock.calls[0][0];
+        // Tool-guidance prose lives in systemMessage (once per session)
+        // — not stapled to every user turn.
+        expect(call.prompt).not.toContain('ask_user');
         const systemContent = call.systemMessage?.content ?? '';
-        expect(systemContent).not.toContain('ask_user');
+        expect(systemContent).toContain('ask_user');
     });
 });
 
@@ -817,9 +820,10 @@ describe('create_work_item / create_bug tool wiring', () => {
             await executor.execute(task, 'Hello');
 
             const call = sdkMocks.mockSendMessage.mock.calls[0][0];
-            expect(call.prompt).toContain('create-work-item');
-            expect(call.prompt).toContain('create-bug');
-            expect(call.prompt).toContain('update-work-item');
+            const systemContent = call.systemMessage?.content ?? '';
+            expect(systemContent).toContain('create-work-item');
+            expect(systemContent).toContain('create-bug');
+            expect(systemContent).toContain('update-work-item');
         }
     });
 
@@ -843,7 +847,8 @@ describe('create_work_item / create_bug tool wiring', () => {
             const call = sdkMocks.mockSendMessage.mock.calls[0][0];
             const toolNames = (call.tools ?? []).map((t: any) => t.name);
             expect(toolNames).toContain('tavily_web_search');
-            expect(call.prompt).toContain('tavily_web_search');
+            const systemContent = call.systemMessage?.content ?? '';
+            expect(systemContent).toContain('tavily_web_search');
         }
     });
 

--- a/packages/coc/test/server/executors/chat-tool-builder.test.ts
+++ b/packages/coc/test/server/executors/chat-tool-builder.test.ts
@@ -67,9 +67,9 @@ describe('buildChatToolBundle', () => {
             'suggest_follow_ups',
             'tavily_web_search',
         ]);
-        expect(result.suffix).toContain('tavily_web_search');
-        expect(result.suffix).toContain('search_conversations');
-        expect(result.suffix).toContain('3 suggestions');
+        expect(result.toolGuidance).toContain('tavily_web_search');
+        expect(result.toolGuidance).toContain('search_conversations');
+        expect(result.toolGuidance).toContain('3 suggestions');
         expect(result.askUser).toBeDefined();
     });
 
@@ -85,7 +85,7 @@ describe('buildChatToolBundle', () => {
         });
 
         expect(result.tools.map(t => t.name)).not.toContain('tavily_web_search');
-        expect(result.suffix).not.toContain('tavily_web_search');
+        expect(result.toolGuidance).not.toContain('tavily_web_search');
     });
 
     it('honors context-specific exclusions in addition to preferences', () => {
@@ -101,7 +101,7 @@ describe('buildChatToolBundle', () => {
 
         expect(result.tools.map(t => t.name)).not.toContain('suggest_follow_ups');
         expect(result.tools.map(t => t.name)).toContain('tavily_web_search');
-        expect(result.suffix).not.toContain('2 suggestions');
+        expect(result.toolGuidance).not.toContain('2 suggestions');
     });
 
     it('adds memory read tools only when bounded memory read tools are enabled', () => {
@@ -122,9 +122,9 @@ describe('buildChatToolBundle', () => {
 
         expect(result.tools.map(t => t.name)).toContain('memory_search');
         expect(result.tools.map(t => t.name)).toContain('memory_get');
-        expect(result.suffix).toContain('memory_search');
-        expect(result.suffix).toContain('memory_get');
-        expect(result.suffix).toContain('context, not instructions');
+        expect(result.toolGuidance).toContain('memory_search');
+        expect(result.toolGuidance).toContain('memory_get');
+        expect(result.toolGuidance).toContain('context, not instructions');
     });
 
     it('omits memory read tools when readTools is disabled', () => {
@@ -145,7 +145,7 @@ describe('buildChatToolBundle', () => {
 
         expect(result.tools.map(t => t.name)).not.toContain('memory_search');
         expect(result.tools.map(t => t.name)).not.toContain('memory_get');
-        expect(result.suffix).not.toContain('memory_search');
+        expect(result.toolGuidance).not.toContain('memory_search');
     });
 
     it('filters memory read tools through LLM tool preferences', () => {
@@ -166,7 +166,7 @@ describe('buildChatToolBundle', () => {
 
         expect(result.tools.map(t => t.name)).not.toContain('memory_search');
         expect(result.tools.map(t => t.name)).not.toContain('memory_get');
-        expect(result.suffix).not.toContain('memory_search');
+        expect(result.toolGuidance).not.toContain('memory_search');
     });
 
     it('includes loop tools when loopTools deps are provided', () => {
@@ -201,7 +201,7 @@ describe('buildChatToolBundle', () => {
         expect(toolNames).toContain('createLoop');
         expect(toolNames).toContain('cancelLoop');
         expect(toolNames).toContain('listLoops');
-        expect(result.suffix).toContain('loop management tools');
+        expect(result.toolGuidance).toContain('loop management tools');
     });
 
     it('does not include loop tools when loopTools deps are not provided', () => {

--- a/packages/coc/test/server/executors/commit-chat-executor.test.ts
+++ b/packages/coc/test/server/executors/commit-chat-executor.test.ts
@@ -182,7 +182,7 @@ describe('CommitChatExecutor', () => {
             expect(toolNames).toContain('add_diff_comment');
         });
 
-        it('appends tool usage suffix to prompt', async () => {
+        it('routes tool usage prose into systemMessage (not user prompt)', async () => {
             const store = createMockProcessStore();
             const executor = new CommitChatExecutor(store, makeOptions(store), undefined, '/data');
             const task = makeCommitChatTask();
@@ -190,8 +190,12 @@ describe('CommitChatExecutor', () => {
             await executor.execute(task, 'Review this commit');
 
             const callArgs = sdkMocks.service.sendMessage.mock.calls[0][0];
-            expect(callArgs.prompt).toContain('add_diff_comment');
-            expect(callArgs.prompt).toContain('diff review panel');
+            // After the refactor: tool guidance lives in systemMessage,
+            // not stapled to every user prompt.
+            expect(callArgs.prompt).not.toContain('add_diff_comment');
+            const systemContent = callArgs.systemMessage?.content ?? '';
+            expect(systemContent).toContain('add_diff_comment');
+            expect(systemContent).toContain('diff review panel');
         });
 
         it('returns response from AI SDK', async () => {

--- a/packages/coc/test/server/executors/follow-up-executor.test.ts
+++ b/packages/coc/test/server/executors/follow-up-executor.test.ts
@@ -39,22 +39,22 @@ const mockBuildConversationHistoryContext = vi.fn().mockReturnValue(undefined);
 const mockBuildFollowUpSuggestionsAddon = vi.fn().mockReturnValue({ tools: [], suffix: '' });
 const mockApplyLlmToolPreferences = vi.fn().mockImplementation((addons: Array<{ tools: any[]; suffix: string }>, disabled?: string[]) => {
     const tools: any[] = [];
-    let suffix = '';
+    let toolGuidance = '';
     for (const addon of addons) {
         const filtered = disabled
             ? addon.tools.filter(tool => !disabled.includes(tool.name))
             : addon.tools;
         if (filtered.length > 0) {
             tools.push(...filtered);
-            suffix += addon.suffix;
+            toolGuidance += addon.suffix;
         }
     }
-    return { tools, suffix };
+    return { tools, toolGuidance };
 });
 function makeMockToolBundle(overrides?: Partial<ReturnType<typeof makeMockToolBundle>>) {
     return {
         tools: [],
-        suffix: '',
+        toolGuidance: '',
         askUser: {
             answerQuestion: vi.fn(() => false),
             skipQuestion: vi.fn(() => false),
@@ -573,10 +573,10 @@ describe('FollowUpExecutor', () => {
         }));
     });
 
-    it('passes shared chat tools and suffix to sendMessage on follow-up turns', async () => {
+    it('passes shared chat tools and routes tool guidance into the system message on follow-up turns', async () => {
         mockBuildChatToolBundle.mockReturnValue(makeMockToolBundle({
             tools: [{ name: 'tavily_web_search' }],
-            suffix: '\n\nTavily suffix',
+            toolGuidance: '\n\nTavily tool guidance prose',
         }));
         const proc = makeProcess({
             id: 'proc-shared-tools',
@@ -589,8 +589,12 @@ describe('FollowUpExecutor', () => {
 
         const callArg = sdkMocks.mockSendMessage.mock.calls[0][0] as any;
         expect(callArg.tools.map((tool: any) => tool.name)).toContain('tavily_web_search');
+        // After the refactor: the tool-guidance prose lives in systemMessage
+        // (sent once at SDK session creation), not stapled onto every user
+        // turn. The user prompt should remain the raw message.
         expect(callArg.prompt).toContain('another question');
-        expect(callArg.prompt).toContain('Tavily suffix');
+        expect(callArg.prompt).not.toContain('Tavily tool guidance prose');
+        expect(callArg.systemMessage.content).toContain('Tavily tool guidance prose');
     });
 
     it('passes enabled ask_user configuration on ask follow-up turns', async () => {

--- a/packages/coc/test/server/llm-tools/llm-tools-preferences.test.ts
+++ b/packages/coc/test/server/llm-tools/llm-tools-preferences.test.ts
@@ -178,7 +178,7 @@ describe('applyLlmToolPreferences', () => {
         ];
         const result = applyLlmToolPreferences(addons, ['tavily_web_search']);
         expect(result.tools.map(t => t.name)).toEqual(['suggest_follow_ups', 'memory']);
-        expect(result.suffix).toBe(' A C');
+        expect(result.toolGuidance).toBe(' A C');
     });
 
     it('uses default disabled list when undefined', () => {
@@ -188,7 +188,7 @@ describe('applyLlmToolPreferences', () => {
         ];
         const result = applyLlmToolPreferences(addons, undefined);
         expect(result.tools.map(t => t.name)).toEqual(['suggest_follow_ups']);
-        expect(result.suffix).toBe(' A');
+        expect(result.toolGuidance).toBe(' A');
     });
 
     it('keeps all tools when disabled list is empty', () => {
@@ -198,7 +198,7 @@ describe('applyLlmToolPreferences', () => {
         ];
         const result = applyLlmToolPreferences(addons, []);
         expect(result.tools.map(t => t.name)).toEqual(['suggest_follow_ups', 'tavily_web_search']);
-        expect(result.suffix).toBe(' A B');
+        expect(result.toolGuidance).toBe(' A B');
     });
 
     it('removes suffix when all tools from an addon are disabled', () => {
@@ -207,7 +207,7 @@ describe('applyLlmToolPreferences', () => {
             { tools: [makeTool('tavily_web_search')], suffix: ' B' },
         ];
         const result = applyLlmToolPreferences(addons, ['tavily_web_search']);
-        expect(result.suffix).toBe(' A');
+        expect(result.toolGuidance).toBe(' A');
     });
 
     it('handles addon with multiple tools — partial filtering', () => {
@@ -216,7 +216,7 @@ describe('applyLlmToolPreferences', () => {
         ];
         const result = applyLlmToolPreferences(addons, ['get_conversation']);
         expect(result.tools.map(t => t.name)).toEqual(['search_conversations']);
-        expect(result.suffix).toBe(' X');
+        expect(result.toolGuidance).toBe(' X');
     });
 
     it('handles addon with multiple tools — all filtered', () => {
@@ -225,13 +225,13 @@ describe('applyLlmToolPreferences', () => {
         ];
         const result = applyLlmToolPreferences(addons, ['search_conversations', 'get_conversation']);
         expect(result.tools).toHaveLength(0);
-        expect(result.suffix).toBe('');
+        expect(result.toolGuidance).toBe('');
     });
 
     it('handles empty addons array', () => {
         const result = applyLlmToolPreferences([], ['tavily_web_search']);
         expect(result.tools).toHaveLength(0);
-        expect(result.suffix).toBe('');
+        expect(result.toolGuidance).toBe('');
     });
 
     it('handles addon with empty tools array', () => {
@@ -241,6 +241,6 @@ describe('applyLlmToolPreferences', () => {
         ];
         const result = applyLlmToolPreferences(addons, []);
         expect(result.tools.map(t => t.name)).toEqual(['memory']);
-        expect(result.suffix).toBe(' M');
+        expect(result.toolGuidance).toBe(' M');
     });
 });

--- a/packages/coc/test/server/queue-executor-bridge-ask-mode.test.ts
+++ b/packages/coc/test/server/queue-executor-bridge-ask-mode.test.ts
@@ -142,10 +142,8 @@ describe('ask mode system message — initial chat', () => {
 
         expect(sdkMocks.mockSendMessage).toHaveBeenCalledTimes(1);
         const callArgs = sdkMocks.mockSendMessage.mock.calls[0][0];
-        expect(callArgs.systemMessage).toEqual({
-            mode: 'append',
-            content: READ_ONLY_SYSTEM_MESSAGE,
-        });
+        expect(callArgs.systemMessage?.mode).toBe('append');
+        expect(callArgs.systemMessage?.content).toContain(READ_ONLY_SYSTEM_MESSAGE);
     });
 
     it('should NOT include read-only systemMessage when chat starts in autopilot mode', async () => {
@@ -156,7 +154,12 @@ describe('ask mode system message — initial chat', () => {
 
         expect(sdkMocks.mockSendMessage).toHaveBeenCalledTimes(1);
         const callArgs = sdkMocks.mockSendMessage.mock.calls[0][0];
-        expect(callArgs.systemMessage).toBeUndefined();
+        // systemMessage may still carry tool-guidance prose (now routed into
+        // systemMessage rather than the user prompt), but it must not contain
+        // the read-only directive in autopilot mode.
+        if (callArgs.systemMessage) {
+            expect(callArgs.systemMessage.content).not.toContain(READ_ONLY_SYSTEM_MESSAGE);
+        }
     });
 
     it('should include read-only systemMessage when chat starts in plan mode', async () => {
@@ -167,10 +170,8 @@ describe('ask mode system message — initial chat', () => {
 
         expect(sdkMocks.mockSendMessage).toHaveBeenCalledTimes(1);
         const callArgs = sdkMocks.mockSendMessage.mock.calls[0][0];
-        expect(callArgs.systemMessage).toEqual({
-            mode: 'append',
-            content: READ_ONLY_SYSTEM_MESSAGE,
-        });
+        expect(callArgs.systemMessage?.mode).toBe('append');
+        expect(callArgs.systemMessage?.content).toContain(READ_ONLY_SYSTEM_MESSAGE);
     });
 });
 
@@ -363,7 +364,7 @@ describe('ask mode system message — auto-folder location block', () => {
         await executor.execute(task);
 
         const callArgs = sdkMocks.mockSendMessage.mock.calls[0][0];
-        expect(callArgs.systemMessage?.content).toBe(READ_ONLY_SYSTEM_MESSAGE);
+        expect(callArgs.systemMessage?.content).toContain(READ_ONLY_SYSTEM_MESSAGE);
         expect(callArgs.systemMessage?.content).not.toContain('<chosen-folder>');
     });
 
@@ -424,6 +425,11 @@ describe('ask mode system message — auto-folder location block', () => {
         await executor.execute(task);
 
         const callArgs = sdkMocks.mockSendMessage.mock.calls[0][0];
-        expect(callArgs.systemMessage).toBeUndefined();
+        // systemMessage may still carry tool-guidance prose, but autopilot mode
+        // must not include the read-only directive nor the auto-folder block.
+        if (callArgs.systemMessage) {
+            expect(callArgs.systemMessage.content).not.toContain(READ_ONLY_SYSTEM_MESSAGE);
+            expect(callArgs.systemMessage.content).not.toContain('<chosen-folder>');
+        }
     });
 });

--- a/packages/coc/test/server/queue-executor-bridge.test.ts
+++ b/packages/coc/test/server/queue-executor-bridge.test.ts
@@ -6796,7 +6796,7 @@ describe('suggest_follow_ups tool wiring', () => {
         expect(callOpts.tools).toHaveLength(1);
     });
 
-    it('should append follow-up suggestion instruction to follow-up messages', async () => {
+    it('should append follow-up suggestion instruction to follow-up systemMessage', async () => {
         const process = createCompletedProcessWithSession('queue_suggest-fu-noinstr', 'sess-fu-noinstr');
         store.processes.set(process.id, process);
 
@@ -6804,8 +6804,12 @@ describe('suggest_follow_ups tool wiring', () => {
         await executor.executeFollowUp('queue_suggest-fu-noinstr', 'follow-up question');
 
         expect(mockSendMessage).toHaveBeenCalledTimes(1);
-        const sentMessage = mockSendMessage.mock.calls[0][0].prompt;
-        expect(sentMessage).toContain('When suggesting follow-ups');
+        const callOpts = mockSendMessage.mock.calls[0][0];
+        // After the refactor: tool-guidance prose lives in systemMessage,
+        // not stapled to every follow-up user prompt.
+        const systemContent = callOpts.systemMessage?.content ?? '';
+        expect(systemContent).toContain('When suggesting follow-ups');
+        expect(callOpts.prompt).not.toContain('When suggesting follow-ups');
     });
 
     it('should include suggest_follow_ups tool on first turn with no prior assistant turns', async () => {
@@ -7075,7 +7079,7 @@ describe('suggest_follow_ups tool wiring', () => {
         expect(callOpts.prompt).not.toContain('When suggesting follow-ups');
     });
 
-    it('should append count instruction to prompt when suggestions are enabled', async () => {
+    it('should append count instruction to system message when suggestions are enabled', async () => {
         const executor = new CLITaskExecutor(store, { followUpSuggestions: { enabled: true, count: 2 } });
 
         const task: QueuedTask = {
@@ -7092,7 +7096,11 @@ describe('suggest_follow_ups tool wiring', () => {
         await executor.execute(task);
 
         const callOpts = mockSendMessage.mock.calls[0][0];
-        expect(callOpts.prompt).toContain('provide exactly 2 suggestions');
+        const systemContent = callOpts.systemMessage?.content ?? '';
+        expect(systemContent).toContain('provide exactly 2 suggestions');
+        // After the refactor: tool guidance lives in systemMessage, not stapled
+        // to the user prompt.
+        expect(callOpts.prompt).not.toContain('provide exactly 2 suggestions');
     });
 
     it('should exclude suggestion tool from sendMessage on follow-up when disabled', async () => {


### PR DESCRIPTION
## Why

Every chat-style executor was concatenating `toolBundle.suffix` onto the user prompt on every turn, replaying ~1.5–2 KB of tool-help prose in every single user message. This caused linear token blow-up across follow-ups (~10 k tokens wasted over 20 turns) and sandwiched the user's actual question with tool prose.

The suffix content is **session-stable** for all 9 current addons (it varies only by mode, repo prefs, and store capabilities — none of which change mid-turn in practice), so it belongs in `systemMessage` where it's applied at session creation and inherited on resume.

## What

- Add `systemMessageBuilder().appendToolGuidance(block)` step, placed in the chain after `appendMemory` and before `appendAutoFolder` / `appendNoteFile`.
- Rename the aggregated return field `suffix` → `toolGuidance` in `applyLlmToolPreferences` and `ChatToolBundle`. (Per-addon factory return fields keep `suffix` internally — pure prose rename, not worth the churn.)
- Migrate every chat-style executor to drop the user-prompt suffix and route the block through the builder instead:
  - `chat-base-executor` (first-turn chats)
  - `follow-up-executor` (follow-up turns; the `historyContext` rebuild path inherits the block automatically)
  - `commit-chat-executor`, `note-chat-executor`, `note-create-executor`, `classification-executor`, `autopilot-executor`, `ralph-executor`
- Tool bundle is now built **before** the system message so the builder can consume `toolBundle.toolGuidance`.
- Tests updated: rename field assertions, migrate `prompt.toContain(...)` assertions to `systemMessage.content.toContain(...)`, and add coverage for the new builder step (ordering, no-op semantics).

## What did NOT change

- `tools` array is still sent on every turn (schemas unchanged), so mid-session tool availability changes still take effect immediately.
- Dashboard / `conversationTurns` transcript was already clean — no change there.
- No SDK-wrapper / forge-layer changes.
- No feature flag — internal refactor, behavior-equivalent for the model.

## Verification

- `npx tsc --noEmit` clean across coc package.
- Vitest targeted runs (`test/server/executors/`, `test/server/llm-tools/`, `test/server/executors-prompt-builder.test.ts`, `test/server/queue-executor-bridge.test.ts`, etc.) all pass after migration.

## Edge cases handled

| Concern | Resolution |
|---|---|
| SDK ignores systemMessage on resume | Expected — that's why this works. Prose is baked in once at session creation. |
| Cold resume / compaction | New SDK session → new systemMessage → includes up-to-date tool-guidance block. ✅ |
| historyContext rebuild path in follow-up | Already concatenates `systemMessage.content` into the new system message — block comes along for free. ✅ |
| User disables a tool mid-session | Tool removed from next turn's `tools` array (SDK no longer offers it). Prose persists until next session restart — same characteristic as today's stale-prose-in-past-user-turns. |
