### PR TITLE
fix(ci): add missing teams-bot build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         run: npm run build
         working-directory: packages/coc-client
 
+      - name: Build teams-bot
+        run: npm run build
+        working-directory: packages/teams-bot
+
       - name: Build coc SPA client
         run: npm run build:client
         working-directory: packages/coc


### PR DESCRIPTION
The release workflow was failing because coc depends on @plusplusoneplusplus/teams-bot but the package was never built before the coc build step. The CI workflow already had this step; this aligns the release workflow to match.