### PR TITLE
fix(ci): add teams-bot build step to e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,10 @@ jobs:
         run: npm run build
         working-directory: packages/coc-client
 
+      - name: Build teams-bot package
+        run: npm run build
+        working-directory: packages/teams-bot
+
       - name: Build coc SPA client bundle
         run: npm run build:client
         working-directory: packages/coc


### PR DESCRIPTION
The e2e job was missing the teams-bot build step, causing coc build to fail with 'Cannot find module @plusplusoneplusplus/teams-bot'. The test job already had this step; the e2e job was not updated when teams-bot was added as a coc dependency.