### PR TITLE
feat(coc): RuntimeConfigService and admin config classification (AC-02 through AC-08)

### DIFF
--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -70,10 +70,25 @@ export interface AdminResolvedConfig {
   [key: string]: unknown;
 }
 
+export type AdminConfigFieldRuntime = 'live' | 'reloadable' | 'restartRequired';
+
+export interface AdminConfigFieldMeta {
+  runtime: AdminConfigFieldRuntime;
+}
+
+export interface AdminConfigChangeEffect {
+  field: string;
+  runtime: AdminConfigFieldRuntime;
+  requiresRestart: boolean;
+}
+
 export interface AdminConfigResponse {
   config?: Record<string, unknown>;
   resolved?: AdminResolvedConfig;
   sources?: Record<string, string>;
+  revision?: number;
+  fieldMetadata?: Record<string, AdminConfigFieldMeta>;
+  effects?: AdminConfigChangeEffect[];
   [key: string]: unknown;
 }
 
@@ -103,6 +118,34 @@ export interface AdminConfigUpdate {
   'excalidraw.enabled'?: boolean;
   'mcpOauth.enabled'?: boolean;
   [key: string]: unknown;
+}
+
+/**
+ * Response from GET /api/config/runtime.
+ * Contains current feature flags and revision for the SPA to consume
+ * without relying on stale HTML-embedded config.
+ */
+export interface RuntimeDashboardConfig {
+  revision: number;
+  features: {
+    terminalEnabled: boolean;
+    notesEnabled: boolean;
+    myWorkEnabled: boolean;
+    myLifeEnabled: boolean;
+    scratchpadEnabled: boolean;
+    scratchpadLayout: 'horizontal' | 'vertical';
+    workflowsEnabled: boolean;
+    pullRequestsEnabled: boolean;
+    serversEnabled: boolean;
+    ralphEnabled: boolean;
+    vimNavigationEnabled: boolean;
+    loopsEnabled: boolean;
+    excalidrawEnabled: boolean;
+    mcpOauthEnabled: boolean;
+    focusedDiffEnabled: boolean;
+  };
+  hostname?: string;
+  bindAddress?: string;
 }
 
 export interface AdminVersionResponse {

--- a/packages/coc/src/config/runtime-config-service.ts
+++ b/packages/coc/src/config/runtime-config-service.ts
@@ -208,11 +208,11 @@ export class RuntimeConfigService {
         // 6. Bump revision
         this._revision++;
 
-        // 7. Build effects
+        // 7. Build effects using actual field runtime classification
         const effects: ConfigChangeEffect[] = matchedFields.map(field => ({
             field: field.key,
-            runtime: 'live' as ConfigFieldRuntime,
-            requiresRestart: false,
+            runtime: field.runtime,
+            requiresRestart: field.runtime === 'restartRequired',
         }));
 
         const snapshot = this.getSnapshot();

--- a/packages/coc/src/config/runtime-config-service.ts
+++ b/packages/coc/src/config/runtime-config-service.ts
@@ -1,0 +1,239 @@
+/**
+ * Runtime Config Service
+ *
+ * Central service that owns config loading, validation, persistence,
+ * resolved snapshots, source metadata, revisioning, and update notifications.
+ *
+ * Consumers obtain the current config snapshot from this service instead of
+ * independently calling resolveConfig(). Admin config writes go through
+ * updateConfig() so disk writes, validation, source refresh, revision bumping,
+ * and listener notifications happen in one place.
+ */
+
+import type {
+    CLIConfig,
+    ResolvedCLIConfig,
+    ConfigSourceKey,
+    ConfigFieldSource,
+    AdminConfigWithSource,
+} from '../config';
+import {
+    loadConfigFile,
+    writeConfigFile,
+    getConfigFilePath,
+    resolveConfig,
+    getResolvedConfigWithSource,
+} from '../config';
+import { ADMIN_CONFIG_FIELDS } from '../server/admin/admin-config-fields';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Runtime behavior classification for admin-editable config fields. */
+export type ConfigFieldRuntime = 'live' | 'reloadable' | 'restartRequired';
+
+/** Effect of a config field change after an update. */
+export interface ConfigChangeEffect {
+    field: string;
+    runtime: ConfigFieldRuntime;
+    requiresRestart: boolean;
+}
+
+/** Snapshot of the current runtime config state. */
+export interface RuntimeConfigSnapshot {
+    config: ResolvedCLIConfig;
+    sources: Record<ConfigSourceKey, ConfigFieldSource>;
+    revision: number;
+}
+
+/** Result of a successful config update. */
+export interface RuntimeConfigUpdateResult extends RuntimeConfigSnapshot {
+    effects: ConfigChangeEffect[];
+}
+
+/** Listener callback invoked after a successful config update. */
+export type ConfigChangeListener = (snapshot: RuntimeConfigSnapshot) => void;
+
+// ============================================================================
+// Runtime Config Service
+// ============================================================================
+
+export class RuntimeConfigService {
+    private _config: ResolvedCLIConfig;
+    private _sources: Record<ConfigSourceKey, ConfigFieldSource>;
+    private _revision: number;
+    private _configPath: string;
+    private _listeners: Set<ConfigChangeListener> = new Set();
+    private _updateQueue: Promise<void> = Promise.resolve();
+
+    constructor(options?: {
+        configPath?: string;
+        /** Pre-loaded file config (skips file I/O for initial resolution). */
+        fileConfig?: CLIConfig;
+    }) {
+        this._configPath = options?.configPath ?? getConfigFilePath();
+        this._revision = 0;
+
+        // Initial resolution reuses getResolvedConfigWithSource for consistency
+        const initial = getResolvedConfigWithSource(options?.configPath);
+        this._config = initial.resolved;
+        this._sources = initial.sources;
+    }
+
+    // ── Snapshot ─────────────────────────────────────────────────────────
+
+    /** Current resolved config. */
+    get config(): ResolvedCLIConfig {
+        return this._config;
+    }
+
+    /** Current per-field source metadata. */
+    get sources(): Record<ConfigSourceKey, ConfigFieldSource> {
+        return this._sources;
+    }
+
+    /** Monotonically increasing revision counter (starts at 0, bumps on each successful update). */
+    get revision(): number {
+        return this._revision;
+    }
+
+    /** Config file path used by this service. */
+    get configPath(): string {
+        return this._configPath;
+    }
+
+    /** Return a snapshot object (config + sources + revision). */
+    getSnapshot(): RuntimeConfigSnapshot {
+        return {
+            config: this._config,
+            sources: { ...this._sources },
+            revision: this._revision,
+        };
+    }
+
+    // ── Refresh ──────────────────────────────────────────────────────────
+
+    /**
+     * Re-read config from disk and refresh the in-memory snapshot.
+     * Does NOT increment the revision (no user-initiated change).
+     */
+    refresh(): void {
+        const fresh = getResolvedConfigWithSource(this._configPath);
+        this._config = fresh.resolved;
+        this._sources = fresh.sources;
+    }
+
+    // ── Update ───────────────────────────────────────────────────────────
+
+    /**
+     * Validate and apply a config patch.
+     *
+     * Serialized through a promise queue so concurrent admin writes
+     * cannot corrupt the config file.
+     *
+     * @param patch - Flat key/value pairs matching ADMIN_CONFIG_FIELDS keys.
+     * @returns Updated snapshot with effects describing which fields changed.
+     * @throws Error with validation message if any field is invalid.
+     */
+    async updateConfig(
+        patch: Record<string, unknown>,
+    ): Promise<RuntimeConfigUpdateResult> {
+        // Wrap in the serialization queue
+        return new Promise<RuntimeConfigUpdateResult>((resolve, reject) => {
+            this._updateQueue = this._updateQueue.then(async () => {
+                try {
+                    const result = this._applyUpdate(patch);
+                    resolve(result);
+                } catch (err) {
+                    reject(err);
+                }
+            });
+        });
+    }
+
+    /**
+     * Internal: validate, write, refresh, bump revision, notify.
+     * Called inside the serialization queue.
+     */
+    private _applyUpdate(
+        patch: Record<string, unknown>,
+    ): RuntimeConfigUpdateResult {
+        // 1. Validate all present editable fields via registry
+        const errors: string[] = [];
+        const matchedFields: typeof ADMIN_CONFIG_FIELDS[number][] = [];
+
+        for (const field of ADMIN_CONFIG_FIELDS) {
+            if (field.key in patch) {
+                const err = field.validate(patch[field.key]);
+                if (err) {
+                    errors.push(err);
+                } else {
+                    matchedFields.push(field);
+                }
+            }
+        }
+
+        if (errors.length > 0) {
+            throw new Error(errors.join('; '));
+        }
+
+        if (matchedFields.length === 0) {
+            throw new Error('No valid editable fields in patch');
+        }
+
+        // 2. Load current file config
+        const existing: CLIConfig = loadConfigFile(this._configPath) ?? {};
+
+        // 3. Apply validated fields
+        for (const field of matchedFields) {
+            field.apply(existing, patch[field.key]);
+        }
+
+        // 4. Write to disk (atomic write-then-rename)
+        writeConfigFile(this._configPath, existing);
+
+        // 5. Refresh in-memory snapshot from disk
+        const fresh = getResolvedConfigWithSource(this._configPath);
+        this._config = fresh.resolved;
+        this._sources = fresh.sources;
+
+        // 6. Bump revision
+        this._revision++;
+
+        // 7. Build effects
+        const effects: ConfigChangeEffect[] = matchedFields.map(field => ({
+            field: field.key,
+            runtime: 'live' as ConfigFieldRuntime,
+            requiresRestart: false,
+        }));
+
+        const snapshot = this.getSnapshot();
+
+        // 8. Notify listeners
+        for (const listener of this._listeners) {
+            try {
+                listener(snapshot);
+            } catch {
+                // Listener errors must not block the update
+            }
+        }
+
+        return { ...snapshot, effects };
+    }
+
+    // ── Listeners ────────────────────────────────────────────────────────
+
+    /** Register a listener that will be called after each successful update. */
+    onChange(listener: ConfigChangeListener): () => void {
+        this._listeners.add(listener);
+        return () => {
+            this._listeners.delete(listener);
+        };
+    }
+
+    /** Remove all listeners (for cleanup/tests). */
+    removeAllListeners(): void {
+        this._listeners.clear();
+    }
+}

--- a/packages/coc/src/config/runtime-config-service.ts
+++ b/packages/coc/src/config/runtime-config-service.ts
@@ -75,10 +75,17 @@ export class RuntimeConfigService {
         this._configPath = options?.configPath ?? getConfigFilePath();
         this._revision = 0;
 
-        // Initial resolution reuses getResolvedConfigWithSource for consistency
-        const initial = getResolvedConfigWithSource(options?.configPath);
-        this._config = initial.resolved;
-        this._sources = initial.sources;
+        if (options?.fileConfig) {
+            // When a pre-loaded config is supplied, merge it with defaults
+            // instead of reading from disk. This is used by tests and by
+            // callers that have already parsed the config file.
+            this._config = resolveConfig(undefined, options.fileConfig);
+            this._sources = {} as Record<ConfigSourceKey, ConfigFieldSource>;
+        } else {
+            const initial = getResolvedConfigWithSource(options?.configPath);
+            this._config = initial.resolved;
+            this._sources = initial.sources;
+        }
     }
 
     // ── Snapshot ─────────────────────────────────────────────────────────

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -206,7 +206,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     bool('mcpOauth.enabled', (cfg, v) => {
         if (!cfg.mcpOauth) { cfg.mcpOauth = {}; }
         cfg.mcpOauth.enabled = v;
-    }),
+    }, 'restartRequired'),
     bool('features.focusedDiff', (cfg, v) => {
         if (!cfg.features) { cfg.features = {}; }
         cfg.features.focusedDiff = v;

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -16,9 +16,14 @@
 
 import type { CLIConfig } from '../../config';
 
+/** Runtime behavior classification for admin-editable config fields. */
+export type AdminConfigFieldRuntime = 'live' | 'reloadable' | 'restartRequired';
+
 export interface AdminConfigFieldSpec {
     /** Flat key used in the PUT /api/admin/config request body, e.g. 'loops.enabled' */
     key: string;
+    /** Runtime behavior: 'live' (immediate), 'reloadable', or 'restartRequired' */
+    runtime: AdminConfigFieldRuntime;
     /** Return an error message string if invalid, undefined if valid */
     validate: (value: unknown) => string | undefined;
     /** Write the (already-validated) value into the CLIConfig that will be persisted */
@@ -27,8 +32,9 @@ export interface AdminConfigFieldSpec {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-const bool = (key: string, set: (cfg: CLIConfig, v: boolean) => void): AdminConfigFieldSpec => ({
+const bool = (key: string, set: (cfg: CLIConfig, v: boolean) => void, runtime: AdminConfigFieldRuntime = 'live'): AdminConfigFieldSpec => ({
     key,
+    runtime,
     validate: (v) => typeof v === 'boolean' ? undefined : `${key} must be a boolean`,
     apply: (cfg, v) => set(cfg, v as boolean),
 });
@@ -45,16 +51,19 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     // ── AI execution ──────────────────────────────────────────────────────────
     {
         key: 'model',
+        runtime: 'live',
         validate: (v) => typeof v === 'string' && v.length > 0 ? undefined : 'model must be a non-empty string',
         apply: (cfg, v) => { cfg.model = v as string; },
     },
     {
         key: 'parallel',
+        runtime: 'live',
         validate: (v) => typeof v === 'number' && v > 0 ? undefined : 'parallel must be a number greater than 0',
         apply: (cfg, v) => { cfg.parallel = v as number; },
     },
     {
         key: 'timeout',
+        runtime: 'live',
         validate: (v) => v === null || (typeof v === 'number' && v > 0)
             ? undefined
             : 'timeout must be a number greater than 0, or null to clear',
@@ -64,6 +73,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     },
     {
         key: 'output',
+        runtime: 'live',
         validate: (v) => typeof v === 'string' && (VALID_OUTPUT_VALUES as readonly string[]).includes(v)
             ? undefined
             : `output must be one of: ${VALID_OUTPUT_VALUES.join(', ')}`,
@@ -74,6 +84,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     bool('showReportIntent', (cfg, v) => { cfg.showReportIntent = v; }),
     {
         key: 'toolCompactness',
+        runtime: 'live',
         validate: (v) =>
             typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 3
                 ? undefined
@@ -82,6 +93,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     },
     {
         key: 'taskCardDensity',
+        runtime: 'live',
         validate: (v) => v === 'compact' || v === 'dense'
             ? undefined
             : 'taskCardDensity must be "compact" or "dense"',
@@ -92,6 +104,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     // ── serve ─────────────────────────────────────────────────────────────────
     {
         key: 'serve.serverName',
+        runtime: 'live',
         validate: (v) => v === null || v === undefined || (typeof v === 'string' && v.length <= 64)
             ? undefined
             : 'serve.serverName must be a string of at most 64 characters, or null to clear',
@@ -113,6 +126,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     }),
     {
         key: 'chat.followUpSuggestions.count',
+        runtime: 'live',
         validate: (v) =>
             typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 5
                 ? undefined
@@ -133,7 +147,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     bool('terminal.enabled', (cfg, v) => {
         if (!cfg.terminal) { cfg.terminal = {}; }
         cfg.terminal.enabled = v;
-    }),
+    }, 'restartRequired'),
     bool('notes.enabled', (cfg, v) => {
         if (!cfg.notes) { cfg.notes = {}; }
         cfg.notes.enabled = v;
@@ -152,6 +166,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     }),
     {
         key: 'scratchpad.layout',
+        runtime: 'live',
         validate: (v) => v === 'horizontal' || v === 'vertical'
             ? undefined
             : 'scratchpad.layout must be "horizontal" or "vertical"',
@@ -183,7 +198,7 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     bool('loops.enabled', (cfg, v) => {
         if (!cfg.loops) { cfg.loops = {}; }
         cfg.loops.enabled = v;
-    }),
+    }, 'restartRequired'),
     bool('excalidraw.enabled', (cfg, v) => {
         if (!cfg.excalidraw) { cfg.excalidraw = {}; }
         cfg.excalidraw.enabled = v;
@@ -200,3 +215,12 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
 
 /** Flat keys accepted by PUT /api/admin/config — derived from the registry. */
 export const ADMIN_EDITABLE_KEYS: readonly string[] = ADMIN_CONFIG_FIELDS.map(f => f.key);
+
+/** Build a key→metadata map for API responses. */
+export function getAdminFieldMetadata(): Record<string, { runtime: AdminConfigFieldRuntime }> {
+    const meta: Record<string, { runtime: AdminConfigFieldRuntime }> = {};
+    for (const field of ADMIN_CONFIG_FIELDS) {
+        meta[field.key] = { runtime: field.runtime };
+    }
+    return meta;
+}

--- a/packages/coc/src/server/admin/admin-handler.ts
+++ b/packages/coc/src/server/admin/admin-handler.ts
@@ -29,7 +29,7 @@ import { StorageMigrationEngine } from '../storage/storage-migration';
 import type { ProcessWebSocketServer } from '../streaming/websocket';
 import type { Route } from '../types';
 import { sendSSE } from '../wiki/ask-handler';
-import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS } from './admin-config-fields';
+import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS, getAdminFieldMetadata } from './admin-config-fields';
 
 // ============================================================================
 // Token Management
@@ -200,6 +200,7 @@ export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions)
                     sources: snapshot.sources,
                     configFilePath: runtimeConfigService.configPath,
                     revision: snapshot.revision,
+                    fieldMetadata: getAdminFieldMetadata(),
                 });
             } else {
                 const result = configFunctions?.getResolvedConfigWithSource?.(configPath) ?? { config: {}, sources: {} };
@@ -242,6 +243,7 @@ export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions)
                         configFilePath: runtimeConfigService.configPath,
                         revision: updateResult.revision,
                         effects: updateResult.effects,
+                        fieldMetadata: getAdminFieldMetadata(),
                     });
                 } catch (err) {
                     return handleAPIError(res, badRequest((err as Error).message));

--- a/packages/coc/src/server/admin/admin-handler.ts
+++ b/packages/coc/src/server/admin/admin-handler.ts
@@ -14,6 +14,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
+import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import { parseBody, sendJSON } from '../core/api-handler';
 import { badRequest, forbidden, handleAPIError, invalidJSON } from '../errors';
 import { exportAllData } from '../storage/data-exporter';
@@ -130,8 +131,10 @@ export interface AdminRouteOptions {
     getQueueManager?: () => TaskQueueManager | undefined;
     /** Lazy getter for queue persistence (for import restore). */
     getQueuePersistence?: () => QueuePersistence | undefined;
-    /** Config file functions (injected from CLI layer). */
+    /** Config file functions (injected from CLI layer). Falls back when runtimeConfigService is absent. */
     configFunctions?: AdminConfigFunctions;
+    /** Central runtime config service. When provided, GET/PUT admin config use this instead of configFunctions. */
+    runtimeConfigService?: RuntimeConfigService;
     /** Exit code to use for restart (injected to avoid circular import). Defaults to 75. */
     restartExitCode?: number;
     /** Override token TTL in ms (for testing). Defaults to TOKEN_EXPIRY_MS (5 min). */
@@ -143,7 +146,7 @@ export interface AdminRouteOptions {
  * Mutates the `routes` array in-place.
  */
 export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions): void {
-    const { store, dataDir, getWsServer, configPath, configFunctions } = options;
+    const { store, dataDir, getWsServer, configPath, configFunctions, runtimeConfigService } = options;
     const wiper = new DataWiper(dataDir, store);
     const resolvedConfigPath = configPath ?? configFunctions?.getConfigFilePath?.() ?? '';
 
@@ -190,8 +193,18 @@ export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions)
         method: 'GET',
         pattern: '/api/admin/config',
         handler: async (_req, res) => {
-            const result = configFunctions?.getResolvedConfigWithSource?.(configPath) ?? { config: {}, sources: {} };
-            sendJSON(res, 200, result);
+            if (runtimeConfigService) {
+                const snapshot = runtimeConfigService.getSnapshot();
+                sendJSON(res, 200, {
+                    resolved: snapshot.config,
+                    sources: snapshot.sources,
+                    configFilePath: runtimeConfigService.configPath,
+                    revision: snapshot.revision,
+                });
+            } else {
+                const result = configFunctions?.getResolvedConfigWithSource?.(configPath) ?? { config: {}, sources: {} };
+                sendJSON(res, 200, result);
+            }
         },
     });
 
