### PR TITLE
Codex: exclude archived plans from Plans tab count

### DIFF
--- a/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
+++ b/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
@@ -171,6 +171,11 @@ export function hashString(s: string): string {
 /** Recursively count tasks from the server task tree response. */
 export function countTasks(node: any): number {
     if (!node) return 0;
+    const nodeName = typeof node.name === 'string' ? node.name.toLowerCase() : '';
+    const relativePath = typeof node.relativePath === 'string' ? node.relativePath.toLowerCase() : '';
+    if (nodeName === 'archive' || relativePath === 'archive' || relativePath.startsWith('archive/')) {
+        return 0;
+    }
     let count = 0;
     if (node.singleDocuments) count += node.singleDocuments.length;
     if (node.documentGroups) count += node.documentGroups.length;

--- a/packages/coc/test/spa/react/ReposView.test.tsx
+++ b/packages/coc/test/spa/react/ReposView.test.tsx
@@ -257,6 +257,17 @@ describe('countTasks', () => {
             children: [{ singleDocuments: [2, 3], documentGroups: [4] }],
         })).toBe(4);
     });
+
+    it('excludes archive folders recursively', () => {
+        expect(countTasks({
+            singleDocuments: [1],
+            children: [
+                { name: 'archive', singleDocuments: [2, 3], documentGroups: [4] },
+                { relativePath: 'archive/sub', singleDocuments: [5] },
+                { name: 'work-items', singleDocuments: [6], children: [{ relativePath: 'archive', singleDocuments: [7] }] },
+            ],
+        })).toBe(2);
+    });
 });
 
 describe('truncatePath', () => {


### PR DESCRIPTION
### Motivation
- The Plans badge and repo-level plan counts currently include items inside the `archive` folder, causing the displayed number to include archived plans.
- The intention is to show only active (non-archived) plans in the Plans tab count.

### Description
- Update `countTasks` to ignore any node whose `name` is `archive` or whose `relativePath` is `archive` or starts with `archive/`, ensuring archived folders and nested archive paths are excluded from counts (`packages/coc/src/server/spa/client/react/repos/repoGrouping.ts`).
- Add a regression test to assert archived folders (including nested `archive/...`) are excluded while active plan folders are still counted (`packages/coc/test/spa/react/ReposView.test.tsx`).

### Testing
- Built the monorepo packages with `npm run build:packages`, which completed successfully.
- Ran the related unit tests with `cd packages/coc && npm run test:run -- test/spa/react/ReposView.test.tsx`, and the test file passed (`88 tests` passed in the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d51878b088322bc9d33f2e51f2c42)