### PR TITLE
pr/e6efb7e68 featcoc add mcp config crud rest endpoin

### DIFF
--- a/.github/skills/coc-knowledge/references/mcp-settings.md
+++ b/.github/skills/coc-knowledge/references/mcp-settings.md
@@ -1,6 +1,13 @@
 # MCP Settings (Workspace-Scoped)
 
-Workspace MCP servers in CoC are a merge of two sources: global servers from `~/.copilot/mcp-config.json` and workspace servers from `<repo>/.vscode/mcp.json`. Workspace entries override global entries with the same name. CoC's REST API surfaces both the effective merge and the source-separated views, and persists a name-based allow-list per workspace.
+Workspace MCP servers in CoC are a merge of two sources: global servers from `~/.copilot/mcp-config.json` and workspace servers from `<repo>/.vscode/mcp.json`. Workspace entries override global entries with the same name. CoC's REST API surfaces both the effective merge and the source-separated views, persists a name-based allow-list per workspace, and provides full CRUD on MCP server entries.
+
+## Config Files
+
+- **Global**: `~/.copilot/mcp-config.json` — root key `mcpServers`
+- **Workspace**: `<repo>/.vscode/mcp.json` — root key `servers`
+
+Extra fields (`description`, `toolScope`) are stored directly on server entries in config files. VS Code ignores unknown keys; CoC reads and surfaces them.
 
 ## REST API
 
@@ -11,15 +18,63 @@ Returns both the effective `availableServers` list and source-separated `sources
 - Global servers come from `~/.copilot/mcp-config.json`.
 - Workspace servers come from `<repo>/.vscode/mcp.json` via Forge MCP loader helpers.
 - Workspace entries override global entries with the same name.
+- Each entry in `availableServers` includes:
+  - `status`: `"ok"` | `"auth"` | `"off"` | `"err"` (derived server-side from type + enabled state)
+  - `description`: from config file, or empty string
 - The endpoint only exposes safe row metadata (`name`, `type`, optional `url`/`command`, source/effective flags) and must **not** return secrets such as `env`, headers, or full argument arrays.
 - `?forceReload=true` bypasses the path-keyed MCP config cache for manual dashboard refreshes; no file watcher is used.
 
+### `GET /api/workspaces/:id/mcp-config/:server/detail`
+
+Returns full server detail for the named server. Only accessible through this endpoint (not the list).
+
+- `description`: from config file (or empty string)
+- `envKeys`: list of env var key names — values masked
+- `args`: full command arguments array
+- `toolScope`: `"all"` | `"readonly"` | `"allowlist"`
+- `source`: `"global"` | `"workspace"`
+- `rawJson`: the actual JSON block for this server from its config file
+
 ### `PUT /api/workspaces/:id/mcp-config`
 
-Stores only the name-based `enabledMcpServers` allow-list. Workflow run filtering must resolve that list against the same effective global-plus-workspace MCP merge used at runtime.
+Stores the name-based `enabledMcpServers` allow-list and optionally `enabledMcpTools`.
+
+- `enabledMcpServers`: array of server name strings or `null` (enable all)
+- `enabledMcpTools`: `Record<string, string[]>` (server name → enabled tool names) stored in per-repo preferences JSON. When set for a server, only those tools are used at runtime.
+
+### `PUT /api/workspaces/:id/mcp-config/:server`
+
+Updates a server's config in its source file. Writes to the correct file (global or workspace) based on where the server is currently defined.
+
+Can update: `description`, `args`, `env` (key-value pairs merged into existing), `toolScope`.
+
+### `DELETE /api/workspaces/:id/mcp-config/:server`
+
+Removes the server from its source config file only.
+
+### `POST /api/workspaces/:id/mcp-config`
+
+Adds a new server entry. Body: `{ name, type, command?, url?, args?, env?, description?, toolScope?, scope: "global"|"workspace" }`. No PATH validation — saves immediately.
+
+### `POST /api/workspaces/:id/mcp-config/test`
+
+Tests connectivity to an MCP server (does not need to be registered in config).
+
+Body: `{ type, command?, url?, args?, env? }`
+
+- **stdio**: spawns the process, sends JSON-RPC `initialize`, awaits response. 10-second timeout; process is always killed after.
+- **http/sse**: sends an HTTP GET to the URL; any 2xx–4xx response counts as reachable.
+
+Response: `{ success, message, protocolVersion?, serverName? }` with HTTP 200 on success, 422 on failure.
+
+### `POST /api/workspaces/:id/mcp-config/:server/migrate`
+
+Moves a server between global and workspace config. Body: `{ targetScope: "global"|"workspace" }`.
 
 ## Invariants
 
-- Never expose secrets (`env`, headers, full `args`) through the REST surface.
+- Never expose secrets (`env`, headers, full `args`) through the list endpoint. Only the detail endpoint exposes env keys (masked) and full args.
 - Allow-list is name-only — the effective server set is always re-resolved at run time.
 - File watching is intentionally avoided; clients drive cache invalidation via `?forceReload=true`.
+- Multi-repo: all endpoints are workspace-scoped (`:id` param).
+- `enabledMcpTools` is stored in per-repo preferences JSON at `~/.coc/repos/<workspaceId>/preferences.json`.

--- a/packages/coc-client/src/contracts/workspaces.ts
+++ b/packages/coc-client/src/contracts/workspaces.ts
@@ -14,6 +14,8 @@ export interface WorkspaceInfo {
 }
 
 export type WorkspaceMcpServerSource = 'global' | 'workspace';
+export type McpConfigScope = 'global' | 'workspace';
+export type McpToolScope = 'all' | 'readonly' | 'allowlist';
 
 export interface WorkspaceMcpServerEntry {
   name: string;
@@ -23,6 +25,38 @@ export interface WorkspaceMcpServerEntry {
   source?: WorkspaceMcpServerSource;
   effective?: boolean;
   overriddenBy?: WorkspaceMcpServerSource;
+  /** Derived server status included in availableServers. */
+  status?: 'ok' | 'auth' | 'off' | 'err';
+  /** User-provided description from config file. */
+  description?: string;
+}
+
+export interface McpServerDetail {
+  description: string;
+  envKeys: string[];
+  args: string[];
+  toolScope: McpToolScope;
+  source: McpConfigScope;
+  rawJson: Record<string, unknown>;
+}
+
+export interface McpServerCreateRequest {
+  name: string;
+  type: 'stdio' | 'http' | 'sse';
+  command?: string;
+  url?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  description?: string;
+  toolScope?: McpToolScope;
+  scope: McpConfigScope;
+}
+
+export interface McpServerUpdateRequest {
+  description?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  toolScope?: McpToolScope;
 }
 
 export interface WorkspaceMcpSourceSection {

--- a/packages/coc-client/src/domains/workspaces.ts
+++ b/packages/coc-client/src/domains/workspaces.ts
@@ -6,6 +6,10 @@ import type {
   DiscoverWorkspacesResponse,
   GitInfoBatchResponse,
   GitInfoResponse,
+  McpConfigScope,
+  McpServerCreateRequest,
+  McpServerDetail,
+  McpServerUpdateRequest,
   MyLifeSummaryResponse,
   MyLifeSyncRequest,
   MyLifeSyncResponse,
@@ -127,6 +131,40 @@ export class WorkspacesClient {
       method: 'PUT',
       body: { enabledMcpServers: request.enabledMcpServers === null ? null : [...request.enabledMcpServers] },
     });
+  }
+
+  getMcpServerDetail(workspaceId: string, serverName: string): Promise<McpServerDetail> {
+    return this.transport.request<McpServerDetail>(
+      `/workspaces/${encodePathSegment(workspaceId)}/mcp-config/${encodePathSegment(serverName)}/detail`,
+    );
+  }
+
+  addMcpServer(workspaceId: string, request: McpServerCreateRequest): Promise<{ name: string; scope: string }> {
+    return this.transport.request<{ name: string; scope: string }>(
+      `/workspaces/${encodePathSegment(workspaceId)}/mcp-config`,
+      { method: 'POST', body: { ...request } },
+    );
+  }
+
+  updateMcpServer(workspaceId: string, serverName: string, request: McpServerUpdateRequest): Promise<{ name: string; updated: boolean }> {
+    return this.transport.request<{ name: string; updated: boolean }>(
+      `/workspaces/${encodePathSegment(workspaceId)}/mcp-config/${encodePathSegment(serverName)}`,
+      { method: 'PUT', body: { ...request } },
+    );
+  }
+
+  deleteMcpServer(workspaceId: string, serverName: string): Promise<{ name: string; deleted: boolean }> {
+    return this.transport.request<{ name: string; deleted: boolean }>(
+      `/workspaces/${encodePathSegment(workspaceId)}/mcp-config/${encodePathSegment(serverName)}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  migrateMcpServer(workspaceId: string, serverName: string, targetScope: McpConfigScope): Promise<{ name: string; scope: string }> {
+    return this.transport.request<{ name: string; scope: string }>(
+      `/workspaces/${encodePathSegment(workspaceId)}/mcp-config/${encodePathSegment(serverName)}/migrate`,
+      { method: 'POST', body: { targetScope } },
+    );
   }
 
   getInstructions(workspaceId: string): Promise<WorkspaceInstructionsResponse> {

--- a/packages/coc/src/server/preferences-handler.ts
+++ b/packages/coc/src/server/preferences-handler.ts
@@ -247,6 +247,13 @@ export interface PerRepoPreferences {
         /** Sync interval in minutes (default: 5). */
         intervalMinutes?: number;
     };
+    /**
+     * Per-server tool allow-list.
+     * - `undefined` — all tools for every server are enabled (default).
+     * - Keys are MCP server names; values are arrays of tool names that are
+     *   allowed. Only effective when the server itself is also enabled.
+     */
+    enabledMcpTools?: Record<string, string[]>;
 }
 
 /** Hardcoded fallback for Ralph max iterations when no preference is set. */
@@ -747,6 +754,21 @@ export function validatePerRepoPreferences(raw: unknown): PerRepoPreferences {
         // Deduplicate
         const unique = [...new Set(roots)];
         result.additionalNotesRoots = unique.slice(0, MAX_ADDITIONAL_NOTES_ROOTS);
+    }
+
+    if (typeof obj.enabledMcpTools === 'object' && obj.enabledMcpTools !== null && !Array.isArray(obj.enabledMcpTools)) {
+        const validated: Record<string, string[]> = {};
+        for (const [serverName, tools] of Object.entries(obj.enabledMcpTools as Record<string, unknown>)) {
+            if (typeof serverName === 'string' && serverName.length > 0 && Array.isArray(tools)) {
+                const toolNames = (tools as unknown[]).filter(
+                    (t): t is string => typeof t === 'string' && t.length > 0
+                );
+                validated[serverName] = toolNames;
+            }
+        }
+        if (Object.keys(validated).length > 0) {
+            result.enabledMcpTools = validated;
+        }
     }
 
     return result;

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -38,6 +38,7 @@ import {
     type McpToolScope,
     type McpConfigScope,
 } from './mcp-config-writer';
+import { testMcpConnection } from './mcp-connection-tester';
 
 // Lazy singleton service
 let _branchService: BranchService | undefined;
@@ -620,6 +621,38 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
                 return handleAPIError(res, notFound('MCP server'));
             }
             sendJSON(res, 200, { name: serverName, scope: body.targetScope });
+        },
+    });
+
+    // POST /api/workspaces/:id/mcp-config/test — Test MCP server connectivity
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config\/test$/,
+        handler: async (req, res, match) => {
+            const ws = await resolveWorkspaceOrFail(store, match!, res);
+            if (!ws) return;
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+
+            if (!['stdio', 'http', 'sse'].includes(body.type)) {
+                return handleAPIError(res, badRequest('`type` must be "stdio", "http", or "sse"'));
+            }
+            if (body.type === 'stdio' && (typeof body.command !== 'string' || !body.command.trim())) {
+                return handleAPIError(res, badRequest('`command` is required for stdio transport'));
+            }
+            if ((body.type === 'http' || body.type === 'sse') && (typeof body.url !== 'string' || !body.url.trim())) {
+                return handleAPIError(res, badRequest('`url` is required for http/sse transport'));
+            }
+
+            const result = await testMcpConnection({
+                type: body.type as 'stdio' | 'http' | 'sse',
+                command: typeof body.command === 'string' ? body.command : undefined,
+                url: typeof body.url === 'string' ? body.url : undefined,
+                args: Array.isArray(body.args) ? body.args : undefined,
+                env: (typeof body.env === 'object' && body.env !== null && !Array.isArray(body.env)) ? body.env : undefined,
+            });
+
+            sendJSON(res, result.success ? 200 : 422, result);
         },
     });
 

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -540,7 +540,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
                 return handleAPIError(res, badRequest(`Server "${body.name}" already exists in ${existing.source} config`));
             }
 
-            addServerToConfig(ws.rootPath, {
+            await addServerToConfig(ws.rootPath, {
                 name: body.name,
                 type: body.type,
                 command: typeof body.command === 'string' ? body.command : undefined,
@@ -577,7 +577,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
                 update.toolScope = body.toolScope as McpToolScope;
             }
 
-            const ok = updateServerConfig(serverName, ws.rootPath, update);
+            const ok = await updateServerConfig(serverName, ws.rootPath, update);
             if (!ok) {
                 return handleAPIError(res, notFound('MCP server'));
             }
@@ -593,7 +593,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
             const ws = await resolveWorkspaceOrFail(store, match!, res);
             if (!ws) return;
             const serverName = decodeURIComponent(match![2]);
-            const ok = deleteServerFromConfig(serverName, ws.rootPath);
+            const ok = await deleteServerFromConfig(serverName, ws.rootPath);
             if (!ok) {
                 return handleAPIError(res, notFound('MCP server'));
             }
@@ -616,7 +616,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
                 return handleAPIError(res, badRequest('`targetScope` must be "global" or "workspace"'));
             }
 
-            const ok = migrateServerScope(serverName, ws.rootPath, body.targetScope as McpConfigScope);
+            const ok = await migrateServerScope(serverName, ws.rootPath, body.targetScope as McpConfigScope);
             if (!ok) {
                 return handleAPIError(res, notFound('MCP server'));
             }

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -27,6 +27,17 @@ import {
 import { getEffectiveDefaultDisabledTools, getEffectiveLlmToolRegistry } from '../llm-tools/llm-tool-registry';
 import { detectEnDevEligibility } from '../endev/endev-detector';
 import { skillCache } from '../skills/skill-handler';
+import {
+    getServerDetail,
+    updateServerConfig,
+    deleteServerFromConfig,
+    addServerToConfig,
+    migrateServerScope,
+    readAllDescriptions,
+    findServerSource,
+    type McpToolScope,
+    type McpConfigScope,
+} from './mcp-config-writer';
 
 // Lazy singleton service
 let _branchService: BranchService | undefined;
@@ -64,6 +75,10 @@ interface WorkspaceMcpServerEntry {
     source?: WorkspaceMcpServerSource;
     effective?: boolean;
     overriddenBy?: WorkspaceMcpServerSource;
+    /** Derived server status (added to availableServers only). */
+    status?: 'ok' | 'auth' | 'off' | 'err';
+    /** User-provided description from config file (added to availableServers only). */
+    description?: string;
 }
 
 interface WorkspaceMcpSourceSection {
@@ -104,6 +119,13 @@ function toMcpSourceSection(
     };
 }
 
+/** Derive server status for the list view: ok | auth | off | err. */
+function deriveServerStatus(type: string, isEnabled: boolean): 'ok' | 'auth' | 'off' | 'err' {
+    if (!isEnabled) return 'off';
+    if (type === 'http' || type === 'sse') return 'auth';
+    return 'ok';
+}
+
 function buildMcpConfigResponse(ws: WorkspaceInfo, forceReload = false) {
     const globalConfig = loadDefaultMcpConfig(forceReload);
     const workspaceConfig = loadWorkspaceMcpConfig(ws.rootPath, forceReload);
@@ -115,12 +137,24 @@ function buildMcpConfigResponse(ws: WorkspaceInfo, forceReload = false) {
     const workspaceServers = Object.entries(workspaceConfig.mcpServers).map(([name, config]) =>
         toMcpServerEntry(name, config, 'workspace', true)
     );
+
+    // Read descriptions from raw config files (not filtered/normalized by loader)
+    const descriptions = readAllDescriptions(ws.rootPath);
+
+    // Compute effective server list with status and description
+    const enabledSet = ws.enabledMcpServers;
     const availableServers = Object.entries({
         ...globalConfig.mcpServers,
         ...workspaceConfig.mcpServers,
-    }).map(([name, config]) =>
-        toMcpServerEntry(name, config, workspaceNames.has(name) ? 'workspace' : 'global', true)
-    );
+    }).map(([name, config]) => {
+        const isEnabled = enabledSet === null || enabledSet === undefined || enabledSet.includes(name);
+        const type = config.type ?? 'stdio';
+        const entry = toMcpServerEntry(name, config, workspaceNames.has(name) ? 'workspace' : 'global', true);
+        entry.status = deriveServerStatus(type, isEnabled);
+        const desc = descriptions[name];
+        if (desc) entry.description = desc;
+        return entry;
+    });
 
     return {
         availableServers,
@@ -415,7 +449,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
         },
     });
 
-    // PUT /api/workspaces/:id/mcp-config — Save workspace-enabled MCP server list
+    // PUT /api/workspaces/:id/mcp-config — Save workspace-enabled MCP server list (+ optional enabledMcpTools)
     routes.push({
         method: 'PUT',
         pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config$/,
@@ -438,7 +472,154 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
             if (!updated) {
                 return handleAPIError(res, notFound('Workspace'));
             }
+
+            // Optional enabledMcpTools — stored in per-repo preferences
+            if (Object.prototype.hasOwnProperty.call(body, 'enabledMcpTools')) {
+                if (!ctx.dataDir) {
+                    return handleAPIError(res, badRequest('dataDir is required to save enabledMcpTools'));
+                }
+                if (body.enabledMcpTools !== null
+                    && (typeof body.enabledMcpTools !== 'object' || Array.isArray(body.enabledMcpTools))) {
+                    return handleAPIError(res, badRequest('`enabledMcpTools` must be a Record<string, string[]> or null'));
+                }
+                const existing = readRepoPreferences(ctx.dataDir, id);
+                const patch = body.enabledMcpTools === null ? { enabledMcpTools: undefined } : { enabledMcpTools: body.enabledMcpTools };
+                const merged = validatePerRepoPreferences({ ...existing, ...patch });
+                writeRepoPreferences(ctx.dataDir, id, merged);
+            }
+
             sendJSON(res, 200, { workspace: updated });
+        },
+    });
+
+    // GET /api/workspaces/:id/mcp-config/:server/detail — Full server detail
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config\/([^/]+)\/detail$/,
+        handler: async (_req, res, match) => {
+            const ws = await resolveWorkspaceOrFail(store, match!, res);
+            if (!ws) return;
+            const serverName = decodeURIComponent(match![2]);
+            const detail = getServerDetail(serverName, ws.rootPath);
+            if (!detail) {
+                return handleAPIError(res, notFound('MCP server'));
+            }
+            sendJSON(res, 200, detail);
+        },
+    });
+
+    // POST /api/workspaces/:id/mcp-config — Add a new MCP server entry
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config$/,
+        handler: async (req, res, match) => {
+            const ws = await resolveWorkspaceOrFail(store, match!, res);
+            if (!ws) return;
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+
+            if (typeof body.name !== 'string' || !body.name.trim()) {
+                return handleAPIError(res, missingFields(['name']));
+            }
+            if (!['stdio', 'http', 'sse'].includes(body.type)) {
+                return handleAPIError(res, badRequest('`type` must be "stdio", "http", or "sse"'));
+            }
+            if (!['global', 'workspace'].includes(body.scope)) {
+                return handleAPIError(res, badRequest('`scope` must be "global" or "workspace"'));
+            }
+            if (body.type === 'http' || body.type === 'sse') {
+                if (typeof body.url !== 'string' || !body.url.trim()) {
+                    return handleAPIError(res, badRequest('`url` is required for http/sse transport'));
+                }
+            }
+
+            // Check for name conflict
+            const existing = findServerSource(body.name, ws.rootPath);
+            if (existing) {
+                return handleAPIError(res, badRequest(`Server "${body.name}" already exists in ${existing.source} config`));
+            }
+
+            addServerToConfig(ws.rootPath, {
+                name: body.name,
+                type: body.type,
+                command: typeof body.command === 'string' ? body.command : undefined,
+                url: typeof body.url === 'string' ? body.url : undefined,
+                args: Array.isArray(body.args) ? body.args : undefined,
+                env: (typeof body.env === 'object' && body.env !== null && !Array.isArray(body.env)) ? body.env : undefined,
+                description: typeof body.description === 'string' ? body.description : undefined,
+                toolScope: (['all', 'readonly', 'allowlist'] as McpToolScope[]).includes(body.toolScope) ? body.toolScope as McpToolScope : undefined,
+                scope: body.scope as McpConfigScope,
+            });
+
+            sendJSON(res, 201, { name: body.name, scope: body.scope });
+        },
+    });
+
+    // PUT /api/workspaces/:id/mcp-config/:server — Update a server's config in its source file
+    routes.push({
+        method: 'PUT',
+        pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config\/([^/]+)$/,
+        handler: async (req, res, match) => {
+            const ws = await resolveWorkspaceOrFail(store, match!, res);
+            if (!ws) return;
+            const serverName = decodeURIComponent(match![2]);
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+
+            const update: { description?: string; args?: string[]; env?: Record<string, string>; toolScope?: McpToolScope } = {};
+            if (typeof body.description === 'string') update.description = body.description;
+            if (Array.isArray(body.args)) update.args = body.args;
+            if (typeof body.env === 'object' && body.env !== null && !Array.isArray(body.env)) {
+                update.env = body.env;
+            }
+            if (['all', 'readonly', 'allowlist'].includes(body.toolScope)) {
+                update.toolScope = body.toolScope as McpToolScope;
+            }
+
+            const ok = updateServerConfig(serverName, ws.rootPath, update);
+            if (!ok) {
+                return handleAPIError(res, notFound('MCP server'));
+            }
+            sendJSON(res, 200, { name: serverName, updated: true });
+        },
+    });
+
+    // DELETE /api/workspaces/:id/mcp-config/:server — Remove a server from its source config
+    routes.push({
+        method: 'DELETE',
+        pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config\/([^/]+)$/,
+        handler: async (_req, res, match) => {
+            const ws = await resolveWorkspaceOrFail(store, match!, res);
+            if (!ws) return;
+            const serverName = decodeURIComponent(match![2]);
+            const ok = deleteServerFromConfig(serverName, ws.rootPath);
+            if (!ok) {
+                return handleAPIError(res, notFound('MCP server'));
+            }
+            sendJSON(res, 200, { name: serverName, deleted: true });
+        },
+    });
+
+    // POST /api/workspaces/:id/mcp-config/:server/migrate — Move a server between global/workspace
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/workspaces\/([^/]+)\/mcp-config\/([^/]+)\/migrate$/,
+        handler: async (req, res, match) => {
+            const ws = await resolveWorkspaceOrFail(store, match!, res);
+            if (!ws) return;
+            const serverName = decodeURIComponent(match![2]);
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+
+            if (!['global', 'workspace'].includes(body.targetScope)) {
+                return handleAPIError(res, badRequest('`targetScope` must be "global" or "workspace"'));
+            }
+
+            const ok = migrateServerScope(serverName, ws.rootPath, body.targetScope as McpConfigScope);
+            if (!ok) {
+                return handleAPIError(res, notFound('MCP server'));
+            }
+            sendJSON(res, 200, { name: serverName, scope: body.targetScope });
         },
     });
 

