### PR TITLE
ci: add coc-serve-smoke job to verify server starts correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $job = Start-Job { Set-Location $using:PWD; node packages/coc/dist/index.js serve --no-open --port 4111 }
+          $proc = Start-Process -FilePath node -ArgumentList "packages/coc/dist/index.js","serve","--no-open","--port","4111" -PassThru -NoNewWindow -RedirectStandardOutput coc-stdout.log -RedirectStandardError coc-stderr.log
           $healthy = $false
           for ($i = 1; $i -le 30; $i++) {
             Start-Sleep -Seconds 1
@@ -474,12 +474,13 @@ jobs:
               }
             } catch {}
           }
-          Stop-Job $job -ErrorAction SilentlyContinue
-          Remove-Job $job -Force -ErrorAction SilentlyContinue
           if (-not $healthy) {
             Write-Host "✗ Server failed to respond within 30s"
-            exit 1
+            if (Test-Path coc-stdout.log) { Write-Host "--- stdout ---"; Get-Content coc-stdout.log }
+            if (Test-Path coc-stderr.log) { Write-Host "--- stderr ---"; Get-Content coc-stderr.log }
           }
+          Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          if (-not $healthy) { exit 1 }
 
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,10 +461,19 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $proc = Start-Process -FilePath node -ArgumentList "packages/coc/dist/index.js","serve","--no-open","--port","4111" -PassThru -NoNewWindow -RedirectStandardOutput coc-stdout.log -RedirectStandardError coc-stderr.log
+          $nodeExe = (Get-Command node).Source
+          Write-Host "Using node: $nodeExe"
+          $scriptPath = Resolve-Path "packages/coc/dist/index.js"
+          Write-Host "Script: $scriptPath"
+          $proc = Start-Process -FilePath $nodeExe -ArgumentList $scriptPath,"serve","--no-open","--port","4111" -PassThru -RedirectStandardOutput coc-stdout.log -RedirectStandardError coc-stderr.log
+          Write-Host "Started PID: $($proc.Id)"
           $healthy = $false
