### PR TITLE
fix(coc): fix coc-serve-loop build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -3797,7 +3797,7 @@
     "coverage": "npm run coverage -w packages/forge && npm run coverage -w packages/coc-client && npm run coverage -w packages/coc && npm run coverage -w packages/deep-wiki",
     "coverage:diff": "npm run coverage:diff -w packages/forge && npm run coverage:diff -w packages/coc-client && npm run coverage:diff -w packages/coc && npm run coverage:diff -w packages/deep-wiki",
     "build:packages": "npm run build -w packages/forge && npm run build -w packages/coc-client && npm run build -w packages/teams-bot && npm run build -w packages/coc && npm run build -w packages/deep-wiki",
-    "coc:link": "cd packages/forge && npm run build && npm link && cd ../coc-client && npm run build && cd ../coc && npm run build && npm link && node -e \"require('fs').rmSync('node_modules/@plusplusoneplusplus/forge', {recursive:true,force:true})\"",
+    "coc:link": "cd packages/forge && npm run build && npm link && cd ../coc-client && npm run build && cd ../teams-bot && npm run build && cd ../coc && npm run build && npm link && node -e \"require('fs').rmSync('node_modules/@plusplusoneplusplus/forge', {recursive:true,force:true})\"",
     "deep-wiki:link": "cd packages/deep-wiki && npm run build && npm link",
     "vsce:package": "vsce package",
     "vsce:publish": "vsce publish",

--- a/scripts/coc-serve-loop.ps1
+++ b/scripts/coc-serve-loop.ps1
@@ -59,7 +59,7 @@ if (-not [string]::IsNullOrWhiteSpace($TunnelId) -and $portWasProvided) {
     exit 2
 }
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$repoRoot = Split-Path -Parent $PSScriptRoot
 
 # If invoked from repo root, use that instead
 if (Test-Path (Join-Path $PWD 'packages\coc')) {


### PR DESCRIPTION
- Fix repoRoot in coc-serve-loop.ps1: was going up 2 levels from scripts/ (landing outside the repo) instead of 1 level
- Add teams-bot build step to coc:link script so coc can resolve its @plusplusoneplusplus/teams-bot dependency during the serve-loop build