--- a/packages/coc/src/server/routes/mcp-config-writer.ts
+++ b/packages/coc/src/server/routes/mcp-config-writer.ts
@@ -12,7 +12,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { getMcpConfigPath, getWorkspaceMcpConfigPath } from '@plusplusoneplusplus/forge';
+import { getMcpConfigPath, getWorkspaceMcpConfigPath, invalidateCachedConfig } from '@plusplusoneplusplus/forge';
 
 // ============================================================================
 // Types
@@ -78,10 +78,13 @@ export function readRawGlobalConfig(): Record<string, unknown> {
 }
 
 /** Write raw JSON to the global MCP config file (creates parent dirs if needed). */
-export function writeRawGlobalConfig(data: Record<string, unknown>): void {
+export async function writeRawGlobalConfig(data: Record<string, unknown>): Promise<void> {
     const configPath = getMcpConfigPath();
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+    const tmpPath = configPath + '.tmp';
+    await fs.promises.writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.promises.rename(tmpPath, configPath);
+    invalidateCachedConfig(configPath);
 }
 
 /**
@@ -106,10 +109,13 @@ export function readRawWorkspaceConfig(rootPath: string): Record<string, unknown
 }
 
 /** Write raw JSON to the workspace MCP config file (creates parent dirs if needed). */
-export function writeRawWorkspaceConfig(rootPath: string, data: Record<string, unknown>): void {
+export async function writeRawWorkspaceConfig(rootPath: string, data: Record<string, unknown>): Promise<void> {
     const configPath = getWorkspaceMcpConfigPath(rootPath);
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+    const tmpPath = configPath + '.tmp';
+    await fs.promises.writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.promises.rename(tmpPath, configPath);
+    invalidateCachedConfig(configPath);
 }
 
 // ============================================================================
@@ -198,11 +204,11 @@ export function getServerDetail(serverName: string, rootPath: string): McpServer
  * Update a server entry in its source config file.
  * Returns `false` if the server is not found.
  */
-export function updateServerConfig(
+export async function updateServerConfig(
     serverName: string,
     rootPath: string,
     update: McpServerUpdate,
-): boolean {
+): Promise<boolean> {
     const found = findServerSource(serverName, rootPath);
     if (!found) return false;
 
@@ -215,7 +221,7 @@ export function updateServerConfig(
         applyUpdate(entry, update);
         servers[serverName] = entry;
         config.mcpServers = servers;
-        writeRawGlobalConfig(config);
+        await writeRawGlobalConfig(config);
     } else {
         const config = readRawWorkspaceConfig(rootPath);
         const servers = asRecord(config.servers);
@@ -223,7 +229,7 @@ export function updateServerConfig(
         applyUpdate(entry, update);
         servers[serverName] = entry;
         config.servers = servers;
-        writeRawWorkspaceConfig(rootPath, config);
+        await writeRawWorkspaceConfig(rootPath, config);
     }
 
     return true;
@@ -233,7 +239,7 @@ export function updateServerConfig(
  * Remove a server entry from its source config file.
  * Returns `false` if the server is not found.
  */
-export function deleteServerFromConfig(serverName: string, rootPath: string): boolean {
+export async function deleteServerFromConfig(serverName: string, rootPath: string): Promise<boolean> {
     const found = findServerSource(serverName, rootPath);
     if (!found) return false;
 
@@ -242,13 +248,13 @@ export function deleteServerFromConfig(serverName: string, rootPath: string): bo
         const servers = asRecord(config.mcpServers);
         delete servers[serverName];
         config.mcpServers = servers;
-        writeRawGlobalConfig(config);
+        await writeRawGlobalConfig(config);
     } else {
         const config = readRawWorkspaceConfig(rootPath);
         const servers = asRecord(config.servers);
         delete servers[serverName];
         config.servers = servers;
-        writeRawWorkspaceConfig(rootPath, config);
+        await writeRawWorkspaceConfig(rootPath, config);
     }
 
     return true;
@@ -258,7 +264,7 @@ export function deleteServerFromConfig(serverName: string, rootPath: string): bo
  * Add a new server entry to the specified config file.
  * Does not validate if the name already exists — caller must check.
  */
-export function addServerToConfig(rootPath: string, serverData: McpServerCreate): void {
+export async function addServerToConfig(rootPath: string, serverData: McpServerCreate): Promise<void> {
     const entry: Record<string, unknown> = {};
 
     if (serverData.type === 'http' || serverData.type === 'sse') {
@@ -284,13 +290,13 @@ export function addServerToConfig(rootPath: string, serverData: McpServerCreate)
         const servers = asRecord(config.mcpServers);
         servers[serverData.name] = entry;
         config.mcpServers = servers;
-        writeRawGlobalConfig(config);
+        await writeRawGlobalConfig(config);
     } else {
         const config = readRawWorkspaceConfig(rootPath);
         const servers = asRecord(config.servers);
         servers[serverData.name] = entry;
         config.servers = servers;
-        writeRawWorkspaceConfig(rootPath, config);
+        await writeRawWorkspaceConfig(rootPath, config);
     }
 }
 
@@ -298,11 +304,11 @@ export function addServerToConfig(rootPath: string, serverData: McpServerCreate)
  * Move a server entry between global and workspace config files.
  * Returns `false` if the server is not found or is already in `targetScope`.
  */
-export function migrateServerScope(
+export async function migrateServerScope(
     serverName: string,
     rootPath: string,
     targetScope: McpConfigScope,
-): boolean {
+): Promise<boolean> {
     const found = findServerSource(serverName, rootPath);
     if (!found) return false;
     if (found.source === targetScope) return true; // already there
@@ -316,13 +322,13 @@ export function migrateServerScope(
         const servers = asRecord(config.mcpServers);
         delete servers[serverName];
         config.mcpServers = servers;
-        writeRawGlobalConfig(config);
+        await writeRawGlobalConfig(config);
     } else {
         const config = readRawWorkspaceConfig(rootPath);
         const servers = asRecord(config.servers);
         delete servers[serverName];
         config.servers = servers;
-        writeRawWorkspaceConfig(rootPath, config);
+        await writeRawWorkspaceConfig(rootPath, config);
     }
 
     // Add to the target source
@@ -331,13 +337,13 @@ export function migrateServerScope(
         const servers = asRecord(config.mcpServers);
         servers[serverName] = rawEntry;
         config.mcpServers = servers;
-        writeRawGlobalConfig(config);
+        await writeRawGlobalConfig(config);
     } else {
         const config = readRawWorkspaceConfig(rootPath);
         const servers = asRecord(config.servers);
         servers[serverName] = rawEntry;
         config.servers = servers;
-        writeRawWorkspaceConfig(rootPath, config);
+        await writeRawWorkspaceConfig(rootPath, config);
     }
 
     return true;

--- a/packages/coc/src/server/routes/mcp-config-writer.ts
+++ b/packages/coc/src/server/routes/mcp-config-writer.ts
@@ -1,0 +1,366 @@
+/**
+ * MCP Config Writer
+ *
+ * Utilities for reading raw JSON and writing to MCP config files:
+ *  - Global:    ~/.copilot/mcp-config.json   (key: "mcpServers")
+ *  - Workspace: <repo>/.vscode/mcp.json      (key: "servers")
+ *
+ * These helpers intentionally bypass the forge mcp-config-loader cache so
+ * that mutations are reflected immediately and extra fields like `description`
+ * and `toolScope` (which the normalising loader strips) are preserved.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getMcpConfigPath, getWorkspaceMcpConfigPath } from '@plusplusoneplusplus/forge';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type McpToolScope = 'all' | 'readonly' | 'allowlist';
+export type McpConfigScope = 'global' | 'workspace';
+
+export interface McpServerDetail {
+    description: string;
+    envKeys: string[];
+    args: string[];
+    toolScope: McpToolScope;
+    source: McpConfigScope;
+    /** Raw JSON block for the server entry as stored in the config file. */
+    rawJson: Record<string, unknown>;
+}
+
+export interface McpServerUpdate {
+    description?: string;
+    args?: string[];
+    /** Full env map replacement for specified keys (merged into existing keys). */
+    env?: Record<string, string>;
+    toolScope?: McpToolScope;
+}
+
+export interface McpServerCreate {
+    name: string;
+    /** Transport type. */
+    type: 'stdio' | 'http' | 'sse';
+    command?: string;
+    url?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    description?: string;
+    toolScope?: McpToolScope;
+    scope: McpConfigScope;
+}
+
+// ============================================================================
+// Raw file read/write helpers
+// ============================================================================
+
+/**
+ * Read raw JSON from the global MCP config file.
+ * Returns `{ mcpServers: {} }` if the file doesn't exist or is invalid.
+ */
+export function readRawGlobalConfig(): Record<string, unknown> {
+    const configPath = getMcpConfigPath();
+    if (!fs.existsSync(configPath)) {
+        return { mcpServers: {} };
+    }
+    try {
+        const content = fs.readFileSync(configPath, 'utf-8');
+        const parsed: unknown = JSON.parse(content);
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return { mcpServers: {} };
+        }
+        return parsed as Record<string, unknown>;
+    } catch {
+        return { mcpServers: {} };
+    }
+}
+
+/** Write raw JSON to the global MCP config file (creates parent dirs if needed). */
+export function writeRawGlobalConfig(data: Record<string, unknown>): void {
+    const configPath = getMcpConfigPath();
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+/**
+ * Read raw JSON from the workspace MCP config file (`.vscode/mcp.json`).
+ * Returns `{ servers: {} }` if the file doesn't exist or is invalid.
+ */
+export function readRawWorkspaceConfig(rootPath: string): Record<string, unknown> {
+    const configPath = getWorkspaceMcpConfigPath(rootPath);
+    if (!fs.existsSync(configPath)) {
+        return { servers: {} };
+    }
+    try {
+        const content = fs.readFileSync(configPath, 'utf-8');
+        const parsed: unknown = JSON.parse(content);
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return { servers: {} };
+        }
+        return parsed as Record<string, unknown>;
+    } catch {
+        return { servers: {} };
+    }
+}
+
+/** Write raw JSON to the workspace MCP config file (creates parent dirs if needed). */
+export function writeRawWorkspaceConfig(rootPath: string, data: Record<string, unknown>): void {
+    const configPath = getWorkspaceMcpConfigPath(rootPath);
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+// ============================================================================
+// Description helpers
+// ============================================================================
+
+/**
+ * Build a map of server name → description for all servers in both config
+ * files. Workspace descriptions win when the same name appears in both.
+ */
+export function readAllDescriptions(rootPath: string): Record<string, string> {
+    const result: Record<string, string> = {};
+
+    const globalConfig = readRawGlobalConfig();
+    const globalServers = asRecord(globalConfig.mcpServers);
+    for (const [name, entry] of Object.entries(globalServers)) {
+        if (isRecord(entry) && typeof entry.description === 'string') {
+            result[name] = entry.description;
+        }
+    }
+
+    const wsConfig = readRawWorkspaceConfig(rootPath);
+    const wsServers = asRecord(wsConfig.servers);
+    for (const [name, entry] of Object.entries(wsServers)) {
+        if (isRecord(entry) && typeof entry.description === 'string') {
+            result[name] = entry.description;
+        } else if (isRecord(entry)) {
+            // Workspace entry exists but no description — don't overwrite global description
+        }
+    }
+
+    return result;
+}
+
+// ============================================================================
+// CRUD operations
+// ============================================================================
+
+/**
+ * Find which config file a named server lives in and return its raw entry.
+ * Workspace takes precedence over global (matching effective merge order).
+ */
+export function findServerSource(
+    serverName: string,
+    rootPath: string,
+): { source: McpConfigScope; rawEntry: Record<string, unknown> } | null {
+    const wsConfig = readRawWorkspaceConfig(rootPath);
+    const wsServers = asRecord(wsConfig.servers);
+    if (serverName in wsServers && isRecord(wsServers[serverName])) {
+        return { source: 'workspace', rawEntry: wsServers[serverName] as Record<string, unknown> };
+    }
+
+    const globalConfig = readRawGlobalConfig();
+    const globalServers = asRecord(globalConfig.mcpServers);
+    if (serverName in globalServers && isRecord(globalServers[serverName])) {
+        return { source: 'global', rawEntry: globalServers[serverName] as Record<string, unknown> };
+    }
+
+    return null;
+}
+
+/**
+ * Return full detail for a named server, or `null` if not found.
+ */
+export function getServerDetail(serverName: string, rootPath: string): McpServerDetail | null {
+    const found = findServerSource(serverName, rootPath);
+    if (!found) return null;
+
+    const { source, rawEntry } = found;
+    const envObj = rawEntry.env;
+    const envKeys =
+        typeof envObj === 'object' && envObj !== null && !Array.isArray(envObj)
+            ? Object.keys(envObj as Record<string, unknown>)
+            : [];
+    const args = Array.isArray(rawEntry.args) ? (rawEntry.args as unknown[]).map(String) : [];
+    const toolScope: McpToolScope =
+        rawEntry.toolScope === 'readonly' ? 'readonly'
+        : rawEntry.toolScope === 'allowlist' ? 'allowlist'
+        : 'all';
+    const description = typeof rawEntry.description === 'string' ? rawEntry.description : '';
+
+    return { description, envKeys, args, toolScope, source, rawJson: rawEntry };
+}
+
+/**
+ * Update a server entry in its source config file.
+ * Returns `false` if the server is not found.
+ */
+export function updateServerConfig(
+    serverName: string,
+    rootPath: string,
+    update: McpServerUpdate,
+): boolean {
+    const found = findServerSource(serverName, rootPath);
+    if (!found) return false;
+
+    const { source } = found;
+
+    if (source === 'global') {
+        const config = readRawGlobalConfig();
+        const servers = asRecord(config.mcpServers);
+        const entry = asRecord(servers[serverName]);
+        applyUpdate(entry, update);
+        servers[serverName] = entry;
+        config.mcpServers = servers;
+        writeRawGlobalConfig(config);
+    } else {
+        const config = readRawWorkspaceConfig(rootPath);
+        const servers = asRecord(config.servers);
+        const entry = asRecord(servers[serverName]);
+        applyUpdate(entry, update);
+        servers[serverName] = entry;
+        config.servers = servers;
+        writeRawWorkspaceConfig(rootPath, config);
+    }
+
+    return true;
+}
+
+/**
+ * Remove a server entry from its source config file.
+ * Returns `false` if the server is not found.
+ */
+export function deleteServerFromConfig(serverName: string, rootPath: string): boolean {
+    const found = findServerSource(serverName, rootPath);
+    if (!found) return false;
+
+    if (found.source === 'global') {
+        const config = readRawGlobalConfig();
+        const servers = asRecord(config.mcpServers);
+        delete servers[serverName];
+        config.mcpServers = servers;
+        writeRawGlobalConfig(config);
+    } else {
+        const config = readRawWorkspaceConfig(rootPath);
+        const servers = asRecord(config.servers);
+        delete servers[serverName];
+        config.servers = servers;
+        writeRawWorkspaceConfig(rootPath, config);
+    }
+
+    return true;
+}
+
+/**
+ * Add a new server entry to the specified config file.
+ * Does not validate if the name already exists — caller must check.
+ */
+export function addServerToConfig(rootPath: string, serverData: McpServerCreate): void {
+    const entry: Record<string, unknown> = {};
+
+    if (serverData.type === 'http' || serverData.type === 'sse') {
+        entry.type = serverData.type;
+        if (serverData.url) entry.url = serverData.url;
+    } else {
+        // stdio is the default; only write type if explicitly specified
+        if (serverData.type && serverData.type !== 'stdio') entry.type = serverData.type;
+        if (serverData.command) entry.command = serverData.command;
+        if (serverData.args && serverData.args.length > 0) entry.args = serverData.args;
+    }
+
+    if (serverData.env && Object.keys(serverData.env).length > 0) {
+        entry.env = serverData.env;
+    }
+    if (serverData.description) entry.description = serverData.description;
+    if (serverData.toolScope && serverData.toolScope !== 'all') {
+        entry.toolScope = serverData.toolScope;
+    }
+
+    if (serverData.scope === 'global') {
+        const config = readRawGlobalConfig();
+        const servers = asRecord(config.mcpServers);
+        servers[serverData.name] = entry;
+        config.mcpServers = servers;
+        writeRawGlobalConfig(config);
+    } else {
+        const config = readRawWorkspaceConfig(rootPath);
+        const servers = asRecord(config.servers);
+        servers[serverData.name] = entry;
+        config.servers = servers;
+        writeRawWorkspaceConfig(rootPath, config);
+    }
+}
+
+/**
+ * Move a server entry between global and workspace config files.
+ * Returns `false` if the server is not found or is already in `targetScope`.
+ */
+export function migrateServerScope(
+    serverName: string,
+    rootPath: string,
+    targetScope: McpConfigScope,
+): boolean {
+    const found = findServerSource(serverName, rootPath);
+    if (!found) return false;
+    if (found.source === targetScope) return true; // already there
+
+    // Capture the raw entry before deletion
+    const rawEntry = { ...found.rawEntry };
+
+    // Remove from the current source
+    if (found.source === 'global') {
+        const config = readRawGlobalConfig();
+        const servers = asRecord(config.mcpServers);
+        delete servers[serverName];
+        config.mcpServers = servers;
+        writeRawGlobalConfig(config);
+    } else {
+        const config = readRawWorkspaceConfig(rootPath);
+        const servers = asRecord(config.servers);
+        delete servers[serverName];
+        config.servers = servers;
+        writeRawWorkspaceConfig(rootPath, config);
+    }
+
+    // Add to the target source
+    if (targetScope === 'global') {
+        const config = readRawGlobalConfig();
+        const servers = asRecord(config.mcpServers);
+        servers[serverName] = rawEntry;
+        config.mcpServers = servers;
+        writeRawGlobalConfig(config);
+    } else {
+        const config = readRawWorkspaceConfig(rootPath);
+        const servers = asRecord(config.servers);
+        servers[serverName] = rawEntry;
+        config.servers = servers;
+        writeRawWorkspaceConfig(rootPath, config);
+    }
+
+    return true;
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+    return isRecord(value) ? (value as Record<string, unknown>) : {};
+}
+
+function applyUpdate(entry: Record<string, unknown>, update: McpServerUpdate): void {
+    if (update.description !== undefined) entry.description = update.description;
+    if (update.args !== undefined) entry.args = update.args;
+    if (update.env !== undefined) {
+        const existing = asRecord(entry.env);
+        entry.env = { ...existing, ...update.env };
+    }
+    if (update.toolScope !== undefined) entry.toolScope = update.toolScope;
+}

--- a/packages/coc/src/server/routes/mcp-connection-tester.ts
+++ b/packages/coc/src/server/routes/mcp-connection-tester.ts
@@ -1,0 +1,250 @@
+/**
+ * MCP Connection Tester
+ *
+ * Spawns a temporary MCP server process (stdio) or checks HTTP/SSE reachability,
+ * sends a JSON-RPC `initialize` handshake, and returns success/error.
+ *
+ * Timeout: 10 seconds. Process is always killed after the test.
+ */
+
+import { spawn } from 'child_process';
+import * as http from 'http';
+import * as https from 'https';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface McpTestRequest {
+    type: 'stdio' | 'http' | 'sse';
+    command?: string;
+    url?: string;
+    args?: string[];
+    env?: Record<string, string>;
+}
+
+export interface McpTestResult {
+    success: boolean;
+    message: string;
+    /** Server's declared protocolVersion, if returned (stdio only). */
+    protocolVersion?: string;
+    /** Server's declared name, if returned (stdio only). */
+    serverName?: string;
+}
+
+// ============================================================================
+// Public entry point
+// ============================================================================
+
+const TEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Test connectivity to an MCP server.
+ * - stdio: spawns the process, sends `initialize`, awaits response
+ * - http/sse: sends an HTTP GET to the URL
+ */
+export async function testMcpConnection(req: McpTestRequest): Promise<McpTestResult> {
+    if (req.type === 'stdio') {
+        return testStdioMcpServer(req);
+    }
+    return testHttpMcpServer(req);
+}
+
+// ============================================================================
+// stdio transport
+// ============================================================================
+
+function testStdioMcpServer(req: McpTestRequest): Promise<McpTestResult> {
+    return new Promise((resolve) => {
+        const command = req.command;
+        if (!command) {
+            resolve({ success: false, message: '`command` is required for stdio transport' });
+            return;
+        }
+
+        const args = req.args ?? [];
+        const mergedEnv = { ...process.env, ...(req.env ?? {}) };
+
+        let child: ReturnType<typeof spawn>;
+        try {
+            child = spawn(command, args, {
+                env: mergedEnv,
+                stdio: ['pipe', 'pipe', 'pipe'],
+                shell: false,
+            });
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            resolve({ success: false, message: `Failed to spawn process: ${msg}` });
+            return;
+        }
+
+        let settled = false;
+        let stdout = '';
+
+        const done = (result: McpTestResult) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            try { child.kill('SIGKILL'); } catch { /* ignore */ }
+            resolve(result);
+        };
+
+        const timer = setTimeout(() => {
+            done({ success: false, message: 'Timed out waiting for MCP initialize response (10 s)' });
+        }, TEST_TIMEOUT_MS);
+
+        child.on('error', (err) => {
+            done({ success: false, message: `Process error: ${err.message}` });
+        });
+
+        child.on('close', (code) => {
+            if (!settled) {
+                done({ success: false, message: `Process exited with code ${code} before responding` });
+            }
+        });
+
+        child.stdout?.on('data', (chunk: Buffer) => {
+            stdout += chunk.toString('utf-8');
+            // Each MCP message is a JSON object on its own line (newline-delimited JSON-RPC)
+            const lines = stdout.split('\n');
+            // Keep the last incomplete line in the buffer
+            stdout = lines.pop() ?? '';
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                tryParseRpcResponse(trimmed, done);
+            }
+        });
+
+        // Send JSON-RPC `initialize`
+        const initMsg = JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2024-11-05',
+                capabilities: {},
+                clientInfo: { name: 'coc-test', version: '1.0.0' },
+            },
+        }) + '\n';
+
+        try {
+            child.stdin?.write(initMsg);
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            done({ success: false, message: `Failed to write to process stdin: ${msg}` });
+        }
+    });
+}
+
+function tryParseRpcResponse(
+    line: string,
+    done: (result: McpTestResult) => void,
+): void {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(line);
+    } catch {
+        // Not JSON — ignore
+        return;
+    }
+    if (typeof parsed !== 'object' || parsed === null) return;
+
+    const obj = parsed as Record<string, unknown>;
+    // Must be a JSON-RPC 2.0 response to our request id=1
+    if (obj.jsonrpc !== '2.0' || obj.id !== 1) return;
+
+    if ('error' in obj) {
+        const errObj = obj.error as Record<string, unknown> | null | undefined;
+        const errMsg = typeof errObj?.message === 'string' ? errObj.message : JSON.stringify(errObj);
+        done({ success: false, message: `MCP server returned error: ${errMsg}` });
+        return;
+    }
+
+    if ('result' in obj) {
+        const result = obj.result as Record<string, unknown> | null | undefined;
+        const protoVersion = typeof result?.protocolVersion === 'string' ? result.protocolVersion : undefined;
+        const serverInfo = result?.serverInfo as Record<string, unknown> | undefined;
+        const serverName = typeof serverInfo?.name === 'string' ? serverInfo.name : undefined;
+        done({
+            success: true,
+            message: 'MCP server responded successfully',
+            ...(protoVersion ? { protocolVersion: protoVersion } : {}),
+            ...(serverName ? { serverName } : {}),
+        });
+    }
+}
+
+// ============================================================================
+// HTTP / SSE transport
+// ============================================================================
+
+function testHttpMcpServer(req: McpTestRequest): Promise<McpTestResult> {
+    return new Promise((resolve) => {
+        const rawUrl = req.url;
+        if (!rawUrl) {
+            resolve({ success: false, message: '`url` is required for http/sse transport' });
+            return;
+        }
+
+        let parsedUrl: URL;
+        try {
+            parsedUrl = new URL(rawUrl);
+        } catch {
+            resolve({ success: false, message: `Invalid URL: ${rawUrl}` });
+            return;
+        }
+
+        const transport = parsedUrl.protocol === 'https:' ? https : http;
+        let settled = false;
+
+        const done = (result: McpTestResult) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+        };
+
+        const timer = setTimeout(() => {
+            done({ success: false, message: 'HTTP connection timed out (10 s)' });
+        }, TEST_TIMEOUT_MS);
+
+        const options: http.RequestOptions = {
+            hostname: parsedUrl.hostname,
+            port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? '443' : '80'),
+            path: parsedUrl.pathname + parsedUrl.search,
+            method: 'GET',
+            headers: { 'Accept': 'application/json, text/event-stream' },
+            timeout: TEST_TIMEOUT_MS,
+        };
+
+        const clientReq = transport.request(options, (incomingRes) => {
+            // Accept any 2xx or 4xx (reachable but may require auth)
+            clearTimeout(timer);
+            const status = incomingRes.statusCode ?? 0;
+            if (status >= 200 && status < 500) {
+                done({
+                    success: true,
+                    message: `Server responded with HTTP ${status}`,
+                });
+            } else {
+                done({
+                    success: false,
+                    message: `Server responded with HTTP ${status}`,
+                });
+            }
+            incomingRes.resume(); // drain
+        });
+
+        clientReq.on('error', (err) => {
+            clearTimeout(timer);
+            done({ success: false, message: `Connection failed: ${err.message}` });
+        });
+
+        clientReq.on('timeout', () => {
+            clientReq.destroy();
+            done({ success: false, message: 'HTTP connection timed out (10 s)' });
+        });
+
+        clientReq.end();
+    });
+}

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoCopilotTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoCopilotTab.tsx
@@ -54,6 +54,19 @@ export function RepoCopilotTab({ workspaceId }: RepoCopilotTabProps) {
             .finally(() => setLoading(false));
     }, [workspaceId]);
 