-          for ($i = 1; $i -le 30; $i++) {
+          for ($i = 1; $i -le 60; $i++) {
             Start-Sleep -Seconds 1
+            if ($proc.HasExited) {
+              Write-Host "Process exited early with code $($proc.ExitCode)"
+              break
+            }
             try {
               $resp = Invoke-WebRequest -Uri http://127.0.0.1:4111/api/health -UseBasicParsing -ErrorAction Stop
               if ($resp.StatusCode -eq 200) {
@@ -475,10 +484,10 @@ jobs:
             } catch {}
           }
           if (-not $healthy) {
-            Write-Host "✗ Server failed to respond within 30s"
-            if (Test-Path coc-stdout.log) { Write-Host "--- stdout ---"; Get-Content coc-stdout.log }
-            if (Test-Path coc-stderr.log) { Write-Host "--- stderr ---"; Get-Content coc-stderr.log }
+            Write-Host "✗ Server failed to respond within 60s"
           }
+          if (Test-Path coc-stdout.log) { Write-Host "--- stdout ---"; Get-Content coc-stdout.log }
+          if (Test-Path coc-stderr.log) { Write-Host "--- stderr ---"; Get-Content coc-stderr.log }
           Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
           if (-not $healthy) { exit 1 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,9 +405,85 @@ jobs:
           path: packages/coc/playwright-report/
           retention-days: 7
 
+  coc-serve-smoke:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Start coc serve and verify health (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          npx coc serve --no-open --port 4111 &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:4111/api/health > /dev/null 2>&1; then
+              echo "✓ Server healthy after ${i}s"
+              kill $SERVER_PID
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "✗ Server failed to respond within 30s"
+          kill $SERVER_PID 2>/dev/null || true
+          exit 1
+
+      - name: Start coc serve and verify health (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $job = Start-Job { Set-Location $using:PWD; npx coc serve --no-open --port 4111 }
+          $healthy = $false
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 1
+            try {
+              $resp = Invoke-WebRequest -Uri http://127.0.0.1:4111/api/health -UseBasicParsing -ErrorAction Stop
+              if ($resp.StatusCode -eq 200) {
+                Write-Host "✓ Server healthy after ${i}s"
+                $healthy = $true
+                break
+              }
+            } catch {}
+          }
+          Stop-Job $job -ErrorAction SilentlyContinue
+          Remove-Job $job -Force -ErrorAction SilentlyContinue
+          if (-not $healthy) {
+            Write-Host "✗ Server failed to respond within 30s"
+            exit 1
+          }
+
   ci:
     runs-on: ubuntu-latest
-    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, extension-test, e2e]
+    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, extension-test, e2e, coc-serve-smoke]
     if: always()
     steps:
       - name: Verify all required jobs succeeded
@@ -420,6 +496,7 @@ jobs:
             [deep-wiki-test]="${{ needs.deep-wiki-test.result }}"
             [extension-test]="${{ needs.extension-test.result }}"
             [e2e]="${{ needs.e2e.result }}"
+            [coc-serve-smoke]="${{ needs.coc-serve-smoke.result }}"
           )
           failed=0
           for job in "${!results[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,56 +440,23 @@ jobs:
       - name: Build packages
         run: npm run build:packages
 
-      - name: Start coc serve and verify health (Linux)
-        if: runner.os == 'Linux'
+      - name: Start coc serve and verify health
+        shell: bash
         run: |
-          node packages/coc/dist/index.js serve --no-open --port 4111 &
+          # Pipe from sleep to keep stdin open (prevents Windows readline 'close' shutdown)
+          sleep 120 | node packages/coc/dist/index.js serve --no-open --port 4111 &
           SERVER_PID=$!
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             if curl -sf http://127.0.0.1:4111/api/health > /dev/null 2>&1; then
               echo "✓ Server healthy after ${i}s"
-              kill $SERVER_PID
+              kill $SERVER_PID 2>/dev/null || true
               exit 0
             fi
             sleep 1
           done
-          echo "✗ Server failed to respond within 30s"
+          echo "✗ Server failed to respond within 60s"
           kill $SERVER_PID 2>/dev/null || true
           exit 1
-
-      - name: Start coc serve and verify health (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $nodeExe = (Get-Command node).Source
-          Write-Host "Using node: $nodeExe"
-          $scriptPath = Resolve-Path "packages/coc/dist/index.js"
-          Write-Host "Script: $scriptPath"
-          $proc = Start-Process -FilePath $nodeExe -ArgumentList $scriptPath,"serve","--no-open","--port","4111" -PassThru -RedirectStandardOutput coc-stdout.log -RedirectStandardError coc-stderr.log
-          Write-Host "Started PID: $($proc.Id)"
-          $healthy = $false
-          for ($i = 1; $i -le 60; $i++) {
-            Start-Sleep -Seconds 1
-            if ($proc.HasExited) {
-              Write-Host "Process exited early with code $($proc.ExitCode)"
-              break
-            }
-            try {
-              $resp = Invoke-WebRequest -Uri http://127.0.0.1:4111/api/health -UseBasicParsing -ErrorAction Stop
-              if ($resp.StatusCode -eq 200) {
-                Write-Host "✓ Server healthy after ${i}s"
-                $healthy = $true
-                break
-              }
-            } catch {}
-          }
-          if (-not $healthy) {
-            Write-Host "✗ Server failed to respond within 60s"
-          }
-          if (Test-Path coc-stdout.log) { Write-Host "--- stdout ---"; Get-Content coc-stdout.log }
-          if (Test-Path coc-stderr.log) { Write-Host "--- stderr ---"; Get-Content coc-stderr.log }
-          Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-          if (-not $healthy) { exit 1 }
 
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
       - name: Start coc serve and verify health (Linux)
         if: runner.os == 'Linux'
         run: |
-          npx coc serve --no-open --port 4111 &
+          node packages/coc/dist/index.js serve --no-open --port 4111 &
           SERVER_PID=$!
           for i in $(seq 1 30); do
             if curl -sf http://127.0.0.1:4111/api/health > /dev/null 2>&1; then
@@ -461,7 +461,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $job = Start-Job { Set-Location $using:PWD; npx coc serve --no-open --port 4111 }
+          $job = Start-Job { Set-Location $using:PWD; node packages/coc/dist/index.js serve --no-open --port 4111 }
           $healthy = $false
           for ($i = 1; $i -le 30; $i++) {
             Start-Sleep -Seconds 1


### PR DESCRIPTION
Adds a new CI job that builds all packages and starts coc serve, then polls /api/health for up to 30s to confirm the server is responsive. Runs on both Linux and Windows.