@@ -219,31 +232,45 @@ export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions)
                 return handleAPIError(res, badRequest('Request body must contain at least one editable field'));
             }
 
-            // Validate all present editable fields via registry
-            const errors: string[] = [];
-            for (const field of ADMIN_CONFIG_FIELDS) {
-                if (field.key in body) {
-                    const err = field.validate(body[field.key]);
-                    if (err) { errors.push(err); }
+            if (runtimeConfigService) {
+                // Delegate validation, disk write, refresh, and revision bump to the service
+                try {
+                    const updateResult = await runtimeConfigService.updateConfig(body);
+                    sendJSON(res, 200, {
+                        resolved: updateResult.config,
+                        sources: updateResult.sources,
+                        configFilePath: runtimeConfigService.configPath,
+                        revision: updateResult.revision,
+                        effects: updateResult.effects,
+                    });
+                } catch (err) {
+                    return handleAPIError(res, badRequest((err as Error).message));
                 }
-            }
-            if (errors.length > 0) {
-                return handleAPIError(res, badRequest(errors.join('; ')));
-            }
-
-            // Merge with existing config via registry
-            const existing: CLIConfig = configFunctions?.loadConfigFile?.(configPath) ?? {};
-            for (const field of ADMIN_CONFIG_FIELDS) {
-                if (field.key in body) {
-                    field.apply(existing, body[field.key]);
+            } else {
+                // Legacy path: validate and write through configFunctions
+                const errors: string[] = [];
+                for (const field of ADMIN_CONFIG_FIELDS) {
+                    if (field.key in body) {
+                        const err = field.validate(body[field.key]);
+                        if (err) { errors.push(err); }
+                    }
                 }
+                if (errors.length > 0) {
+                    return handleAPIError(res, badRequest(errors.join('; ')));
+                }
+
+                const existing: CLIConfig = configFunctions?.loadConfigFile?.(configPath) ?? {};
+                for (const field of ADMIN_CONFIG_FIELDS) {
+                    if (field.key in body) {
+                        field.apply(existing, body[field.key]);
+                    }
+                }
+
+                configFunctions?.writeConfigFile?.(resolvedConfigPath, existing);
+
+                const result = configFunctions?.getResolvedConfigWithSource?.(configPath) ?? { config: {}, sources: {} };
+                sendJSON(res, 200, result);
             }
-
-            configFunctions?.writeConfigFile?.(resolvedConfigPath, existing);
-
-            // Return updated resolved config (same shape as GET)
-            const result = configFunctions?.getResolvedConfigWithSource?.(configPath) ?? { config: {}, sources: {} };
-            sendJSON(res, 200, result);
         },
     });
 

