### PR TITLE
Remove Admin h1 title from admin sub-pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -681,6 +681,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@changesets/cli/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -732,6 +744,15 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@changesets/cli/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@changesets/cli/node_modules/universalify": {
       "version": "0.1.2",

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -866,7 +866,6 @@ export function AdminPanel() {
                         <header className="ar-page-header">
                             <div className="ar-page-header-row">
                                 <div>
-                                    <h1 className="ar-page-title">Admin</h1>
                                     <p className="ar-page-desc">{TAB_DESCRIPTIONS[activeTab]}</p>
                                 </div>
                             </div>

--- a/packages/coc/test/spa/react/AdminPanel.test.tsx
+++ b/packages/coc/test/spa/react/AdminPanel.test.tsx
@@ -39,7 +39,7 @@ async function gotoSettingsSubTab(sub: 'ai' | 'chat' | 'appearance' | 'features'
 }
 
 describe('AdminPanel', () => {
-    it('renders the Admin heading', async () => {
+    it('does not render the Admin heading', async () => {
         mockFetch.mockResolvedValue({
             ok: true,
             json: () => Promise.resolve({}),
@@ -48,7 +48,7 @@ describe('AdminPanel', () => {
         await act(async () => {
             renderWithProviders();
         });
-        expect(screen.getByText('Admin')).toBeDefined();
+        expect(screen.queryByRole('heading', { name: 'Admin' })).toBeNull();
     });
 
     it('renders storage stats section', async () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the hardcoded `<h1 className="ar-page-title">Admin</h1>` heading from all admin sub-pages (`#admin/providers`, `#admin/data`, `#admin/server`, etc.)
- The breadcrumb and sidebar navigation already indicate the current section, making the "Admin" title redundant

## Test plan

- [ ] Verify admin sub-pages (`#admin/providers`, `#admin/settings`, etc.) no longer show the "Admin" h1 heading
- [ ] Verify the tab description paragraph still renders correctly below the removed heading
- [ ] Updated unit test: `does not render the Admin heading` passes (all 38 AdminPanel tests green)

https://claude.ai/code/session_019YqpboAjCWEmHiCNyXYqma
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YqpboAjCWEmHiCNyXYqma)_