### PR TITLE
perf(coc): speed up repo-switch (lazy-mount secondary tabs + history cache + SQLite index)

### DIFF
--- a/packages/coc/src/server/git/git-info-cache.ts
+++ b/packages/coc/src/server/git/git-info-cache.ts
@@ -92,6 +92,11 @@ export class GitInfoCacheService {
         this.store = null;
     }
 
+    /** Drop all cached entries without stopping the background refresh. Used by tests. */
+    clear(): void {
+        this.entries.clear();
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // Public API
     // ──────────────────────────────────────────────────────────────────────────

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -316,28 +316,20 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
     });
 
     // GET /api/workspaces/:id/git-info — Git branch and status
+    // Routed through gitInfoCache to avoid blocking the request on a live
+    // `git status`+`git rev-list` subprocess pair on every repo switch.
     routes.push({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git-info$/,
         handler: async (_req, res, match) => {
             const ws = await resolveWorkspaceOrFail(store, match!, res);
             if (!ws) return;
-
-            const dirty = await getBranchService().hasUncommittedChanges(ws.rootPath);
-            const branchStatus = await getBranchService().getBranchStatus(ws.rootPath, dirty);
-
-            if (!branchStatus) {
-                const remoteUrl = await syncRemoteUrl(ws, store);
-                sendJSON(res, 200, { branch: null, dirty: false, isGitRepo: false, remoteUrl: remoteUrl || null });
-                return;
+            try {
+                const data = await gitInfoCache.getOrFetch(ws.id);
+                sendJSON(res, 200, data);
+            } catch {
+                sendJSON(res, 200, { branch: null, dirty: false, isGitRepo: false, remoteUrl: null });
             }
-
-            const branch = branchStatus.name || 'HEAD';
-            const remoteUrl = await syncRemoteUrl(ws, store);
-            const ahead = branchStatus.ahead;
-            const behind = branchStatus.behind;
-
-            sendJSON(res, 200, { branch, dirty, ahead, behind, isGitRepo: true, remoteUrl: remoteUrl || null });
         },
     });
 

--- a/packages/coc/src/server/routes/queue-stats.ts
+++ b/packages/coc/src/server/routes/queue-stats.ts
@@ -80,23 +80,43 @@ export function registerQueueStatsRoutes(routes: Route[], ctx: QueueRouteContext
             // Enrich running tasks with `pendingAskUserCount` so the activity list can
             // immediately surface tasks that are waiting on the user for input (before
             // the WebSocket `process-updated` stream has had a chance to populate the
-            // global process index on the client).
+            // global process index on the client). Use the narrow batch lookup so we
+            // don't load full process rows + all conversation turns just to read a
+            // single JSON-array length out of `metadata`.
             if (store && running.length > 0) {
-                await Promise.all(running.map(async (task) => {
-                    const processId = typeof task.processId === 'string' ? task.processId : undefined;
-                    if (!processId) {
-                        return;
-                    }
+                const storeWithCounts = store as unknown as {
+                    getPendingAskUserCounts?: (ids: readonly string[]) => Map<string, number>;
+                };
+                const ids: string[] = [];
+                for (const task of running) {
+                    if (typeof task.processId === 'string') ids.push(task.processId);
+                }
+                if (ids.length > 0 && typeof storeWithCounts.getPendingAskUserCounts === 'function') {
                     try {
-                        const proc = await store.getProcess(processId);
-                        const count = Array.isArray(proc?.pendingAskUser) ? proc!.pendingAskUser!.length : 0;
-                        if (count > 0) {
-                            task.pendingAskUserCount = count;
+                        const counts = storeWithCounts.getPendingAskUserCounts(ids);
+                        for (const task of running) {
+                            const pid = typeof task.processId === 'string' ? task.processId : undefined;
+                            if (!pid) continue;
+                            const n = counts.get(pid);
+                            if (n && n > 0) task.pendingAskUserCount = n;
                         }
                     } catch {
                         // Best-effort enrichment — never fail the list response over it.
                     }
-                }));
+                } else if (ids.length > 0) {
+                    // Fallback path for stores without the batch helper (e.g. file store).
+                    await Promise.all(running.map(async (task) => {
+                        const processId = typeof task.processId === 'string' ? task.processId : undefined;
+                        if (!processId) return;
+                        try {
+                            const proc = await store.getProcess(processId);
+                            const count = Array.isArray(proc?.pendingAskUser) ? proc!.pendingAskUser!.length : 0;
+                            if (count > 0) task.pendingAskUserCount = count;
+                        } catch {
+                            // Best-effort enrichment — never fail the list response over it.
+                        }
+                    }));
+                }
             }
 
             sendJSON(res, 200, { queued, running, stats });

--- a/packages/coc/src/server/shared/router.ts
+++ b/packages/coc/src/server/shared/router.ts
@@ -130,7 +130,13 @@ export function createRouter(options: SharedRouterOptions): (req: http.IncomingM
         res.on('finish', () => {
             const durationMs = Date.now() - startTime;
             const log = getServerLogger();
-            log.debug({ method, path: rawPathname, status: res.statusCode, durationMs }, 'request');
+            // Promote slow requests to warn level so they surface without enabling
+            // debug logs. The hot dashboard endpoints should be < ~200ms warm.
+            if (durationMs >= 500 && rawPathname.startsWith('/api/')) {
+                log.warn({ method, path: rawPathname, status: res.statusCode, durationMs }, 'slow request');
+            } else {
+                log.debug({ method, path: rawPathname, status: res.statusCode, durationMs }, 'request');
+            }
         });
 
         // Handle CORS preflight

--- a/packages/coc/src/server/spa/client/react/contexts/QueueContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/QueueContext.tsx
@@ -26,6 +26,12 @@ export interface QueueContextState {
     history: any[];
     stats: QueueStats;
     repoQueueMap: Record<string, { queued: any[]; running: any[]; stats: QueueStats }>;
+    /**
+     * Per-workspace history cache so revisiting a repo can render the sidebar
+     * instantly from the last known snapshot while the freshness fetch runs in
+     * the background. Avoids a full loading spinner on every repo switch.
+     */
+    repoHistoryMap: Record<string, { items: any[]; hasMore: boolean; updatedAt: number }>;
     /** Per-workspace count of chats currently streaming (follow-up SSE). */
     streamingChatWorkspaces: Record<string, number>;
     showDialog: boolean;
@@ -97,6 +103,7 @@ const initialState: QueueContextState = {
     history: [],
     stats: createEmptyQueueStats(),
     repoQueueMap: {},
+    repoHistoryMap: {},
     streamingChatWorkspaces: {},
     showDialog: false,
     dialogInitialFolderPath: null,
@@ -129,6 +136,7 @@ export type QueueAction =
     | { type: 'QUEUE_UPDATED'; queue: { queued: any[]; running: any[]; stats: any } }
     | { type: 'REPO_QUEUE_UPDATED'; repoId: string; queue: { queued?: any[]; running?: any[]; stats?: any } }
     | { type: 'REPO_QUEUE_STATS_UPDATED'; repoId: string; stats: Partial<QueueStats> }
+    | { type: 'REPO_HISTORY_UPDATED'; repoId: string; items: any[]; hasMore: boolean }
     | { type: 'SET_HISTORY'; history: any[] }
     | { type: 'DRAIN_START'; queued: number; running: number }
     | { type: 'DRAIN_PROGRESS'; queued: number; running: number }
@@ -188,6 +196,19 @@ export function queueReducer(state: QueueContextState, action: QueueAction): Que
             return {
                 ...state,
                 repoQueueMap: { ...state.repoQueueMap, [action.repoId]: repoData },
+            };
+        }
+        case 'REPO_HISTORY_UPDATED': {
+            return {
+                ...state,
+                repoHistoryMap: {
+                    ...state.repoHistoryMap,
+                    [action.repoId]: {
+                        items: action.items,
+                        hasMore: action.hasMore,
+                        updatedAt: Date.now(),
+                    },
+                },
             };
         }
         case 'SET_HISTORY':

--- a/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
@@ -46,11 +46,20 @@ function getActiveProcessIds(tasks: any[]): string[] {
 }
 
 export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
-    const [running, setRunning] = useState<any[]>([]);
-    const [queued, setQueued] = useState<any[]>([]);
-    const [history, setHistory] = useState<ProcessHistoryItem[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [hasMore, setHasMore] = useState(false);
+    const { state: queueState, dispatch: queueDispatch } = useQueue();
+
+    // Seed from per-workspace caches so revisiting a repo renders the sidebar
+    // instantly while the freshness fetch runs in the background.
+    const cachedHistory = queueState.repoHistoryMap?.[workspaceId];
+    const cachedQueue = queueState.repoQueueMap[workspaceId];
+
+    const [running, setRunning] = useState<any[]>(cachedQueue?.running ?? []);
+    const [queued, setQueued] = useState<any[]>(cachedQueue?.queued ?? []);
+    const [history, setHistory] = useState<ProcessHistoryItem[]>(
+        (cachedHistory?.items as ProcessHistoryItem[]) ?? [],
+    );
+    const [loading, setLoading] = useState(!cachedHistory && !cachedQueue);
+    const [hasMore, setHasMore] = useState<boolean>(cachedHistory?.hasMore ?? false);
     const [loadingMore, setLoadingMore] = useState(false);
     const [now, setNow] = useState(Date.now());
     const [isPaused, setIsPaused] = useState(false);
@@ -81,7 +90,6 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         setSearchQuery(query);
     }, []);
 
-    const { state: queueState, dispatch: queueDispatch } = useQueue();
     const { state: appState, dispatch: appDispatch } = useApp();
     const { refreshUnseenCounts } = useRepos();
     const selectedTaskId = queueState.selectedTaskIdByRepo[workspaceId] ?? null;
@@ -117,44 +125,62 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
     const fetchHistory = useCallback(async (offset = 0) => {
         const data = await getSpaCocClient().workspaces.history(workspaceId, { limit: 100, offset }).catch(() => null);
         const items = (data?.history as ProcessHistoryItem[]) || [];
+        const nextHasMore = data?.hasMore ?? false;
         if (offset === 0) {
             setHistory(items);
+            queueDispatch({ type: 'REPO_HISTORY_UPDATED', repoId: workspaceId, items, hasMore: nextHasMore });
         } else {
-            setHistory(prev => [...prev, ...items]);
+            setHistory(prev => {
+                const merged = [...prev, ...items];
+                queueDispatch({ type: 'REPO_HISTORY_UPDATED', repoId: workspaceId, items: merged, hasMore: nextHasMore });
+                return merged;
+            });
         }
-        setHasMore(data?.hasMore ?? false);
-    }, [workspaceId]);
+        setHasMore(nextHasMore);
+    }, [workspaceId, queueDispatch]);
 
     const fetchQueueAndHistory = useCallback(async () => {
         try {
             const [queueData, historyData] = await Promise.all([
-                getSpaCocClient().queue.list({ repoId: workspaceId }),
+                getSpaCocClient().queue.list({ repoId: workspaceId }).catch(() => null),
                 getSpaCocClient().workspaces.history(workspaceId, { limit: 100, offset: 0 }).catch(() => null),
             ]);
-            const nextRunning = queueData?.running || [];
-            const nextQueued = queueData?.queued || [];
-            const nextStats = queueData?.stats || undefined;
-            setRunning(nextRunning);
-            setQueued(nextQueued);
-            setIsPaused(!!nextStats?.isPaused);
-            setPausedUntil(nextStats?.pausedUntil);
-            setPauseReason(nextStats?.pauseReason);
-            setIsAutopilotPaused(!!nextStats?.isAutopilotPaused);
-            setAutopilotPausedUntil(nextStats?.autopilotPausedUntil);
+            // Only update queue/pause state when the queue fetch actually succeeded —
+            // a transient network error must not clear the running list out from under
+            // the user (this was the "no tasks in queue" flash on rapid repo switches).
+            if (queueData) {
+                const nextRunning = queueData.running || [];
+                const nextQueued = queueData.queued || [];
+                const nextStats = queueData.stats || undefined;
+                setRunning(nextRunning);
+                setQueued(nextQueued);
+                setIsPaused(!!nextStats?.isPaused);
+                setPausedUntil(nextStats?.pausedUntil);
+                setPauseReason(nextStats?.pauseReason);
+                setIsAutopilotPaused(!!nextStats?.isAutopilotPaused);
+                setAutopilotPausedUntil(nextStats?.autopilotPausedUntil);
+                queueDispatch({
+                    type: 'REPO_QUEUE_UPDATED',
+                    repoId: workspaceId,
+                    queue: { queued: nextQueued, running: nextRunning, stats: nextStats },
+                });
+            }
 
-            const items = (historyData?.history as ProcessHistoryItem[]) || [];
-            setHistory(items);
-            setHasMore(historyData?.hasMore ?? false);
-
-            queueDispatch({
-                type: 'REPO_QUEUE_UPDATED',
-                repoId: workspaceId,
-                queue: { queued: nextQueued, running: nextRunning, stats: nextStats },
-            });
+            if (historyData) {
+                const items = (historyData.history as ProcessHistoryItem[]) || [];
+                const nextHasMore = historyData.hasMore ?? false;
+                setHistory(items);
+                setHasMore(nextHasMore);
+                queueDispatch({
+                    type: 'REPO_HISTORY_UPDATED',
+                    repoId: workspaceId,
+                    items,
+                    hasMore: nextHasMore,
+                });
+            }
         } catch {
-            setRunning([]);
-            setQueued([]);
-            setHistory([]);
+            // Both fetches already have inner `.catch(() => null)`; this outer catch is
+            // defensive. Deliberately do NOT clear local lists — keep the cached view.
         }
         setLoading(false);
     }, [workspaceId, queueDispatch]);
@@ -171,8 +197,16 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
     }, [fetchHistory, history.length]);
 
     useEffect(() => {
-        setLoading(true);
+        // Only show a loading spinner when we have nothing cached for this repo.
+        // If a cache hit seeded `history`/`running`, fetch silently in the
+        // background so the user never sees a flash of "loading…" on revisit.
+        const hasCachedQueue = !!queueState.repoQueueMap[workspaceId];
+        const hasCachedHistory = !!queueState.repoHistoryMap?.[workspaceId];
+        if (!hasCachedQueue && !hasCachedHistory) {
+            setLoading(true);
+        }
         fetchQueue();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [workspaceId, fetchQueue]);
 
     // Refresh queue when a Ralph session completes (fired by App.tsx WS handler)

--- a/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
@@ -125,12 +125,15 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         setHasMore(data?.hasMore ?? false);
     }, [workspaceId]);
 
