### PR TITLE
fix(coc): stabilize flaky E2E streaming and empty-conversation tests

### DIFF
--- a/packages/coc/test/e2e/queue-conversation-coverage.spec.ts
+++ b/packages/coc/test/e2e/queue-conversation-coverage.spec.ts
@@ -1199,8 +1199,15 @@ test.describe('Empty Conversation Fallback', () => {
             });
 
             // Intercept process API to return empty conversation (clear all paths getConversationTurns checks)
-            await page.route(`**/api/processes/**`, async (route) => {
-                const originalResponse = await route.fetch();
+            const routePattern = `**/api/processes/**`;
+            await page.route(routePattern, async (route) => {
+                let originalResponse;
+                try {
+                    originalResponse = await route.fetch();
+                } catch {
+                    // Browser/server may close during cleanup; abort silently
+                    return route.abort().catch(() => {});
+                }
                 const body = await originalResponse.json().catch(() => ({}));
 
                 if (body?.process) {
@@ -1217,13 +1224,16 @@ test.describe('Empty Conversation Fallback', () => {
                     status: originalResponse.status(),
                     contentType: 'application/json',
                     body: JSON.stringify(body),
-                });
+                }).catch(() => {});
             });
 
             await gotoQueueTask(page, serverUrl, wsId, task.id as string);
 
             // Should show "No conversation data available." text
             await expect(page.locator('text=No conversation data available.')).toBeVisible({ timeout: 5_000 });
+
+            // Unroute before cleanup to avoid stale route handlers
+            await page.unroute(routePattern);
         } finally {
             cleanup();
         }

--- a/packages/coc/test/e2e/queue-conversation.spec.ts
+++ b/packages/coc/test/e2e/queue-conversation.spec.ts
@@ -278,19 +278,12 @@ test.describe('Queue Task Conversation – Streaming', () => {
     test('updates message content progressively as chunks arrive', async ({ page, serverUrl, mockAI }) => {
         const { wsId, cleanup } = await makeWorkspace(serverUrl, 'stream-2');
         try {
-            mockAI.mockSendMessage.mockImplementation(async (opts: any) => {
-                // Wait for SSE to connect
-                await new Promise((r) => setTimeout(r, 2500));
-                if (opts && opts.onStreamingChunk) {
-                    opts.onStreamingChunk('First');
-                    await new Promise((r) => setTimeout(r, 500));
-                    opts.onStreamingChunk(' second');
-                    await new Promise((r) => setTimeout(r, 500));
-                    opts.onStreamingChunk(' third');
-                }
-                await new Promise((r) => setTimeout(r, 1000));
-                return { success: true, response: 'First second third', sessionId: 'sess-prog' };
+            const chunks = ['First', ' second', ' third'];
+            const { implementation, gate } = mockAI.createGatedStreamingResponse(chunks, {
+                finalResponse: 'First second third',
+                sessionId: 'sess-prog',
             });
+            mockAI.mockSendMessage.mockImplementation(implementation);
 
             const task = await seedQueueTask(serverUrl, {
                 repoId: wsId,
@@ -298,15 +291,24 @@ test.describe('Queue Task Conversation – Streaming', () => {
             });
             const taskId = task.id as string;
 
+            const sseConnected = page.waitForRequest(req => req.url().includes('/stream'), { timeout: 10_000 });
             await gotoQueueTask(page, serverUrl, wsId, taskId);
 
-            // Wait for progressive content (timeline may render each chunk as separate content div)
-            await expect(page.locator('.chat-message.assistant').last())
-                .toContainText('First', { timeout: 8000 });
+            // Wait for SSE to be fully established before releasing chunks
+            await expect(page.locator('.streaming-indicator')).toBeVisible({ timeout: 8000 });
+            await sseConnected;
 
-            // Full content eventually
-            await expect(page.locator('.chat-message.assistant').last())
-                .toContainText('First second third', { timeout: 8000 });
+            const bubbleContent = page.locator('.chat-message.assistant').last().locator('.chat-message-content');
+
+            // Release chunks one at a time and verify progressive content
+            await gate.releaseNext();
+            await expect(bubbleContent).toContainText('First', { timeout: 5000 });
+
+            await gate.releaseNext();
+            await expect(bubbleContent).toContainText('First second', { timeout: 5000 });
+
+            await gate.releaseNext();
+            await expect(bubbleContent).toContainText('First second third', { timeout: 5000 });
         } finally {
             cleanup();
         }


### PR DESCRIPTION
## Problem
Two E2E tests in shard 3 fail intermittently on CI:

1. **\queue-conversation.spec.ts\ – 'updates message content progressively as chunks arrive'**
   - Root cause: The 2500ms initial delay before releasing streaming chunks was insufficient for CI runners to complete page load + SSE EventSource connection. Chunks fired before the listener was ready, resulting in only \'First'\ being received instead of \'First second third'\.

2. **\queue-conversation-coverage.spec.ts\ – 'shows no conversation data message when turns array is empty'**
   - Root cause: The \page.route()\ interceptor's \oute.fetch()\ call throws \Target page, context or browser has been closed\ or \ECONNREFUSED\ when the browser/server closes during test cleanup while the route handler is still active.

## Fix

1. **Streaming test**: Replaced raw timing with the existing \ChunkGate\ mechanism (already used in section 8 tests). Now explicitly waits for \streaming-indicator\ visibility + SSE request before releasing chunks one-by-one, making the test fully deterministic.

2. **Empty conversation test**: Added try/catch around \oute.fetch()\ to gracefully handle browser/server closure. Also calls \page.unroute()\ before cleanup to prevent stale route handlers from firing during teardown.