--- a/packages/coc/src/server/config/runtime-config-handler.ts
+++ b/packages/coc/src/server/config/runtime-config-handler.ts
@@ -1,0 +1,72 @@
+/**
+ * Runtime Config API Handler
+ *
+ * Exposes GET /api/config/runtime so the SPA can fetch current feature
+ * flags from the RuntimeConfigService instead of relying on stale
+ * HTML-embedded window.__DASHBOARD_CONFIG__.
+ */
+
+import type { Route } from '../types';
+import type { RuntimeConfigService } from '../../config/runtime-config-service';
+import { sendJson } from '../shared/router';
+import type { RuntimeDashboardConfig } from '@plusplusoneplusplus/coc-client';
+import { shortenHostname } from '../core/hostname-utils';
+
+export interface RuntimeConfigRouteOptions {
+    runtimeConfigService: RuntimeConfigService;
+    hostname: string;
+    bindAddress: string;
+}
+
+/**
+ * Build the runtime dashboard config response from the current config snapshot.
+ */
+export function buildRuntimeDashboardConfig(
+    runtimeConfigService: RuntimeConfigService,
+    hostname: string,
+    bindAddress: string,
+): RuntimeDashboardConfig {
+    const config = runtimeConfigService.config;
+    return {
+        revision: runtimeConfigService.revision,
+        features: {
+            terminalEnabled: config.terminal?.enabled ?? true,
+            notesEnabled: config.notes?.enabled ?? true,
+            myWorkEnabled: config.myWork?.enabled ?? false,
+            myLifeEnabled: config.myLife?.enabled ?? false,
+            scratchpadEnabled: config.scratchpad?.enabled ?? false,
+            scratchpadLayout: config.scratchpad?.layout ?? 'horizontal',
+            workflowsEnabled: config.workflows?.enabled ?? false,
+            pullRequestsEnabled: config.pullRequests?.enabled ?? false,
+            serversEnabled: config.servers?.enabled ?? false,
+            ralphEnabled: config.ralph?.enabled ?? false,
+            vimNavigationEnabled: config.vimNavigation?.enabled ?? false,
+            loopsEnabled: config.loops?.enabled ?? false,
+            excalidrawEnabled: config.excalidraw?.enabled ?? false,
+            mcpOauthEnabled: config.mcpOauth?.enabled ?? false,
+            focusedDiffEnabled: config.features?.focusedDiff ?? false,
+        },
+        hostname: config.serve?.serverName || shortenHostname(hostname),
+        bindAddress,
+    };
+}
+
+export function registerRuntimeConfigRoutes(
+    routes: Route[],
+    options: RuntimeConfigRouteOptions,
+): void {
+    const { runtimeConfigService, hostname, bindAddress } = options;
+
+    routes.push({
+        method: 'GET',
+        pattern: '/api/config/runtime',
+        handler: (_req, res) => {
+            const response = buildRuntimeDashboardConfig(
+                runtimeConfigService,
+                hostname,
+                bindAddress,
+            );
+            sendJson(res, response);
+        },
+    });
+}

--- a/packages/coc/src/server/core/api-handler.ts
+++ b/packages/coc/src/server/core/api-handler.ts
@@ -214,7 +214,12 @@ export function stripExcludedFields(process: any, exclude?: string[]): any {
  * Register all API routes on the given route table.
  * Mutates the `routes` array in-place.
  */
-export function registerApiRoutes(routes: Route[], store: ProcessStore, bridge?: QueueExecutorBridge, dataDir?: string, getWsServer?: () => ProcessWebSocketServer | undefined, db?: Database.Database, loopsEnabled?: boolean, excalidrawEnabled?: boolean): void {
+export function registerApiRoutes(
+    routes: Route[], store: ProcessStore, bridge?: QueueExecutorBridge,
+    dataDir?: string, getWsServer?: () => ProcessWebSocketServer | undefined,
+    db?: Database.Database, loopsEnabled?: boolean,
+    getLiveFeatureFlags?: () => { excalidrawEnabled: boolean },
+): void {
     // Wrap routes.push to automatically log API mutations (POST/PATCH/DELETE).
     const MUTATION_METHODS = new Set(['POST', 'PATCH', 'DELETE']);
     const _origPush = routes.push.bind(routes);
@@ -258,7 +263,7 @@ export function registerApiRoutes(routes: Route[], store: ProcessStore, bridge?:
             initializeDatabase(resolvedDb);
         }
 
-        const ctx: ApiRouteContext = { routes, store, bridge, dataDir, getWsServer, gitOpsStore, db: resolvedDb, loopsEnabled, excalidrawEnabled };
+        const ctx: ApiRouteContext = { routes, store, bridge, dataDir, getWsServer, gitOpsStore, db: resolvedDb, loopsEnabled, getLiveFeatureFlags };
 
         registerApiWorkspaceRoutes(ctx);
         registerApiGitRoutes(ctx);

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -38,7 +38,6 @@ import { createWebSocketInfrastructure } from './infrastructure/websocket-infras
 import { createWatcherInfrastructure } from './infrastructure/watcher-infrastructure';
 import { createTerminalInfrastructure } from './infrastructure/terminal-infrastructure';
 import { HeapMonitor } from './admin/heap-monitor';
-import { resolveConfig } from '../config';
 import { RuntimeConfigService } from '../config/runtime-config-service';
 import { DEFAULT_AI_TIMEOUT_MS } from '@plusplusoneplusplus/forge';
 import { autoUpdateBundledSkills, autoInstallDefaultSkills, autoInstallMyWorkSkills, DEFAULT_SKILLS_SETTINGS } from '@plusplusoneplusplus/forge';
@@ -370,6 +369,8 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         loopExecutor: loopInfra?.loopExecutor,
         mcpOauthManager: mcpOauthInfra?.manager,
         loopEmit: loopInfra?.emit,
+        hostname: os.hostname(),
+        bindAddress: host,
     });
     // Restore auto-commit timers for all workspaces that had it enabled
     notesGitTimerManager.startAll(store, dataDir).catch(() => { /* best-effort */ });
@@ -377,9 +378,11 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     const rawHostname = os.hostname();
     const handler = createRequestHandler({
         routes, spaHtml: () => {
-            // Re-read config on each page load so that feature-flag changes made via the
-            // admin UI take effect on the next browser refresh — no server restart needed.
-            const liveConfig = resolveConfig(options.configPath);
+            // Use RuntimeConfigService snapshot for feature flags so admin
+            // config updates are reflected without re-reading disk on every
+            // page load. The SPA also fetches /api/config/runtime for fresh
+            // feature flags, making the embedded values bootstrap-only.
+            const liveConfig = runtimeConfigService.config;
             return generateDashboardHtml({
                 enableWiki: true,
                 hostname: liveConfig.serve?.serverName || shortenHostname(rawHostname),
@@ -401,7 +404,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
                 bindAddress: host,
             });
         },
-        store, spaETag: getBundleETag,
+        store, spaETag: () => getBundleETag(runtimeConfigService.revision),
         staticDir: path.join(__dirname, 'spa', 'client', 'dist'),
         getIconSvg: () => generateIconSvg(rawHostname),
     });

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -154,6 +154,27 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     fs.mkdirSync(dataDir, { recursive: true });
 
     const runtimeConfigService = new RuntimeConfigService({ configPath: options.configPath, fileConfig: options.fileConfig });
+
+    // Startup-captured config snapshot. Consumers below that use this directly
+    // are infrastructure that wires once at startup. Admin-editable fields among
+    // them are classified as follows:
+    //
+    //   restartRequired (infrastructure wired at startup):
+    //     - terminal.enabled   → terminal pty/session manager
+    //     - loops.enabled      → loop executor, timer registry
+    //
+    //   Live but still startup-captured in queue infrastructure (future migration):
+    //     - timeout            → defaultTimeoutMs passed to queue infra
+    //     - chat.followUpSuggestions, chat.askUser → queue executor behavior
+    //
+    //   Non-admin-editable (no migration needed):
+    //     - mcpOauth.enabled   → MCP OAuth infra
+    //     - monitoring.heapCheck → heap monitor
+    //     - skills.autoUpdate, skills.defaultSkills → startup skill install
+    //     - features.autoMemoryPromotion → auto-promote scheduler
+    //
+    // Route handlers and SPA feature flags use runtimeConfigService for live
+    // reads (see registerAllRoutes and spaHtml closure below).
     const resolvedConfig = runtimeConfigService.config;
     const defaultTimeoutMs = resolvedConfig.timeout ? resolvedConfig.timeout * 1000 : DEFAULT_AI_TIMEOUT_MS;
 

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -39,6 +39,7 @@ import { createWatcherInfrastructure } from './infrastructure/watcher-infrastruc
 import { createTerminalInfrastructure } from './infrastructure/terminal-infrastructure';
 import { HeapMonitor } from './admin/heap-monitor';
 import { resolveConfig } from '../config';
+import { RuntimeConfigService } from '../config/runtime-config-service';
 import { DEFAULT_AI_TIMEOUT_MS } from '@plusplusoneplusplus/forge';
 import { autoUpdateBundledSkills, autoInstallDefaultSkills, autoInstallMyWorkSkills, DEFAULT_SKILLS_SETTINGS } from '@plusplusoneplusplus/forge';
 import { createStubStore } from './processes/in-memory-process-store';
@@ -153,7 +154,8 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     const store = options.store ?? createStubStore();
     fs.mkdirSync(dataDir, { recursive: true });
 
-    const resolvedConfig = resolveConfig(options.configPath, options.fileConfig);
+    const runtimeConfigService = new RuntimeConfigService({ configPath: options.configPath, fileConfig: options.fileConfig });
+    const resolvedConfig = runtimeConfigService.config;
     const defaultTimeoutMs = resolvedConfig.timeout ? resolvedConfig.timeout * 1000 : DEFAULT_AI_TIMEOUT_MS;
 
     // Forward declaration — bridge captures this via closure before wsServer is assigned
@@ -361,6 +363,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         aiInvoker,
         getTerminalSessionManager: () => terminalInfra?.terminalSessionManager,
         resolvedConfig,
+        runtimeConfigService,
         remoteServerStore,
         remoteServerConnector,
         loopStore: loopInfra?.loopStore,
@@ -470,6 +473,10 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
 
 export type { ExecutionServerOptions, ExecutionServer, Route, WikiServerOptions, ServerCloseOptions, ServeCommandOptions } from './types';
 export type { ProcessStore } from '@plusplusoneplusplus/forge';
+
+// Runtime Config Service
+export { RuntimeConfigService } from '../config/runtime-config-service';
+export type { RuntimeConfigSnapshot, RuntimeConfigUpdateResult, ConfigChangeEffect, ConfigFieldRuntime, ConfigChangeListener } from '../config/runtime-config-service';
 
 // HTTP helpers (canonical source: shared/router.ts)
 export { sendJson, send404, send400, send500, sendError, readJsonBody } from './shared/router';

--- a/packages/coc/src/server/routes/api-shared.ts
+++ b/packages/coc/src/server/routes/api-shared.ts
@@ -24,10 +24,19 @@ export interface ApiRouteContext {
     getWsServer?: () => ProcessWebSocketServer | undefined;
     gitOpsStore: GitOpsStore;
     db?: Database.Database;
-    /** Whether the loops/recurring follow-up subsystem is enabled. */
+    /**
+     * Whether the loops/recurring follow-up subsystem is enabled.
+     * Remains startup-captured because loop infrastructure (executor, timers)
+     * is wired once at startup — classified as `restartRequired`.
+     */
     loopsEnabled?: boolean;
-    /** Whether Excalidraw diagram tools are enabled. */
-    excalidrawEnabled?: boolean;
+    /**
+     * Live getter for runtime config feature flags.
+     * Reads from RuntimeConfigService so per-request handlers see admin
+     * config changes without a server restart. Falls back to startup
+     * values when runtimeConfigService is not available.
+     */
+    getLiveFeatureFlags?: () => { excalidrawEnabled: boolean };
 }
 
 /** Maximum git output buffer size (50 MB) — matches forge DEFAULT_MAX_BUFFER. */

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -507,7 +507,8 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
         handler: async (_req, res, match) => {
             const ws = await resolveWorkspaceOrFail(store, match!, res);
             if (!ws) return;
-            const effectiveRegistry = getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, excalidrawEnabled: ctx.excalidrawEnabled });
+            const liveFlags = ctx.getLiveFeatureFlags?.() ?? { excalidrawEnabled: false };
+            const effectiveRegistry = getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, excalidrawEnabled: liveFlags.excalidrawEnabled });
             if (!ctx.dataDir) {
                 sendJSON(res, 200, { tools: effectiveRegistry, disabledLlmTools: getEffectiveDefaultDisabledTools() });
                 return;
@@ -548,7 +549,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
             writeRepoPreferences(ctx.dataDir, ws.id, merged);
             const globalPrefs = readGlobalPreferences(ctx.dataDir);
             sendJSON(res, 200, {
-                tools: getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, excalidrawEnabled: ctx.excalidrawEnabled }),
+                tools: getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, excalidrawEnabled: ctx.getLiveFeatureFlags?.()?.excalidrawEnabled ?? false }),
                 disabledLlmTools: merged.disabledLlmTools ?? getEffectiveDefaultDisabledTools(globalPrefs.uiLayoutMode),
             });
         },

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -85,6 +85,7 @@ import type { LoopExecutor, LoopEventEmit } from '../loops/loop-executor';
 import { registerMcpOauthRoutes } from '../mcp-oauth';
 import type { McpOauthManager } from '../mcp-oauth';
 import { registerDiagramRoutes } from '../diagrams/diagrams-handler';