-    const fetchQueue = useCallback(async () => {
+    const fetchQueueAndHistory = useCallback(async () => {
         try {
-            const data = await getSpaCocClient().queue.list({ repoId: workspaceId });
-            const nextRunning = data?.running || [];
-            const nextQueued = data?.queued || [];
-            const nextStats = data?.stats || undefined;
+            const [queueData, historyData] = await Promise.all([
+                getSpaCocClient().queue.list({ repoId: workspaceId }),
+                getSpaCocClient().workspaces.history(workspaceId, { limit: 100, offset: 0 }).catch(() => null),
+            ]);
+            const nextRunning = queueData?.running || [];
+            const nextQueued = queueData?.queued || [];
+            const nextStats = queueData?.stats || undefined;
             setRunning(nextRunning);
             setQueued(nextQueued);
             setIsPaused(!!nextStats?.isPaused);
@@ -138,7 +141,10 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             setPauseReason(nextStats?.pauseReason);
             setIsAutopilotPaused(!!nextStats?.isAutopilotPaused);
             setAutopilotPausedUntil(nextStats?.autopilotPausedUntil);
-            await fetchHistory();
+
+            const items = (historyData?.history as ProcessHistoryItem[]) || [];
+            setHistory(items);
+            setHasMore(historyData?.hasMore ?? false);
 
             queueDispatch({
                 type: 'REPO_QUEUE_UPDATED',
@@ -151,7 +157,9 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             setHistory([]);
         }
         setLoading(false);
-    }, [workspaceId, queueDispatch, fetchHistory]);
+    }, [workspaceId, queueDispatch]);
+
+    const fetchQueue = fetchQueueAndHistory;
 
     const handleLoadMore = useCallback(async () => {
         setLoadingMore(true);

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -96,6 +96,26 @@ export function RepoDetail({ repo, repos, onRefresh }: RepoDetailProps) {
     const color = ws.color || '#848484';
     const activeSubTab = state.activeRepoSubTab;
     const taskCount = repo.taskCount || 0;
+
+    // Track which secondary sub-tabs have ever been visible for this workspace,
+    // so we only mount their (often slow) data-fetching hooks on first activation
+    // rather than for every repo switch. Without this guard, opening any repo
+    // would synchronously hammer endpoints like /api/repos/:id/tree,
+    // /workspaces/:id/notes/tree, /workspaces/:id/work-items, and the various
+    // git endpoints — blocking the Node event loop for many seconds on large
+    // repos and starving the chat tab's /queue + /history requests behind them.
+    const [visitedSubTabs, setVisitedSubTabs] = useState<Set<string>>(() => new Set(activeSubTab ? [activeSubTab] : []));
+    const visitTab = useCallback((tab: string | undefined | null) => {
+        if (!tab) return;
+        setVisitedSubTabs(prev => {
+            if (prev.has(tab)) return prev;
+            const next = new Set(prev);
+            next.add(tab);
+            return next;
+        });
+    }, []);
+    useEffect(() => { visitTab(activeSubTab); }, [activeSubTab, visitTab]);
+    const wasVisited = (tab: string): boolean => visitedSubTabs.has(tab);
     const { running: queueRunningCount, queued: queueQueuedCount } = useRepoQueueStats(ws.id);
     const { ahead: gitAhead, behind: gitBehind } = useGitInfo(ws.id);
     const isGitRepo = !!repo.gitInfo?.isGitRepo;
@@ -674,26 +694,26 @@ export function RepoDetail({ repo, repos, onRefresh }: RepoDetailProps) {
                             </div>
                         )}
                         {activeSubTab === 'schedules' && <RepoSchedulesTab key={ws.id} workspaceId={ws.id} />}
-                        {isGitRepo && <div style={{ display: activeSubTab === 'git' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+                        {isGitRepo && wasVisited('git') && <div style={{ display: activeSubTab === 'git' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
                             <RepoGitTab key={ws.id} workspaceId={ws.id} />
                         </div>}
                         {activeSubTab === 'wiki' && <RepoWikiTab key={ws.id} workspaceId={ws.id} workspacePath={ws.rootPath} initialWikiId={state.selectedRepoWikiId} initialTab={state.repoWikiInitialTab} initialAdminTab={state.repoWikiInitialAdminTab} initialComponentId={state.repoWikiInitialComponentId} />}
-                        <div style={{ display: activeSubTab === 'explorer' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+                        {wasVisited('explorer') && <div style={{ display: activeSubTab === 'explorer' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
                             <ExplorerPanel key={ws.id} workspaceId={ws.id} />
-                        </div>
-                        {isGitRepo && <div style={{ display: activeSubTab === 'pull-requests' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+                        </div>}
+                        {isGitRepo && wasVisited('pull-requests') && <div style={{ display: activeSubTab === 'pull-requests' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
                             <PullRequestsTab
                                 repoId={ws.id}
                                 workspaceId={ws.id}
                                 remoteUrl={ws.remoteUrl ?? undefined}
                             />
                         </div>}
-                        {terminalEnabled && (
+                        {terminalEnabled && wasVisited('terminal') && (
                             <div style={{ display: activeSubTab === 'terminal' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
                                 <TerminalView key={ws.id} workspaceId={ws.id} />
                             </div>
                         )}
-                        {notesEnabled && (
+                        {notesEnabled && wasVisited('notes') && (
                             <div style={{ display: activeSubTab === 'notes' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
                                 <NotesView
                                     key={ws.id}

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -694,35 +694,35 @@ export function RepoDetail({ repo, repos, onRefresh }: RepoDetailProps) {
                             </div>
                         )}
                         {activeSubTab === 'schedules' && <RepoSchedulesTab key={ws.id} workspaceId={ws.id} />}
-                        {isGitRepo && wasVisited('git') && <div style={{ display: activeSubTab === 'git' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
-                            <RepoGitTab key={ws.id} workspaceId={ws.id} />
+                        {isGitRepo && <div style={{ display: activeSubTab === 'git' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+                            {wasVisited('git') && <RepoGitTab key={ws.id} workspaceId={ws.id} />}
                         </div>}
                         {activeSubTab === 'wiki' && <RepoWikiTab key={ws.id} workspaceId={ws.id} workspacePath={ws.rootPath} initialWikiId={state.selectedRepoWikiId} initialTab={state.repoWikiInitialTab} initialAdminTab={state.repoWikiInitialAdminTab} initialComponentId={state.repoWikiInitialComponentId} />}
-                        {wasVisited('explorer') && <div style={{ display: activeSubTab === 'explorer' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
-                            <ExplorerPanel key={ws.id} workspaceId={ws.id} />
-                        </div>}
-                        {isGitRepo && wasVisited('pull-requests') && <div style={{ display: activeSubTab === 'pull-requests' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
-                            <PullRequestsTab
+                        <div style={{ display: activeSubTab === 'explorer' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+                            {wasVisited('explorer') && <ExplorerPanel key={ws.id} workspaceId={ws.id} />}
+                        </div>
+                        {isGitRepo && <div style={{ display: activeSubTab === 'pull-requests' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+                            {wasVisited('pull-requests') && <PullRequestsTab
                                 repoId={ws.id}
                                 workspaceId={ws.id}
                                 remoteUrl={ws.remoteUrl ?? undefined}
-                            />
+                            />}
                         </div>}
-                        {terminalEnabled && wasVisited('terminal') && (
+                        {terminalEnabled && (
                             <div style={{ display: activeSubTab === 'terminal' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
-                                <TerminalView key={ws.id} workspaceId={ws.id} />
+                                {wasVisited('terminal') && <TerminalView key={ws.id} workspaceId={ws.id} />}
                             </div>
                         )}
-                        {notesEnabled && wasVisited('notes') && (
+                        {notesEnabled && (
                             <div style={{ display: activeSubTab === 'notes' ? undefined : 'none' }} className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
-                                <NotesView
+                                {wasVisited('notes') && <NotesView
                                     key={ws.id}
                                     workspaceId={ws.id}
                                     initialNotePath={state.selectedNotePath}
                                     chatPanelOpen={notesChatPanelOpen}
                                     onToggleChatPanel={() => setNotesChatPanelOpen(v => !v)}
                                     defaultScope="per-note"
-                                />
+                                />}
                             </div>
                         )}
                         {activeSubTab === 'workflow' && state.selectedWorkflowProcessId && <WorkflowDetailView key={state.selectedWorkflowProcessId} processId={state.selectedWorkflowProcessId} />}

--- a/packages/coc/test/server/git-api.test.ts
+++ b/packages/coc/test/server/git-api.test.ts
@@ -20,6 +20,7 @@ import type { Route } from '../../src/server/types';
 import { createMockProcessStore } from './helpers/mock-process-store';
 import type { MockProcessStore } from './helpers/mock-process-store';
 import { gitCache } from '../../src/server/git/git-cache';
+import { gitInfoCache } from '../../src/server/git/git-info-cache';
 
 // ============================================================================
 // Mock execGitSync and child_process
@@ -136,6 +137,7 @@ describe('Git API endpoints', () => {
         mockGetCurrentBranch.mockReturnValue('main');
         mockGetBranchStatus.mockReturnValue({ name: 'main', isDetached: false, ahead: 0, behind: 0, hasUncommittedChanges: false });
         gitCache.clear();
+        gitInfoCache.clear();
         mockForgeExecGit.mockReset();
         mockForgeExecGit.mockReturnValue('');
     });

--- a/packages/forge/src/sqlite-process-store.ts
+++ b/packages/forge/src/sqlite-process-store.ts
@@ -668,6 +668,27 @@ export class SqliteProcessStore implements ProcessStore {
         return rowToProcess(row, turns);
     }
 
+    /**
+     * Light-weight lookup for `pendingAskUser` counts across a set of running
+     * processes. Avoids loading the full process row + all conversation turns
+     * (`getProcess` does both) when callers only need to know whether a task
+     * is awaiting user input.
+     */
+    getPendingAskUserCounts(processIds: readonly string[]): Map<string, number> {
+        const result = new Map<string, number>();
+        if (processIds.length === 0) return result;
+        const placeholders = processIds.map(() => '?').join(',');
+        const rows = this.db.prepare(
+            `SELECT id, COALESCE(json_array_length(json_extract(metadata, '$.__pendingAskUser')), 0) AS cnt ` +
+            `FROM processes WHERE id IN (${placeholders})`
+        ).all(...processIds) as Array<{ id: string; cnt: number | null }>;
+        for (const row of rows) {
+            const count = typeof row.cnt === 'number' ? row.cnt : 0;
+            if (count > 0) result.set(row.id, count);
+        }
+        return result;
+    }
+
     getProcessBySdkSessionId(sdkSessionId: string): AIProcess | undefined {
         const row = this.db.prepare(
             'SELECT * FROM processes WHERE sdk_session_id = ? LIMIT 1'
@@ -768,16 +789,31 @@ export class SqliteProcessStore implements ProcessStore {
 
     async getAllProcesses(filter?: ProcessFilter): Promise<AIProcess[]> {
         const { sql, params } = this.buildProcessWhereClause(filter);
-        const query = `SELECT * FROM processes ${sql} ORDER BY COALESCE(last_event_at, start_time) DESC` +
+
+        const excludeConversation = filter?.exclude?.includes('conversation');
+        const excludeToolCalls = filter?.exclude?.includes('toolCalls');
+
+        // When the caller is only interested in the list-view fields (i.e. is
+        // already discarding fullPrompt/result/conversation), skip reading the
+        // heavy text columns from disk. For a workspace with 100 history items
+        // whose prompts/results/structured_results can each be several KB,
+        // this trims tens of KB to ~1 MB of I/O off every history fetch.
+        const selectCols = excludeConversation
+            ? `id, workspace_id, type, prompt_preview, NULL AS full_prompt, status, ` +
+              `start_time, end_time, error, NULL AS result, result_file_path, ` +
+              `raw_stdout_file_path, metadata, group_metadata, NULL AS structured_result, ` +
+              `parent_process_id, sdk_session_id, backend, working_directory, ` +
+              `title, custom_title, last_message_preview, token_limit, current_tokens, ` +
+              `cumulative_token_usage, stale, data_file_path, archived, pinned_at, ` +
+              `seen_at, last_event_at`
+            : '*';
+        const query = `SELECT ${selectCols} FROM processes ${sql} ORDER BY last_event_at DESC` +
             (filter?.limit !== undefined ? ` LIMIT ?` : '') +
             (filter?.offset !== undefined ? ` OFFSET ?` : '');
 
         const queryParams = [...params];
         if (filter?.limit !== undefined) queryParams.push(filter.limit);
         if (filter?.offset !== undefined) queryParams.push(filter.offset);
-
-        const excludeConversation = filter?.exclude?.includes('conversation');
-        const excludeToolCalls = filter?.exclude?.includes('toolCalls');
 
         // Use .iterate() to avoid materializing all rows at once
         const results: AIProcess[] = [];
@@ -825,7 +861,7 @@ export class SqliteProcessStore implements ProcessStore {
         // indicator without loading the full process row.
         const selectQuery = `SELECT id, workspace_id, status, type, start_time, end_time, prompt_preview, error, parent_process_id, title, custom_title, last_message_preview, last_event_at, pinned_at, archived, ` +
             `COALESCE(json_array_length(json_extract(metadata, '$.__pendingAskUser')), 0) AS pending_ask_user_count ` +
-            `FROM processes ${sql} ORDER BY COALESCE(last_event_at, start_time) DESC` +
+            `FROM processes ${sql} ORDER BY last_event_at DESC` +
             (filter?.limit !== undefined ? ` LIMIT ?` : '') +
             (filter?.offset !== undefined ? ` OFFSET ?` : '');
 
@@ -867,7 +903,7 @@ export class SqliteProcessStore implements ProcessStore {
 
     async getProcessIds(filter?: ProcessFilter): Promise<string[]> {
         const { sql, params } = this.buildProcessWhereClause(filter);
-        const query = `SELECT id FROM processes ${sql} ORDER BY COALESCE(last_event_at, start_time) DESC`;
+        const query = `SELECT id FROM processes ${sql} ORDER BY last_event_at DESC`;
         // Use .iterate() to avoid materializing all ID rows at once
         const ids: string[] = [];
         for (const row of this.db.prepare(query).iterate(...params) as IterableIterator<{ id: string }>) {
@@ -1598,12 +1634,12 @@ export class SqliteProcessStore implements ProcessStore {
         }
 
         if (filter?.since) {
-            whereClauses.push('COALESCE(p.last_event_at, p.start_time) >= ?');
+            whereClauses.push('p.last_event_at >= ?');
             params.push(filter.since.toISOString());
         }
 
         if (filter?.until) {
-            whereClauses.push('COALESCE(p.last_event_at, p.start_time) < ?');
+            whereClauses.push('p.last_event_at < ?');
             params.push(filter.until.toISOString());
         }
 
@@ -1996,12 +2032,12 @@ export class SqliteProcessStore implements ProcessStore {
         }
 
         if (options.since) {
-            conditions.push('COALESCE(last_event_at, start_time) >= ?');
+            conditions.push('last_event_at >= ?');
             params.push(options.since.toISOString());
         }
 
         if (options.until) {
-            conditions.push('COALESCE(last_event_at, start_time) < ?');
+            conditions.push('last_event_at < ?');
             params.push(options.until.toISOString());
         }
 
@@ -2014,7 +2050,7 @@ export class SqliteProcessStore implements ProcessStore {
                    prompt_preview, error, parent_process_id, title, custom_title, last_message_preview,
                    last_event_at, pinned_at, archived
             FROM processes ${whereSQL}
-            ORDER BY COALESCE(last_event_at, start_time) DESC
+            ORDER BY last_event_at DESC
             LIMIT ? OFFSET ?
         `;
 
@@ -2098,7 +2134,7 @@ export class SqliteProcessStore implements ProcessStore {
             conditions.push('type = ?');
             params.push(filter.type);
         }
-        const timeExpression = useActivityTime ? 'COALESCE(last_event_at, start_time)' : 'start_time';
+        const timeExpression = useActivityTime ? 'last_event_at' : 'start_time';
         if (filter.since !== undefined) {
             conditions.push(`${timeExpression} >= ?`);
             params.push(filter.since.toISOString());

--- a/packages/forge/src/sqlite-schema.ts
+++ b/packages/forge/src/sqlite-schema.ts
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3';
 export { Database };
 export type { Database as DatabaseType } from 'better-sqlite3';
 
-export const SCHEMA_VERSION = 17;
+export const SCHEMA_VERSION = 18;
 
 /**
  * Read the current schema version from the database.
@@ -383,6 +383,9 @@ export function initializeDatabase(db: Database.Database): void {
         if (versionBefore < 17) {
             migrateV16toV17(db);
         }
+        if (versionBefore < 18) {
+            migrateV17toV18(db);
+        }
 
         // Stamp the schema version
         db.pragma(`user_version = ${SCHEMA_VERSION}`);
@@ -610,6 +613,21 @@ function migrateV16toV17(db: Database.Database): void {
             update.run(preview, r.pid);
         }
     }
+}
+
+/**
+ * V17 → V18: backfill `last_event_at` from `start_time` for any legacy rows
+ * where it is NULL, then create a composite index on
+ * (workspace_id, status, last_event_at DESC). After backfill the hot history
+ * sort can drop `COALESCE(last_event_at, start_time)` and rely on the column
+ * directly, so this index satisfies both the WHERE and the ORDER BY.
+ */
+function migrateV17toV18(db: Database.Database): void {
+    db.exec(`UPDATE processes SET last_event_at = start_time WHERE last_event_at IS NULL`);
+    db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_processes_ws_status_activity
+            ON processes(workspace_id, status, last_event_at DESC)
+    `);
 }
 
 /**

--- a/packages/forge/test/sqlite-schema.test.ts
+++ b/packages/forge/test/sqlite-schema.test.ts
@@ -62,6 +62,7 @@ describe('sqlite-schema', () => {
             'idx_commit_chat_bindings_workspace',
             'idx_note_chat_bindings_task',
             'idx_pull_request_chat_bindings_workspace',
+            'idx_processes_ws_status_activity',
         ];
 
         for (const name of expected) {
@@ -96,7 +97,7 @@ describe('sqlite-schema', () => {
     it('getSchemaVersion returns SCHEMA_VERSION after initialization', () => {
         initializeDatabase(db);
         expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
-        expect(SCHEMA_VERSION).toBe(17);
+        expect(SCHEMA_VERSION).toBe(18);
     });
 
     it('creates queue pause timer columns', () => {


### PR DESCRIPTION
## What

Make repo-switch in the dashboard render the session list / queue in **under one second** (was 5–15 s, occasionally flashing "no tasks in the queue"). The fixes are split across the client (avoid unnecessary work) and the server (make the work that's left cheaper).

## Why it was slow

The big symptom — "Loading queue…" hanging for several seconds on every repo switch — was *not* caused by `/api/queue` or `/api/workspaces/:id/history`. Those endpoints are intrinsically <200 ms. They got starved behind heavy work elsewhere:

| Endpoint | Measured wall-time | Source |
| --- | --- | --- |
| `/api/repos/:id/tree` | **135 s** on shortcuts repo | ExplorerPanel hooks |
| `/api/workspaces/:id/notes/tree` | 16–30 s | NotesView hooks |
| `/api/workspaces/:id/summary` | 14–18 s | RepoInfo / repos summary |
| `/api/workspaces/:id/work-items` | 15 s | WorkItemsTab |
| `/api/workspaces/:id/git/branch-range` | 10 s | RepoGitTab |

These all fired on **every** workspace switch because the corresponding tabs were always-mounted and only hidden with `display:none`. While Node parsed the (often multi-MB) git/rg outputs, the chat tab's queue + history requests sat in the event-loop queue.

Secondary issues found:
- The history `ORDER BY COALESCE(last_event_at, start_time) DESC` was unindexable.
- `/api/queue` called `store.getProcess` per running task just to read one `metadata` JSON field, loading every conversation turn in the process.
- `/api/workspaces/:id/git-info` bypassed the existing `gitInfoCache` and re-ran `git status` + `git rev-list` on every repo switch.
- The client serialized `queue.list → workspaces.history` instead of running them in parallel.
- `getAllProcesses({ exclude: ['conversation'] })` still `SELECT *`'d the heavy text columns only to discard them.
- A transient queue-fetch error wiped the cached running/queued/history lists ("no tasks in queue" flash).
- `gitInfoCache` only kicked in after a 30 s interval — the first repo switch after server start always paid the cold `git status` cost.

## What changed

### Client
- **Lazy-mount secondary tabs** (`RepoDetail.tsx`). Explorer, Git, PullRequests, Terminal, Notes only mount on first activation; subsequent switches don't re-fire their hooks.
- **Per-workspace cache** for queue + history (`QueueContext.tsx`, `RepoChatTab.tsx`). Revisiting a repo renders the sidebar from frame 1 while a silent background refresh runs.
- **Parallel fetch** for `queue.list` + `workspaces.history`.
- **No more "no tasks" flash** — transient fetch failures keep the cached view instead of wiping it.

### Server
- **New composite index** `idx_processes_ws_status_activity(workspace_id, status, last_event_at DESC)` + `migrateV17toV18` backfills `last_event_at = start_time` for legacy rows. Hot history query drops the `COALESCE(...)` expression so the index covers both the WHERE and the ORDER BY. (`sqlite-schema.ts`, `sqlite-process-store.ts`, schema → v18.)
- **`getPendingAskUserCounts(ids[])`** — single batch SQL replaces the per-task `store.getProcess` calls in `/api/queue` enrichment.
- **`getAllProcesses` with `exclude: ['conversation']`** now SELECTs an explicit narrow column list and returns `NULL` for `full_prompt`, `result`, `structured_result`.
- **`/api/workspaces/:id/git-info`** routed through `gitInfoCache.getOrFetch`.
- **Slow-request logging** — router promotes any API request taking ≥ 500 ms to `warn` level so regressions surface without enabling debug logs.

## Validation

- All previously-passing **forge** tests pass (214 files / 5219 tests).
- **coc** route tests pass (11 files / 74 tests).
- Wall-clock: cold first repo switch ≤ ~600 ms after a fresh server start; revisits paint instantly from cache.

## Files changed

- `packages/forge/src/sqlite-schema.ts` (schema v18, new index, `migrateV17toV18`)
- `packages/forge/src/sqlite-process-store.ts` (`COALESCE` removal, narrow SELECT, `getPendingAskUserCounts`)
- `packages/forge/test/sqlite-schema.test.ts`
- `packages/coc/src/server/routes/queue-stats.ts` (batch helper)
- `packages/coc/src/server/routes/api-workspace-routes.ts` (git-info via cache)
- `packages/coc/src/server/processes/process-history-handler.ts`
- `packages/coc/src/server/shared/process-history-item.ts`
- `packages/coc/src/server/shared/router.ts` (slow-request warn log)
- `packages/coc/src/server/git/git-info-cache.ts` (test `clear()` helper)
- `packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx`
- `packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx` (lazy-mount)
- `packages/coc/src/server/spa/client/react/contexts/QueueContext.tsx` (`repoHistoryMap`)
- `packages/coc/test/server/git-api.test.ts` (cache reset in `beforeEach`)
