### PR TITLE
fix(coc): stop auto-scrolling notes sidebar on selection change

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NotesSidebar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NotesSidebar.tsx
@@ -155,7 +155,6 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
     const dragDrop = useNotesDragDrop();
     const [addDropdownOpen, setAddDropdownOpen] = useState(false);
     const addDropdownRef = useRef<HTMLDivElement>(null);
-    const treeAreaRef = useRef<HTMLDivElement>(null);
 
     // Close dropdown on outside click
     useEffect(() => {
@@ -238,21 +237,6 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
             window.removeEventListener('notes-changed', handler);
         };
     }, [workspaceId]);
-
-    // Scroll the selected tree item into view after tree renders (only if off-screen)
-    useEffect(() => {
-        if (!selectedPath || loading) return;
-        // Defer to allow DOM update after expansion
-        const timer = setTimeout(() => {
-            const el = document.querySelector(`[data-node-path="${CSS.escape(selectedPath)}"]`);
-            if (!el || !treeAreaRef.current) return;
-            const elRect = el.getBoundingClientRect();
-            const cRect = treeAreaRef.current.getBoundingClientRect();
-            if (elRect.top >= cRect.top && elRect.bottom <= cRect.bottom) return;
-            el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-        }, 50);
-        return () => clearTimeout(timer);
-    }, [selectedPath, loading]);
 
     const handleToggleExpand = useCallback((path: string) => {
         setExpandedPaths(prev => {
@@ -719,7 +703,7 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
             </div>
 
             {/* Tree area */}
-            <div ref={treeAreaRef} className="flex-1 overflow-y-auto py-1" data-testid="notes-tree-area" onContextMenu={handleBackgroundContextMenu}>
+            <div className="flex-1 overflow-y-auto py-1" data-testid="notes-tree-area" onContextMenu={handleBackgroundContextMenu}>
                 {loading && (
                     <div className="flex items-center justify-center py-6" data-testid="notes-loading">
                         <Spinner size="md" />

--- a/packages/coc/test/spa/react/notes-sidebar.test.tsx
+++ b/packages/coc/test/spa/react/notes-sidebar.test.tsx
@@ -1003,30 +1003,32 @@ describe('NotesSidebar', () => {
     });
 
     // ── Scroll behaviour ───────────────────────────────────────────────
+    //
+    // The sidebar must NEVER auto-scroll the tree on selection changes. The
+    // user's scroll position should be preserved regardless of whether the
+    // selected item is visible, off-screen, or partially visible. Auto-scroll
+    // on click was confusing because clicking a partially-visible item caused
+    // the list to jump so the item aligned to the nearest container edge.
 
-    it('does not scroll when the selected item is already visible', async () => {
+    it('does not auto-scroll the tree when selection changes (item visible)', async () => {
         const scrollIntoViewMock = vi.fn();
 
         const { findByTestId, rerender } = render(
             <NotesSidebar workspaceId="ws1" selectedPath={null} onSelectPage={vi.fn()} />,
         );
-        // Wait for tree to load
         await findByTestId('notes-tree-area');
         await waitFor(() => expect(mockGetTree).toHaveBeenCalled());
 
-        // Expand Notebook1 so Page1 is visible
         rerender(
             <NotesSidebar workspaceId="ws1" selectedPath="Notebook1/Section1/Page1" onSelectPage={vi.fn()} />,
         );
 
         const treeArea = await findByTestId('notes-tree-area');
 
-        // Wait for the 50ms deferred scroll effect to fire
         await act(async () => { await new Promise(r => setTimeout(r, 100)); });
 
         const selectedEl = treeArea.querySelector('[data-node-path="Notebook1/Section1/Page1"]');
         if (selectedEl) {
-            // Mock for next re-render: element is visible
             (selectedEl as HTMLElement).scrollIntoView = scrollIntoViewMock;
             vi.spyOn(selectedEl, 'getBoundingClientRect').mockReturnValue({
                 top: 100, bottom: 120, left: 0, right: 200, width: 200, height: 20, x: 0, y: 100, toJSON: () => ({}),
@@ -1036,7 +1038,6 @@ describe('NotesSidebar', () => {
             top: 0, bottom: 500, left: 0, right: 200, width: 200, height: 500, x: 0, y: 0, toJSON: () => ({}),
         });
 
-        // Trigger re-selection to fire the useEffect again
         rerender(
             <NotesSidebar workspaceId="ws1" selectedPath={null} onSelectPage={vi.fn()} />,
         );
@@ -1049,7 +1050,7 @@ describe('NotesSidebar', () => {
         expect(scrollIntoViewMock).not.toHaveBeenCalled();
     });
 
-    it('scrolls into view when the selected item is off-screen', async () => {
+    it('does not auto-scroll the tree when selection changes (item off-screen)', async () => {
         const scrollIntoViewMock = vi.fn();
 
         const { findByTestId, rerender } = render(
@@ -1064,13 +1065,14 @@ describe('NotesSidebar', () => {
 
         const treeArea = await findByTestId('notes-tree-area');
 
-        // Wait for initial effect
         await act(async () => { await new Promise(r => setTimeout(r, 100)); });
 
         const selectedEl = treeArea.querySelector('[data-node-path="Notebook1/Section1/Page1"]');
         if (selectedEl) {
             (selectedEl as HTMLElement).scrollIntoView = scrollIntoViewMock;
-            // Element is below visible area
+            // Pretend the element is well below the visible area — previously
+            // this would have triggered an auto-scroll, but the sidebar must
+            // now leave the user's scroll position untouched.
             vi.spyOn(selectedEl, 'getBoundingClientRect').mockReturnValue({
                 top: 600, bottom: 620, left: 0, right: 200, width: 200, height: 20, x: 0, y: 600, toJSON: () => ({}),
             });
@@ -1079,7 +1081,6 @@ describe('NotesSidebar', () => {
             top: 0, bottom: 500, left: 0, right: 200, width: 200, height: 500, x: 0, y: 0, toJSON: () => ({}),
         });
 
-        // Trigger re-selection
         rerender(
             <NotesSidebar workspaceId="ws1" selectedPath={null} onSelectPage={vi.fn()} />,
         );
@@ -1089,6 +1090,6 @@ describe('NotesSidebar', () => {
 
         await act(async () => { await new Promise(r => setTimeout(r, 100)); });
 
-        expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
+        expect(scrollIntoViewMock).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
The notes sidebar previously ran a scrollIntoView effect whenever
selectedPath changed. With block: 'nearest', clicking a partially-visible
item caused the list to jump so the item aligned to the container edge,
which felt jarring on long notebooks. Remove the effect (and the
unused treeAreaRef) so the user's scroll position is preserved on every
selection change. Update the existing scroll-behaviour tests to assert
no auto-scroll occurs regardless of item visibility.

Co-authored-by: Cursor <cursoragent@cursor.com>