+import { registerRuntimeConfigRoutes } from '../config/runtime-config-handler';
 
 /** Collect git commits made between headBefore and current HEAD. Non-fatal — returns [] on error. */
 function collectWorkItemCommits(
@@ -130,6 +131,8 @@ export interface RegisterRoutesOptions {
     loopExecutor?: LoopExecutor;
     mcpOauthManager?: McpOauthManager;
     loopEmit?: LoopEventEmit;
+    hostname?: string;
+    bindAddress?: string;
 }
 
 export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions): { wikiManager: WikiManager | undefined } {
@@ -235,6 +238,16 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         runtimeConfigService: opts.runtimeConfigService,
         tokenTtlMs,
     });
+
+    // Runtime config endpoint for SPA feature flag freshness
+    if (opts.runtimeConfigService) {
+        registerRuntimeConfigRoutes(routes, {
+            runtimeConfigService: opts.runtimeConfigService,
+            hostname: opts.hostname ?? '',
+            bindAddress: opts.bindAddress ?? '127.0.0.1',
+        });
+    }
+
     registerScheduleRoutes(routes, scheduleManager, async (repoId) => {
         const workspaces = await store.getWorkspaces();
         return workspaces.find(w => w.id === repoId)?.rootPath;

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -144,25 +144,31 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         aiInvoker,
     } = opts;
 
-    registerApiRoutes(routes, store, bridge, dataDir, getWsServer, undefined, opts.resolvedConfig?.loops?.enabled ?? false, opts.resolvedConfig?.excalidraw?.enabled ?? false);
+    // excalidrawEnabled uses a live getter via runtimeConfigService so admin
+    // changes take effect without restart. loopsEnabled stays startup-captured
+    // (restartRequired — loop executor infrastructure wires at startup).
+    const getLiveFeatureFlags = opts.runtimeConfigService
+        ? () => ({ excalidrawEnabled: opts.runtimeConfigService!.config.excalidraw?.enabled ?? false })
+        : () => ({ excalidrawEnabled: opts.resolvedConfig?.excalidraw?.enabled ?? false });
+    registerApiRoutes(routes, store, bridge, dataDir, getWsServer, undefined, opts.resolvedConfig?.loops?.enabled ?? false, getLiveFeatureFlags);
     const repoTreeService = new RepoTreeService(dataDir, undefined, store);
     registerRepoRoutes(routes, dataDir, repoTreeService);
     registerPrRoutes(routes, dataDir, repoTreeService);
-    // Focused-diff classification routes (feature-flagged)
-    if (opts.resolvedConfig?.features?.focusedDiff) {
-        registerPrClassificationRoutes(routes, {
-            dataDir,
-            store,
-            bridge,
-            repoTreeService,
-        });
-        registerGenericClassificationRoutes(routes, {
-            dataDir,
-            store,
-            bridge,
-            repoTreeService,
-        });
-    }
+    // Focused-diff classification routes — always registered so the feature
+    // can be toggled live via admin config. The SPA gates the UI based on
+    // runtime config; having the routes present when disabled is harmless.
+    registerPrClassificationRoutes(routes, {
+        dataDir,
+        store,
+        bridge,
+        repoTreeService,
+    });
+    registerGenericClassificationRoutes(routes, {
+        dataDir,
+        store,
+        bridge,
+        repoTreeService,
+    });
     registerRemoteServerRoutes(routes, {
         store: opts.remoteServerStore ?? new RemoteServerStore(dataDir),
         connector: opts.remoteServerConnector ?? new DevTunnelConnector(),
@@ -170,7 +176,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerProviderRoutes(routes, dataDir);
     registerProcessResumeRoutes(routes, store);
     registerFreshChatTerminalRoutes(routes);
-    registerTerminalRoutes(routes, store, opts.getTerminalSessionManager ?? (() => undefined), opts.resolvedConfig);
+    registerTerminalRoutes(routes, store, opts.getTerminalSessionManager ?? (() => undefined), opts.resolvedConfig, opts.runtimeConfigService);
 
     // Queue routes receive the bridge directly for per-repo routing
     registerQueueRoutes(routes, bridge, store, globalWorkspaceRootPath);
@@ -192,10 +198,10 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerNotesAICreateRoutes(routes, store, dataDir, bridge);
     registerNotesEditsRoutes(routes, store, dataDir);
 
-    // Diagram routes (feature-flagged via excalidraw.enabled)
-    if (opts.resolvedConfig?.excalidraw?.enabled) {
-        registerDiagramRoutes(routes, store, dataDir);
-    }
+    // Diagram routes — always registered so excalidraw.enabled (classified
+    // as live) can be toggled via admin config without restart. The SPA
+    // gates the UI via runtime config.
+    registerDiagramRoutes(routes, store, dataDir);
     registerWorkflowRoutes(routes, store);
     registerWorkspaceSummaryRoutes(routes, store, dataDir);
     registerWorkflowWriteRoutes(routes, store, (workspaceId) => {

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -232,6 +232,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         getQueuePersistence: () => queuePersistence,
         restartExitCode: 75,
         configFunctions: { getConfigFilePath, getResolvedConfigWithSource, loadConfigFile, writeConfigFile },
+        runtimeConfigService: opts.runtimeConfigService,
         tokenTtlMs,
     });
     registerScheduleRoutes(routes, scheduleManager, async (repoId) => {

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -69,6 +69,7 @@ import { execGit } from '@plusplusoneplusplus/forge';
 import type { WorkItemChangeCommit } from '../work-items/types';
 import { getResolvedConfigWithSource, loadConfigFile, writeConfigFile, getConfigFilePath } from '../../config';
 import type { ResolvedCLIConfig } from '../../config';
+import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import type { TerminalSessionManager } from '../terminal/index';
 import { registerRemoteServerRoutes } from '../servers/remote-server-routes';
 import { RemoteServerStore } from '../servers/remote-server-store';
@@ -122,6 +123,7 @@ export interface RegisterRoutesOptions {
     aiInvoker: AIInvoker;
     getTerminalSessionManager?: () => TerminalSessionManager | undefined;
     resolvedConfig?: ResolvedCLIConfig;
+    runtimeConfigService?: RuntimeConfigService;
     remoteServerStore?: RemoteServerStore;
     remoteServerConnector?: DevTunnelConnector;
     loopStore?: LoopStore;

--- a/packages/coc/src/server/spa/client/entry.tsx
+++ b/packages/coc/src/server/spa/client/entry.tsx
@@ -14,6 +14,7 @@ import { PopOutChatShell } from './react/layout/PopOutChatShell';
 import { PopOutMarkdownShell } from './react/layout/PopOutMarkdownShell';
 import { PopOutGitReviewShell } from './react/layout/PopOutGitReviewShell';
 import { DiagramViewerShell } from './react/features/diagrams';
+import { loadRuntimeConfig } from './react/utils/config';
 import './react/shared/file-path/file-path-preview';
 import './react/features/repo-detail/explorer/monaco-setup';
 // Excalidraw ships its renderer styles in a separate CSS entry point. Without
@@ -37,5 +38,9 @@ if (window.location.pathname.startsWith('/diagram/')) {
 } else if (window.location.hash.startsWith('#popout/git-review')) {
     root.render(<PopOutGitReviewShell />);
 } else {
-    root.render(<App />);
+    // Load fresh feature flags from API before rendering the main app.
+    // Non-fatal: falls back to bootstrap config embedded in HTML if API fails.
+    loadRuntimeConfig().finally(() => {
+        root.render(<App />);
+    });
 }

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -1175,7 +1175,7 @@ export function AdminPanel() {
                                     onCancel={handleCancelFeatures}
                                     data-testid="settings-features"
                                 >
-                                    <AdminRow name="Terminal" hint="Web terminal for shell access to the server machine.">
+                                    <AdminRow name={<>Terminal <span className="ar-badge ar-badge-warning">Restart</span></>} hint="Web terminal for shell access to the server machine. Toggling requires a server restart.">
                                         <SourceBadge source={sources['terminal.enabled']} />
                                         <AdminToggle checked={terminalEnabled} onChange={setTerminalEnabled} data-testid="toggle-terminal-enabled" />
                                     </AdminRow>

--- a/packages/coc/src/server/spa/client/react/utils/config.ts
+++ b/packages/coc/src/server/spa/client/react/utils/config.ts
@@ -1,6 +1,10 @@
 /**
- * Dashboard config — reads server-provided configuration
- * from the global window.__DASHBOARD_CONFIG__ set by the HTML template.
+ * Dashboard config — reads server-provided configuration.
+ *
+ * Bootstrap config comes from window.__DASHBOARD_CONFIG__ (set by the HTML
+ * template).  Feature flags are refreshed at page load from the
+ * GET /api/config/runtime endpoint so that admin config changes take effect
+ * on refresh without a server restart.
  */
 
 interface DashboardConfig {
@@ -26,12 +30,75 @@ interface DashboardConfig {
     bindAddress?: string;
 }
 
-function getConfig(): DashboardConfig {
+/** Cached runtime config loaded from the API. */
+let _runtimeConfig: DashboardConfig | null = null;
+let _runtimeConfigPromise: Promise<void> | null = null;
+
+function getBootstrapConfig(): DashboardConfig {
     const config = (window as any).__DASHBOARD_CONFIG__;
     if (!config) {
         return { apiBasePath: '/api', wsPath: '/ws' };
     }
     return config;
+}
+
+function getConfig(): DashboardConfig {
+    if (_runtimeConfig) return _runtimeConfig;
+    return getBootstrapConfig();
+}
+
+/**
+ * Fetch fresh feature flags from GET /api/config/runtime and merge them
+ * into the active config.  Called once on page load from App initialization.
+ * Non-fatal: if the endpoint fails, the SPA falls back to bootstrap config.
+ */
+export async function loadRuntimeConfig(): Promise<void> {
+    if (_runtimeConfigPromise) return _runtimeConfigPromise;
+    _runtimeConfigPromise = _doLoadRuntimeConfig();
+    return _runtimeConfigPromise;
+}
+
+async function _doLoadRuntimeConfig(): Promise<void> {
+    try {
+        const bootstrap = getBootstrapConfig();
+        const resp = await fetch(`${bootstrap.apiBasePath}/config/runtime`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (!data || typeof data !== 'object' || !data.features) return;
+
+        // Merge runtime features into the active config, preserving bootstrap-only fields
+        _runtimeConfig = {
+            ...bootstrap,
+            terminalEnabled: data.features.terminalEnabled,
+            notesEnabled: data.features.notesEnabled,
+            myWorkEnabled: data.features.myWorkEnabled,
+            myLifeEnabled: data.features.myLifeEnabled,
+            scratchpadEnabled: data.features.scratchpadEnabled,
+            scratchpadLayout: data.features.scratchpadLayout,
+            workflowsEnabled: data.features.workflowsEnabled,
+            pullRequestsEnabled: data.features.pullRequestsEnabled,
+            serversEnabled: data.features.serversEnabled,
+            ralphEnabled: data.features.ralphEnabled,
+            vimNavigationEnabled: data.features.vimNavigationEnabled,
+            loopsEnabled: data.features.loopsEnabled,
+            excalidrawEnabled: data.features.excalidrawEnabled,
+            mcpOauthEnabled: data.features.mcpOauthEnabled,
+            focusedDiffEnabled: data.features.focusedDiffEnabled,
+            hostname: data.hostname ?? bootstrap.hostname,
+            bindAddress: data.bindAddress ?? bootstrap.bindAddress,
+        };
+    } catch {
+        // Non-fatal — fall back to bootstrap config
+    }
+}
+
+/**
+ * Reset the runtime config cache.  Exposed for testing only.
+ * @internal
+ */
+export function _resetRuntimeConfig(): void {
+    _runtimeConfig = null;
+    _runtimeConfigPromise = null;
 }
 
 /**

--- a/packages/coc/src/server/spa/html-template.ts
+++ b/packages/coc/src/server/spa/html-template.ts
@@ -45,7 +45,7 @@ function getBundleJs(): string {
     return cachedJs.content;
 }
 
-let cachedETag: { hash: string; cssMtime: number; jsMtime: number } | null = null;
+let cachedETag: { hash: string; cssMtime: number; jsMtime: number; configRevision: number } | null = null;
 
 /**
  * Nonce unique to this server process.  Included in the ETag so that every
@@ -57,19 +57,22 @@ const processNonce = crypto.randomBytes(4).toString('hex');
 
 /**
  * Compute a short SHA-256 ETag from the bundle CSS + JS content plus a
- * per-process nonce.  The nonce ensures that a server restart always
- * invalidates the browser cache, even when the bundle files haven't changed.
- * Cached alongside mtime — only rehashed when files change on disk.
+ * per-process nonce and optional config revision.  The nonce ensures that
+ * a server restart always invalidates the browser cache; the config
+ * revision ensures that admin config changes invalidate cached SPA HTML
+ * containing stale feature flags.
+ * Cached alongside mtime + revision — only rehashed when files or revision change.
  */
-export function getBundleETag(): string {
+export function getBundleETag(configRevision?: number): string {
     const css = (cachedCss = readBundleFile(bundleCssPath, cachedCss));
     const js = (cachedJs = readBundleFile(bundleJsPath, cachedJs));
-    if (cachedETag && cachedETag.cssMtime === css.mtime && cachedETag.jsMtime === js.mtime) {
+    const rev = configRevision ?? 0;
+    if (cachedETag && cachedETag.cssMtime === css.mtime && cachedETag.jsMtime === js.mtime && cachedETag.configRevision === rev) {
         return cachedETag.hash;
     }
-    const hash = crypto.createHash('sha256').update(css.content).update(js.content).update(processNonce).digest('hex').slice(0, 16);
+    const hash = crypto.createHash('sha256').update(css.content).update(js.content).update(processNonce).update(String(rev)).digest('hex').slice(0, 16);
     const etag = `"${hash}"`;
-    cachedETag = { hash: etag, cssMtime: css.mtime, jsMtime: js.mtime };
+    cachedETag = { hash: etag, cssMtime: css.mtime, jsMtime: js.mtime, configRevision: rev };
     return etag;
 }
 

--- a/packages/coc/src/server/terminal/terminal-routes.ts
+++ b/packages/coc/src/server/terminal/terminal-routes.ts
@@ -15,6 +15,7 @@ import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import type { TerminalSessionManager } from './terminal-session-manager';
 import type { ResolvedCLIConfig } from '../../config';
 import { toSessionInfo } from './terminal-session-manager';
+import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import { sendJSON } from '../core/api-handler';
 import { handleAPIError, notFound } from '../errors';
 import { resolveWorkspaceOrFail } from '../shared/handler-utils';
@@ -24,15 +25,22 @@ export function registerTerminalRoutes(
     store: ProcessStore,
     getTerminalSessionManager: () => TerminalSessionManager | undefined,
     resolvedConfig?: ResolvedCLIConfig,
+    runtimeConfigService?: RuntimeConfigService,
 ): void {
-    // GET /api/terminal/status — always registered regardless of manager
+    // GET /api/terminal/status — always registered regardless of manager.
+    // Uses runtimeConfigService (when available) so the status endpoint
+    // reports the saved config value, not just the startup-captured one.
+    // Terminal infrastructure itself is restart-required.
     routes.push({
         method: 'GET',
         pattern: '/api/terminal/status',
         handler: async (_req, res) => {
             const mgr = getTerminalSessionManager();
+            const liveEnabled = runtimeConfigService
+                ? (runtimeConfigService.config.terminal?.enabled ?? true)
+                : (resolvedConfig?.terminal?.enabled ?? true);
             sendJSON(res, 200, {
-                enabled: resolvedConfig?.terminal?.enabled ?? true,
+                enabled: liveEnabled,
                 nodePtyAvailable: mgr != null,
                 activeSessions: mgr?.size ?? 0,
             });

--- a/packages/coc/test/config/runtime-config-service.test.ts
+++ b/packages/coc/test/config/runtime-config-service.test.ts
@@ -309,4 +309,51 @@ describe('RuntimeConfigService', () => {
             expect(raw.timeout).toBe(300);
         });
     });
+
+    // ── Field runtime classification ─────────────────────────────────────
+
+    describe('field runtime classification', () => {
+        it('should return correct runtime classification in effects for live fields', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const result = await svc.updateConfig({ 'ralph.enabled': true });
+
+            const ralphEffect = result.effects.find(e => e.field === 'ralph.enabled');
+            expect(ralphEffect).toBeDefined();
+            expect(ralphEffect!.runtime).toBe('live');
+            expect(ralphEffect!.requiresRestart).toBe(false);
+        });
+
+        it('should return restartRequired classification for infrastructure fields', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const result = await svc.updateConfig({ 'loops.enabled': true });
+
+            const loopsEffect = result.effects.find(e => e.field === 'loops.enabled');
+            expect(loopsEffect).toBeDefined();
+            expect(loopsEffect!.runtime).toBe('restartRequired');
+            expect(loopsEffect!.requiresRestart).toBe(true);
+        });
+
+        it('should return mixed classifications for mixed updates', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const result = await svc.updateConfig({
+                'ralph.enabled': true,
+                'loops.enabled': true,
+                'terminal.enabled': false,
+            });
+
+            expect(result.effects).toHaveLength(3);
+
+            const ralph = result.effects.find(e => e.field === 'ralph.enabled')!;
+            expect(ralph.runtime).toBe('live');
+            expect(ralph.requiresRestart).toBe(false);
+
+            const loops = result.effects.find(e => e.field === 'loops.enabled')!;
+            expect(loops.runtime).toBe('restartRequired');
+            expect(loops.requiresRestart).toBe(true);
+
+            const terminal = result.effects.find(e => e.field === 'terminal.enabled')!;
+            expect(terminal.runtime).toBe('restartRequired');
+            expect(terminal.requiresRestart).toBe(true);
+        });
+    });
 });

--- a/packages/coc/test/config/runtime-config-service.test.ts
+++ b/packages/coc/test/config/runtime-config-service.test.ts
@@ -63,6 +63,28 @@ describe('RuntimeConfigService', () => {
             const svc = new RuntimeConfigService({ configPath });
             expect(svc.configPath).toBe(configPath);
         });
+
+        it('should use fileConfig when provided instead of reading from disk', () => {
+            // Write a config file with ralph enabled
+            writeConfig({ ralph: { enabled: true }, parallel: 99 });
+            // But pass fileConfig that disables ralph and sets different parallel
+            const svc = new RuntimeConfigService({
+                configPath,
+                fileConfig: { ralph: { enabled: false }, parallel: 5 },
+            });
+            // fileConfig should win over file on disk
+            expect(svc.config.ralph.enabled).toBe(false);
+            expect(svc.config.parallel).toBe(5);
+        });
+
+        it('should merge fileConfig with defaults', () => {
+            const svc = new RuntimeConfigService({
+                fileConfig: { excalidraw: { enabled: true } },
+            });
+            expect(svc.config.excalidraw.enabled).toBe(true);
+            // Other defaults should still be applied
+            expect(svc.config.parallel).toBe(DEFAULT_CONFIG.parallel);
+        });
     });
 
     // ── getSnapshot ──────────────────────────────────────────────────────

--- a/packages/coc/test/config/runtime-config-service.test.ts
+++ b/packages/coc/test/config/runtime-config-service.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Runtime Config Service Tests
+ *
+ * Tests for the central runtime config service that owns config loading,
+ * validation, persistence, resolved snapshots, source metadata, and revisioning.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import yaml from 'js-yaml';
+
+import { RuntimeConfigService } from '../../src/config/runtime-config-service';
+import type { RuntimeConfigSnapshot } from '../../src/config/runtime-config-service';
+import { DEFAULT_CONFIG } from '../../src/config';
+import type { CLIConfig } from '../../src/config';
+
+describe('RuntimeConfigService', () => {
+    let tmpDir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-rtcfg-'));
+        configPath = path.join(tmpDir, 'config.yaml');
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeConfig(config: CLIConfig): void {
+        fs.writeFileSync(configPath, yaml.dump(config, { lineWidth: -1 }), 'utf-8');
+    }
+
+    // ── Constructor / Initialization ─────────────────────────────────────
+
+    describe('initialization', () => {
+        it('should resolve defaults when no config file exists', () => {
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.config.parallel).toBe(DEFAULT_CONFIG.parallel);
+            expect(svc.config.ralph.enabled).toBe(false);
+            expect(svc.revision).toBe(0);
+        });
+
+        it('should load config from file at construction', () => {
+            writeConfig({ parallel: 10, ralph: { enabled: true } });
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.config.parallel).toBe(10);
+            expect(svc.config.ralph.enabled).toBe(true);
+            expect(svc.revision).toBe(0);
+        });
+
+        it('should track sources correctly', () => {
+            writeConfig({ ralph: { enabled: true } });
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.sources['ralph.enabled']).toBe('file');
+            // parallel is not in file, should be default
+            expect(svc.sources['parallel']).toBe('default');
+        });
+
+        it('should expose configPath', () => {
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.configPath).toBe(configPath);
+        });
+    });
+
+    // ── getSnapshot ──────────────────────────────────────────────────────
+
+    describe('getSnapshot', () => {
+        it('should return config, sources, and revision', () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snap = svc.getSnapshot();
+            expect(snap.config).toBeDefined();
+            expect(snap.sources).toBeDefined();
+            expect(snap.revision).toBe(0);
+        });
+
+        it('should return a copy of sources', () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snap1 = svc.getSnapshot();
+            const snap2 = svc.getSnapshot();
+            expect(snap1.sources).not.toBe(snap2.sources);
+            expect(snap1.sources).toEqual(snap2.sources);
+        });
+    });
+
+    // ── refresh ──────────────────────────────────────────────────────────
+
+    describe('refresh', () => {
+        it('should re-read config from disk without incrementing revision', () => {
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.config.ralph.enabled).toBe(false);
+
+            // External write
+            writeConfig({ ralph: { enabled: true } });
+            svc.refresh();
+
+            expect(svc.config.ralph.enabled).toBe(true);
+            expect(svc.revision).toBe(0); // revision unchanged
+        });
+    });
+
+    // ── updateConfig ─────────────────────────────────────────────────────
+
+    describe('updateConfig', () => {
+        it('should apply valid update and increment revision', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.config.ralph.enabled).toBe(false);
+            expect(svc.revision).toBe(0);
+
+            const result = await svc.updateConfig({ 'ralph.enabled': true });
+
+            expect(result.config.ralph.enabled).toBe(true);
+            expect(result.revision).toBe(1);
+            expect(svc.config.ralph.enabled).toBe(true);
+            expect(svc.revision).toBe(1);
+        });
+
+        it('should persist changes to disk', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            await svc.updateConfig({ 'ralph.enabled': true });
+
+            // Read back from disk independently
+            const raw = yaml.load(fs.readFileSync(configPath, 'utf-8')) as CLIConfig;
+            expect(raw.ralph?.enabled).toBe(true);
+        });
+
+        it('should return effects for changed fields', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const result = await svc.updateConfig({
+                'ralph.enabled': true,
+                'loops.enabled': true,
+            });
+
+            expect(result.effects).toHaveLength(2);
+            const fieldNames = result.effects.map(e => e.field).sort();
+            expect(fieldNames).toEqual(['loops.enabled', 'ralph.enabled']);
+        });
+
+        it('should update source metadata after write', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            expect(svc.sources['ralph.enabled']).toBe('default');
+
+            await svc.updateConfig({ 'ralph.enabled': true });
+            expect(svc.sources['ralph.enabled']).toBe('file');
+        });
+
+        it('should reject invalid field values without mutating disk or revision', async () => {
+            writeConfig({ parallel: 5 });
+            const svc = new RuntimeConfigService({ configPath });
+
+            await expect(
+                svc.updateConfig({ 'parallel': -1 }),
+            ).rejects.toThrow('parallel must be a number greater than 0');
+
+            expect(svc.revision).toBe(0);
+
+            // Disk should be unchanged
+            const raw = yaml.load(fs.readFileSync(configPath, 'utf-8')) as CLIConfig;
+            expect(raw.parallel).toBe(5);
+        });
+
+        it('should reject patch with no valid editable fields', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            await expect(
+                svc.updateConfig({ 'nonexistent.field': 42 }),
+            ).rejects.toThrow('No valid editable fields');
+        });
+
+        it('should handle multiple sequential updates correctly', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+
+            await svc.updateConfig({ 'ralph.enabled': true });
+            expect(svc.revision).toBe(1);
+
+            await svc.updateConfig({ 'loops.enabled': true });
+            expect(svc.revision).toBe(2);
+
+            expect(svc.config.ralph.enabled).toBe(true);
+            expect(svc.config.loops.enabled).toBe(true);
+        });
+
+        it('should serialize concurrent updates', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+
+            // Fire two updates concurrently
+            const [r1, r2] = await Promise.all([
+                svc.updateConfig({ 'ralph.enabled': true }),
+                svc.updateConfig({ 'loops.enabled': true }),
+            ]);
+
+            // Both should succeed with sequential revisions
+            expect(r1.revision).toBe(1);
+            expect(r2.revision).toBe(2);
+            expect(svc.revision).toBe(2);
+            expect(svc.config.ralph.enabled).toBe(true);
+            expect(svc.config.loops.enabled).toBe(true);
+        });
+    });
+
+    // ── Listeners ────────────────────────────────────────────────────────
+
+    describe('onChange', () => {
+        it('should notify listeners on successful update', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snapshots: RuntimeConfigSnapshot[] = [];
+
+            svc.onChange(snap => snapshots.push(snap));
+            await svc.updateConfig({ 'ralph.enabled': true });
+
+            expect(snapshots).toHaveLength(1);
+            expect(snapshots[0].config.ralph.enabled).toBe(true);
+            expect(snapshots[0].revision).toBe(1);
+        });
+
+        it('should not notify listeners on failed update', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snapshots: RuntimeConfigSnapshot[] = [];
+
+            svc.onChange(snap => snapshots.push(snap));
+            await svc.updateConfig({ 'parallel': -1 }).catch(() => {});
+
+            expect(snapshots).toHaveLength(0);
+        });
+
+        it('should support unsubscribe', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snapshots: RuntimeConfigSnapshot[] = [];
+
+            const unsub = svc.onChange(snap => snapshots.push(snap));
+            await svc.updateConfig({ 'ralph.enabled': true });
+            expect(snapshots).toHaveLength(1);
+
+            unsub();
+            await svc.updateConfig({ 'loops.enabled': true });
+            expect(snapshots).toHaveLength(1); // not called again
+        });
+
+        it('should tolerate listener errors', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snapshots: RuntimeConfigSnapshot[] = [];
+
+            svc.onChange(() => { throw new Error('boom'); });
+            svc.onChange(snap => snapshots.push(snap));
+
+            await svc.updateConfig({ 'ralph.enabled': true });
+            expect(snapshots).toHaveLength(1); // second listener still called
+        });
+
+        it('should clear all listeners with removeAllListeners', async () => {
+            const svc = new RuntimeConfigService({ configPath });
+            const snapshots: RuntimeConfigSnapshot[] = [];
+
+            svc.onChange(snap => snapshots.push(snap));
+            svc.removeAllListeners();
+
+            await svc.updateConfig({ 'ralph.enabled': true });
+            expect(snapshots).toHaveLength(0);
+        });
+    });
+
+    // ── Config precedence ────────────────────────────────────────────────
+
+    describe('config precedence', () => {
+        it('should preserve existing config values when updating unrelated fields', async () => {
+            writeConfig({ parallel: 10, ralph: { enabled: true } });
+            const svc = new RuntimeConfigService({ configPath });
+
+            await svc.updateConfig({ 'loops.enabled': true });
+
+            // Pre-existing values should be preserved
+            expect(svc.config.parallel).toBe(10);
+            expect(svc.config.ralph.enabled).toBe(true);
+            expect(svc.config.loops.enabled).toBe(true);
+        });
+
+        it('should preserve non-admin fields in config file', async () => {
+            writeConfig({ model: 'gpt-4o', timeout: 300 });
+            const svc = new RuntimeConfigService({ configPath });
+
+            await svc.updateConfig({ 'ralph.enabled': true });
+
+            // Read back from disk — model should still be there
+            const raw = yaml.load(fs.readFileSync(configPath, 'utf-8')) as CLIConfig;
+            expect(raw.model).toBe('gpt-4o');
+            expect(raw.timeout).toBe(300);
+        });
+    });
+});

