### PR TITLE
fix(ralph): prefer goal file over last-turn synthesis in grilling-phase Start Ralph

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1172,13 +1172,18 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     {/* Ralph grilling complete — show Start Ralph panel */}
                     {(() => {
                         const ralphCtx = getRalphContext(task);
+                        const goalPath = detectedGoalFile || (task?.metadata?.goalFilePath as string | undefined) || '';
                         // Path 1: traditional grilling-phase → start
+                        // Prefer the goal file (authoritative spec) over
+                        // extracting from the last assistant turn, which is
+                        // often a short synthesis that drops detail.
                         if (ralphCtx && ralphCtx.phase === 'grilling' && task?.status === 'completed') {
                             return (
                                 <RalphStartPanel
                                     processId={processId ?? taskId}
                                     workspaceId={workspaceId}
                                     turns={turns}
+                                    goalFilePath={goalPath || undefined}
                                     onStarted={(newProcessId) => {
                                         queueDispatch({ type: 'SELECT_QUEUE_TASK', id: newProcessId, repoId: workspaceId });
                                     }}
@@ -1186,7 +1191,6 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                             );
                         }
                         // Path 2: goal.md detected → direct launch (skip grilling)
-                        const goalPath = detectedGoalFile || (task?.metadata?.goalFilePath as string | undefined) || '';
                         if (
                             goalPath
                             && isRalphEnabled()
@@ -1199,6 +1203,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                                     workspaceId={workspaceId}
                                     turns={turns}
                                     goalFilePath={goalPath}
+                                    useLaunchEndpoint
                                     onStarted={(newProcessId) => {
                                         queueDispatch({ type: 'SELECT_QUEUE_TASK', id: newProcessId, repoId: workspaceId });
                                     }}

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphStartPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphStartPanel.tsx
@@ -2,9 +2,20 @@
  * RalphStartPanel — shown below a completed grilling-phase process,
  * or when a goal.md / *.goal.md file was created during the conversation.
  *
- * Two flows:
- * - **Turn-based (existing):** extracts the goal spec from the last assistant turn.
- * - **File-based (new):** reads goal spec from a goal.md file via /api/fs/blob.
+ * Source of the goal spec (independent of endpoint):
+ * - **File-based:** when `goalFilePath` is set, reads the goal spec from that
+ *   file via `/api/fs/blob`. This is preferred whenever a goal file exists,
+ *   because the file is the authoritative spec — the last assistant turn is
+ *   often a short synthesis/confirmation that drops detail.
+ * - **Turn-based fallback:** when no `goalFilePath` is provided, extracts the
+ *   goal spec from the last assistant turn (looking for a `## Goal` block).
+ *
+ * Endpoint (independent of source):
+ * - When `useLaunchEndpoint` is true, posts to `/api/ralph-launch` (mints a
+ *   fresh Ralph session — used when a goal file was authored outside any
+ *   grilling-phase process).
+ * - Otherwise, posts to `/api/processes/:id/ralph-start` (continues a
+ *   completed grilling-phase process).
  */
 import { useState, useEffect } from 'react';
 import { getApiBase } from '../../utils/config';
@@ -16,8 +27,18 @@ export interface RalphStartPanelProps {
     workspaceId?: string;
     turns: ClientConversationTurn[];
     onStarted: (newProcessId: string) => void;
-    /** When set, reads goal from this file instead of extracting from turns */
+    /**
+     * Optional path to a goal spec file. When set, the panel loads the goal
+     * text from this file instead of extracting it from the conversation
+     * turns. Independent of which endpoint is called.
+     */
     goalFilePath?: string;
+    /**
+     * When true, confirm posts to `/api/ralph-launch` (mints a fresh session).
+     * When false/unset, confirm posts to `/api/processes/:id/ralph-start`
+     * (continues the referenced grilling-phase process). Default: false.
+     */
+    useLaunchEndpoint?: boolean;
 }
 
 /** Extract goal spec from last assistant turn: find block starting with ## Goal, or use full content. */
@@ -30,7 +51,7 @@ function extractGoalSpec(turns: ClientConversationTurn[]): string {
     return content.trim();
 }
 
-export function RalphStartPanel({ processId, workspaceId, turns, onStarted, goalFilePath }: RalphStartPanelProps) {
+export function RalphStartPanel({ processId, workspaceId, turns, onStarted, goalFilePath, useLaunchEndpoint }: RalphStartPanelProps) {
     const [open, setOpen] = useState(false);
     const [goalSpec, setGoalSpec] = useState('');
     const [starting, setStarting] = useState(false);
@@ -68,13 +89,14 @@ export function RalphStartPanel({ processId, workspaceId, turns, onStarted, goal
         setStarting(true);
         setError(null);
         try {
-            // Choose endpoint: file-based uses ralph-launch, turn-based uses ralph-start
-            const url = goalFilePath
+            // Endpoint is controlled by `useLaunchEndpoint`, independent of
+            // whether the goal came from a file. Grilling-phase callers pass a
+            // `goalFilePath` to load the file's content but keep the
+            // ralph-start endpoint so the existing process/session is reused.
+            const url = useLaunchEndpoint
                 ? `${getApiBase()}/ralph-launch`
                 : `${getApiBase()}/processes/${encodeURIComponent(processId)}/ralph-start`;
-            const body = goalFilePath
-                ? { goalSpec: trimmed, workspaceId }
-                : { goalSpec: trimmed, workspaceId };
+            const body = { goalSpec: trimmed, workspaceId };
             const resp = await fetch(url, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },

--- a/packages/coc/test/server/spa/client/repos/RalphStartPanel.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/RalphStartPanel.test.tsx
@@ -265,7 +265,7 @@ describe('RalphStartPanel', () => {
         });
     });
 
-    it('calls /api/ralph-launch instead of ralph-start when goalFilePath is set', async () => {
+    it('calls /api/ralph-launch when useLaunchEndpoint is set', async () => {
         const mockFetch = vi.fn()
             // First call: fs/blob (goal file content)
             .mockResolvedValueOnce({
@@ -285,6 +285,7 @@ describe('RalphStartPanel', () => {
                 workspaceId="ws-1"
                 turns={[]}
                 goalFilePath="/repos/myrepo/goal.md"
+                useLaunchEndpoint
                 onStarted={mockOnStarted}
             />,
         );
@@ -309,5 +310,68 @@ describe('RalphStartPanel', () => {
         // Verify the second fetch call went to ralph-launch, not ralph-start
         const launchCall = mockFetch.mock.calls[1];
         expect(launchCall[0]).toContain('/api/ralph-launch');
+    });
+
+    // -----------------------------------------------------------------------
+    // Grilling-phase with a goal file: source = file, endpoint = ralph-start
+    // -----------------------------------------------------------------------
+
+    it('loads goal text from the file but still posts to ralph-start when useLaunchEndpoint is unset', async () => {
+        const longSpec = '## Goal\nLong, detailed goal spec\n\n## Acceptance Criteria\n- AC1\n- AC2\n- AC3';
+        const mockFetch = vi.fn()
+            // First call: fs/blob (goal file content)
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ content: longSpec, encoding: 'utf-8' }),
+            })
+            // Second call: ralph-start
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ processId: 'queue_started' }),
+            });
+        vi.stubGlobal('fetch', mockFetch);
+
+        // Turns contain only a short synthesis — file should take precedence.
+        const shortSynthesisTurns: ClientConversationTurn[] = [
+            makeTurn('user', 'looks good'),
+            makeTurn('assistant', '## Goal\nShort summary only'),
+        ];
+
+        render(
+            <RalphStartPanel
+                processId="queue_grill-123"
+                workspaceId="ws-1"
+                turns={shortSynthesisTurns}
+                goalFilePath="/repos/myrepo/goal.md"
+                onStarted={mockOnStarted}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('ralph-start-btn'));
+        await waitFor(() => expect(screen.getByTestId('ralph-start-panel')).toBeTruthy());
+
+        // Textarea should contain the long spec from the file, not the short
+        // synthesis from the last assistant turn.
+        await waitFor(() => {
+            const textarea = screen.getByTestId('ralph-goal-spec-input') as HTMLTextAreaElement;
+            expect(textarea.value).toContain('Long, detailed goal spec');
+            expect(textarea.value).not.toContain('Short summary only');
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('ralph-confirm-start-btn'));
+        });
+
+        await waitFor(() => {
+            expect(mockOnStarted).toHaveBeenCalledWith('queue_started');
+        });
+
+        // Endpoint must be ralph-start (the existing grilling process), not ralph-launch.
+        const startCall = mockFetch.mock.calls[1];
+        expect(startCall[0]).toContain('/processes/queue_grill-123/ralph-start');
+        expect(startCall[0]).not.toContain('/ralph-launch');
+        // And the body should carry the file's long spec, not the short synthesis.
+        const body = JSON.parse(startCall[1].body);
+        expect(body.goalSpec).toContain('Long, detailed goal spec');
     });
 });


### PR DESCRIPTION
When a goal.md (or *.goal.md) file is detected during a grilling-phase

process, the `Start Ralph` panel now loads the goal spec from that file

instead of extracting it from the last assistant turn. The last turn is

often a short synthesis that drops detail from the authoritative spec.

Decouples `goalFilePath` (source of goal text) from endpoint selection

by introducing a new `useLaunchEndpoint` prop on RalphStartPanel:

- Grilling-phase (Path 1): passes `goalFilePath` when a goal file

  exists; still posts to `/api/processes/:id/ralph-start` to continue

  the existing session.

- Direct launch (Path 2): unchanged behavior, now sets

  `useLaunchEndpoint` explicitly to post to `/api/ralph-launch`.

Adds a regression test asserting the grilling-phase flow loads the file

content (long spec) rather than the short synthesis turn, and that the

endpoint remains `ralph-start`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
