### PR TITLE
fix(coc): prioritize AI title over lastMessagePreview in session display

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -1235,13 +1235,13 @@ export function ChatListPane({
         //   2) Latest message preview (denormalized snapshot of newest turn)
         //   3) Prompt-based fallback (truncated)
         //   4) Task type / 'Task'
-        // We intentionally do NOT fall back to `displayName` or AI-generated `title`
-        // in the sidebar — those are shown in the chat header instead.
         const promptText = (task.prompt || task.promptPreview || task.payload?.promptContent || task.payload?.prompt || '') as string;
         const promptFallback = promptText && !/^Use the \S+ skill\.$/.test(promptText)
             ? (promptText.length > 50 ? promptText.substring(0, 47) + '…' : promptText)
             : (task.type === 'chat' ? 'Chat' : (task.type || 'Task'));
+        // Display priority: customTitle → AI title → lastMessagePreview → promptFallback
         const titleText = (task.customTitle as string | undefined)
+            || (task.title as string | undefined)
             || (task.lastMessagePreview as string | undefined)
             || promptFallback;
 

--- a/packages/coc/src/server/spa/client/react/processes/ProcessesSidebar.tsx
+++ b/packages/coc/src/server/spa/client/react/processes/ProcessesSidebar.tsx
@@ -320,14 +320,14 @@ export function ProcessesSidebar() {
                                 : '';
                         const hasCustomTitle = Boolean(p.customTitle);
                         const hasAITitle = !hasCustomTitle && Boolean(p.title);
-                        // Display priority (per rename feature):
+                        // Display priority:
                         //   1) user-set custom title
-                        //   2) latest message preview (newest turn)
-                        //   3) AI-generated title (legacy fallback)
+                        //   2) AI-generated title
+                        //   3) latest message preview (newest turn)
                         //   4) prompt preview / id
                         const previewSource = p.customTitle
-                            || p.lastMessagePreview
                             || p.title
+                            || p.lastMessagePreview
                             || p.promptPreview
                             || p.id;
                         const preview = typeof previewSource === 'string' && previewSource.length > 80

--- a/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
@@ -1810,10 +1810,23 @@ describe('ChatListPane', () => {
             expect(screen.queryByText('Latest message...')).toBeNull();
         });
 
-        it('falls back to lastMessagePreview when no customTitle', () => {
+        it('prefers AI title over lastMessagePreview', () => {
             const task = makeHistoryTask({
                 displayName: undefined,
                 customTitle: undefined,
+                title: 'AI Generated Title',
+                lastMessagePreview: 'recent activity',
+            });
+            renderPane({ history: [task] });
+            expect(screen.getByText('AI Generated Title')).toBeTruthy();
+            expect(screen.queryByText('recent activity')).toBeNull();
+        });
+
+        it('falls back to lastMessagePreview when no customTitle or AI title', () => {
+            const task = makeHistoryTask({
+                displayName: undefined,
+                customTitle: undefined,
+                title: undefined,
                 lastMessagePreview: 'recent activity',
             });
             renderPane({ history: [task] });


### PR DESCRIPTION
Change title display priority order:
  customTitle → title (AI) → lastMessagePreview → promptPreview → id

Previously lastMessagePreview was shown before the AI-generated title,
which meant sessions with both an AI title and recent messages would show
a raw message snippet instead of the meaningful AI-generated title.

Affected locations:
- ProcessesSidebar.tsx: previewSource fallback chain
- ChatListPane.tsx: titleText fallback chain

Tests: updated 'falls back to lastMessagePreview' to also clear title,
added 'prefers AI title over lastMessagePreview' regression test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