--- a/packages/coc/test/server/admin-config-fields.test.ts
+++ b/packages/coc/test/server/admin-config-fields.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS } from '../../src/server/admin/admin-config-fields';
+import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS, getAdminFieldMetadata } from '../../src/server/admin/admin-config-fields';
 import type { AdminConfigFieldSpec } from '../../src/server/admin/admin-config-fields';
 import type { CLIConfig } from '../../src/config';
 
@@ -346,5 +346,55 @@ describe('apply()', () => {
             fieldFor('scratchpad.layout').apply(cfg, 'vertical');
             expect(cfg.scratchpad?.layout).toBe('vertical');
         });
+    });
+});
+
+// ── runtime classification ────────────────────────────────────────────────────
+
+describe('runtime classification', () => {
+    it('marks terminal.enabled as restartRequired', () => {
+        expect(fieldFor('terminal.enabled').runtime).toBe('restartRequired');
+    });
+
+    it('marks loops.enabled as restartRequired', () => {
+        expect(fieldFor('loops.enabled').runtime).toBe('restartRequired');
+    });
+
+    it('marks mcpOauth.enabled as restartRequired', () => {
+        expect(fieldFor('mcpOauth.enabled').runtime).toBe('restartRequired');
+    });
+
+    const liveFeatures = [
+        'notes.enabled', 'myWork.enabled', 'myLife.enabled',
+        'scratchpad.enabled', 'workflows.enabled', 'pullRequests.enabled',
+        'servers.enabled', 'ralph.enabled', 'vimNavigation.enabled',
+        'excalidraw.enabled', 'features.focusedDiff',
+    ];
+
+    for (const key of liveFeatures) {
+        it(`marks ${key} as live`, () => {
+            expect(fieldFor(key).runtime).toBe('live');
+        });
+    }
+});
+
+// ── getAdminFieldMetadata() ───────────────────────────────────────────────────
+
+describe('getAdminFieldMetadata()', () => {
+    it('returns metadata for every registered field', () => {
+        const meta = getAdminFieldMetadata();
+        for (const field of ADMIN_CONFIG_FIELDS) {
+            expect(meta[field.key]).toEqual({ runtime: field.runtime });
+        }
+    });
+
+    it('includes restartRequired for terminal.enabled', () => {
+        const meta = getAdminFieldMetadata();
+        expect(meta['terminal.enabled'].runtime).toBe('restartRequired');
+    });
+
+    it('includes restartRequired for mcpOauth.enabled', () => {
+        const meta = getAdminFieldMetadata();
+        expect(meta['mcpOauth.enabled'].runtime).toBe('restartRequired');
     });
 });