+    const handleRefreshMcp = useCallback(() => {
+        setLoading(true);
+        setError(null);
+        getSpaCocClient().workspaces.getMcpConfig(workspaceId, { forceReload: true })
+            .then((data) => {
+                setAvailableServers(data.availableServers ?? []);
+                setMcpSources(data.sources);
+                setEnabledMcpServers(data.enabledMcpServers ?? null);
+            })
+            .catch((e: unknown) => setError(getSpaCocClientErrorMessage(e, 'Failed to load MCP config')))
+            .finally(() => setLoading(false));
+    }, [workspaceId]);
+
     const isEnabled = (name: string) =>
         enabledMcpServers === null || enabledMcpServers.includes(name);
 
@@ -301,6 +314,7 @@ export function RepoCopilotTab({ workspaceId }: RepoCopilotTabProps) {
             <div className="flex-1 overflow-y-auto p-4" data-testid="copilot-content-panel">
                 {activeSection === 'mcp' && (
                     <McpServersPanel
+                        workspaceId={workspaceId}
                         loading={loading}
                         error={error}
                         saving={saving}
@@ -308,6 +322,8 @@ export function RepoCopilotTab({ workspaceId }: RepoCopilotTabProps) {
                         sources={mcpSources}
                         isEnabled={isEnabled}
                         onToggle={handleToggle}
+                        onRefresh={handleRefreshMcp}
+                        onMutate={handleRefreshMcp}
                     />
                 )}
                 {activeSection === 'skills' && (

--- a/packages/coc/src/server/spa/client/react/features/skills/McpServersPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/skills/McpServersPanel.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import './mcp-servers-redesign.css';
+import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import type { McpServerDetail as ClientMcpServerDetail, McpConfigScope } from '@plusplusoneplusplus/coc-client';
 
 export type McpServerSource = 'global' | 'workspace';
 export type McpServerEntry = {
@@ -10,6 +12,10 @@ export type McpServerEntry = {
     source?: McpServerSource;
     effective?: boolean;
     overriddenBy?: McpServerSource;
+    /** Derived status from the server response. */
+    status?: 'ok' | 'auth' | 'off' | 'err';
+    /** User-provided description from config file. */
+    description?: string;
 };
 
 export type McpServerSourceSection = {
@@ -26,6 +32,7 @@ export type McpServerSources = {
 };
 
 interface McpServersPanelProps {
+    workspaceId?: string;
     loading: boolean;
     error: string | null;
     saving: boolean;
@@ -34,47 +41,13 @@ interface McpServersPanelProps {
     isEnabled: (name: string) => boolean;
     onToggle: (serverName: string, checked: boolean) => void;
     onRefresh?: () => void;
+    /** Called after a server is added or deleted so the parent can refresh the list. */
+    onMutate?: () => void;
 }
 
 type FilterTab = 'all' | 'active' | 'auth' | 'disabled';
+
 type InspectorTab = 'overview' | 'tools' | 'configuration' | 'source' | 'activity';
-
-// Mock descriptions for servers that only have a name/type from the API
-const MOCK_DESCRIPTIONS: Record<string, string> = {
-    github: 'Repo, issues, PRs, and Actions tools from github.com',
-    filesystem: 'Read and search local files inside the repo working tree',
-    linear: 'Linear issues and projects',
-    sentry: 'Errors and performance data',
-    postgres: 'Read-only access to the staging analytics database',
-    slack: 'Post messages and read channels',
-    notion: 'Search and read pages from the team workspace',
-};
-
-const MOCK_TOOL_COUNTS: Record<string, number> = {
-    github: 38, filesystem: 6, linear: 14, sentry: 9, postgres: 4, slack: 7, notion: 11,
-};
-
-const MOCK_HEALTH: Record<string, { uptime: string; handshake: string; calls: string; errors: string }> = {
-    github: { uptime: '4h 12m', handshake: '142 ms', calls: '1,284', errors: '3 (0.2%)' },
-};
-
-const MOCK_TOOLS: { name: string; desc: string; scope: 'read' | 'write'; calls: number; enabled: boolean }[] = [
-    { name: 'search_repositories', desc: 'Search for GitHub repositories by name, owner, language, or topic.', scope: 'read', calls: 312, enabled: true },
-    { name: 'get_file_contents', desc: 'Read the contents of a file or directory from a repository at a specific ref.', scope: 'read', calls: 284, enabled: true },
-    { name: 'list_pull_requests', desc: 'List pull requests in a repository with filters for state, author, and base branch.', scope: 'read', calls: 196, enabled: true },
-    { name: 'create_or_update_file', desc: 'Create or update a file in a repository. Requires write access to the target branch.', scope: 'write', calls: 84, enabled: true },
-    { name: 'create_issue', desc: 'Open a new issue in a repository with title, body, labels, and assignees.', scope: 'write', calls: 42, enabled: true },
-    { name: 'merge_pull_request', desc: 'Merge a pull request using the repository\'s configured merge method.', scope: 'write', calls: 12, enabled: false },
-    { name: 'list_workflow_runs', desc: 'List GitHub Actions workflow runs filtered by status and branch.', scope: 'read', calls: 98, enabled: true },
-];
-
-const MOCK_ACTIVITY = [
-    { time: '3 min ago', event: 'Tool call from code-review agent', tool: 'get_file_contents', result: '200', resultClass: 'ok' },
-    { time: '8 min ago', event: 'Tool call from triage agent', tool: 'list_pull_requests', result: '200', resultClass: 'ok' },
-    { time: '14 min ago', event: 'Server restart — config changed', tool: '—', result: 'info', resultClass: 'muted' },
-    { time: '26 min ago', event: 'Tool call from code-review agent', tool: 'create_or_update_file', result: '201', resultClass: 'ok' },
-    { time: '38 min ago', event: 'Rate-limit warning from upstream', tool: '—', result: '429', resultClass: 'warn' },
-];
 
 function getServerStatus(server: McpServerEntry, isEnabled: boolean): 'ok' | 'auth' | 'off' | 'err' {
     if (!isEnabled) return 'off';
@@ -82,10 +55,9 @@ function getServerStatus(server: McpServerEntry, isEnabled: boolean): 'ok' | 'au
     return 'ok';
 }
 
-function getServerDescription(server: McpServerEntry, status: string, isEnabled: boolean): string {
-    const base = MOCK_DESCRIPTIONS[server.name] || server.url || server.command || '';
+function getServerDescription(server: McpServerEntry, isEnabled: boolean): string {
+    const base = server.description || server.url || server.command || '';
     if (!isEnabled) return `Disabled · ${base.toLowerCase()}`;
-    if (status === 'auth') return base;
     return base;
 }
 
@@ -201,168 +173,367 @@ function SourcePathsCard({ sources }: { sources?: McpServerSources }) {
     );
 }
 
-function InspectorOverviewPane({ server }: { server: McpServerEntry }) {
-    const health = MOCK_HEALTH[server.name];
-    const command = server.command || `npx -y @modelcontextprotocol/server-${server.name}`;
+function InspectorOverviewPane({ server, detail }: { server: McpServerEntry; detail: ClientMcpServerDetail | null | 'loading' }) {
+    const command = server.command || server.url || `npx -y @modelcontextprotocol/server-${server.name}`;
+    const description = (detail && detail !== 'loading') ? detail.description : (server.description ?? '—');
+    const source = (detail && detail !== 'loading') ? detail.source : (server.source ?? '—');
     return (
         <div className="mcp-overview-grid">
             <dl className="mcp-kv">
                 <dt>Server name</dt><dd><code>{server.name}</code></dd>
-                <dt>Description</dt><dd>{MOCK_DESCRIPTIONS[server.name] || '—'}</dd>
+                <dt>Description</dt><dd>{detail === 'loading' ? <span className="mcp-small">Loading…</span> : (description || '—')}</dd>
                 <dt>Transport</dt><dd>{server.type}</dd>
                 <dt>Command</dt><dd><code>{command}</code></dd>
-                <dt>Source</dt><dd>{server.source === 'workspace' ? 'Repo config' : 'Global config'}</dd>
-                <dt>Last started</dt><dd>3 minutes ago</dd>
+                <dt>Source</dt><dd>{source === 'workspace' ? 'Repo config' : source === 'global' ? 'Global config' : '—'}</dd>
             </dl>
             <div className="mcp-health">
                 <h4>Health</h4>
                 <div className="mcp-health-row">
                     <span className="mcp-label">Status</span>
-                    <span className="mcp-val"><span className="mcp-pill ok">● Connected</span></span>
+                    <span className="mcp-val">—</span>
                 </div>
                 <div className="mcp-health-row">
                     <span className="mcp-label">Uptime</span>
-                    <span className="mcp-val">{health?.uptime || '—'}</span>
+                    <span className="mcp-val">—</span>
                 </div>
                 <div className="mcp-health-row">
                     <span className="mcp-label">Avg. handshake</span>
-                    <span className="mcp-val">{health?.handshake || '—'}</span>
+                    <span className="mcp-val">—</span>
                 </div>
                 <div className="mcp-health-row">
                     <span className="mcp-label">Tool calls (24h)</span>
-                    <span className="mcp-val">{health?.calls || '—'}</span>
+                    <span className="mcp-val">—</span>
                 </div>
                 <div className="mcp-health-row">
                     <span className="mcp-label">Errors (24h)</span>
-                    <span className="mcp-val">{health?.errors || '—'}</span>
+                    <span className="mcp-val">—</span>
                 </div>
-                <svg className="mcp-sparkline" viewBox="0 0 200 32" preserveAspectRatio="none">
-                    <polyline fill="none" stroke="var(--mcp-success)" strokeWidth="1.5"
-                        points="0,22 10,18 20,20 30,12 40,16 50,8 60,14 70,10 80,16 90,12 100,20 110,14 120,8 130,12 140,6 150,10 160,14 170,8 180,12 190,6 200,10" />
-                    <polyline fill="rgba(31,136,61,0.08)" stroke="none"
-                        points="0,32 0,22 10,18 20,20 30,12 40,16 50,8 60,14 70,10 80,16 90,12 100,20 110,14 120,8 130,12 140,6 150,10 160,14 170,8 180,12 190,6 200,10 200,32" />
-                </svg>
-                <div className="mcp-small">Tool calls over the last 24 hours</div>
+                <div className="mcp-small">Health metrics coming soon</div>
             </div>
         </div>
     );
 }
 
-function InspectorToolsPane({ server }: { server: McpServerEntry }) {
-    const toolCount = MOCK_TOOL_COUNTS[server.name] || 0;
-    const remaining = Math.max(0, toolCount - MOCK_TOOLS.length);
+function InspectorToolsPane() {
     return (
-        <div>
-            <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 12, flexWrap: 'wrap' }}>
-                <div className="mcp-search-wrap" style={{ maxWidth: 280 }}>
-                    <SearchIcon14 />
-                    <input className="mcp-input" type="text" placeholder="Filter tools" readOnly />
-                </div>
-                <div className="mcp-seg">
-                    <button className="active">All {toolCount}</button>
-                    <button>Read {Math.round(toolCount * 0.63)}</button>
-                    <button>Write {Math.round(toolCount * 0.37)}</button>
-                </div>
-                <div className="mcp-spacer" />
-                <span className="mcp-small">All tools enabled · <button className="mcp-link" type="button">disable all</button></span>
-            </div>
-            <table className="mcp-tools-table">
-                <thead>
-                    <tr>
-                        <th style={{ width: '34%' }}>Tool</th>
-                        <th>Description</th>
-                        <th style={{ width: 90 }}>Scope</th>
-                        <th style={{ width: 100, textAlign: 'right' }}>Calls (24h)</th>
-                        <th style={{ width: 60 }}>Enabled</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {MOCK_TOOLS.map(tool => (
-                        <tr key={tool.name}>
-                            <td><div className="mcp-tool-name">{tool.name}</div></td>
-                            <td className="mcp-tool-desc">{tool.desc}</td>
-                            <td><span className={`mcp-scope-pill${tool.scope === 'write' ? ' write' : ''}`}>{tool.scope}</span></td>
-                            <td className="mcp-calls">{tool.calls}</td>
-                            <td><ToggleSwitch checked={tool.enabled} /></td>
-                        </tr>
-                    ))}
-                    {remaining > 0 && (
-                        <tr>
-                            <td colSpan={5} style={{ textAlign: 'center' }}>
-                                <button className="mcp-link mcp-small" type="button">Show {remaining} more tools</button>
-                            </td>
-                        </tr>
-                    )}
-                </tbody>
-            </table>
+        <div className="mcp-empty-state" style={{ padding: '32px 0' }}>
+            Connect to view tools
         </div>
     );
 }
 
-function InspectorConfigPane({ server }: { server: McpServerEntry }) {
+function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }: {
+    server: McpServerEntry;
+    detail: ClientMcpServerDetail | null | 'loading';
+    workspaceId: string;
+    onSaved: () => void;
+    onDeleted: () => void;
+}) {
+    const loaded = detail && detail !== 'loading' ? detail : null;
+
+    // Args state
+    const [argsText, setArgsText] = useState('');
+    const [argsSaving, setArgsSaving] = useState(false);
+    const [argsError, setArgsError] = useState('');
+
+    // Env state
+    const [newEnvKey, setNewEnvKey] = useState('');
+    const [newEnvValue, setNewEnvValue] = useState('');
+    const [envSaving, setEnvSaving] = useState(false);
+    const [envError, setEnvError] = useState('');
+
+    // Tool scope state
+    const [toolScope, setToolScope] = useState<'all' | 'readonly' | 'allowlist'>('all');
+    const [scopeSaving, setScopeSaving] = useState(false);
+
+    // Config scope state
+    const [configScope, setConfigScope] = useState<McpServerSource>('workspace');
+    const [migrateSaving, setMigrateSaving] = useState(false);
+
+    // Delete confirmation
+    const [deleteConfirm, setDeleteConfirm] = useState(false);
+    const [deleteSaving, setDeleteSaving] = useState(false);
+
+    // Initialize from detail when loaded
+    useEffect(() => {
+        if (loaded) {
+            setArgsText(loaded.args.join('\n'));
+            setToolScope(loaded.toolScope);
+            setConfigScope(loaded.source as McpServerSource);
+        }
+    }, [loaded]);
+
+    const handleSaveArgs = async () => {
+        if (!workspaceId) return;
+        setArgsSaving(true);
+        setArgsError('');
+        try {
+            const args = argsText.split('\n').map(s => s.trim()).filter(Boolean);
+            await getSpaCocClient().workspaces.updateMcpServer(workspaceId, server.name, { args });
+            onSaved();
+        } catch (e) {
+            setArgsError(getSpaCocClientErrorMessage(e, 'Failed to save args'));
+        } finally {
+            setArgsSaving(false);
+        }
+    };
+
+    const handleSaveToolScope = async (scope: 'all' | 'readonly' | 'allowlist') => {
+        if (!workspaceId) return;
+        setToolScope(scope);
+        setScopeSaving(true);
+        try {
+            await getSpaCocClient().workspaces.updateMcpServer(workspaceId, server.name, { toolScope: scope });
+            onSaved();
+        } catch {
+            // revert
+            if (loaded) setToolScope(loaded.toolScope);
+        } finally {
+            setScopeSaving(false);
+        }
+    };
+
+    const handleMigrate = async (targetScope: 'global' | 'workspace') => {
+        if (!workspaceId) return;
+        const prevScope = configScope;
+        setConfigScope(targetScope);
+        setMigrateSaving(true);
+        try {
+            await getSpaCocClient().workspaces.migrateMcpServer(workspaceId, server.name, targetScope as McpConfigScope);
+            onSaved();
+        } catch {
+            setConfigScope(prevScope);
+        } finally {
+            setMigrateSaving(false);
+        }
+    };
+
+    const handleAddEnvVar = async () => {
+        if (!workspaceId || !newEnvKey.trim()) return;
+        setEnvSaving(true);
+        setEnvError('');
+        try {
+            await getSpaCocClient().workspaces.updateMcpServer(workspaceId, server.name, {
+                env: { [newEnvKey.trim()]: newEnvValue },
+            });
+            setNewEnvKey('');
+            setNewEnvValue('');
+            onSaved();
+        } catch (e) {
+            setEnvError(getSpaCocClientErrorMessage(e, 'Failed to add env var'));
+        } finally {
+            setEnvSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!workspaceId) return;
+        setDeleteSaving(true);
+        try {
+            await getSpaCocClient().workspaces.deleteMcpServer(workspaceId, server.name);
+            onDeleted();
+        } catch {
+            setDeleteConfirm(false);
+        } finally {
+            setDeleteSaving(false);
+        }
+    };
+
     return (
         <div>
             <div className="mcp-config-section">
                 <h4>Environment variables</h4>
-                <p className="mcp-help">Secrets are stored encrypted in the workspace keychain and never written to config files.</p>
-                <table className="mcp-env-table">
-                    <thead><tr><th style={{ width: '40%' }}>Key</th><th>Value</th><th style={{ width: 60 }} /></tr></thead>
-                    <tbody>
-                        <tr>
-                            <td><span className="mcp-env-key">GITHUB_TOKEN</span></td>
-                            <td><div className="mcp-env-val"><span className="mcp-secret">••••••••••••••••</span></div></td>
-                            <td><button className="mcp-icon-btn" title="Remove" type="button">×</button></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <button className="mcp-btn sm" style={{ marginTop: 10 }} type="button"><PlusIcon size={12} /> Add variable</button>
+                <p className="mcp-help">Values are stored in the config file. Use secrets/env references for sensitive values.</p>
+                {detail === 'loading' ? (
+                    <div className="mcp-small">Loading…</div>
+                ) : (
+                    <>
+                        <table className="mcp-env-table">
+                            <thead><tr><th style={{ width: '40%' }}>Key</th><th>Value</th></tr></thead>
+                            <tbody>
+                                {(loaded?.envKeys ?? []).map(key => (
+                                    <tr key={key}>
+                                        <td><span className="mcp-env-key">{key}</span></td>
+                                        <td><div className="mcp-env-val"><span className="mcp-secret">••••••••</span></div></td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                        <div style={{ display: 'flex', gap: 8, marginTop: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+                            <input
+                                className="mcp-input"
+                                style={{ fontFamily: 'var(--mcp-font-mono)', width: 160 }}
+                                placeholder="KEY"
+                                value={newEnvKey}
+                                onChange={e => setNewEnvKey(e.target.value)}
+                            />
+                            <input
+                                className="mcp-input"
+                                style={{ fontFamily: 'var(--mcp-font-mono)', width: 180 }}
+                                type="password"
+                                placeholder="value"
+                                value={newEnvValue}
+                                onChange={e => setNewEnvValue(e.target.value)}
+                            />
+                            <button
+                                className="mcp-btn sm"
+                                type="button"
+                                disabled={!newEnvKey.trim() || envSaving}
+                                onClick={handleAddEnvVar}
+                            >
+                                <PlusIcon size={12} /> Add
+                            </button>
+                        </div>
+                        {envError && <div className="mcp-small" style={{ color: 'var(--mcp-danger)', marginTop: 4 }}>{envError}</div>}
+                    </>
+                )}
             </div>
 
             <div className="mcp-config-section">
                 <h4>Command arguments</h4>
                 <p className="mcp-help">Arguments passed to the server process. One per line.</p>
-                <textarea className="mcp-input" readOnly defaultValue={`-y\n@modelcontextprotocol/server-${server.name}\n--read-only=false`} />
+                {detail === 'loading' ? (
+                    <div className="mcp-small">Loading…</div>
+                ) : (
+                    <>
+                        <textarea
+                            className="mcp-input"
+                            value={argsText}
+                            onChange={e => setArgsText(e.target.value)}
+                            placeholder="One argument per line"
+                        />
+                        <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center' }}>
+                            <button
+                                className="mcp-btn sm"
+                                type="button"
+                                disabled={argsSaving}
+                                onClick={handleSaveArgs}
+                            >
+                                {argsSaving ? 'Saving…' : 'Save args'}
+                            </button>
+                            {argsError && <span className="mcp-small" style={{ color: 'var(--mcp-danger)' }}>{argsError}</span>}
+                        </div>
+                    </>
+                )}
             </div>
 
             <div className="mcp-config-section">
                 <h4>Allowed tools</h4>
                 <p className="mcp-help">Restrict which tools agents may call from this server.</p>
-                <div className="mcp-radio-group">
-                    <label><input type="radio" name={`scope-${server.name}`} defaultChecked /> <span><strong>All tools</strong> <span className="mcp-sub">— {MOCK_TOOL_COUNTS[server.name] || 0} tools available</span></span></label>
-                    <label><input type="radio" name={`scope-${server.name}`} /> <span><strong>Read-only</strong> <span className="mcp-sub">— hide tools tagged <code>write</code></span></span></label>
-                    <label><input type="radio" name={`scope-${server.name}`} /> <span><strong>Allow-list</strong> <span className="mcp-sub">— specify tools individually in the Tools tab</span></span></label>
-                </div>
+                {detail === 'loading' ? (
+                    <div className="mcp-small">Loading…</div>
+                ) : (
+                    <div className="mcp-radio-group">
+                        <label>
+                            <input
+                                type="radio"
+                                name={`scope-${server.name}`}
+                                checked={toolScope === 'all'}
+                                disabled={scopeSaving}
+                                onChange={() => handleSaveToolScope('all')}
+                            />
+                            {' '}<span><strong>All tools</strong></span>
+                        </label>
+                        <label>
+                            <input
+                                type="radio"
+                                name={`scope-${server.name}`}
+                                checked={toolScope === 'readonly'}
+                                disabled={scopeSaving}
+                                onChange={() => handleSaveToolScope('readonly')}
+                            />
+                            {' '}<span><strong>Read-only</strong> <span className="mcp-sub">— hide tools tagged <code>write</code></span></span>
+                        </label>
+                        <label>
+                            <input
+                                type="radio"
+                                name={`scope-${server.name}`}
+                                checked={toolScope === 'allowlist'}
+                                disabled={scopeSaving}
+                                onChange={() => handleSaveToolScope('allowlist')}
+                            />
+                            {' '}<span><strong>Allow-list</strong> <span className="mcp-sub">— specify tools individually</span></span>
+                        </label>
+                    </div>
+                )}
             </div>
 
             <div className="mcp-config-section">
                 <h4>Scope</h4>
                 <p className="mcp-help">Where this configuration applies.</p>
-                <div className="mcp-radio-group">
-                    <label><input type="radio" name={`loc-${server.name}`} defaultChecked /> <span><strong>Workspace</strong> <span className="mcp-sub">— shared with collaborators via config file</span></span></label>
-                    <label><input type="radio" name={`loc-${server.name}`} /> <span><strong>User</strong> <span className="mcp-sub">— only on this machine</span></span></label>
-                </div>
+                {detail === 'loading' ? (
+                    <div className="mcp-small">Loading…</div>
+                ) : (
+                    <div className="mcp-radio-group">
+                        <label>
+                            <input
+                                type="radio"
+                                name={`loc-${server.name}`}
+                                checked={configScope === 'workspace'}
+                                disabled={migrateSaving}
+                                onChange={() => handleMigrate('workspace')}
+                            />
+                            {' '}<span><strong>Workspace</strong> <span className="mcp-sub">— shared via config file</span></span>
+                        </label>
+                        <label>
+                            <input
+                                type="radio"
+                                name={`loc-${server.name}`}
+                                checked={configScope === 'global'}
+                                disabled={migrateSaving}
+                                onChange={() => handleMigrate('global')}
+                            />
+                            {' '}<span><strong>User</strong> <span className="mcp-sub">— only on this machine</span></span>
+                        </label>
+                    </div>
+                )}
             </div>
 
             <hr className="mcp-rule" />
 
             <div className="mcp-danger-zone">
                 <h4>Remove server</h4>
-                <p>Removing <code>{server.name}</code> will stop the process and delete its entry from the configuration. Stored secrets are deleted from the keychain.</p>
-                <button className="mcp-btn danger-outline" type="button">Remove this server</button>
+                <p>Removing <code>{server.name}</code> will delete its entry from the configuration file.</p>
+                {deleteConfirm ? (
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <span className="mcp-small">Are you sure?</span>
+                        <button
+                            className="mcp-btn danger-outline"
+                            type="button"
+                            disabled={deleteSaving}
+                            onClick={handleDelete}
+                        >
+                            {deleteSaving ? 'Removing…' : 'Yes, remove'}
+                        </button>
+                        <button className="mcp-btn" type="button" onClick={() => setDeleteConfirm(false)}>Cancel</button>
+                    </div>
+                ) : (
+                    <button
+                        className="mcp-btn danger-outline"
+                        type="button"
+                        onClick={() => setDeleteConfirm(true)}
+                    >
+                        Remove this server
+                    </button>
+                )}
             </div>
         </div>
     );
 }
 
-function InspectorSourcePane({ server }: { server: McpServerEntry }) {
-    const json = JSON.stringify({
-        [server.name]: {
-            command: server.command || 'npx',
-            args: ['-y', `@modelcontextprotocol/server-${server.name}`, '--read-only=false'],
-            env: { [`${server.name.toUpperCase()}_TOKEN`]: '${secrets.TOKEN}' },
-            transport: server.type,
-        },
-    }, null, 2);
+function InspectorSourcePane({ server, detail }: { server: McpServerEntry; detail: ClientMcpServerDetail | null | 'loading' }) {
+    if (detail === 'loading') {
+        return <div className="mcp-small" style={{ marginTop: 8 }}>Loading…</div>;
+    }
+    const json = detail
+        ? JSON.stringify({ [server.name]: detail.rawJson }, null, 2)
+        : JSON.stringify({
+            [server.name]: {
+                command: server.command || 'npx',
+                type: server.type,
+                ...(server.url ? { url: server.url } : {}),
+            },
+        }, null, 2);
     return (
         <div>
             <p className="mcp-small" style={{ marginTop: 0 }}>This is the raw JSON as stored in the config file.</p>
@@ -373,38 +544,24 @@ function InspectorSourcePane({ server }: { server: McpServerEntry }) {
 
 function InspectorActivityPane() {
     return (
-        <table className="mcp-tools-table">
-            <thead>
-                <tr>
-                    <th style={{ width: 120 }}>Time</th>
-                    <th>Event</th>
-                    <th style={{ width: 120 }}>Tool</th>
-                    <th style={{ width: 80 }}>Result</th>
-                </tr>
-            </thead>
-            <tbody>
-                {MOCK_ACTIVITY.map((a, i) => (
-                    <tr key={i}>
-                        <td className="mcp-small">{a.time}</td>
-                        <td>{a.event}</td>
-                        <td><span className="mcp-env-key">{a.tool}</span></td>
-                        <td><span className={`mcp-pill ${a.resultClass}`}>{a.result}</span></td>
-                    </tr>
-                ))}
-            </tbody>
-        </table>
+        <div className="mcp-empty-state" style={{ padding: '32px 0' }}>
+            Activity logging coming soon
+        </div>
     );
 }
 
-function ServerInspector({ server, activeTab, onTabChange }: {
+function ServerInspector({ server, activeTab, onTabChange, detail, workspaceId, onSaved, onDeleted }: {
     server: McpServerEntry;
     activeTab: InspectorTab;
     onTabChange: (tab: InspectorTab) => void;
+    detail: ClientMcpServerDetail | null | 'loading';
+    workspaceId: string;
+    onSaved: () => void;
+    onDeleted: () => void;
 }) {
-    const toolCount = MOCK_TOOL_COUNTS[server.name] || 0;
-    const tabs: { id: InspectorTab; label: string; badge?: string }[] = [
+    const tabs: { id: InspectorTab; label: string }[] = [
         { id: 'overview', label: 'Overview' },
-        { id: 'tools', label: 'Tools', badge: String(toolCount) },
+        { id: 'tools', label: 'Tools' },
         { id: 'configuration', label: 'Configuration' },
         { id: 'source', label: 'Source' },
         { id: 'activity', label: 'Activity' },
@@ -421,22 +578,78 @@ function ServerInspector({ server, activeTab, onTabChange }: {
                         type="button"
                     >
                         {tab.label}
-                        {tab.badge && <span className="mcp-badge">{tab.badge}</span>}
                     </button>
                 ))}
             </div>
             <div className="mcp-inspector-body">
-                {activeTab === 'overview' && <InspectorOverviewPane server={server} />}
-                {activeTab === 'tools' && <InspectorToolsPane server={server} />}
-                {activeTab === 'configuration' && <InspectorConfigPane server={server} />}
-                {activeTab === 'source' && <InspectorSourcePane server={server} />}
+                {activeTab === 'overview' && <InspectorOverviewPane server={server} detail={detail} />}
+                {activeTab === 'tools' && <InspectorToolsPane />}
+                {activeTab === 'configuration' && (
+                    <InspectorConfigPane
+                        server={server}
+                        detail={detail}
+                        workspaceId={workspaceId}
+                        onSaved={onSaved}
+                        onDeleted={onDeleted}
+                    />
+                )}
+                {activeTab === 'source' && <InspectorSourcePane server={server} detail={detail} />}
                 {activeTab === 'activity' && <InspectorActivityPane />}
             </div>
         </div>
     );
 }
 
-function AddServerCard() {
+function AddServerCard({ workspaceId, onAdded }: { workspaceId?: string; onAdded?: () => void }) {
+    const [transport, setTransport] = useState<'stdio' | 'http' | 'sse'>('stdio');
+    const [name, setName] = useState('');
+    const [desc, setDesc] = useState('');
+    const [command, setCommand] = useState('npx');
+    const [argsText, setArgsText] = useState('');
+    const [url, setUrl] = useState('');
+    const [toolScope, setToolScope] = useState<'all' | 'readonly'>('all');
+    const [scope, setScope] = useState<'workspace' | 'global'>('workspace');
+    const [envRows, setEnvRows] = useState<{ key: string; value: string }[]>([{ key: '', value: '' }]);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleAddEnvRow = () => setEnvRows(prev => [...prev, { key: '', value: '' }]);
+    const handleEnvChange = (idx: number, field: 'key' | 'value', val: string) => {
+        setEnvRows(prev => prev.map((r, i) => i === idx ? { ...r, [field]: val } : r));
+    };
+    const handleRemoveEnvRow = (idx: number) => setEnvRows(prev => prev.filter((_, i) => i !== idx));
+
+    const handleAdd = async () => {
+        if (!workspaceId || !name.trim()) return;
+        setSaving(true);
+        setError('');
+        try {
+            const envObj: Record<string, string> = {};
+            for (const row of envRows) {
+                if (row.key.trim()) envObj[row.key.trim()] = row.value;
+            }
+            await getSpaCocClient().workspaces.addMcpServer(workspaceId, {
+                name: name.trim(),
+                type: transport,
+                command: transport === 'stdio' ? (command.trim() || undefined) : undefined,
+                url: (transport === 'http' || transport === 'sse') ? (url.trim() || undefined) : undefined,
+                args: transport === 'stdio' ? argsText.split('\n').map(s => s.trim()).filter(Boolean) : undefined,
+                env: Object.keys(envObj).length > 0 ? envObj : undefined,
+                description: desc.trim() || undefined,
+                toolScope: toolScope !== 'all' ? toolScope : undefined,
+                scope,
+            });
+            // Reset form
+            setName(''); setDesc(''); setCommand('npx'); setArgsText(''); setUrl('');
+            setEnvRows([{ key: '', value: '' }]); setToolScope('all'); setScope('workspace');
+            onAdded?.();
+        } catch (e) {
+            setError(getSpaCocClientErrorMessage(e, 'Failed to add server'));
+        } finally {
+            setSaving(false);
+        }
+    };
+
     return (
         <div className="mcp-add-card" id="add">
             <div className="mcp-add-head">
@@ -449,9 +662,16 @@ function AddServerCard() {
                     <label>Transport</label>
                     <span className="mcp-field-hint">How the agent talks to this server.</span>
                     <div className="mcp-seg">
-                        <button className="active">stdio (local process)</button>
-                        <button>http (URL)</button>
-                        <button>sse</button>
+                        {(['stdio', 'http', 'sse'] as const).map(t => (
+                            <button
+                                key={t}
+                                className={transport === t ? 'active' : ''}
+                                type="button"
+                                onClick={() => setTransport(t)}
+                            >
+                                {t === 'stdio' ? 'stdio (local process)' : t}
+                            </button>
+                        ))}
                     </div>
                 </div>
 
@@ -459,41 +679,108 @@ function AddServerCard() {
                     <div className="mcp-field">
                         <label htmlFor="srv-name">Server name</label>
                         <span className="mcp-field-hint">Lowercase, no spaces. Used as the key in the config.</span>
-                        <input id="srv-name" className="mcp-input full" placeholder="e.g. github, postgres, internal-docs" readOnly />
+                        <input
+                            id="srv-name"
+                            className="mcp-input full"
+                            placeholder="e.g. github, postgres, internal-docs"
+                            value={name}
+                            onChange={e => setName(e.target.value)}
+                        />
                     </div>
                     <div className="mcp-field">
                         <label htmlFor="srv-desc">Description <span className="mcp-small" style={{ fontWeight: 400 }}>(optional)</span></label>
                         <span className="mcp-field-hint">Shown in this list and in the agent picker.</span>
-                        <input id="srv-desc" className="mcp-input full" placeholder="e.g. Read access to the internal API docs site" readOnly />
+                        <input
+                            id="srv-desc"
+                            className="mcp-input full"
+                            placeholder="e.g. Read access to the internal API docs site"
+                            value={desc}
+                            onChange={e => setDesc(e.target.value)}
+                        />
                     </div>
                 </div>
 
-                <div className="mcp-field">
-                    <label htmlFor="srv-cmd">Command</label>
-                    <span className="mcp-field-hint">The executable to run. Use <code>npx -y &lt;package&gt;</code> for npm-published servers.</span>
-                    <input id="srv-cmd" className="mcp-input full" placeholder="npx" defaultValue="npx" readOnly />
-                </div>
-
-                <div className="mcp-field">
-                    <label htmlFor="srv-args">Arguments</label>
-                    <span className="mcp-field-hint">One per line. Will be passed to the command.</span>
-                    <textarea id="srv-args" className="mcp-input" placeholder={`-y\n@modelcontextprotocol/server-postgres\npostgres://readonly@db.example.com/app`} readOnly />
-                </div>
+                {transport === 'stdio' ? (
+                    <>
+                        <div className="mcp-field">
+                            <label htmlFor="srv-cmd">Command</label>
+                            <span className="mcp-field-hint">The executable to run.</span>
+                            <input
+                                id="srv-cmd"
+                                className="mcp-input full"
+                                placeholder="npx"
+                                value={command}
+                                onChange={e => setCommand(e.target.value)}
+                            />
+                        </div>
+                        <div className="mcp-field">
+                            <label htmlFor="srv-args">Arguments</label>
+                            <span className="mcp-field-hint">One per line.</span>
+                            <textarea
+                                id="srv-args"
+                                className="mcp-input"
+                                placeholder={`-y\n@modelcontextprotocol/server-postgres\npostgres://readonly@db.example.com/app`}
+                                value={argsText}
+                                onChange={e => setArgsText(e.target.value)}
+                            />
+                        </div>
+                    </>
+                ) : (
+                    <div className="mcp-field">
+                        <label htmlFor="srv-url">URL</label>
+                        <span className="mcp-field-hint">The endpoint URL for the MCP server.</span>
+                        <input
+                            id="srv-url"
+                            className="mcp-input full"
+                            placeholder="https://mcp.example.com/api"
+                            value={url}
+                            onChange={e => setUrl(e.target.value)}
+                        />
+                    </div>
+                )}
 
                 <div className="mcp-field">
                     <label>Environment variables</label>
-                    <span className="mcp-field-hint">Secrets are stored in the workspace keychain.</span>
+                    <span className="mcp-field-hint">Passed to the server process.</span>
                     <table className="mcp-env-table">
                         <thead><tr><th style={{ width: '40%' }}>Key</th><th>Value</th><th style={{ width: 60 }} /></tr></thead>
                         <tbody>
-                            <tr>
-                                <td><input className="mcp-input" style={{ width: '100%', fontFamily: 'var(--mcp-font-mono)' }} placeholder="API_TOKEN" readOnly /></td>
-                                <td><input className="mcp-input" style={{ width: '100%', fontFamily: 'var(--mcp-font-mono)' }} type="password" placeholder="paste secret" readOnly /></td>
-                                <td><button className="mcp-icon-btn" title="Remove" type="button">×</button></td>
-                            </tr>
+                            {envRows.map((row, i) => (
+                                <tr key={i}>
+                                    <td>
+                                        <input
+                                            className="mcp-input"
+                                            style={{ width: '100%', fontFamily: 'var(--mcp-font-mono)' }}
+                                            placeholder="API_TOKEN"
+                                            value={row.key}
+                                            onChange={e => handleEnvChange(i, 'key', e.target.value)}
+                                        />
+                                    </td>
+                                    <td>
+                                        <input
+                                            className="mcp-input"
+                                            style={{ width: '100%', fontFamily: 'var(--mcp-font-mono)' }}
+                                            type="password"
+                                            placeholder="paste secret"
+                                            value={row.value}
+                                            onChange={e => handleEnvChange(i, 'value', e.target.value)}
+                                        />
+                                    </td>
+                                    <td>
+                                        <button
+                                            className="mcp-icon-btn"
+                                            title="Remove"
+                                            type="button"
+                                            onClick={() => handleRemoveEnvRow(i)}
+                                        >×</button>
+                                    </td>
+                                </tr>
+                            ))}
                         </tbody>
                     </table>
-                    <button className="mcp-btn sm" style={{ marginTop: 10 }} type="button"><PlusIcon size={12} /> Add variable</button>
+                    <button className="mcp-btn sm" style={{ marginTop: 10 }} type="button" onClick={handleAddEnvRow}>
+                        <PlusIcon size={12} /> Add variable
+                    </button>
                 </div>
 
                 <div className="mcp-field-grid">
@@ -501,30 +788,69 @@ function AddServerCard() {
                         <label>Allowed tools</label>
                         <span className="mcp-field-hint">Restrict which tools this server can offer.</span>
                         <div className="mcp-radio-group">
-                            <label><input type="radio" name="scope-new" defaultChecked /> <span><strong>All tools</strong> <span className="mcp-sub">— allow every tool the server exposes</span></span></label>
-                            <label><input type="radio" name="scope-new" /> <span><strong>Read-only</strong> <span className="mcp-sub">— block tools tagged <code>write</code></span></span></label>
-                            <label><input type="radio" name="scope-new" /> <span><strong>Pick after connect</strong> <span className="mcp-sub">— connect first, then choose</span></span></label>
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="scope-new"
+                                    checked={toolScope === 'all'}
+                                    onChange={() => setToolScope('all')}
+                                />
+                                {' '}<span><strong>All tools</strong></span>
+                            </label>
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="scope-new"
+                                    checked={toolScope === 'readonly'}
+                                    onChange={() => setToolScope('readonly')}
+                                />
+                                {' '}<span><strong>Read-only</strong></span>
+                            </label>
                         </div>
                     </div>
                     <div className="mcp-field">
                         <label>Where should this be saved?</label>
                         <span className="mcp-field-hint">Workspace config is checked in and shared with collaborators.</span>
                         <div className="mcp-radio-group">
-                            <label><input type="radio" name="loc-new" defaultChecked /> <span><strong>Workspace</strong> <span className="mcp-sub">— writes to the repo config file</span></span></label>
-                            <label><input type="radio" name="loc-new" /> <span><strong>Just me</strong> <span className="mcp-sub">— writes to the user override file</span></span></label>
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="loc-new"
+                                    checked={scope === 'workspace'}
+                                    onChange={() => setScope('workspace')}
+                                />
+                                {' '}<span><strong>Workspace</strong> <span className="mcp-sub">— writes to the repo config file</span></span>
+                            </label>
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="loc-new"
+                                    checked={scope === 'global'}
+                                    onChange={() => setScope('global')}
+                                />
+                                {' '}<span><strong>Just me</strong> <span className="mcp-sub">— writes to the user override file</span></span>
+                            </label>
                         </div>
                     </div>
                 </div>
             </div>
+            {error && <div className="mcp-small" style={{ color: 'var(--mcp-danger)', padding: '0 16px 8px' }}>{error}</div>}
             <div className="mcp-form-actions">
-                <button className="mcp-btn" type="button">Test connection</button>
-                <button className="mcp-btn primary" type="button">Add server</button>
+                <button
+                    className="mcp-btn primary"
+                    type="button"
+                    disabled={!name.trim() || saving || !workspaceId}
+                    onClick={handleAdd}
+                >
+                    {saving ? 'Adding…' : 'Add server'}
+                </button>
             </div>
         </div>
     );
 }
 
 export function McpServersPanel({
+    workspaceId = '',
     loading,
     error,
     saving,
@@ -533,11 +859,24 @@ export function McpServersPanel({
     isEnabled,
     onToggle,
     onRefresh,
+    onMutate,
 }: McpServersPanelProps) {
     const [filterTab, setFilterTab] = useState<FilterTab>('all');
     const [searchQuery, setSearchQuery] = useState('');
     const [expandedServer, setExpandedServer] = useState<string | null>(null);
     const [inspectorTab, setInspectorTab] = useState<InspectorTab>('overview');
+    const [detailCache, setDetailCache] = useState<Record<string, ClientMcpServerDetail | null | 'loading'>>({});
+
+    const fetchDetail = useCallback(async (name: string) => {
+        if (!workspaceId || detailCache[name] !== undefined) return;
+        setDetailCache(prev => ({ ...prev, [name]: 'loading' }));
+        try {
+            const detail = await getSpaCocClient().workspaces.getMcpServerDetail(workspaceId, name);
+            setDetailCache(prev => ({ ...prev, [name]: detail }));
+        } catch {
+            setDetailCache(prev => ({ ...prev, [name]: null }));
+        }
+    }, [workspaceId, detailCache]);
 
     const legacySources: McpServerSources | undefined = sources ?? (availableServers.length > 0 ? {
         global: {
@@ -557,11 +896,8 @@ export function McpServersPanel({
     const allServers = availableServers;
 
     const counts = useMemo(() => {
-        const active = allServers.filter(s => isEnabled(s.name) && s.effective !== false).length;
-        const needsAuth = allServers.filter(s => {
-            const status = getServerStatus(s, isEnabled(s.name));
-            return status === 'auth';
-        }).length;
+        const active = allServers.filter(s => isEnabled(s.name) && s.effective !== false && getServerStatus(s, true) === 'ok').length;
+        const needsAuth = allServers.filter(s => getServerStatus(s, isEnabled(s.name)) === 'auth').length;
         const disabled = allServers.filter(s => !isEnabled(s.name) || s.effective === false).length;
         return { all: allServers.length, active, auth: needsAuth, disabled };
     }, [allServers, isEnabled]);
@@ -581,7 +917,7 @@ export function McpServersPanel({
         if (q) {
             list = list.filter(s =>
                 s.name.toLowerCase().includes(q) ||
-                (MOCK_DESCRIPTIONS[s.name] || '').toLowerCase().includes(q)
+                (s.description ?? '').toLowerCase().includes(q)
             );
         }
 
@@ -594,8 +930,24 @@ export function McpServersPanel({
         } else {
             setExpandedServer(name);
             setInspectorTab('overview');
+            fetchDetail(name);
         }
-    }, [expandedServer]);
+    }, [expandedServer, fetchDetail]);
+
+    // After a detail-mutating save, invalidate the cached detail so it re-fetches on next open
+    const handleDetailSaved = useCallback((serverName: string) => {
+        setDetailCache(prev => {
+            const next = { ...prev };
+            delete next[serverName];
+            return next;
+        });
+    }, []);
+
+    const handleServerDeleted = useCallback(() => {
+        setExpandedServer(null);
+        onMutate?.();
+        onRefresh?.();
+    }, [onMutate, onRefresh]);
 
     if (loading) {
         return (
@@ -680,10 +1032,9 @@ export function McpServersPanel({
                         const enabled = isEnabled(server.name);
                         const isOverridden = server.effective === false;
                         const status = getServerStatus(server, enabled);
-                        const description = getServerDescription(server, status, enabled);
+                        const description = getServerDescription(server, enabled);
                         const transportCls = getTransportPillClass(server.type);
                         const sourcePill = getSourcePillInfo(server);
-                        const toolCount = MOCK_TOOL_COUNTS[server.name] || 0;
                         const isExpanded = expandedServer === server.name;
 
                         return (
@@ -705,11 +1056,11 @@ export function McpServersPanel({
                                         <strong className="mcp-server-name" style={!enabled ? { color: 'var(--mcp-fg-muted)' } : undefined}>
                                             {server.name}
                                         </strong>
-                                        <span className="mcp-server-desc">— {description}</span>
+                                        {description && <span className="mcp-server-desc">— {description}</span>}
                                     </div>
                                     <div className="mcp-meta"><span className={`mcp-pill ${transportCls}`}>{server.type}</span></div>
                                     <div className="mcp-meta"><span className={`mcp-pill ${sourcePill.cls}`}>{sourcePill.label}</span></div>
-                                    <div className="mcp-tools-count">{toolCount} tools</div>
+                                    <div className="mcp-tools-count">—</div>
                                     <ToggleSwitch
                                         checked={!isOverridden && enabled}
                                         disabled={saving || isOverridden}
@@ -722,6 +1073,10 @@ export function McpServersPanel({
                                         server={server}
                                         activeTab={inspectorTab}
                                         onTabChange={setInspectorTab}
+                                        detail={detailCache[server.name] ?? null}
+                                        workspaceId={workspaceId}
+                                        onSaved={() => handleDetailSaved(server.name)}
+                                        onDeleted={handleServerDeleted}
                                     />
                                 )}
                             </React.Fragment>
@@ -731,7 +1086,13 @@ export function McpServersPanel({
             </div>
 
             {/* Add server card */}
-            <AddServerCard />
+            <AddServerCard
+                workspaceId={workspaceId}
+                onAdded={() => {
+                    onMutate?.();
+                    onRefresh?.();
+                }}
+            />
 
             {/* Footer */}
             <div className="mcp-footer">

--- a/packages/coc/src/server/spa/client/react/features/skills/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/skills/index.ts
@@ -3,7 +3,7 @@ export type { Skill, SkillDetail } from './AgentSkillsPanel';
 export { CustomInstructionsPanel } from './CustomInstructionsPanel';
 export type { InstructionMode } from './CustomInstructionsPanel';
 export { McpServersPanel } from './McpServersPanel';
-export type { McpServerEntry } from './McpServersPanel';
+export type { McpServerEntry, McpServerSources, McpServerSourceSection } from './McpServersPanel';
 export { useRecentSkills } from './hooks/useRecentSkills';
 export { SkillsView } from './SkillsView';
 export { SkillsBundledPanel } from './SkillsBundledPanel';

--- a/packages/coc/test/server/mcp-config-api.test.ts
+++ b/packages/coc/test/server/mcp-config-api.test.ts
@@ -28,6 +28,13 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     };
 });
 
+// Mock mcp-config-writer so readAllDescriptions doesn't touch real filesystem
+const mockReadAllDescriptions = vi.hoisted(() => vi.fn().mockReturnValue({}));
+vi.mock('../../src/server/routes/mcp-config-writer', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, readAllDescriptions: mockReadAllDescriptions };
+});
+
 // ============================================================================
 // Test Helpers
 // ============================================================================
@@ -102,6 +109,8 @@ describe('MCP Config API endpoints', () => {
     beforeEach(() => {
         mockLoadDefaultMcpConfig.mockReset();
         mockLoadWorkspaceMcpConfig.mockReset();
+        mockReadAllDescriptions.mockReset();
+        mockReadAllDescriptions.mockReturnValue({});
         mockLoadDefaultMcpConfig.mockReturnValue({ mcpServers: {}, configPath: '~/.copilot/mcp-config.json', fileExists: false });
         mockLoadWorkspaceMcpConfig.mockReturnValue({ mcpServers: {}, configPath: '/projects/my/.vscode/mcp.json', fileExists: false });
         (mockStore.getWorkspaces as any).mockResolvedValue([
@@ -184,15 +193,17 @@ describe('MCP Config API endpoints', () => {
             const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
             expect(res.status).toBe(200);
             const data = res.json();
-            expect(data.availableServers).toEqual([{
+            // availableServers now includes a `status` field derived server-side
+            expect(data.availableServers).toMatchObject([{
                 name: 'repo',
                 type: 'sse',
                 url: 'http://localhost:1234/sse',
                 source: 'workspace',
                 effective: true,
+                status: 'auth', // sse → 'auth' when enabled
             }]);
+            expect(data.availableServers[0].env).toBeUndefined();
             expect(data.sources.global.servers).toEqual([]);
-            expect(data.sources.workspace.servers).toEqual(data.availableServers);
         });
 
         it('returns distinct global and workspace servers in source sections', async () => {
@@ -323,9 +334,10 @@ describe('MCP Config API endpoints', () => {
             const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
             expect(res.status).toBe(200);
             const data = res.json();
-            expect(data.availableServers).toEqual([
-                { name: 'workspace', type: 'stdio', command: 'workspace-cmd', source: 'workspace', effective: true },
+            expect(data.availableServers).toMatchObject([
+                { name: 'workspace', type: 'stdio', command: 'workspace-cmd', source: 'workspace', effective: true, status: 'ok' },
             ]);
+            expect(data.availableServers[0].env).toBeUndefined();
             expect(data.sources.global).toMatchObject({
                 success: false,
                 error: 'Failed to parse MCP config: bad global JSON',
@@ -355,9 +367,11 @@ describe('MCP Config API endpoints', () => {
             const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
             expect(res.status).toBe(200);
             const data = res.json();
-            expect(data.availableServers).toEqual([
-                { name: 'global', type: 'stdio', command: 'global-cmd', source: 'global', effective: true },
+            expect(data.availableServers).toMatchObject([
+                { name: 'global', type: 'stdio', command: 'global-cmd', source: 'global', effective: true, status: 'ok' },
             ]);
+            expect(data.availableServers[0].env).toBeUndefined();
+            expect(data.availableServers[0].args).toBeUndefined();
             expect(data.sources.global.success).toBe(true);
             expect(data.sources.global.servers[0].args).toBeUndefined();
             expect(data.sources.workspace).toMatchObject({
@@ -451,6 +465,78 @@ describe('MCP Config API endpoints', () => {
             expect(res.status).toBe(400);
             const data = res.json();
             expect(data.code).toBe('BAD_REQUEST');
+        });
+    });
+
+    // ========================================================================
+    // GET /api/workspaces/:id/mcp-config — status and description fields
+    // ========================================================================
+
+    describe('GET /api/workspaces/:id/mcp-config — status and description', () => {
+        it('includes status:ok for stdio server that is enabled', async () => {
+            mockLoadDefaultMcpConfig.mockReturnValue({
+                configPath: '~/.copilot/mcp-config.json',
+                fileExists: true,
+                mcpServers: { github: { command: 'npx', type: 'stdio' } },
+            });
+            (mockStore.getWorkspaces as any).mockResolvedValue([
+                { id: WORKSPACE_ID, name: 'My Project', rootPath: '/projects/my', enabledMcpServers: null },
+            ]);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
+            const data = res.json();
+            expect(data.availableServers[0].status).toBe('ok');
+        });
+
+        it('includes status:auth for http server that is enabled', async () => {
+            mockLoadDefaultMcpConfig.mockReturnValue({
+                configPath: '~/.copilot/mcp-config.json',
+                fileExists: true,
+                mcpServers: { myapi: { type: 'http', url: 'http://localhost:8080' } },
+            });
+            (mockStore.getWorkspaces as any).mockResolvedValue([
+                { id: WORKSPACE_ID, name: 'My Project', rootPath: '/projects/my', enabledMcpServers: null },
+            ]);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
+            const data = res.json();
+            expect(data.availableServers[0].status).toBe('auth');
+        });
+
+        it('includes status:off for server that is disabled in enabledMcpServers', async () => {
+            mockLoadDefaultMcpConfig.mockReturnValue({
+                configPath: '~/.copilot/mcp-config.json',
+                fileExists: true,
+                mcpServers: { github: { command: 'npx', type: 'stdio' } },
+            });
+            (mockStore.getWorkspaces as any).mockResolvedValue([
+                { id: WORKSPACE_ID, name: 'My Project', rootPath: '/projects/my', enabledMcpServers: [] },
+            ]);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
+            const data = res.json();
+            expect(data.availableServers[0].status).toBe('off');
+        });
+
+        it('includes description from readAllDescriptions when present', async () => {
+            mockLoadDefaultMcpConfig.mockReturnValue({
+                configPath: '~/.copilot/mcp-config.json',
+                fileExists: true,
+                mcpServers: { github: { command: 'npx', type: 'stdio' } },
+            });
+            mockReadAllDescriptions.mockReturnValue({ github: 'GitHub MCP server' });
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
+            const data = res.json();
+            expect(data.availableServers[0].description).toBe('GitHub MCP server');
+        });
+
+        it('omits description when readAllDescriptions returns nothing for that server', async () => {
+            mockLoadDefaultMcpConfig.mockReturnValue({
+                configPath: '~/.copilot/mcp-config.json',
+                fileExists: true,
+                mcpServers: { github: { command: 'npx', type: 'stdio' } },
+            });
+            // default mock returns {}
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`);
+            const data = res.json();
+            expect(data.availableServers[0].description).toBeUndefined();
         });
     });
 });

--- a/packages/coc/test/server/mcp-config-crud-api.test.ts
+++ b/packages/coc/test/server/mcp-config-crud-api.test.ts
@@ -50,6 +50,11 @@ vi.mock('../../src/server/routes/mcp-config-writer', () => ({
     findServerSource: mockFindServerSource,
 }));
 
+const mockTestMcpConnection = vi.hoisted(() => vi.fn());
+vi.mock('../../src/server/routes/mcp-connection-tester', () => ({
+    testMcpConnection: mockTestMcpConnection,
+}));
+
 // ============================================================================
 // Test Helpers
 // ============================================================================
@@ -425,6 +430,115 @@ describe('MCP Config CRUD API endpoints', () => {
             });
             expect(res.status).toBe(200);
             expect(mockMigrateServerScope).toHaveBeenCalledWith('github', '/projects/my', 'workspace');
+        });
+    });
+
+    // ========================================================================
+    // POST /api/workspaces/:id/mcp-config/test
+    // ========================================================================
+
+    describe('POST /api/workspaces/:id/mcp-config/test', () => {
+        beforeEach(() => {
+            mockTestMcpConnection.mockResolvedValue({ success: true, message: 'MCP server responded successfully' });
+        });
+
+        it('returns 404 when workspace not found', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'stdio', command: 'npx', args: ['-y', 'some-server'] }),
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 400 when type is invalid', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'unknown' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when stdio type has no command', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'stdio' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when http type has no url', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'http' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 200 and success when stdio test passes', async () => {
+            mockTestMcpConnection.mockResolvedValue({
+                success: true,
+                message: 'MCP server responded successfully',
+                protocolVersion: '2024-11-05',
+                serverName: 'github-mcp',
+            });
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'stdio', command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'], env: { GITHUB_TOKEN: 'token' } }),
+            });
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.success).toBe(true);
+            expect(data.protocolVersion).toBe('2024-11-05');
+            expect(data.serverName).toBe('github-mcp');
+            expect(mockTestMcpConnection).toHaveBeenCalledWith({
+                type: 'stdio',
+                command: 'npx',
+                args: ['-y', '@modelcontextprotocol/server-github'],
+                env: { GITHUB_TOKEN: 'token' },
+                url: undefined,
+            });
+        });
+
+        it('returns 422 when test fails', async () => {
+            mockTestMcpConnection.mockResolvedValue({
+                success: false,
+                message: 'Timed out waiting for MCP initialize response (10 s)',
+            });
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'stdio', command: 'bad-command' }),
+            });
+            expect(res.status).toBe(422);
+            const data = res.json();
+            expect(data.success).toBe(false);
+            expect(data.message).toContain('Timed out');
+        });
+
+        it('returns 200 for successful http test', async () => {
+            mockTestMcpConnection.mockResolvedValue({ success: true, message: 'Server responded with HTTP 200' });
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'http', url: 'http://localhost:8080/mcp' }),
+            });
+            expect(res.status).toBe(200);
+            expect(res.json().success).toBe(true);
+            expect(mockTestMcpConnection).toHaveBeenCalledWith({
+                type: 'http',
+                url: 'http://localhost:8080/mcp',
+                command: undefined,
+                args: undefined,
+                env: undefined,
+            });
+        });
+
+        it('returns 422 for failed http test', async () => {
+            mockTestMcpConnection.mockResolvedValue({ success: false, message: 'Connection failed: ECONNREFUSED' });
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/test`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'sse', url: 'http://localhost:9999/events' }),
+            });
+            expect(res.status).toBe(422);
+            expect(res.json().success).toBe(false);
         });
     });
 });

--- a/packages/coc/test/server/mcp-config-crud-api.test.ts
+++ b/packages/coc/test/server/mcp-config-crud-api.test.ts
@@ -1,0 +1,430 @@
+/**
+ * MCP Config CRUD API Endpoint Tests
+ *
+ * Tests for the new MCP server management REST endpoints:
+ * - GET  /api/workspaces/:id/mcp-config/:server/detail
+ * - POST /api/workspaces/:id/mcp-config  (create)
+ * - PUT  /api/workspaces/:id/mcp-config/:server  (update)
+ * - DELETE /api/workspaces/:id/mcp-config/:server
+ * - POST /api/workspaces/:id/mcp-config/:server/migrate
+ * - PUT  /api/workspaces/:id/mcp-config (enabledMcpTools support)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import * as http from 'http';
+import { createRouter } from '../../src/server/shared/router';
+import { registerApiRoutes } from '../../src/server/core/api-handler';
+import type { Route } from '../../src/server/types';
+import { createMockProcessStore } from './helpers/mock-process-store';
+
+// ============================================================================
+// Mocks for forge and mcp-config-writer
+// ============================================================================
+
+const mockLoadDefaultMcpConfig = vi.hoisted(() => vi.fn());
+const mockLoadWorkspaceMcpConfig = vi.hoisted(() => vi.fn());
+vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        loadDefaultMcpConfig: mockLoadDefaultMcpConfig,
+        loadWorkspaceMcpConfig: mockLoadWorkspaceMcpConfig,
+    };
+});
+
+const mockGetServerDetail = vi.hoisted(() => vi.fn());
+const mockUpdateServerConfig = vi.hoisted(() => vi.fn());
+const mockDeleteServerFromConfig = vi.hoisted(() => vi.fn());
+const mockAddServerToConfig = vi.hoisted(() => vi.fn());
+const mockMigrateServerScope = vi.hoisted(() => vi.fn());
+const mockReadAllDescriptions = vi.hoisted(() => vi.fn().mockReturnValue({}));
+const mockFindServerSource = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/server/routes/mcp-config-writer', () => ({
+    getServerDetail: mockGetServerDetail,
+    updateServerConfig: mockUpdateServerConfig,
+    deleteServerFromConfig: mockDeleteServerFromConfig,
+    addServerToConfig: mockAddServerToConfig,
+    migrateServerScope: mockMigrateServerScope,
+    readAllDescriptions: mockReadAllDescriptions,
+    findServerSource: mockFindServerSource,
+}));
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function request(
+    url: string,
+    options: { method?: string; body?: string; headers?: Record<string, string> } = {},
+): Promise<{ status: number; body: string; json: () => any }> {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const req = http.request(
+            {
+                hostname: parsed.hostname,
+                port: parsed.port,
+                path: parsed.pathname + parsed.search,
+                method: options.method || 'GET',
+                headers: { 'Content-Type': 'application/json', ...options.headers },
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk) => chunks.push(chunk));
+                res.on('end', () => {
+                    const bodyStr = Buffer.concat(chunks).toString('utf-8');
+                    resolve({
+                        status: res.statusCode || 0,
+                        body: bodyStr,
+                        json: () => JSON.parse(bodyStr),
+                    });
+                });
+            },
+        );
+        req.on('error', reject);
+        if (options.body) { req.write(options.body); }
+        req.end();
+    });
+}
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('MCP Config CRUD API endpoints', () => {
+    let server: http.Server;
+    let port: number;
+    let mockStore: ReturnType<typeof createMockProcessStore>;
+
+    const WORKSPACE_ID = 'ws-crud';
+
+    beforeAll(async () => {
+        mockStore = createMockProcessStore({
+            initialWorkspaces: [{ id: WORKSPACE_ID, name: 'My Project', rootPath: '/projects/my' }],
+        });
+
+        const routes: Route[] = [];
+        registerApiRoutes(routes, mockStore);
+        const handleRequest = createRouter({ routes, spaHtml: '<html></html>' });
+        server = http.createServer(handleRequest);
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        port = (server.address() as any).port;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockReadAllDescriptions.mockReturnValue({});
+        mockLoadDefaultMcpConfig.mockReturnValue({ mcpServers: {}, configPath: '~/.copilot/mcp-config.json', fileExists: false });
+        mockLoadWorkspaceMcpConfig.mockReturnValue({ mcpServers: {}, configPath: '/projects/my/.vscode/mcp.json', fileExists: false });
+        (mockStore.getWorkspaces as any).mockResolvedValue([
+            { id: WORKSPACE_ID, name: 'My Project', rootPath: '/projects/my' },
+        ]);
+        (mockStore.updateWorkspace as any).mockImplementation(async (id: string, updates: any) => {
+            return { id, name: 'My Project', rootPath: '/projects/my', ...updates };
+        });
+    });
+
+    const base = () => `http://127.0.0.1:${port}`;
+
+    // ========================================================================
+    // GET /api/workspaces/:id/mcp-config/:server/detail
+    // ========================================================================
+
+    describe('GET /api/workspaces/:id/mcp-config/:server/detail', () => {
+        it('returns 404 when workspace not found', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown/mcp-config/github/detail`);
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 404 when server not found', async () => {
+            mockGetServerDetail.mockReturnValue(null);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/unknown-server/detail`);
+            expect(res.status).toBe(404);
+        });
+
+        it('returns server detail when found', async () => {
+            const detail = {
+                description: 'GitHub MCP server',
+                envKeys: ['GITHUB_TOKEN'],
+                args: ['-y', '@modelcontextprotocol/server-github'],
+                toolScope: 'all',
+                source: 'global',
+                rawJson: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'], env: { GITHUB_TOKEN: 'secret' } },
+            };
+            mockGetServerDetail.mockReturnValue(detail);
+
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github/detail`);
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.description).toBe('GitHub MCP server');
+            expect(data.envKeys).toEqual(['GITHUB_TOKEN']);
+            expect(data.args).toEqual(['-y', '@modelcontextprotocol/server-github']);
+            expect(data.toolScope).toBe('all');
+            expect(data.source).toBe('global');
+            expect(data.rawJson).toBeDefined();
+            // rawJson should not expose secret values in keys (they're part of rawJson by design)
+            expect(mockGetServerDetail).toHaveBeenCalledWith('github', '/projects/my');
+        });
+
+        it('URL-decodes server names with special characters', async () => {
+            mockGetServerDetail.mockReturnValue({
+                description: '', envKeys: [], args: [], toolScope: 'all', source: 'workspace', rawJson: {},
+            });
+            await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/my%20server/detail`);
+            expect(mockGetServerDetail).toHaveBeenCalledWith('my server', '/projects/my');
+        });
+    });
+
+    // ========================================================================
+    // POST /api/workspaces/:id/mcp-config  (create)
+    // ========================================================================
+
+    describe('POST /api/workspaces/:id/mcp-config', () => {
+        beforeEach(() => {
+            mockFindServerSource.mockReturnValue(null); // no conflict by default
+            mockAddServerToConfig.mockImplementation(() => undefined);
+        });
+
+        it('returns 404 when workspace not found', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({ name: 'github', type: 'stdio', scope: 'global' }),
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 400 when name is missing', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'stdio', scope: 'global' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when type is invalid', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({ name: 'test', type: 'websocket', scope: 'global' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when scope is invalid', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({ name: 'test', type: 'stdio', scope: 'invalid' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when http server is missing url', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({ name: 'test', type: 'http', scope: 'global' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when server name already exists', async () => {
+            mockFindServerSource.mockReturnValue({ source: 'global', rawEntry: {} });
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({ name: 'github', type: 'stdio', scope: 'global' }),
+            });
+            expect(res.status).toBe(400);
+            const data = res.json();
+            expect(data.code).toBe('BAD_REQUEST');
+        });
+
+        it('creates a stdio server and returns 201', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    name: 'myserver',
+                    type: 'stdio',
+                    command: 'npx',
+                    args: ['-y', '@org/mcp-server'],
+                    description: 'My custom server',
+                    scope: 'workspace',
+                }),
+            });
+            expect(res.status).toBe(201);
+            const data = res.json();
+            expect(data.name).toBe('myserver');
+            expect(data.scope).toBe('workspace');
+            expect(mockAddServerToConfig).toHaveBeenCalledWith('/projects/my', expect.objectContaining({
+                name: 'myserver',
+                type: 'stdio',
+                command: 'npx',
+                args: ['-y', '@org/mcp-server'],
+                description: 'My custom server',
+                scope: 'workspace',
+            }));
+        });
+
+        it('creates an http server and returns 201', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    name: 'remote',
+                    type: 'http',
+                    url: 'https://api.example.com/mcp',
+                    scope: 'global',
+                }),
+            });
+            expect(res.status).toBe(201);
+            expect(mockAddServerToConfig).toHaveBeenCalledWith('/projects/my', expect.objectContaining({
+                name: 'remote',
+                type: 'http',
+                url: 'https://api.example.com/mcp',
+                scope: 'global',
+            }));
+        });
+    });
+
+    // ========================================================================
+    // PUT /api/workspaces/:id/mcp-config/:server  (update)
+    // ========================================================================
+
+    describe('PUT /api/workspaces/:id/mcp-config/:server', () => {
+        it('returns 404 when workspace not found', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown/mcp-config/github`, {
+                method: 'PUT',
+                body: JSON.stringify({ description: 'new desc' }),
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 404 when server not found', async () => {
+            mockUpdateServerConfig.mockReturnValue(false);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/unknown`, {
+                method: 'PUT',
+                body: JSON.stringify({ description: 'new desc' }),
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('updates server config and returns 200', async () => {
+            mockUpdateServerConfig.mockReturnValue(true);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github`, {
+                method: 'PUT',
+                body: JSON.stringify({
+                    description: 'Updated description',
+                    args: ['--verbose'],
+                    toolScope: 'readonly',
+                }),
+            });
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.updated).toBe(true);
+            expect(mockUpdateServerConfig).toHaveBeenCalledWith('github', '/projects/my', {
+                description: 'Updated description',
+                args: ['--verbose'],
+                toolScope: 'readonly',
+            });
+        });
+
+        it('only passes defined fields to updateServerConfig', async () => {
+            mockUpdateServerConfig.mockReturnValue(true);
+            await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github`, {
+                method: 'PUT',
+                body: JSON.stringify({ description: 'Only desc' }),
+            });
+            const call = mockUpdateServerConfig.mock.calls[0][2];
+            expect(call.description).toBe('Only desc');
+            expect(call.args).toBeUndefined();
+            expect(call.env).toBeUndefined();
+            expect(call.toolScope).toBeUndefined();
+        });
+    });
+
+    // ========================================================================
+    // DELETE /api/workspaces/:id/mcp-config/:server
+    // ========================================================================
+
+    describe('DELETE /api/workspaces/:id/mcp-config/:server', () => {
+        it('returns 404 when workspace not found', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown/mcp-config/github`, {
+                method: 'DELETE',
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 404 when server not found', async () => {
+            mockDeleteServerFromConfig.mockReturnValue(false);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/unknown`, {
+                method: 'DELETE',
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('deletes server and returns 200', async () => {
+            mockDeleteServerFromConfig.mockReturnValue(true);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github`, {
+                method: 'DELETE',
+            });
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.deleted).toBe(true);
+            expect(mockDeleteServerFromConfig).toHaveBeenCalledWith('github', '/projects/my');
+        });
+    });
+
+    // ========================================================================
+    // POST /api/workspaces/:id/mcp-config/:server/migrate
+    // ========================================================================
+
+    describe('POST /api/workspaces/:id/mcp-config/:server/migrate', () => {
+        it('returns 404 when workspace not found', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown/mcp-config/github/migrate`, {
+                method: 'POST',
+                body: JSON.stringify({ targetScope: 'global' }),
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 400 when targetScope is invalid', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github/migrate`, {
+                method: 'POST',
+                body: JSON.stringify({ targetScope: 'local' }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 404 when server not found', async () => {
+            mockMigrateServerScope.mockReturnValue(false);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/unknown/migrate`, {
+                method: 'POST',
+                body: JSON.stringify({ targetScope: 'global' }),
+            });
+            expect(res.status).toBe(404);
+        });
+
+        it('migrates server to global scope and returns 200', async () => {
+            mockMigrateServerScope.mockReturnValue(true);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github/migrate`, {
+                method: 'POST',
+                body: JSON.stringify({ targetScope: 'global' }),
+            });
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.name).toBe('github');
+            expect(data.scope).toBe('global');
+            expect(mockMigrateServerScope).toHaveBeenCalledWith('github', '/projects/my', 'global');
+        });
+
+        it('migrates server to workspace scope and returns 200', async () => {
+            mockMigrateServerScope.mockReturnValue(true);
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/mcp-config/github/migrate`, {
+                method: 'POST',
+                body: JSON.stringify({ targetScope: 'workspace' }),
+            });
+            expect(res.status).toBe(200);
+            expect(mockMigrateServerScope).toHaveBeenCalledWith('github', '/projects/my', 'workspace');
+        });
+    });
+});

--- a/packages/coc/test/server/mcp-config-writer.test.ts
+++ b/packages/coc/test/server/mcp-config-writer.test.ts
@@ -23,6 +23,13 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
 });
 
 import {
+    loadDefaultMcpConfig,
+    loadWorkspaceMcpConfig,
+    setHomeDirectoryOverride,
+    clearMcpConfigCache,
+} from '@plusplusoneplusplus/forge';
+
+import {
     readRawGlobalConfig,
     writeRawGlobalConfig,
     readRawWorkspaceConfig,
@@ -123,24 +130,24 @@ describe('readRawWorkspaceConfig', () => {
 // ============================================================================
 
 describe('writeRawGlobalConfig', () => {
-    it('writes JSON to the global config path', () => {
-        writeRawGlobalConfig({ mcpServers: { test: { command: 'node' } } });
+    it('writes JSON to the global config path', async () => {
+        await writeRawGlobalConfig({ mcpServers: { test: { command: 'node' } } });
         const content = fs.readFileSync(globalConfigPath, 'utf-8');
         const parsed = JSON.parse(content);
         expect(parsed.mcpServers.test.command).toBe('node');
     });
 
-    it('creates parent directories if they do not exist', () => {
+    it('creates parent directories if they do not exist', async () => {
         const deepPath = path.join(tmpDir, 'deep', 'nested', 'mcp-config.json');
         mockGetMcpConfigPath.mockReturnValue(deepPath);
-        writeRawGlobalConfig({ mcpServers: {} });
+        await writeRawGlobalConfig({ mcpServers: {} });
         expect(fs.existsSync(deepPath)).toBe(true);
     });
 });
 
 describe('writeRawWorkspaceConfig', () => {
-    it('writes JSON to the workspace config path', () => {
-        writeRawWorkspaceConfig(workspaceRoot, { servers: { test: { command: 'node' } } });
+    it('writes JSON to the workspace config path', async () => {
+        await writeRawWorkspaceConfig(workspaceRoot, { servers: { test: { command: 'node' } } });
         const content = fs.readFileSync(workspaceConfigPath, 'utf-8');
         const parsed = JSON.parse(content);
         expect(parsed.servers.test.command).toBe('node');
@@ -244,53 +251,53 @@ describe('getServerDetail', () => {
 // ============================================================================
 
 describe('updateServerConfig', () => {
-    it('returns false when server not found', () => {
-        const result = updateServerConfig('missing', workspaceRoot, { description: 'new' });
+    it('returns false when server not found', async () => {
+        const result = await updateServerConfig('missing', workspaceRoot, { description: 'new' });
         expect(result).toBe(false);
     });
 
-    it('updates description in global config', () => {
+    it('updates description in global config', async () => {
         writeGlobal({ mcpServers: { github: { command: 'npx' } } });
-        const result = updateServerConfig('github', workspaceRoot, { description: 'Updated' });
+        const result = await updateServerConfig('github', workspaceRoot, { description: 'Updated' });
         expect(result).toBe(true);
         const config = readRawGlobalConfig();
         expect((config.mcpServers as any).github.description).toBe('Updated');
     });
 
-    it('updates description in workspace config', () => {
+    it('updates description in workspace config', async () => {
         writeWorkspace({ servers: { local: { command: 'node' } } });
-        const result = updateServerConfig('local', workspaceRoot, { description: 'Local server' });
+        const result = await updateServerConfig('local', workspaceRoot, { description: 'Local server' });
         expect(result).toBe(true);
         const config = readRawWorkspaceConfig(workspaceRoot);
         expect((config.servers as any).local.description).toBe('Local server');
     });
 
-    it('updates args', () => {
+    it('updates args', async () => {
         writeGlobal({ mcpServers: { server: { command: 'npx', args: ['old-arg'] } } });
-        updateServerConfig('server', workspaceRoot, { args: ['new-arg', '--flag'] });
+        await updateServerConfig('server', workspaceRoot, { args: ['new-arg', '--flag'] });
         const config = readRawGlobalConfig();
         expect((config.mcpServers as any).server.args).toEqual(['new-arg', '--flag']);
     });
 
-    it('merges new env vars with existing ones', () => {
+    it('merges new env vars with existing ones', async () => {
         writeGlobal({ mcpServers: { server: { command: 'npx', env: { OLD_KEY: 'old-val' } } } });
-        updateServerConfig('server', workspaceRoot, { env: { NEW_KEY: 'new-val' } });
+        await updateServerConfig('server', workspaceRoot, { env: { NEW_KEY: 'new-val' } });
         const config = readRawGlobalConfig();
         const env = (config.mcpServers as any).server.env;
         expect(env.OLD_KEY).toBe('old-val');
         expect(env.NEW_KEY).toBe('new-val');
     });
 
-    it('updates toolScope', () => {
+    it('updates toolScope', async () => {
         writeGlobal({ mcpServers: { server: { command: 'npx' } } });
-        updateServerConfig('server', workspaceRoot, { toolScope: 'allowlist' });
+        await updateServerConfig('server', workspaceRoot, { toolScope: 'allowlist' });
         const config = readRawGlobalConfig();
         expect((config.mcpServers as any).server.toolScope).toBe('allowlist');
     });
 
-    it('only updates provided fields and leaves others intact', () => {
+    it('only updates provided fields and leaves others intact', async () => {
         writeGlobal({ mcpServers: { server: { command: 'npx', args: ['a'], description: 'orig' } } });
-        updateServerConfig('server', workspaceRoot, { description: 'new desc' });
+        await updateServerConfig('server', workspaceRoot, { description: 'new desc' });
         const config = readRawGlobalConfig();
         const entry = (config.mcpServers as any).server;
         expect(entry.description).toBe('new desc');
@@ -304,23 +311,23 @@ describe('updateServerConfig', () => {
 // ============================================================================
 
 describe('deleteServerFromConfig', () => {
-    it('returns false when server not found', () => {
-        const result = deleteServerFromConfig('missing', workspaceRoot);
+    it('returns false when server not found', async () => {
+        const result = await deleteServerFromConfig('missing', workspaceRoot);
         expect(result).toBe(false);
     });
 
-    it('removes server from global config', () => {
+    it('removes server from global config', async () => {
         writeGlobal({ mcpServers: { github: { command: 'npx' }, other: { command: 'other' } } });
-        const result = deleteServerFromConfig('github', workspaceRoot);
+        const result = await deleteServerFromConfig('github', workspaceRoot);
         expect(result).toBe(true);
         const config = readRawGlobalConfig();
         expect((config.mcpServers as any).github).toBeUndefined();
         expect((config.mcpServers as any).other).toBeDefined();
     });
 
-    it('removes server from workspace config', () => {
+    it('removes server from workspace config', async () => {
         writeWorkspace({ servers: { local: { command: 'node' }, other: { command: 'other' } } });
-        const result = deleteServerFromConfig('local', workspaceRoot);
+        const result = await deleteServerFromConfig('local', workspaceRoot);
         expect(result).toBe(true);
         const config = readRawWorkspaceConfig(workspaceRoot);
         expect((config.servers as any).local).toBeUndefined();
@@ -333,8 +340,8 @@ describe('deleteServerFromConfig', () => {
 // ============================================================================
 
 describe('addServerToConfig', () => {
-    it('adds a stdio server to global config', () => {
-        addServerToConfig(workspaceRoot, {
+    it('adds a stdio server to global config', async () => {
+        await addServerToConfig(workspaceRoot, {
             name: 'myserver',
             type: 'stdio',
             command: 'npx',
@@ -347,8 +354,8 @@ describe('addServerToConfig', () => {
         expect(entry.args).toEqual(['-y', '@org/server']);
     });
 
-    it('adds an http server to global config', () => {
-        addServerToConfig(workspaceRoot, {
+    it('adds an http server to global config', async () => {
+        await addServerToConfig(workspaceRoot, {
             name: 'remote',
             type: 'http',
             url: 'https://api.example.com/mcp',
@@ -360,8 +367,8 @@ describe('addServerToConfig', () => {
         expect(entry.url).toBe('https://api.example.com/mcp');
     });
 
-    it('adds a server to workspace config', () => {
-        addServerToConfig(workspaceRoot, {
+    it('adds a server to workspace config', async () => {
+        await addServerToConfig(workspaceRoot, {
             name: 'local',
             type: 'stdio',
             command: 'node',
@@ -371,8 +378,8 @@ describe('addServerToConfig', () => {
         expect((config.servers as any).local.command).toBe('node');
     });
 
-    it('stores description and toolScope when provided', () => {
-        addServerToConfig(workspaceRoot, {
+    it('stores description and toolScope when provided', async () => {
+        await addServerToConfig(workspaceRoot, {
             name: 'srvr',
             type: 'stdio',
             command: 'cmd',
@@ -386,8 +393,8 @@ describe('addServerToConfig', () => {
         expect(entry.toolScope).toBe('readonly');
     });
 
-    it('omits toolScope from config when "all" (the default)', () => {
-        addServerToConfig(workspaceRoot, {
+    it('omits toolScope from config when "all" (the default)', async () => {
+        await addServerToConfig(workspaceRoot, {
             name: 'srvr',
             type: 'stdio',
             command: 'cmd',
@@ -399,8 +406,8 @@ describe('addServerToConfig', () => {
         expect(entry.toolScope).toBeUndefined();
     });
 
-    it('stores env vars when provided', () => {
-        addServerToConfig(workspaceRoot, {
+    it('stores env vars when provided', async () => {
+        await addServerToConfig(workspaceRoot, {
             name: 'srvr',
             type: 'stdio',
             command: 'cmd',
@@ -417,23 +424,23 @@ describe('addServerToConfig', () => {
 // ============================================================================
 
 describe('migrateServerScope', () => {
-    it('returns false when server not found', () => {
-        const result = migrateServerScope('missing', workspaceRoot, 'global');
+    it('returns false when server not found', async () => {
+        const result = await migrateServerScope('missing', workspaceRoot, 'global');
         expect(result).toBe(false);
     });
 
-    it('returns true without moving when server is already in target scope', () => {
+    it('returns true without moving when server is already in target scope', async () => {
         writeGlobal({ mcpServers: { github: { command: 'npx' } } });
-        const result = migrateServerScope('github', workspaceRoot, 'global');
+        const result = await migrateServerScope('github', workspaceRoot, 'global');
         expect(result).toBe(true);
         // Still in global
         const config = readRawGlobalConfig();
         expect((config.mcpServers as any).github).toBeDefined();
     });
 
-    it('moves server from global to workspace', () => {
+    it('moves server from global to workspace', async () => {
         writeGlobal({ mcpServers: { github: { command: 'npx', description: 'GitHub server' } } });
-        const result = migrateServerScope('github', workspaceRoot, 'workspace');
+        const result = await migrateServerScope('github', workspaceRoot, 'workspace');
         expect(result).toBe(true);
         // Removed from global
         const globalConfig = readRawGlobalConfig();
@@ -446,9 +453,9 @@ describe('migrateServerScope', () => {
         expect(entry.description).toBe('GitHub server');
     });
 
-    it('moves server from workspace to global', () => {
+    it('moves server from workspace to global', async () => {
         writeWorkspace({ servers: { local: { command: 'node', args: ['app.js'] } } });
-        const result = migrateServerScope('local', workspaceRoot, 'global');
+        const result = await migrateServerScope('local', workspaceRoot, 'global');
         expect(result).toBe(true);
         // Removed from workspace
         const wsConfig = readRawWorkspaceConfig(workspaceRoot);
@@ -461,11 +468,11 @@ describe('migrateServerScope', () => {
         expect(entry.args).toEqual(['app.js']);
     });
 
-    it('preserves extra fields during migration', () => {
+    it('preserves extra fields during migration', async () => {
         writeGlobal({
             mcpServers: { server: { command: 'npx', description: 'My server', toolScope: 'readonly' } },
         });
-        migrateServerScope('server', workspaceRoot, 'workspace');
+        await migrateServerScope('server', workspaceRoot, 'workspace');
         const wsConfig = readRawWorkspaceConfig(workspaceRoot);
         const entry = (wsConfig.servers as any).server;
         expect(entry.description).toBe('My server');
@@ -510,5 +517,73 @@ describe('readAllDescriptions', () => {
         writeWorkspace({ servers: { shared: { command: 'ws-cmd', description: 'Workspace desc' } } });
         const result = readAllDescriptions(workspaceRoot);
         expect(result.shared).toBe('Workspace desc');
+    });
+});
+
+// ============================================================================
+// Cache invalidation
+// ============================================================================
+
+describe('cache invalidation after write', () => {
+    beforeEach(() => {
+        // Point the forge loader's home directory at the temp dir so
+        // loadDefaultMcpConfig / loadWorkspaceMcpConfig use the same paths
+        // as the writer's mocked getMcpConfigPath / getWorkspaceMcpConfigPath.
+        setHomeDirectoryOverride(tmpDir);
+    });
+
+    afterEach(() => {
+        setHomeDirectoryOverride(null);
+        clearMcpConfigCache();
+    });
+
+    it('invalidates global loader cache after writeRawGlobalConfig', async () => {
+        // Seed initial config and prime the loader cache
+        writeGlobal({ mcpServers: { server: { command: 'cmd-v1' } } });
+        const firstLoad = loadDefaultMcpConfig();
+        expect(Object.keys(firstLoad.mcpServers)).toContain('server');
+
+        // Write a different config via the writer — should invalidate the cache
+        await writeRawGlobalConfig({ mcpServers: { newserver: { command: 'cmd-v2' } } });
+
+        // Loader must return fresh data (not the stale cached version)
+        const secondLoad = loadDefaultMcpConfig();
+        expect(Object.keys(secondLoad.mcpServers)).toContain('newserver');
+        expect(Object.keys(secondLoad.mcpServers)).not.toContain('server');
+    });
+
+    it('invalidates workspace loader cache after writeRawWorkspaceConfig', async () => {
+        // Seed initial workspace config and prime the loader cache
+        writeWorkspace({ servers: { local: { command: 'node-v1' } } });
+        const firstLoad = loadWorkspaceMcpConfig(workspaceRoot);
+        expect(Object.keys(firstLoad.mcpServers)).toContain('local');
+
+        // Write updated workspace config via the writer
+        await writeRawWorkspaceConfig(workspaceRoot, { servers: { newlocal: { command: 'node-v2' } } });
+
+        // Loader must see the new server, not the cached old one
+        const secondLoad = loadWorkspaceMcpConfig(workspaceRoot);
+        expect(Object.keys(secondLoad.mcpServers)).toContain('newlocal');
+        expect(Object.keys(secondLoad.mcpServers)).not.toContain('local');
+    });
+
+    it('invalidates global cache after addServerToConfig', async () => {
+        writeGlobal({ mcpServers: {} });
+        loadDefaultMcpConfig(); // populate cache
+
+        await addServerToConfig(workspaceRoot, { name: 'added', type: 'stdio', command: 'npx', scope: 'global' });
+
+        const result = loadDefaultMcpConfig();
+        expect(Object.keys(result.mcpServers)).toContain('added');
+    });
+
+    it('invalidates global cache after deleteServerFromConfig', async () => {
+        writeGlobal({ mcpServers: { todelete: { command: 'npx' } } });
+        loadDefaultMcpConfig(); // populate cache
+
+        await deleteServerFromConfig('todelete', workspaceRoot);
+
+        const result = loadDefaultMcpConfig();
+        expect(Object.keys(result.mcpServers)).not.toContain('todelete');
     });
 });

--- a/packages/coc/test/server/mcp-config-writer.test.ts
+++ b/packages/coc/test/server/mcp-config-writer.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Unit tests for mcp-config-writer.ts
+ *
+ * Uses a temporary directory to exercise real file read/write operations.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock forge so getMcpConfigPath and getWorkspaceMcpConfigPath return paths inside our temp dir
+const mockGetMcpConfigPath = vi.hoisted(() => vi.fn<[], string>());
+const mockGetWorkspaceMcpConfigPath = vi.hoisted(() => vi.fn<[string], string>());
+
+vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        getMcpConfigPath: mockGetMcpConfigPath,
+        getWorkspaceMcpConfigPath: mockGetWorkspaceMcpConfigPath,
+    };
+});
+
+import {
+    readRawGlobalConfig,
+    writeRawGlobalConfig,
+    readRawWorkspaceConfig,
+    writeRawWorkspaceConfig,
+    findServerSource,
+    getServerDetail,
+    updateServerConfig,
+    deleteServerFromConfig,
+    addServerToConfig,
+    migrateServerScope,
+    readAllDescriptions,
+} from '../../src/server/routes/mcp-config-writer';
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+let tmpDir: string;
+let globalConfigPath: string;
+let workspaceRoot: string;
+let workspaceConfigPath: string;
+
+beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-writer-test-'));
+    const globalDir = path.join(tmpDir, '.copilot');
+    fs.mkdirSync(globalDir, { recursive: true });
+    globalConfigPath = path.join(globalDir, 'mcp-config.json');
+
+    workspaceRoot = path.join(tmpDir, 'workspace');
+    fs.mkdirSync(path.join(workspaceRoot, '.vscode'), { recursive: true });
+    workspaceConfigPath = path.join(workspaceRoot, '.vscode', 'mcp.json');
+
+    mockGetMcpConfigPath.mockReturnValue(globalConfigPath);
+    mockGetWorkspaceMcpConfigPath.mockImplementation((_root: string) => workspaceConfigPath);
+});
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeGlobal(data: Record<string, unknown>) {
+    fs.writeFileSync(globalConfigPath, JSON.stringify(data), 'utf-8');
+}
+function writeWorkspace(data: Record<string, unknown>) {
+    fs.writeFileSync(workspaceConfigPath, JSON.stringify(data), 'utf-8');
+}
+
+// ============================================================================
+// readRawGlobalConfig / readRawWorkspaceConfig
+// ============================================================================
+
+describe('readRawGlobalConfig', () => {
+    it('returns { mcpServers: {} } when file does not exist', () => {
+        const result = readRawGlobalConfig();
+        expect(result).toEqual({ mcpServers: {} });
+    });
+
+    it('returns parsed JSON when file exists', () => {
+        writeGlobal({ mcpServers: { github: { command: 'npx' } } });
+        const result = readRawGlobalConfig();
+        expect(result).toMatchObject({ mcpServers: { github: { command: 'npx' } } });
+    });
+
+    it('returns { mcpServers: {} } when file contains invalid JSON', () => {
+        fs.writeFileSync(globalConfigPath, '{ bad json', 'utf-8');
+        const result = readRawGlobalConfig();
+        expect(result).toEqual({ mcpServers: {} });
+    });
+});
+
+describe('readRawWorkspaceConfig', () => {
+    it('returns { servers: {} } when file does not exist', () => {
+        const result = readRawWorkspaceConfig(workspaceRoot);
+        expect(result).toEqual({ servers: {} });
+    });
+
+    it('returns parsed JSON when file exists', () => {
+        writeWorkspace({ servers: { local: { command: 'node', args: ['server.js'] } } });
+        const result = readRawWorkspaceConfig(workspaceRoot);
+        expect(result).toMatchObject({ servers: { local: { command: 'node' } } });
+    });
+
+    it('preserves extra fields like description and toolScope', () => {
+        writeWorkspace({
+            servers: {
+                myserver: { command: 'npx', description: 'My server', toolScope: 'readonly' },
+            },
+        });
+        const result = readRawWorkspaceConfig(workspaceRoot);
+        const entry = (result.servers as any).myserver;
+        expect(entry.description).toBe('My server');
+        expect(entry.toolScope).toBe('readonly');
+    });
+});
+
+// ============================================================================
+// writeRawGlobalConfig / writeRawWorkspaceConfig
+// ============================================================================
+
+describe('writeRawGlobalConfig', () => {
+    it('writes JSON to the global config path', () => {
+        writeRawGlobalConfig({ mcpServers: { test: { command: 'node' } } });
+        const content = fs.readFileSync(globalConfigPath, 'utf-8');
+        const parsed = JSON.parse(content);
+        expect(parsed.mcpServers.test.command).toBe('node');
+    });
+
+    it('creates parent directories if they do not exist', () => {
+        const deepPath = path.join(tmpDir, 'deep', 'nested', 'mcp-config.json');
+        mockGetMcpConfigPath.mockReturnValue(deepPath);
+        writeRawGlobalConfig({ mcpServers: {} });
+        expect(fs.existsSync(deepPath)).toBe(true);
+    });
+});
+
+describe('writeRawWorkspaceConfig', () => {
+    it('writes JSON to the workspace config path', () => {
+        writeRawWorkspaceConfig(workspaceRoot, { servers: { test: { command: 'node' } } });
+        const content = fs.readFileSync(workspaceConfigPath, 'utf-8');
+        const parsed = JSON.parse(content);
+        expect(parsed.servers.test.command).toBe('node');
+    });
+});
+
+// ============================================================================
+// findServerSource
+// ============================================================================
+
+describe('findServerSource', () => {
+    it('returns null when server not in either config', () => {
+        const result = findServerSource('missing', workspaceRoot);
+        expect(result).toBeNull();
+    });
+
+    it('finds server in global config', () => {
+        writeGlobal({ mcpServers: { github: { command: 'npx' } } });
+        const result = findServerSource('github', workspaceRoot);
+        expect(result).not.toBeNull();
+        expect(result!.source).toBe('global');
+        expect((result!.rawEntry as any).command).toBe('npx');
+    });
+
+    it('finds server in workspace config', () => {
+        writeWorkspace({ servers: { local: { command: 'node' } } });
+        const result = findServerSource('local', workspaceRoot);
+        expect(result).not.toBeNull();
+        expect(result!.source).toBe('workspace');
+    });
+
+    it('prefers workspace over global when same name in both', () => {
+        writeGlobal({ mcpServers: { shared: { command: 'global-cmd' } } });
+        writeWorkspace({ servers: { shared: { command: 'workspace-cmd' } } });
+        const result = findServerSource('shared', workspaceRoot);
+        expect(result!.source).toBe('workspace');
+        expect((result!.rawEntry as any).command).toBe('workspace-cmd');
+    });
+});
+
+// ============================================================================
+// getServerDetail
+// ============================================================================
+
+describe('getServerDetail', () => {
+    it('returns null when server not found', () => {
+        const result = getServerDetail('missing', workspaceRoot);
+        expect(result).toBeNull();
+    });
+
+    it('returns detail for global server', () => {
+        writeGlobal({
+            mcpServers: {
+                github: {
+                    command: 'npx',
+                    args: ['-y', '@modelcontextprotocol/server-github'],
+                    env: { GITHUB_TOKEN: 'secret' },
+                    description: 'GitHub MCP',
+                    toolScope: 'readonly',
+                },
+            },
+        });
+        const result = getServerDetail('github', workspaceRoot);
+        expect(result).not.toBeNull();
+        expect(result!.description).toBe('GitHub MCP');
+        expect(result!.envKeys).toEqual(['GITHUB_TOKEN']);
+        expect(result!.args).toEqual(['-y', '@modelcontextprotocol/server-github']);
+        expect(result!.toolScope).toBe('readonly');
+        expect(result!.source).toBe('global');
+        // env values should NOT be in envKeys (only keys are exposed)
+        expect(result!.rawJson).toMatchObject({ command: 'npx' });
+    });
+
+    it('defaults toolScope to "all" when not specified', () => {
+        writeGlobal({ mcpServers: { server: { command: 'cmd' } } });
+        const result = getServerDetail('server', workspaceRoot);
+        expect(result!.toolScope).toBe('all');
+    });
+
+    it('defaults description to empty string when not specified', () => {
+        writeGlobal({ mcpServers: { server: { command: 'cmd' } } });
+        const result = getServerDetail('server', workspaceRoot);
+        expect(result!.description).toBe('');
+    });
+
+    it('returns empty envKeys when no env field', () => {
+        writeGlobal({ mcpServers: { server: { command: 'cmd' } } });
+        const result = getServerDetail('server', workspaceRoot);
+        expect(result!.envKeys).toEqual([]);
+    });
+
+    it('returns empty args when no args field', () => {
+        writeGlobal({ mcpServers: { server: { command: 'cmd' } } });
+        const result = getServerDetail('server', workspaceRoot);
+        expect(result!.args).toEqual([]);
+    });
+});
+
+// ============================================================================
+// updateServerConfig
+// ============================================================================
+
+describe('updateServerConfig', () => {
+    it('returns false when server not found', () => {
+        const result = updateServerConfig('missing', workspaceRoot, { description: 'new' });
+        expect(result).toBe(false);
+    });
+
+    it('updates description in global config', () => {
+        writeGlobal({ mcpServers: { github: { command: 'npx' } } });
+        const result = updateServerConfig('github', workspaceRoot, { description: 'Updated' });
+        expect(result).toBe(true);
+        const config = readRawGlobalConfig();
+        expect((config.mcpServers as any).github.description).toBe('Updated');
+    });
+
+    it('updates description in workspace config', () => {
+        writeWorkspace({ servers: { local: { command: 'node' } } });
+        const result = updateServerConfig('local', workspaceRoot, { description: 'Local server' });
+        expect(result).toBe(true);
+        const config = readRawWorkspaceConfig(workspaceRoot);
+        expect((config.servers as any).local.description).toBe('Local server');
+    });
+
+    it('updates args', () => {
+        writeGlobal({ mcpServers: { server: { command: 'npx', args: ['old-arg'] } } });
+        updateServerConfig('server', workspaceRoot, { args: ['new-arg', '--flag'] });
+        const config = readRawGlobalConfig();
+        expect((config.mcpServers as any).server.args).toEqual(['new-arg', '--flag']);
+    });
+
+    it('merges new env vars with existing ones', () => {
+        writeGlobal({ mcpServers: { server: { command: 'npx', env: { OLD_KEY: 'old-val' } } } });
+        updateServerConfig('server', workspaceRoot, { env: { NEW_KEY: 'new-val' } });
+        const config = readRawGlobalConfig();
+        const env = (config.mcpServers as any).server.env;
+        expect(env.OLD_KEY).toBe('old-val');
+        expect(env.NEW_KEY).toBe('new-val');
+    });
+
+    it('updates toolScope', () => {
+        writeGlobal({ mcpServers: { server: { command: 'npx' } } });
+        updateServerConfig('server', workspaceRoot, { toolScope: 'allowlist' });
+        const config = readRawGlobalConfig();
+        expect((config.mcpServers as any).server.toolScope).toBe('allowlist');
+    });
+
+    it('only updates provided fields and leaves others intact', () => {
+        writeGlobal({ mcpServers: { server: { command: 'npx', args: ['a'], description: 'orig' } } });
+        updateServerConfig('server', workspaceRoot, { description: 'new desc' });
+        const config = readRawGlobalConfig();
+        const entry = (config.mcpServers as any).server;
+        expect(entry.description).toBe('new desc');
+        expect(entry.args).toEqual(['a']); // unchanged
+        expect(entry.command).toBe('npx'); // unchanged
+    });
+});
+
+// ============================================================================
+// deleteServerFromConfig
+// ============================================================================
+
+describe('deleteServerFromConfig', () => {
+    it('returns false when server not found', () => {
+        const result = deleteServerFromConfig('missing', workspaceRoot);
+        expect(result).toBe(false);
+    });
+
+    it('removes server from global config', () => {
+        writeGlobal({ mcpServers: { github: { command: 'npx' }, other: { command: 'other' } } });
+        const result = deleteServerFromConfig('github', workspaceRoot);
+        expect(result).toBe(true);
+        const config = readRawGlobalConfig();
+        expect((config.mcpServers as any).github).toBeUndefined();
+        expect((config.mcpServers as any).other).toBeDefined();
+    });
+
+    it('removes server from workspace config', () => {
+        writeWorkspace({ servers: { local: { command: 'node' }, other: { command: 'other' } } });
+        const result = deleteServerFromConfig('local', workspaceRoot);
+        expect(result).toBe(true);
+        const config = readRawWorkspaceConfig(workspaceRoot);
+        expect((config.servers as any).local).toBeUndefined();
+        expect((config.servers as any).other).toBeDefined();
+    });
+});
+
+// ============================================================================
+// addServerToConfig
+// ============================================================================
+
+describe('addServerToConfig', () => {
+    it('adds a stdio server to global config', () => {
+        addServerToConfig(workspaceRoot, {
+            name: 'myserver',
+            type: 'stdio',
+            command: 'npx',
+            args: ['-y', '@org/server'],
+            scope: 'global',
+        });
+        const config = readRawGlobalConfig();
+        const entry = (config.mcpServers as any).myserver;
+        expect(entry.command).toBe('npx');
+        expect(entry.args).toEqual(['-y', '@org/server']);
+    });
+
+    it('adds an http server to global config', () => {
+        addServerToConfig(workspaceRoot, {
+            name: 'remote',
+            type: 'http',
+            url: 'https://api.example.com/mcp',
+            scope: 'global',
+        });
+        const config = readRawGlobalConfig();
+        const entry = (config.mcpServers as any).remote;
+        expect(entry.type).toBe('http');
+        expect(entry.url).toBe('https://api.example.com/mcp');
+    });
+
+    it('adds a server to workspace config', () => {
+        addServerToConfig(workspaceRoot, {
+            name: 'local',
+            type: 'stdio',
+            command: 'node',
+            scope: 'workspace',
+        });
+        const config = readRawWorkspaceConfig(workspaceRoot);
+        expect((config.servers as any).local.command).toBe('node');
+    });
+
+    it('stores description and toolScope when provided', () => {
+        addServerToConfig(workspaceRoot, {
+            name: 'srvr',
+            type: 'stdio',
+            command: 'cmd',
+            description: 'My server',
+            toolScope: 'readonly',
+            scope: 'global',
+        });
+        const config = readRawGlobalConfig();
+        const entry = (config.mcpServers as any).srvr;
+        expect(entry.description).toBe('My server');
+        expect(entry.toolScope).toBe('readonly');
+    });
+
+    it('omits toolScope from config when "all" (the default)', () => {
+        addServerToConfig(workspaceRoot, {
+            name: 'srvr',
+            type: 'stdio',
+            command: 'cmd',
+            toolScope: 'all',
+            scope: 'global',
+        });
+        const config = readRawGlobalConfig();
+        const entry = (config.mcpServers as any).srvr;
+        expect(entry.toolScope).toBeUndefined();
+    });
+
+    it('stores env vars when provided', () => {
+        addServerToConfig(workspaceRoot, {
+            name: 'srvr',
+            type: 'stdio',
+            command: 'cmd',
+            env: { TOKEN: 'secret' },
+            scope: 'global',
+        });
+        const config = readRawGlobalConfig();
+        expect((config.mcpServers as any).srvr.env.TOKEN).toBe('secret');
+    });
+});
+
+// ============================================================================
+// migrateServerScope
+// ============================================================================
+
+describe('migrateServerScope', () => {
+    it('returns false when server not found', () => {
+        const result = migrateServerScope('missing', workspaceRoot, 'global');
+        expect(result).toBe(false);
+    });
+
+    it('returns true without moving when server is already in target scope', () => {
+        writeGlobal({ mcpServers: { github: { command: 'npx' } } });
+        const result = migrateServerScope('github', workspaceRoot, 'global');
+        expect(result).toBe(true);
+        // Still in global
+        const config = readRawGlobalConfig();
+        expect((config.mcpServers as any).github).toBeDefined();
+    });
+
+    it('moves server from global to workspace', () => {
+        writeGlobal({ mcpServers: { github: { command: 'npx', description: 'GitHub server' } } });
+        const result = migrateServerScope('github', workspaceRoot, 'workspace');
+        expect(result).toBe(true);
+        // Removed from global
+        const globalConfig = readRawGlobalConfig();
+        expect((globalConfig.mcpServers as any).github).toBeUndefined();
+        // Added to workspace
+        const wsConfig = readRawWorkspaceConfig(workspaceRoot);
+        const entry = (wsConfig.servers as any).github;
+        expect(entry).toBeDefined();
+        expect(entry.command).toBe('npx');
+        expect(entry.description).toBe('GitHub server');
+    });
+
+    it('moves server from workspace to global', () => {
+        writeWorkspace({ servers: { local: { command: 'node', args: ['app.js'] } } });
+        const result = migrateServerScope('local', workspaceRoot, 'global');
+        expect(result).toBe(true);
+        // Removed from workspace
+        const wsConfig = readRawWorkspaceConfig(workspaceRoot);
+        expect((wsConfig.servers as any).local).toBeUndefined();
+        // Added to global
+        const globalConfig = readRawGlobalConfig();
+        const entry = (globalConfig.mcpServers as any).local;
+        expect(entry).toBeDefined();
+        expect(entry.command).toBe('node');
+        expect(entry.args).toEqual(['app.js']);
+    });
+
+    it('preserves extra fields during migration', () => {
+        writeGlobal({
+            mcpServers: { server: { command: 'npx', description: 'My server', toolScope: 'readonly' } },
+        });
+        migrateServerScope('server', workspaceRoot, 'workspace');
+        const wsConfig = readRawWorkspaceConfig(workspaceRoot);
+        const entry = (wsConfig.servers as any).server;
+        expect(entry.description).toBe('My server');
+        expect(entry.toolScope).toBe('readonly');
+    });
+});
+
+// ============================================================================
+// readAllDescriptions
+// ============================================================================
+
+describe('readAllDescriptions', () => {
+    it('returns empty map when no config files exist', () => {
+        const result = readAllDescriptions(workspaceRoot);
+        expect(result).toEqual({});
+    });
+
+    it('returns descriptions from global config', () => {
+        writeGlobal({
+            mcpServers: {
+                github: { command: 'npx', description: 'GitHub MCP' },
+                other: { command: 'other' },
+            },
+        });
+        const result = readAllDescriptions(workspaceRoot);
+        expect(result.github).toBe('GitHub MCP');
+        expect(result.other).toBeUndefined();
+    });
+
+    it('returns descriptions from workspace config', () => {
+        writeWorkspace({
+            servers: {
+                local: { command: 'node', description: 'Local server' },
+            },
+        });
+        const result = readAllDescriptions(workspaceRoot);
+        expect(result.local).toBe('Local server');
+    });
+
+    it('workspace description wins over global when same name', () => {
+        writeGlobal({ mcpServers: { shared: { command: 'global-cmd', description: 'Global desc' } } });
+        writeWorkspace({ servers: { shared: { command: 'ws-cmd', description: 'Workspace desc' } } });
+        const result = readAllDescriptions(workspaceRoot);
+        expect(result.shared).toBe('Workspace desc');
+    });
+});

--- a/packages/coc/test/server/mcp-connection-tester.test.ts
+++ b/packages/coc/test/server/mcp-connection-tester.test.ts
@@ -1,0 +1,326 @@
+/**
+ * MCP Connection Tester Unit Tests
+ *
+ * Tests for testMcpConnection — stdio, http, and sse transports.
+ * Node.js built-in modules (child_process, http) are mocked via vi.mock/vi.hoisted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// ============================================================================
+// Mock child_process
+// ============================================================================
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+    spawn: mockSpawn,
+}));
+
+// ============================================================================
+// Mock http (used for http/sse transport)
+// ============================================================================
+
+const mockHttpRequest = vi.hoisted(() => vi.fn());
+
+vi.mock('http', () => ({
+    request: mockHttpRequest,
+}));
+
+// ============================================================================
+// Mock https (ensure it's available but unused in http tests)
+// ============================================================================
+
+vi.mock('https', () => ({
+    request: vi.fn(),
+}));
+
+// ============================================================================
+// Module under test — imported AFTER mocks
+// ============================================================================
+
+import type { McpTestRequest } from '../../src/server/routes/mcp-connection-tester';
+import { testMcpConnection } from '../../src/server/routes/mcp-connection-tester';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Build a minimal fake ChildProcess stub */
+function makeChildStub() {
+    const stdin = new EventEmitter() as any;
+    stdin.write = vi.fn(() => true);
+    stdin.end = vi.fn();
+
+    const stdout = new EventEmitter() as any;
+    const stderr = new EventEmitter() as any;
+
+    const child = new EventEmitter() as any;
+    child.stdin = stdin;
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.kill = vi.fn();
+    child.pid = 12345;
+
+    return { child, stdin, stdout, stderr };
+}
+
+/** Build a minimal fake http.IncomingMessage stub */
+function makeIncomingMessage(statusCode: number) {
+    const msg = new EventEmitter() as any;
+    msg.statusCode = statusCode;
+    msg.resume = vi.fn();
+    return msg;
+}
+
+/** Build a minimal fake http.ClientRequest stub */
+function makeClientRequest() {
+    const req = new EventEmitter() as any;
+    req.end = vi.fn();
+    req.destroy = vi.fn();
+    return req;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('testMcpConnection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // -------------------------------------------------------------------------
+    // stdio transport
+    // -------------------------------------------------------------------------
+
+    describe('stdio transport', () => {
+        it('returns error when command is missing', async () => {
+            const result = await testMcpConnection({ type: 'stdio' } as McpTestRequest);
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/command/i);
+        });
+
+        it('returns error when spawn throws', async () => {
+            mockSpawn.mockImplementation(() => { throw new Error('spawn ENOENT'); });
+            const result = await testMcpConnection({ type: 'stdio', command: 'does-not-exist' });
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/spawn|ENOENT/i);
+        });
+
+        it('returns error when process emits an error event', async () => {
+            const { child } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+            child.emit('error', new Error('ENOENT'));
+            const result = await resultPromise;
+
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/ENOENT/);
+        });
+
+        it('returns error when process exits before responding', async () => {
+            const { child } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+            child.emit('close', 1);
+            const result = await resultPromise;
+
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/exit/i);
+        });
+
+        it('parses successful JSON-RPC initialize response', async () => {
+            const { child, stdout } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+
+            const response = JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                result: {
+                    protocolVersion: '2024-11-05',
+                    capabilities: {},
+                    serverInfo: { name: 'my-mcp', version: '1.0.0' },
+                },
+            }) + '\n';
+            stdout.emit('data', Buffer.from(response));
+
+            const result = await resultPromise;
+            expect(result.success).toBe(true);
+            expect(result.protocolVersion).toBe('2024-11-05');
+            expect(result.serverName).toBe('my-mcp');
+        });
+
+        it('returns error when JSON-RPC error response is received', async () => {
+            const { child, stdout } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+
+            const response = JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                error: { code: -32600, message: 'Invalid request' },
+            }) + '\n';
+            stdout.emit('data', Buffer.from(response));
+
+            const result = await resultPromise;
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/Invalid request/);
+        });
+
+        it('ignores non-JSON stdout lines then succeeds on valid response', async () => {
+            const { child, stdout } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+
+            stdout.emit('data', Buffer.from('Some debug output\n'));
+            const validResponse = JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'srv' } },
+            }) + '\n';
+            stdout.emit('data', Buffer.from(validResponse));
+
+            const result = await resultPromise;
+            expect(result.success).toBe(true);
+        });
+
+        it('ignores JSON-RPC responses with wrong id then fails on close', async () => {
+            const { child, stdout } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+
+            const wrongId = JSON.stringify({ jsonrpc: '2.0', id: 99, result: { protocolVersion: '2024-11-05' } }) + '\n';
+            stdout.emit('data', Buffer.from(wrongId));
+            child.emit('close', 0);
+
+            const result = await resultPromise;
+            expect(result.success).toBe(false);
+        });
+
+        it('kills process after successful response', async () => {
+            const { child, stdout } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+
+            const response = JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                result: { protocolVersion: '2024-11-05', capabilities: {} },
+            }) + '\n';
+            stdout.emit('data', Buffer.from(response));
+
+            await resultPromise;
+            expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+        });
+
+        it('handles multi-chunk stdout correctly', async () => {
+            const { child, stdout } = makeChildStub();
+            mockSpawn.mockReturnValue(child);
+
+            const resultPromise = testMcpConnection({ type: 'stdio', command: 'fake' });
+
+            const fullMsg = JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'chunked' } },
+            }) + '\n';
+            const half = Math.floor(fullMsg.length / 2);
+            stdout.emit('data', Buffer.from(fullMsg.slice(0, half)));
+            stdout.emit('data', Buffer.from(fullMsg.slice(half)));
+
+            const result = await resultPromise;
+            expect(result.success).toBe(true);
+            expect(result.serverName).toBe('chunked');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // http / sse transport
+    // -------------------------------------------------------------------------
+
+    describe('http/sse transport', () => {
+        it('returns error when url is missing', async () => {
+            const result = await testMcpConnection({ type: 'http' } as McpTestRequest);
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/url/i);
+        });
+
+        it('returns error for invalid url', async () => {
+            const result = await testMcpConnection({ type: 'http', url: 'not-a-url' });
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/Invalid URL/i);
+        });
+
+        it('returns success on 200 response', async () => {
+            const clientReq = makeClientRequest();
+            const incomingMsg = makeIncomingMessage(200);
+            mockHttpRequest.mockImplementation((_opts: any, callback: any) => {
+                callback(incomingMsg);
+                return clientReq;
+            });
+
+            const result = await testMcpConnection({ type: 'http', url: 'http://localhost:8080/mcp' });
+            expect(result.success).toBe(true);
+            expect(result.message).toMatch(/200/);
+        });
+
+        it('returns success on 401 (reachable but auth required)', async () => {
+            const clientReq = makeClientRequest();
+            const incomingMsg = makeIncomingMessage(401);
+            mockHttpRequest.mockImplementation((_opts: any, callback: any) => {
+                callback(incomingMsg);
+                return clientReq;
+            });
+
+            const result = await testMcpConnection({ type: 'http', url: 'http://localhost:8080/mcp' });
+            expect(result.success).toBe(true);
+            expect(result.message).toMatch(/401/);
+        });
+
+        it('returns failure on 500', async () => {
+            const clientReq = makeClientRequest();
+            const incomingMsg = makeIncomingMessage(500);
+            mockHttpRequest.mockImplementation((_opts: any, callback: any) => {
+                callback(incomingMsg);
+                return clientReq;
+            });
+
+            const result = await testMcpConnection({ type: 'http', url: 'http://localhost:8080/mcp' });
+            expect(result.success).toBe(false);
+        });
+
+        it('returns failure on connection error', async () => {
+            const clientReq = makeClientRequest();
+            mockHttpRequest.mockImplementation(() => clientReq);
+
+            const resultPromise = testMcpConnection({ type: 'http', url: 'http://localhost:9999/mcp' });
+            clientReq.emit('error', new Error('ECONNREFUSED'));
+            const result = await resultPromise;
+
+            expect(result.success).toBe(false);
+            expect(result.message).toMatch(/ECONNREFUSED/);
+        });
+
+        it('works for sse type with same http logic', async () => {
+            const clientReq = makeClientRequest();
+            const incomingMsg = makeIncomingMessage(200);
+            mockHttpRequest.mockImplementation((_opts: any, callback: any) => {
+                callback(incomingMsg);
+                return clientReq;
+            });
+
+            const result = await testMcpConnection({ type: 'sse', url: 'http://localhost:8080/events' });
+            expect(result.success).toBe(true);
+        });
+    });
+});

--- a/packages/forge/src/ai/index.ts
+++ b/packages/forge/src/ai/index.ts
@@ -102,6 +102,7 @@ export {
     mergeMcpConfigs,
     mergeMcpConfigSources,
     clearMcpConfigCache,
+    invalidateCachedConfig,
     mcpConfigExists,
     getCachedMcpConfig,
     setHomeDirectoryOverride,

--- a/packages/forge/src/copilot-sdk-wrapper/copilot-sdk-service.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/copilot-sdk-service.ts
@@ -34,6 +34,8 @@ export type { StreamingResult, IStreamableSession, StreamingState, StreamingSess
 import { SessionManager } from './session-manager';
 import { StreamErrorGuard, isStreamDestroyedError } from './stream-error-guard';
 import { RequestRunner } from './request-runner';
+import type { ISDKService } from './sdk-service-interface';
+import { sdkServiceRegistry, COPILOT_PROVIDER } from './sdk-service-registry';
 
 // Re-export types that were previously exported from this file
 export {
@@ -56,7 +58,7 @@ export {
 
 export { tryConvertImageFileToDataUrl } from './image-converter';
 
-export class CopilotSDKService {
+export class CopilotSDKService implements ISDKService {
     private static instance: CopilotSDKService | null = null;
 
     private availabilityCache: SDKAvailabilityResult | null = null;
@@ -82,6 +84,7 @@ export class CopilotSDKService {
     public static getInstance(): CopilotSDKService {
         if (!CopilotSDKService.instance) {
             CopilotSDKService.instance = new CopilotSDKService();
+            sdkServiceRegistry.register(COPILOT_PROVIDER, CopilotSDKService.instance);
         }
         return CopilotSDKService.instance;
     }
@@ -90,6 +93,7 @@ export class CopilotSDKService {
         if (CopilotSDKService.instance) {
             CopilotSDKService.instance.dispose();
             CopilotSDKService.instance = null;
+            sdkServiceRegistry.unregister(COPILOT_PROVIDER);
         }
     }
 

--- a/packages/forge/src/copilot-sdk-wrapper/index.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/index.ts
@@ -144,6 +144,7 @@ export {
     mergeMcpConfigs,
     mergeMcpConfigSources,
     clearMcpConfigCache,
+    invalidateCachedConfig,
     mcpConfigExists,
     getCachedMcpConfig,
     setHomeDirectoryOverride,

--- a/packages/forge/src/copilot-sdk-wrapper/index.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/index.ts
@@ -96,6 +96,21 @@ export {
 
 export type { BackgroundTasksInfo } from './copilot-sdk-service';
 
+// ISDKService interface and provider-agnostic types
+export type {
+    ISDKService,
+    IModelInfo,
+    IAvailabilityResult,
+    IInvocationResult,
+} from './sdk-service-interface';
+
+// SDK Service Registry
+export {
+    SDKServiceRegistry,
+    sdkServiceRegistry,
+    COPILOT_PROVIDER,
+} from './sdk-service-registry';
+
 // Session Manager
 export {
     SessionManager,

--- a/packages/forge/src/copilot-sdk-wrapper/mcp-config-loader.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/mcp-config-loader.ts
@@ -442,6 +442,17 @@ export function loadEffectiveMcpConfig(options: {
 }
 
 /**
+ * Invalidate the cached entry for a specific config file path.
+ * Call this immediately after writing to a config file so subsequent
+ * reads reload from disk instead of returning stale data.
+ *
+ * @param configPath - Absolute path to the config file whose cache entry should be removed
+ */
+export function invalidateCachedConfig(configPath: string): void {
+    cachedConfigs.delete(configPath);
+}
+
+/**
  * Clear the cached MCP config.
  * Useful for testing or when the config file might have changed.
  */

--- a/packages/forge/src/copilot-sdk-wrapper/sdk-service-interface.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/sdk-service-interface.ts
@@ -1,0 +1,150 @@
+/**
+ * ISDKService — Provider-agnostic SDK service interface for forge.
+ *
+ * Defines the contract that any AI SDK service provider must satisfy.
+ * `CopilotSDKService` is the current sole implementation; this interface
+ * enables future Codex SDK and Claude SDK adapters without changing callers.
+ *
+ * Provider-agnostic primitive types are defined here so adapters can translate
+ * provider-specific responses at their own boundaries.
+ */
+
+import type { SendMessageOptions } from './types';
+
+// ============================================================================
+// Provider-Agnostic Primitive Types
+// ============================================================================
+
+/**
+ * Minimal model descriptor that every SDK provider must supply.
+ * Forge-specific `ModelInfo` satisfies this interface structurally.
+ */
+export interface IModelInfo {
+    /** Unique model identifier (e.g. 'gpt-4.1', 'claude-sonnet-4.6') */
+    id: string;
+    /** Human-readable model name */
+    name: string;
+}
+
+/**
+ * Availability check result returned by any SDK provider.
+ * Forge-specific `SDKAvailabilityResult` satisfies this interface structurally.
+ */
+export interface IAvailabilityResult {
+    /** Whether the provider is available and ready */
+    available: boolean;
+    /** Human-readable error message when not available */
+    error?: string;
+}
+
+/**
+ * Invocation result returned by any SDK provider's sendMessage call.
+ * Forge-specific `SDKInvocationResult` satisfies this interface structurally.
+ */
+export interface IInvocationResult {
+    /** Whether the invocation completed without error */
+    success: boolean;
+    /** Response text from the AI (populated on success) */
+    response?: string;
+    /** Error message (populated on failure) */
+    error?: string;
+    /** Session ID used for this request, if a session was created */
+    sessionId?: string;
+}
+
+// ============================================================================
+// ISDKService — Main Interface
+// ============================================================================
+
+/**
+ * Provider-agnostic interface for an AI SDK service.
+ *
+ * Method signatures deliberately mirror `CopilotSDKService`'s public API so
+ * that class satisfies this interface via TypeScript structural typing with
+ * zero changes to its return types.
+ *
+ * Auxiliary services (model metadata store, MCP config loader, image converter)
+ * are intentionally excluded — they are implementation details of the Copilot
+ * provider and not part of the common contract.
+ */
+export interface ISDKService {
+    // ------------------------------------------------------------------
+    // Availability
+    // ------------------------------------------------------------------
+
+    /** Check whether the underlying SDK is installed and loadable. */
+    isAvailable(): Promise<IAvailabilityResult>;
+
+    /** Discard the cached availability result and re-check on next call. */
+    clearAvailabilityCache(): void;
+
+    // ------------------------------------------------------------------
+    // Model discovery
+    // ------------------------------------------------------------------
+
+    /** Return the list of models supported by this provider. */
+    listModels(): Promise<IModelInfo[]>;
+
+    // ------------------------------------------------------------------
+    // Message dispatch
+    // ------------------------------------------------------------------
+
+    /**
+     * Send a message to the AI, optionally streaming the response.
+     * The callback-based pattern in `SendMessageOptions` is preserved
+     * (`onStreamingChunk`, `onToolEvent`, etc.) so existing callers need
+     * no changes.
+     */
+    sendMessage(options: SendMessageOptions): Promise<IInvocationResult>;
+
+    /**
+     * Run a one-shot transformation prompt and return the parsed result.
+     * Equivalent to a non-streaming `sendMessage` focused on text extraction.
+     */
+    transform<T = string>(
+        prompt: string,
+        parse?: (raw: string) => T,
+        options?: { model?: string; timeoutMs?: number; cwd?: string },
+    ): Promise<T>;
+
+    // ------------------------------------------------------------------
+    // Session management
+    // ------------------------------------------------------------------
+
+    /**
+     * Fork an existing session, creating a new session pre-loaded with its
+     * conversation history. Returns the new session ID.
+     */
+    forkSession(sessionId: string): Promise<string>;
+
+    /** Hard-abort a session — terminates in-flight work immediately. */
+    abortSession(sessionId: string): Promise<boolean>;
+
+    /**
+     * Soft-abort a session (Esc-equivalent) — stops in-flight work while
+     * keeping the session alive for potential reuse.
+     */
+    softAbortSession(sessionId: string): Promise<boolean>;
+
+    /**
+     * Inject an immediate steering message into a running session.
+     * Returns `true` when the session was found and the message was sent.
+     */
+    steerSession(sessionId: string, prompt: string): Promise<boolean>;
+
+    /** Returns `true` when a session with the given ID is currently active. */
+    hasActiveSession(sessionId: string): boolean;
+
+    /** Returns the number of currently active sessions. */
+    getActiveSessionCount(): number;
+
+    // ------------------------------------------------------------------
+    // Lifecycle
+    // ------------------------------------------------------------------
+
+    /** Abort all active sessions and release SDK resources. */
+    cleanup(): Promise<void>;
+
+    /** Permanently dispose the service; further calls will throw or no-op. */
+    dispose(): void;
+}

--- a/packages/forge/src/copilot-sdk-wrapper/sdk-service-registry.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/sdk-service-registry.ts
@@ -1,0 +1,91 @@
+/**
+ * SDKServiceRegistry — named-provider registry for ISDKService instances.
+ *
+ * Replaces the singleton access pattern (`CopilotSDKService.getInstance()`)
+ * with a name-keyed registry so multiple providers (Copilot, Codex, Claude, …)
+ * can coexist and callers can look up a provider by name.
+ *
+ * The module also exports the `COPILOT_PROVIDER` constant used as the
+ * well-known registry key for the Copilot SDK provider.
+ */
+
+import type { ISDKService } from './sdk-service-interface';
+
+// Well-known provider name for the Copilot SDK implementation.
+export const COPILOT_PROVIDER = 'copilot';
+
+/**
+ * Registry that maps provider names to `ISDKService` instances.
+ *
+ * Usage:
+ * ```ts
+ * // Registration (done once, typically during provider init):
+ * sdkServiceRegistry.register('copilot', new CopilotSDKService());
+ *
+ * // Lookup:
+ * const svc = sdkServiceRegistry.getOrThrow('copilot');
+ * ```
+ */
+export class SDKServiceRegistry {
+    private readonly providers = new Map<string, ISDKService>();
+
+    /**
+     * Register a provider under the given name.
+     * Overwrites any previously registered provider with the same name.
+     */
+    register(name: string, provider: ISDKService): void {
+        this.providers.set(name, provider);
+    }
+
+    /**
+     * Look up a provider by name.
+     * Returns `undefined` when no provider is registered under that name.
+     */
+    get(name: string): ISDKService | undefined {
+        return this.providers.get(name);
+    }
+
+    /**
+     * Look up a provider by name, throwing when none is found.
+     */
+    getOrThrow(name: string): ISDKService {
+        const provider = this.providers.get(name);
+        if (!provider) {
+            throw new Error(
+                `SDK service provider '${name}' is not registered. ` +
+                `Registered providers: [${[...this.providers.keys()].join(', ')}]`,
+            );
+        }
+        return provider;
+    }
+
+    /**
+     * Remove the provider registered under the given name.
+     * No-ops silently when the name is not found.
+     */
+    unregister(name: string): void {
+        this.providers.delete(name);
+    }
+
+    /** Returns `true` when a provider is registered under the given name. */
+    has(name: string): boolean {
+        return this.providers.has(name);
+    }
+
+    /** Returns the names of all currently registered providers. */
+    getProviderNames(): string[] {
+        return [...this.providers.keys()];
+    }
+
+    /** Returns the count of registered providers. */
+    get size(): number {
+        return this.providers.size;
+    }
+}
+
+/**
+ * Module-level registry singleton.
+ * The Copilot SDK provider is automatically registered when
+ * `CopilotSDKService.getInstance()` is first called.
+ */
+export const sdkServiceRegistry = new SDKServiceRegistry();

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -207,6 +207,7 @@ export {
     mergeMcpConfigs,
     mergeMcpConfigSources,
     clearMcpConfigCache,
+    invalidateCachedConfig,
     mcpConfigExists,
     getCachedMcpConfig,
     setHomeDirectoryOverride,

--- a/packages/forge/test/copilot-sdk-wrapper/sdk-service-registry.test.ts
+++ b/packages/forge/test/copilot-sdk-wrapper/sdk-service-registry.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for SDKServiceRegistry and ISDKService interface.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    SDKServiceRegistry,
+    sdkServiceRegistry,
+    COPILOT_PROVIDER,
+} from '../../src/copilot-sdk-wrapper/sdk-service-registry';
+import type { ISDKService } from '../../src/copilot-sdk-wrapper/sdk-service-interface';
+
+// ---------------------------------------------------------------------------
+// Minimal stub that satisfies ISDKService structurally
+// ---------------------------------------------------------------------------
+function makeMockProvider(id = 'mock'): ISDKService {
+    return {
+        isAvailable: async () => ({ available: true }),
+        clearAvailabilityCache: () => {},
+        listModels: async () => [{ id, name: `Model ${id}` }],
+        sendMessage: async () => ({ success: true, response: 'ok' }),
+        transform: async <T = string>(prompt: string, parse?: (raw: string) => T) => {
+            const raw = `transformed: ${prompt}`;
+            return (parse ? parse(raw) : raw) as T;
+        },
+        forkSession: async (sid: string) => `${sid}-fork`,
+        abortSession: async () => true,
+        softAbortSession: async () => true,
+        steerSession: async () => true,
+        hasActiveSession: () => false,
+        getActiveSessionCount: () => 0,
+        cleanup: async () => {},
+        dispose: () => {},
+    };
+}
+
+// ---------------------------------------------------------------------------
+// SDKServiceRegistry unit tests
+// ---------------------------------------------------------------------------
+
+describe('SDKServiceRegistry', () => {
+    let registry: SDKServiceRegistry;
+
+    beforeEach(() => {
+        registry = new SDKServiceRegistry();
+    });
+
+    it('starts empty', () => {
+        expect(registry.size).toBe(0);
+        expect(registry.getProviderNames()).toEqual([]);
+    });
+
+    it('registers and retrieves a provider', () => {
+        const mock = makeMockProvider('a');
+        registry.register('a', mock);
+        expect(registry.get('a')).toBe(mock);
+        expect(registry.has('a')).toBe(true);
+    });
+
+    it('returns undefined for unknown provider', () => {
+        expect(registry.get('unknown')).toBeUndefined();
+    });
+
+    it('getOrThrow returns provider when registered', () => {
+        const mock = makeMockProvider('b');
+        registry.register('b', mock);
+        expect(registry.getOrThrow('b')).toBe(mock);
+    });
+
+    it('getOrThrow throws for unknown provider', () => {
+        expect(() => registry.getOrThrow('missing')).toThrow("SDK service provider 'missing' is not registered");
+    });
+
+    it('getOrThrow error message lists registered providers', () => {
+        registry.register('alpha', makeMockProvider('alpha'));
+        registry.register('beta', makeMockProvider('beta'));
+        expect(() => registry.getOrThrow('gamma')).toThrow('alpha');
+        expect(() => registry.getOrThrow('gamma')).toThrow('beta');
+    });
+
+    it('unregister removes a provider', () => {
+        registry.register('c', makeMockProvider('c'));
+        expect(registry.has('c')).toBe(true);
+        registry.unregister('c');
+        expect(registry.has('c')).toBe(false);
+        expect(registry.get('c')).toBeUndefined();
+    });
+
+    it('unregister is a no-op when provider does not exist', () => {
+        expect(() => registry.unregister('nonexistent')).not.toThrow();
+    });
+
+    it('overwrite: re-registering same name replaces provider', () => {
+        const first = makeMockProvider('first');
+        const second = makeMockProvider('second');
+        registry.register('slot', first);
+        registry.register('slot', second);
+        expect(registry.get('slot')).toBe(second);
+        expect(registry.size).toBe(1);
+    });
+
+    it('getProviderNames returns all registered names', () => {
+        registry.register('x', makeMockProvider('x'));
+        registry.register('y', makeMockProvider('y'));
+        const names = registry.getProviderNames();
+        expect(names).toContain('x');
+        expect(names).toContain('y');
+        expect(names).toHaveLength(2);
+    });
+
+    it('size tracks provider count correctly', () => {
+        expect(registry.size).toBe(0);
+        registry.register('one', makeMockProvider('one'));
+        expect(registry.size).toBe(1);
+        registry.register('two', makeMockProvider('two'));
+        expect(registry.size).toBe(2);
+        registry.unregister('one');
+        expect(registry.size).toBe(1);
+    });
+
+    it('multiple independent registries do not share state', () => {
+        const r1 = new SDKServiceRegistry();
+        const r2 = new SDKServiceRegistry();
+        r1.register('shared', makeMockProvider('r1'));
+        expect(r2.has('shared')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Module-level singleton & COPILOT_PROVIDER constant
+// ---------------------------------------------------------------------------
+
+describe('sdkServiceRegistry module singleton', () => {
+    it('exports a singleton SDKServiceRegistry instance', () => {
+        expect(sdkServiceRegistry).toBeInstanceOf(SDKServiceRegistry);
+    });
+
+    it('COPILOT_PROVIDER constant equals "copilot"', () => {
+        expect(COPILOT_PROVIDER).toBe('copilot');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ISDKService structural contract
+// ---------------------------------------------------------------------------
+
+describe('ISDKService structural contract', () => {
+    it('mock provider satisfies ISDKService shape', async () => {
+        const svc: ISDKService = makeMockProvider('test');
+
+        const avail = await svc.isAvailable();
+        expect(avail.available).toBe(true);
+
+        const models = await svc.listModels();
+        expect(models[0].id).toBe('test');
+        expect(models[0].name).toContain('test');
+
+        const result = await svc.sendMessage({ prompt: 'hello' });
+        expect(result.success).toBe(true);
+
+        const text = await svc.transform('x');
+        expect(typeof text).toBe('string');
+
+        const forked = await svc.forkSession('s1');
+        expect(forked).toBe('s1-fork');
+
+        expect(await svc.abortSession('s1')).toBe(true);
+        expect(await svc.softAbortSession('s1')).toBe(true);
+        expect(await svc.steerSession('s1', 'steer')).toBe(true);
+        expect(svc.hasActiveSession('s1')).toBe(false);
+        expect(svc.getActiveSessionCount()).toBe(0);
+
+        await expect(svc.cleanup()).resolves.toBeUndefined();
+        expect(() => svc.dispose()).not.toThrow();
+        expect(() => svc.clearAvailabilityCache()).not.toThrow();
+    });
+
+    it('transform with parse function returns parsed result', async () => {
+        const svc: ISDKService = makeMockProvider('p');
+        const result = await svc.transform<number>('prompt', (raw) => raw.length);
+        expect(typeof result).toBe('number');
+        expect(result).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
- **feat(coc): add MCP config CRUD REST endpoints and per-tool enable/disable**
- **feat: wire MCP settings client to real backend endpoints**
- **feat(mcp): add POST /mcp-config/test endpoint with connection tester**
- **feat(forge): extract ISDKService interface and SDKServiceRegistry**
- **fix: invalidate mcp-config-loader cache after writes in mcp-config-writer**
