### PR TITLE
feat(skills): include loop in default bundled skills

### DIFF
--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -366,6 +366,7 @@ export const DEFAULT_BUNDLED_SKILLS: readonly string[] = [
     'for-each',
     'map-reduce',
     'grill-me',
+    'loop',
 ];
 
 /** Default configuration values */

--- a/packages/coc/test/config/skills-config.test.ts
+++ b/packages/coc/test/config/skills-config.test.ts
@@ -31,6 +31,12 @@ describe('skills config', () => {
         expect(config.skills.defaultSkills).toContain('grill-me');
     });
 
+    it('includes loop in default bundled skills', () => {
+        const config = resolveConfig(undefined, undefined);
+        expect(DEFAULT_BUNDLED_SKILLS).toContain('loop');
+        expect(config.skills.defaultSkills).toContain('loop');
+    });
+
     it('can be disabled via override', () => {
         const config = mergeConfig(DEFAULT_CONFIG, { skills: { autoUpdate: false } });
         expect(config.skills.autoUpdate).toBe(false);


### PR DESCRIPTION
## Summary
- Add `loop` to `DEFAULT_BUNDLED_SKILLS` in `packages/coc/src/config.ts` so the loop skill auto-installs into `~/.coc/skills/` on first `coc serve` startup.
- Add a `skills-config.test.ts` case asserting `loop` is in both `DEFAULT_BUNDLED_SKILLS` and the resolved `defaultSkills`, matching the existing pattern for `grill-me`, `for-each`, and `map-reduce`.

## Test plan
- [x] `npm run test:run -w packages/coc -- test/config/skills-config.test.ts` (8 passed)
- [x] `npm run test:run -w packages/coc -- test/config.test.ts test/config/ test/server/bundled-grill-me-skill.test.ts` (247 passed)
- [x] `npm run build -w packages/coc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)