--- a/packages/coc/test/server/admin-handler.test.ts
+++ b/packages/coc/test/server/admin-handler.test.ts
@@ -984,6 +984,101 @@ describe('Admin Handler', () => {
             expect(body.resolved.toolCompactness).toBe(1);
             expect(body.resolved.model).toBe('gpt-4');
         });
+
+        it('should return revision=0 from GET before any updates', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            const srv = await startServerWithConfig(configPath);
+
+            const res = await request(`${srv.url}/api/admin/config`);
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            expect(body.revision).toBe(0);
+        });
+
+        it('should increment revision on successful PUT', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            const srv = await startServerWithConfig(configPath);
+
+            // First update
+            const res1 = await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ model: 'model-v1' }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+            expect(res1.status).toBe(200);
+            const body1 = JSON.parse(res1.body);
+            expect(body1.revision).toBe(1);
+
+            // Second update
+            const res2 = await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ model: 'model-v2' }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+            expect(res2.status).toBe(200);
+            const body2 = JSON.parse(res2.body);
+            expect(body2.revision).toBe(2);
+
+            // GET should also return current revision
+            const res3 = await request(`${srv.url}/api/admin/config`);
+            const body3 = JSON.parse(res3.body);
+            expect(body3.revision).toBe(2);
+        });
+
+        it('should not increment revision on failed PUT', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            const srv = await startServerWithConfig(configPath);
+
+            // Successful update
+            await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ model: 'good-model' }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            // Failed update (invalid parallel)
+            const failRes = await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ parallel: -1 }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+            expect(failRes.status).toBe(400);
+
+            // Revision should still be 1
+            const getRes = await request(`${srv.url}/api/admin/config`);
+            const body = JSON.parse(getRes.body);
+            expect(body.revision).toBe(1);
+        });
+
+        it('should return effects array on successful PUT', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            const srv = await startServerWithConfig(configPath);
+
+            const res = await request(`${srv.url}/api/admin/config`, {
+                method: 'PUT',
+                body: JSON.stringify({ model: 'test-model', parallel: 3 }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            expect(body.effects).toBeDefined();
+            expect(Array.isArray(body.effects)).toBe(true);
+            expect(body.effects.length).toBe(2);
+            expect(body.effects.map((e: any) => e.field).sort()).toEqual(['model', 'parallel']);
+        });
+
+        it('should preserve source metadata through runtime config service', async () => {
+            const configPath = path.join(dataDir, 'config.yaml');
+            fs.writeFileSync(configPath, 'model: gpt-4\n', 'utf-8');
+            const srv = await startServerWithConfig(configPath);
+
+            const res = await request(`${srv.url}/api/admin/config`);
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            expect(body.sources.model).toBe('file');
+            expect(body.sources.output).toBe('default');
+            expect(body.configFilePath).toBeDefined();
+        });
     });
 
     // ========================================================================

--- a/packages/coc/test/server/config/runtime-config-handler.test.ts
+++ b/packages/coc/test/server/config/runtime-config-handler.test.ts
@@ -202,3 +202,62 @@ describe('getBundleETag with config revision', () => {
         expect(etag1Again).toBe(etag1);
     });
 });
+
+describe('AC-08: live-classified route registration', () => {
+    it('diagram routes are always registered (not gated by excalidraw.enabled at startup)', async () => {
+        const routesSrc = await import('fs').then(fs =>
+            fs.readFileSync(
+                require('path').resolve(__dirname, '../../../src/server/routes/index.ts'),
+                'utf-8',
+            ),
+        );
+        // registerDiagramRoutes must be called unconditionally
+        expect(routesSrc).toContain('registerDiagramRoutes(routes');
+        expect(routesSrc).not.toMatch(/if\s*\(.*excalidraw.*\)\s*\{?\s*registerDiagramRoutes/);
+    });
+
+    it('focused-diff classification routes are always registered (not gated by features.focusedDiff at startup)', async () => {
+        const routesSrc = await import('fs').then(fs =>
+            fs.readFileSync(
+                require('path').resolve(__dirname, '../../../src/server/routes/index.ts'),
+                'utf-8',
+            ),
+        );
+        expect(routesSrc).toContain('registerPrClassificationRoutes(routes');
+        expect(routesSrc).not.toMatch(/if\s*\(.*focusedDiff.*\)\s*\{?\s*registerPrClassificationRoutes/);
+        expect(routesSrc).toContain('registerGenericClassificationRoutes(routes');
+        expect(routesSrc).not.toMatch(/if\s*\(.*focusedDiff.*\)\s*\{?\s*registerGenericClassificationRoutes/);
+    });
+
+    it('excalidraw LLM tool visibility uses live getter (not startup boolean)', async () => {
+        const routesSrc = await import('fs').then(fs =>
+            fs.readFileSync(
+                require('path').resolve(__dirname, '../../../src/server/routes/api-workspace-routes.ts'),
+                'utf-8',
+            ),
+        );
+        // Workspace routes should call getLiveFeatureFlags, not read a static excalidrawEnabled
+        expect(routesSrc).toContain('getLiveFeatureFlags');
+        expect(routesSrc).not.toMatch(/ctx\.excalidrawEnabled/);
+    });
+
+    it('excalidraw.enabled and features.focusedDiff are classified as live in admin config fields', async () => {
+        const { ADMIN_CONFIG_FIELDS } = await import('../../../src/server/admin/admin-config-fields');
+        const excalidrawField = ADMIN_CONFIG_FIELDS.find(f => f.key === 'excalidraw.enabled');
+        const focusedDiffField = ADMIN_CONFIG_FIELDS.find(f => f.key === 'features.focusedDiff');
+        expect(excalidrawField).toBeDefined();
+        expect(excalidrawField!.runtime).toBe('live');
+        expect(focusedDiffField).toBeDefined();
+        expect(focusedDiffField!.runtime).toBe('live');
+    });
+
+    it('terminal.enabled and loops.enabled are classified as restartRequired', async () => {
+        const { ADMIN_CONFIG_FIELDS } = await import('../../../src/server/admin/admin-config-fields');
+        const terminalField = ADMIN_CONFIG_FIELDS.find(f => f.key === 'terminal.enabled');
+        const loopsField = ADMIN_CONFIG_FIELDS.find(f => f.key === 'loops.enabled');
+        expect(terminalField).toBeDefined();
+        expect(terminalField!.runtime).toBe('restartRequired');
+        expect(loopsField).toBeDefined();
+        expect(loopsField!.runtime).toBe('restartRequired');
+    });
+});

--- a/packages/coc/test/server/config/runtime-config-handler.test.ts
+++ b/packages/coc/test/server/config/runtime-config-handler.test.ts
@@ -105,6 +105,68 @@ describe('buildRuntimeDashboardConfig', () => {
     });
 });
 
+describe('AC-05: ralph.enabled live enablement end-to-end', () => {
+    it('ralph.enabled update through service is reflected in runtime dashboard config', async () => {
+        const fs = await import('fs');
+        const path = await import('path');
+        const os = await import('os');
+        const { RuntimeConfigService } = await import('../../../src/config/runtime-config-service');
+
+        // Create a real service with a temp config file
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-ac05-'));
+        try {
+            const configPath = path.join(tmpDir, 'config.yaml');
+            const svc = new RuntimeConfigService({ configPath });
+
+            // Initial state: ralph disabled
+            const before = buildRuntimeDashboardConfig(svc, 'test-host', '127.0.0.1');
+            expect(before.features.ralphEnabled).toBe(false);
+            expect(before.revision).toBe(0);
+
+            // Admin update enables ralph
+            const updateResult = await svc.updateConfig({ 'ralph.enabled': true });
+            expect(updateResult.config.ralph.enabled).toBe(true);
+            expect(updateResult.revision).toBe(1);
+
+            // Runtime dashboard config now reflects ralph enabled
+            const after = buildRuntimeDashboardConfig(svc, 'test-host', '127.0.0.1');
+            expect(after.features.ralphEnabled).toBe(true);
+            expect(after.revision).toBe(1);
+
+            // Verify the effect classifies ralph as live (not restartRequired)
+            const ralphEffect = updateResult.effects.find(e => e.field === 'ralph.enabled');
+            expect(ralphEffect).toBeDefined();
+            expect(ralphEffect!.runtime).toBe('live');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('stale ETag is invalidated when ralph.enabled changes', async () => {
+        vi.resetModules();
+        const { getBundleETag } = await import('../../../src/server/spa/html-template');
+
+        // ETag before config change (revision 0) differs from after (revision 1)
+        const etagBefore = getBundleETag(0);
+        const etagAfter = getBundleETag(1);
+        expect(etagBefore).not.toBe(etagAfter);
+        // Browser 304 with old ETag will not match new ETag → fresh HTML served
+    });
+
+    it('ralph backend routes are always registered (not gated by startup config)', async () => {
+        // Verify route registration files import ralph routes unconditionally
+        const routesSrc = await import('fs').then(fs =>
+            fs.readFileSync(
+                require('path').resolve(__dirname, '../../../src/server/routes/index.ts'),
+                'utf-8',
+            ),
+        );
+        // Ralph route registration should not be inside an if block checking config
+        expect(routesSrc).toContain('registerRalphRoutes(routes');
+        expect(routesSrc).not.toMatch(/if\s*\(.*ralph.*\)\s*\{?\s*registerRalphRoutes/);
+    });
+});
+
 describe('getBundleETag with config revision', () => {
     let getBundleETag: (configRevision?: number) => string;
 

--- a/packages/coc/test/server/config/runtime-config-handler.test.ts
+++ b/packages/coc/test/server/config/runtime-config-handler.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for runtime config handler (GET /api/config/runtime)
+ * and ETag config-revision awareness.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildRuntimeDashboardConfig } from '../../../src/server/config/runtime-config-handler';
+import type { RuntimeConfigService } from '../../../src/config/runtime-config-service';
+import type { ResolvedCLIConfig } from '../../../src/config';
+
+function createMockRuntimeConfigService(overrides: Partial<ResolvedCLIConfig> = {}, revision = 0): RuntimeConfigService {
+    const config: ResolvedCLIConfig = {
+        model: 'test-model',
+        parallel: 1,
+        timeout: 30,
+        output: 'table',
+        showReportIntent: false,
+        toolCompactness: 1,
+        taskCardDensity: 'compact',
+        historyGrouping: true,
+        groupSingleLineMessages: false,
+        chat: { followUpSuggestions: { enabled: false, count: 3 }, askUser: { enabled: false } },
+        serve: { serverName: undefined },
+        terminal: { enabled: true },
+        notes: { enabled: true },
+        myWork: { enabled: false },
+        myLife: { enabled: false },
+        scratchpad: { enabled: false, layout: 'horizontal' },
+        workflows: { enabled: false },
+        pullRequests: { enabled: false },
+        servers: { enabled: false },
+        ralph: { enabled: false },
+        vimNavigation: { enabled: false },
+        loops: { enabled: false },
+        excalidraw: { enabled: false },
+        mcpOauth: { enabled: false },
+        features: { focusedDiff: false, autoMemoryPromotion: false },
+        memoryPromotion: { enabled: false },
+        defaultModels: {},
+        ...overrides,
+    } as unknown as ResolvedCLIConfig;
+
+    return {
+        config,
+        revision,
+        sources: {},
+        configPath: '/mock/config.yaml',
+        getSnapshot: () => ({ config, sources: {}, revision }),
+    } as unknown as RuntimeConfigService;
+}
+
+describe('buildRuntimeDashboardConfig', () => {
+    it('returns revision from the service', () => {
+        const svc = createMockRuntimeConfigService({}, 5);
+        const result = buildRuntimeDashboardConfig(svc, 'my-host', '127.0.0.1');
+        expect(result.revision).toBe(5);
+    });
+
+    it('returns all feature flags with correct defaults', () => {
+        const svc = createMockRuntimeConfigService();
+        const result = buildRuntimeDashboardConfig(svc, 'my-host', '127.0.0.1');
+
+        expect(result.features.terminalEnabled).toBe(true);
+        expect(result.features.notesEnabled).toBe(true);
+        expect(result.features.myWorkEnabled).toBe(false);
+        expect(result.features.myLifeEnabled).toBe(false);
+        expect(result.features.scratchpadEnabled).toBe(false);
+        expect(result.features.scratchpadLayout).toBe('horizontal');
+        expect(result.features.workflowsEnabled).toBe(false);
+        expect(result.features.pullRequestsEnabled).toBe(false);
+        expect(result.features.serversEnabled).toBe(false);
+        expect(result.features.ralphEnabled).toBe(false);
+        expect(result.features.vimNavigationEnabled).toBe(false);
+        expect(result.features.loopsEnabled).toBe(false);
+        expect(result.features.excalidrawEnabled).toBe(false);
+        expect(result.features.mcpOauthEnabled).toBe(false);
+        expect(result.features.focusedDiffEnabled).toBe(false);
+    });
+
+    it('reflects ralph.enabled = true from config', () => {
+        const svc = createMockRuntimeConfigService({ ralph: { enabled: true } });
+        const result = buildRuntimeDashboardConfig(svc, 'my-host', '127.0.0.1');
+        expect(result.features.ralphEnabled).toBe(true);
+    });
+
+    it('uses serve.serverName for hostname when set', () => {
+        const svc = createMockRuntimeConfigService({ serve: { serverName: 'custom-name' } } as any);
+        const result = buildRuntimeDashboardConfig(svc, 'raw-hostname.local', '127.0.0.1');
+        expect(result.hostname).toBe('custom-name');
+    });
+
+    it('falls back to shortened raw hostname when serve.serverName is not set', () => {
+        const svc = createMockRuntimeConfigService();
+        const result = buildRuntimeDashboardConfig(svc, 'raw-hostname.local', '0.0.0.0');
+        expect(result.hostname).toBe('raw-hostname');
+        expect(result.bindAddress).toBe('0.0.0.0');
+    });
+
+    it('does not expose secrets or raw config file paths', () => {
+        const svc = createMockRuntimeConfigService();
+        const result = buildRuntimeDashboardConfig(svc, 'h', '127.0.0.1');
+        const json = JSON.stringify(result);
+        expect(json).not.toContain('configPath');
+        expect(json).not.toContain('test-model');
+    });
+});
+
+describe('getBundleETag with config revision', () => {
+    let getBundleETag: (configRevision?: number) => string;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        const mod = await import('../../../src/server/spa/html-template');
+        getBundleETag = mod.getBundleETag;
+    });
+
+    it('returns same ETag for same revision', () => {
+        const etag1 = getBundleETag(0);
+        const etag2 = getBundleETag(0);
+        expect(etag1).toBe(etag2);
+    });
+
+    it('returns different ETag for different revisions', () => {
+        const etag0 = getBundleETag(0);
+        const etag1 = getBundleETag(1);
+        expect(etag0).not.toBe(etag1);
+    });
+
+    it('treats undefined revision as 0', () => {
+        const etagUndef = getBundleETag();
+        const etag0 = getBundleETag(0);
+        expect(etagUndef).toBe(etag0);
+    });
+
+    it('invalidates cache when revision bumps', () => {
+        const etag1 = getBundleETag(1);
+        const etag2 = getBundleETag(2);
+        const etag1Again = getBundleETag(1);
+        expect(etag1).not.toBe(etag2);
+        expect(etag1Again).toBe(etag1);
+    });
+});

--- a/packages/coc/test/server/diagrams-handler.test.ts
+++ b/packages/coc/test/server/diagrams-handler.test.ts
@@ -308,10 +308,11 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
     });
 
     // -------------------------------------------------------------------------
-    // Feature flag — routes not registered when disabled
+    // Feature flag — routes always registered (live-togglable), but runtime
+    // config reports excalidraw as disabled so the SPA gates the UI.
     // -------------------------------------------------------------------------
 
-    it('returns 404 when excalidraw feature is disabled', async () => {
+    it('routes remain accessible when excalidraw is disabled (SPA gates UI)', async () => {
         const store = new FileProcessStore({ dataDir });
         server = await createExecutionServer({
             port: 0,
@@ -330,9 +331,16 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
         });
         expect(wsRes.status).toBe(201);
 
-        // Diagrams endpoint should not exist
+        // Diagram routes are always registered so the feature can be toggled
+        // live via admin config. The endpoint responds normally; the SPA
+        // checks runtime config to decide whether to show the UI.
         const res = await request(`${srv.url}/api/workspaces/${wsId}/diagrams`);
-        // Since routes aren't registered, the server falls through to SPA or 404
-        expect(res.status).not.toBe(200);
+        expect(res.status).toBe(200);
+
+        // Runtime config should report excalidraw as disabled
+        const configRes = await request(`${srv.url}/api/config/runtime`);
+        expect(configRes.status).toBe(200);
+        const configBody = await configRes.json();
+        expect(configBody.excalidrawEnabled).toBe(false);
     });
 });

--- a/packages/coc/test/server/diagrams-handler.test.ts
+++ b/packages/coc/test/server/diagrams-handler.test.ts
@@ -318,7 +318,7 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
             host: '127.0.0.1',
             store,
             dataDir,
-            // No resolvedConfig or excalidraw disabled
+            fileConfig: { excalidraw: { enabled: false } },
         });
         const srv = server;
 

--- a/packages/coc/test/server/diagrams-handler.test.ts
+++ b/packages/coc/test/server/diagrams-handler.test.ts
@@ -340,7 +340,7 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
         // Runtime config should report excalidraw as disabled
         const configRes = await request(`${srv.url}/api/config/runtime`);
         expect(configRes.status).toBe(200);
-        const configBody = await configRes.json();
+        const configBody = JSON.parse(configRes.body);
         expect(configBody.excalidrawEnabled).toBe(false);
     });
 });

--- a/packages/coc/test/server/diagrams-handler.test.ts
+++ b/packages/coc/test/server/diagrams-handler.test.ts
@@ -341,6 +341,6 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
         const configRes = await request(`${srv.url}/api/config/runtime`);
         expect(configRes.status).toBe(200);
         const configBody = JSON.parse(configRes.body);
-        expect(configBody.excalidrawEnabled).toBe(false);
+        expect(configBody.features.excalidrawEnabled).toBe(false);
     });
 });

--- a/packages/coc/test/server/spa-html.test.ts
+++ b/packages/coc/test/server/spa-html.test.ts
@@ -156,7 +156,10 @@ describe('generateDashboardHtml', () => {
 
     it('omits bindAddress key when not provided', () => {
         const html = generateDashboardHtml();
-        expect(html).not.toContain('bindAddress:');
+        // Extract the __DASHBOARD_CONFIG__ block to avoid matching the inlined bundle.js
+        const configMatch = html.match(/window\.__DASHBOARD_CONFIG__\s*=\s*\{([^}]+)\}/s);
+        expect(configMatch).not.toBeNull();
+        expect(configMatch![1]).not.toContain('bindAddress:');
     });
 
     it('defaults serversEnabled to false in __DASHBOARD_CONFIG__', () => {

--- a/packages/coc/test/server/spa/client/config-runtime-load.test.ts
+++ b/packages/coc/test/server/spa/client/config-runtime-load.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for SPA client runtime config loading (loadRuntimeConfig).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('loadRuntimeConfig', () => {
+    let loadRuntimeConfig: () => Promise<void>;
+    let isRalphEnabled: () => boolean;
+    let isContainerMode: () => boolean;
+    let _resetRuntimeConfig: () => void;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        const mod = await import('../../../../src/server/spa/client/react/utils/config');
+        loadRuntimeConfig = mod.loadRuntimeConfig;
+        isRalphEnabled = mod.isRalphEnabled;
+        isContainerMode = mod.isContainerMode;
+        _resetRuntimeConfig = mod._resetRuntimeConfig;
+        delete (window as any).__DASHBOARD_CONFIG__;
+    });
+
+    afterEach(() => {
+        _resetRuntimeConfig();
+        delete (window as any).__DASHBOARD_CONFIG__;
+        vi.restoreAllMocks();
+    });
+
+    it('updates feature flags from API response', async () => {
+        (window as any).__DASHBOARD_CONFIG__ = { apiBasePath: '/api', wsPath: '/ws', ralphEnabled: false };
+        expect(isRalphEnabled()).toBe(false);
+
+        vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                revision: 1,
+                features: {
+                    terminalEnabled: true,
+                    notesEnabled: true,
+                    myWorkEnabled: false,
+                    myLifeEnabled: false,
+                    scratchpadEnabled: false,
+                    scratchpadLayout: 'horizontal',
+                    workflowsEnabled: false,
+                    pullRequestsEnabled: false,
+                    serversEnabled: false,
+                    ralphEnabled: true,
+                    vimNavigationEnabled: false,
+                    loopsEnabled: false,
+                    excalidrawEnabled: false,
+                    mcpOauthEnabled: false,
+                    focusedDiffEnabled: false,
+                },
+                hostname: 'test-host',
+                bindAddress: '127.0.0.1',
+            }),
+        } as Response);
+
+        await loadRuntimeConfig();
+        expect(isRalphEnabled()).toBe(true);
+    });
+
+    it('falls back to bootstrap config on fetch failure', async () => {
+        (window as any).__DASHBOARD_CONFIG__ = { apiBasePath: '/api', wsPath: '/ws', ralphEnabled: false };
+
+        vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('network error'));
+
+        await loadRuntimeConfig();
+        expect(isRalphEnabled()).toBe(false);
+    });
+
+    it('falls back to bootstrap config on non-ok response', async () => {
+        (window as any).__DASHBOARD_CONFIG__ = { apiBasePath: '/api', wsPath: '/ws', ralphEnabled: true };
+
+        vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+        } as Response);
+
+        await loadRuntimeConfig();
+        expect(isRalphEnabled()).toBe(true);
+    });
+
+    it('deduplicates concurrent calls', async () => {
+        (window as any).__DASHBOARD_CONFIG__ = { apiBasePath: '/api', wsPath: '/ws' };
+
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                revision: 1,
+                features: {
+                    terminalEnabled: true,
+                    notesEnabled: true,
+                    myWorkEnabled: false,
+                    myLifeEnabled: false,
+                    scratchpadEnabled: false,
+                    scratchpadLayout: 'horizontal',
+                    workflowsEnabled: false,
+                    pullRequestsEnabled: false,
+                    serversEnabled: false,
+                    ralphEnabled: false,
+                    vimNavigationEnabled: false,
+                    loopsEnabled: false,
+                    excalidrawEnabled: false,
+                    mcpOauthEnabled: false,
+                    focusedDiffEnabled: false,
+                },
+            }),
+        } as Response);
+
+        await Promise.all([loadRuntimeConfig(), loadRuntimeConfig()]);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves bootstrap-only fields like containerMode', async () => {
+        (window as any).__DASHBOARD_CONFIG__ = {
+            apiBasePath: '/api',
+            wsPath: '/ws',
+            containerMode: true,
+        };
+
+        vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                revision: 1,
+                features: {
+                    terminalEnabled: true,
+                    notesEnabled: true,
+                    myWorkEnabled: false,
+                    myLifeEnabled: false,
+                    scratchpadEnabled: false,
+                    scratchpadLayout: 'horizontal',
+                    workflowsEnabled: false,
+                    pullRequestsEnabled: false,
+                    serversEnabled: false,
+                    ralphEnabled: false,
+                    vimNavigationEnabled: false,
+                    loopsEnabled: false,
+                    excalidrawEnabled: false,
+                    mcpOauthEnabled: false,
+                    focusedDiffEnabled: false,
+                },
+            }),
+        } as Response);
+
+        await loadRuntimeConfig();
+        expect(isContainerMode()).toBe(true);
+    });
+});


### PR DESCRIPTION
- **feat(coc): add RuntimeConfigService for centralized config management**
  Add a central RuntimeConfigService in packages/coc/src/config/ that owns
  config loading, validation, persistence, resolved snapshots, source
  metadata, revisioning, and update notifications. This is AC-01 of the
  runtime config system.
  
  Key features:
  - getSnapshot() returns current config, sources, and revision number
  - updateConfig() validates via ADMIN_CONFIG_FIELDS, writes atomically,
    refreshes in-memory snapshot, bumps revision, and notifies listeners
  - refresh() re-reads from disk without bumping revision
  - Promise queue serializes concurrent admin writes
  - onChange() listener pattern for post-update notifications
  
  Server startup now creates a single RuntimeConfigService instance before
  route registration, and passes it through RegisterRoutesOptions.
  
  22 new tests covering initialization, snapshots, refresh, updates,
  validation errors, concurrent serialization, listeners, and config
  precedence preservation. All 232 existing config tests and 277 admin
  tests continue to pass.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc): route admin config GET/PUT through RuntimeConfigService (AC-02)**
  Admin GET /api/admin/config now returns config snapshot from
  RuntimeConfigService including revision number. Admin PUT delegates
  validation, disk write, refresh, and revision bump to the service,
  returning updated snapshot with revision and effects array.
  
  Legacy configFunctions path preserved as fallback when service is absent.
  
  Tests added for:
  - revision=0 before any updates
  - revision increments on successful PUT
  - revision does not increment on failed PUT
  - effects array returned on successful PUT
  - source metadata preservation
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix(coc): RuntimeConfigService now honors fileConfig parameter**
  The RuntimeConfigService constructor accepted a fileConfig option but
  ignored it, always reading from disk. This caused tests that pass
  fileConfig to createExecutionServer to pick up the host machine's
  config instead of test-specific overrides, leading to 3 test failures:
  
  - diagrams-handler: excalidraw routes registered despite test expecting
    them disabled (user config had excalidraw.enabled: true)
  - prompt-handler: skills endpoint returned global/custom skills instead
    of empty list
  - spa-html: bindAddress assertion matched inlined bundle.js content
  
  Fixes:
  - RuntimeConfigService: use resolveConfig(undefined, fileConfig) when
    fileConfig is provided, skipping disk I/O
  - diagrams-handler test: explicitly pass fileConfig disabling excalidraw
  - spa-html test: scope bindAddress assertion to __DASHBOARD_CONFIG__
    block to avoid false matches from inlined bundle.js
  - Add tests for fileConfig behavior in RuntimeConfigService
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc): classify admin config fields by runtime behavior (AC-03)**
  Add runtime classification ('live', 'reloadable', 'restartRequired') to every
  admin-editable config field in the registry:
  
  - Add 'runtime' property to AdminConfigFieldSpec interface
  - Classify terminal.enabled and loops.enabled as restartRequired
    (infrastructure wired at startup)
  - Classify all other fields as live (UI-only or per-request reads)
  - Add getAdminFieldMetadata() helper for API responses
  - Expose fieldMetadata in admin GET and PUT responses
  - Update RuntimeConfigService effects to use actual field classifications
  - Add AdminConfigFieldRuntime/AdminConfigFieldMeta/AdminConfigChangeEffect
    types to coc-client contracts
  - Replace hardcoded restart badges in AdminPanel with metadata-driven badges
  - Add tests for classification correctness and metadata helper
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc): API-driven dashboard runtime config freshness (AC-04)**
  Add GET /api/config/runtime endpoint returning live feature flags and
  revision from RuntimeConfigService. SPA entry point now fetches runtime
  config from this API before rendering, so admin config changes take
  effect on page refresh without server restart.
  
  Key changes:
  - New runtime-config-handler.ts with buildRuntimeDashboardConfig() and
    registerRuntimeConfigRoutes()
  - ETag now includes config revision so browser cache invalidates when
    config changes via admin UI
  - SPA config.ts adds loadRuntimeConfig() that fetches from API and
    merges into active config, with bootstrap fallback on failure
  - Server index.ts uses RuntimeConfigService snapshot for SPA HTML
    generation instead of re-resolving config from disk
  - RuntimeDashboardConfig type added to coc-client contracts
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **test(AC-05): add end-to-end tests for Ralph live enablement**
  Add integration tests proving:
  - ralph.enabled update through RuntimeConfigService is reflected in
    buildRuntimeDashboardConfig without server restart
  - Config revision bump invalidates stale ETag (prevents 304 caching)
  - Ralph backend routes are always registered unconditionally
  
  All 13 runtime-config-handler tests pass, 170 related tests pass.
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **feat(coc): migrate live-classified route consumers to runtime config (AC-08)**
  - Always register diagram routes (excalidraw.enabled is live, not startup-gated)
  - Always register focused-diff classification routes (features.focusedDiff is live)
  - Replace static excalidrawEnabled boolean in ApiRouteContext with getLiveFeatureFlags
    getter that reads from RuntimeConfigService per-request
  - Pass runtimeConfigService to terminal routes for accurate status reporting
  - Add comprehensive documentation of remaining startup-captured resolvedConfig fields
    in server/index.ts (timeout, chat settings, monitoring, skills, loops, terminal)
  - Add 5 AC-08 tests verifying route registration is unconditional for live fields
    and restartRequired for infrastructure fields
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix(coc): add missing runtime classification and getAdminFieldMetadata to admin-config-fields**
  Commit fa7cc7ef (AC-03) updated consumers (admin-handler.ts,
  runtime-config-service.ts) to reference 'runtime' property and
  getAdminFieldMetadata() export from admin-config-fields.ts, but
  never applied the corresponding changes to admin-config-fields.ts
  itself, causing TS2339 and TS2305 build errors.
  
  - Add 'runtime' property to AdminConfigFieldSpec interface
  - Add AdminConfigFieldRuntime type ('live' | 'reloadable' | 'restartRequired')
  - Classify terminal.enabled and loops.enabled as 'restartRequired'
  - Classify all other fields as 'live'
  - Add getAdminFieldMetadata() helper for API responses
  - Update bool() helper to accept optional runtime parameter
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  

- **fix: correct feature config restart tags for Terminal and MCP OAuth**
  - Terminal: add missing 'Restart' badge in AdminPanel UI (registry
    already had restartRequired since terminal infra is created at startup)
  - MCP OAuth: change registry runtime from 'live' to 'restartRequired'
    (OAuth infra is created once at startup, matching the existing UI badge)
  - Add regression tests for runtime classification of all feature flags
    and getAdminFieldMetadata() to prevent future tag drift
  
  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
  