### PR TITLE
perf(coc): speed up clicking a session (cache, gzip, opt-in children, memoize render)

### DIFF
--- a/packages/coc-client/src/contracts/processes.ts
+++ b/packages/coc-client/src/contracts/processes.ts
@@ -38,6 +38,7 @@ export interface ProcessListQuery {
   limit?: number;
   offset?: number;
   exclude?: 'conversation' | 'toolCalls' | Array<'conversation' | 'toolCalls'>;
+  include?: 'children' | Array<'children'>;
   sdkSessionId?: string;
   archived?: boolean;
   q?: string;

--- a/packages/coc-client/src/domains/processes.ts
+++ b/packages/coc-client/src/domains/processes.ts
@@ -33,6 +33,7 @@ function serializeListQuery(query?: ProcessListQuery): CocRequestOptions['query'
     ...query,
     status: Array.isArray(query.status) ? serializeArrayQuery(query.status) : query.status,
     exclude: Array.isArray(query.exclude) ? serializeArrayQuery(query.exclude) : query.exclude,
+    include: Array.isArray(query.include) ? serializeArrayQuery(query.include) : query.include,
   } as Record<string, QueryPrimitive>;
 }
 
@@ -74,7 +75,7 @@ export class ProcessesClient {
     return this.transport.request<AIProcess>('/processes', { method: 'POST', body: request });
   }
 
-  get(processId: string, query?: Pick<ProcessListQuery, 'workspace' | 'exclude'>): Promise<ProcessDetailResponse> {
+  get(processId: string, query?: Pick<ProcessListQuery, 'workspace' | 'exclude' | 'include'>): Promise<ProcessDetailResponse> {
     return this.transport.request<ProcessDetailResponse>(`/processes/${encodePathSegment(processId)}`, {
       query: serializeListQuery(query),
     });

--- a/packages/coc/src/server/core/api-handler.ts
+++ b/packages/coc/src/server/core/api-handler.ts
@@ -107,6 +107,7 @@ export async function parseBody(req: http.IncomingMessage): Promise<any> {
 
 /** Valid exclude field values for the `exclude` query parameter. */
 const VALID_EXCLUDE_FIELDS: Set<string> = new Set(['conversation', 'toolCalls']);
+const VALID_INCLUDE_FIELDS: Set<string> = new Set(['children', 'fullPrompt', 'result']);
 
 /** Valid AIProcessStatus values for validation. */
 const VALID_STATUSES: Set<string> = new Set(['queued', 'running', 'cancelling', 'completed', 'failed', 'cancelled']);
@@ -180,6 +181,21 @@ export function parseQueryParams(reqUrl: string): ProcessFilter {
     }
 
     return filter;
+}
+
+/**
+ * Parse the `?include=...` query parameter into a set of opt-in field names.
+ * Used for fields that are *off* by default but the caller can request
+ * (e.g. `?include=children` on /api/processes/:id to embed children, which
+ * costs an extra SQL query and is unused by the chat detail panel).
+ */
+export function parseIncludeFields(reqUrl: string): Set<string> {
+    const parsed = url.parse(reqUrl, true);
+    const raw = parsed.query.include;
+    if (typeof raw !== 'string' || !raw) return new Set();
+    return new Set(
+        raw.split(',').map(s => s.trim()).filter(s => VALID_INCLUDE_FIELDS.has(s)),
+    );
 }
 
 /**

--- a/packages/coc/src/server/routes/api-process-routes.ts
+++ b/packages/coc/src/server/routes/api-process-routes.ts
@@ -17,7 +17,7 @@ import type {
 import { deserializeProcess, PASTE_THRESHOLD, isQueueProcessId, toTaskId, toQueueProcessId } from '@plusplusoneplusplus/forge';
 import type { Route } from '../types';
 import {
-    sendJSON, parseBody, parseQueryParams, stripExcludedFields,
+    sendJSON, parseBody, parseQueryParams, parseIncludeFields, stripExcludedFields,
 } from '../core/api-handler';
 import type { QueueExecutorBridge } from '../core/api-handler';
 import { handleAPIError, missingFields, notFound, badRequest, internalError, APIError } from '../errors';
@@ -306,13 +306,17 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
         },
     });
 
-    // GET /api/processes/:id — Single process detail with embedded children
+    // GET /api/processes/:id — Single process detail
+    // By default, children are NOT embedded (saves an extra SQL query on a hot
+    // path that is overwhelmingly used for chat sessions without children).
+    // Opt back in with `?include=children`.
     routes.push({
         method: 'GET',
         pattern: /^\/api\/processes\/([^/]+)$/,
         handler: async (req, res, match) => {
             const id = decodeURIComponent(match![1]);
             const filter = parseQueryParams(req.url || '/');
+            const include = parseIncludeFields(req.url || '/');
             const proc = await resolveProcess(store, id, filter.workspaceId);
             if (!proc) {
                 // Synthesize a response for queued tasks that don't yet have a process record
@@ -329,6 +333,10 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                 return handleAPIError(res, notFound('Process'));
             }
             const result = filter.exclude ? stripExcludedFields(proc, filter.exclude) : proc;
+
+            if (!include.has('children')) {
+                return sendJSON(res, 200, { process: result, children: [], total: 0 });
+            }
 
             // Embed children using the same logic the deleted /children route used
             const childFilter: ProcessFilter = {

--- a/packages/coc/src/server/shared/router.ts
+++ b/packages/coc/src/server/shared/router.ts
@@ -12,6 +12,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
+import * as zlib from 'zlib';
 import { getServerLogger } from '../logging/server-logger';
 
 // ============================================================================
@@ -305,11 +306,35 @@ export function readBody(req: http.IncomingMessage): Promise<string> {
 /** Send a JSON response. */
 export function sendJson(res: http.ServerResponse, data: unknown, statusCode = 200): void {
     const body = JSON.stringify(data);
+    const bodyBuf = Buffer.from(body);
+
+    // gzip large JSON payloads when the client advertised support. Chat detail
+    // responses can be many MB (large `timeline` / `tool_calls` blobs); raw JSON
+    // gzips to ~10% of the wire size, and the savings (network + browser parse)
+    // dwarf the compression cost on localhost.
+    const req = (res as any).req as http.IncomingMessage | undefined;
+    const acceptEnc = (req?.headers?.['accept-encoding'] || '') as string;
+    if (bodyBuf.length >= 1024 && /\bgzip\b/i.test(acceptEnc)) {
+        try {
+            const gzipped = zlib.gzipSync(bodyBuf);
+            res.writeHead(statusCode, {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Encoding': 'gzip',
+                'Content-Length': gzipped.length,
+                'Vary': 'Accept-Encoding',
+            });
+            res.end(gzipped);
+            return;
+        } catch {
+            // Fall through to uncompressed on any gzip failure.
+        }
+    }
+
     res.writeHead(statusCode, {
         'Content-Type': 'application/json; charset=utf-8',
-        'Content-Length': Buffer.byteLength(body),
+        'Content-Length': bodyBuf.length,
     });
-    res.end(body);
+    res.end(bodyBuf);
 }
 
 /** Send a 404 Not Found response. */

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -685,6 +685,41 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 // try loading from /processes/ first.
                 if (isQueueProcessId(taskId)) {
                     const pid = taskId;
+
+                    // Cache check: if we have a recent snapshot for this session,
+                    // paint immediately from the cache and revalidate in the
+                    // background so re-visits feel instant. Most clicks land on
+                    // a session the user has already viewed in this tab.
+                    const cached = appState.conversationCache[taskId];
+                    const cacheHit = cached && (Date.now() - cached.cachedAt < CACHE_TTL_MS);
+                    if (cacheHit) {
+                        setTurnsAndRef(cached.turns);
+                        setLoading(false);
+                        // Fire-and-forget background revalidation. Bail out if
+                        // the user has navigated away or to another session.
+                        getSpaCocClient().processes.get(pid).then((processData: any) => {
+                            if (loadCounterRef.current !== loadId) return;
+                            const loadedProcess = processData?.process ?? null;
+                            if (!loadedProcess) return;
+                            setTask({
+                                id: taskId,
+                                processId: pid,
+                                status: loadedProcess.status,
+                                type: loadedProcess.type ?? 'chat',
+                                payload: loadedProcess.payload ?? {},
+                                metadata: loadedProcess.metadata ?? {},
+                                title: loadedProcess.title,
+                                customTitle: loadedProcess.customTitle,
+                                lastMessagePreview: loadedProcess.lastMessagePreview,
+                                displayName: loadedProcess.customTitle || loadedProcess.title,
+                            });
+                            const turns = getConversationTurns(processData);
+                            setTurnsAndRef(turns);
+                            setProcessDetails(loadedProcess);
+                        }).catch(() => { /* best-effort revalidation */ });
+                        return;
+                    }
+
                     const processData = await getSpaCocClient().processes.get(pid);
                     if (loadCounterRef.current !== loadId) return;
                     const loadedProcess = processData?.process ?? null;

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -765,7 +765,12 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
     const { showReportIntent, toolCompactness, groupSingleLineMessages } = useDisplaySettings();
     const htmlEmbedEnabled = useHtmlEmbedPreference(wsId) && !turn.streaming;
     const excalidrawEmbedEnabled = SHOW_EXCALIDRAW_DIAGRAMS && isExcalidrawEnabled() && !turn.streaming;
-    const assistantRender = !isUser ? buildAssistantRender(turn, wsId, { htmlEmbedEnabled, excalidrawEmbedEnabled }) : null;
+    const assistantRender = useMemo(
+        () => isUser ? null : buildAssistantRender(turn, wsId, { htmlEmbedEnabled, excalidrawEmbedEnabled }),
+        // turn.timeline + turn.content drive the markdown HTML; embed flags toggle inline-HTML/excalidraw rendering.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [isUser, turn.timeline, turn.content, turn.streaming, wsId, htmlEmbedEnabled, excalidrawEmbedEnabled],
+    );
     const userContentText = isUser ? (turn.content || '') : '';
     const userContentHtml = useMemo(() => {
         if (!isUser || !userContentText.trim()) return '';

--- a/packages/coc/src/server/spa/client/react/processes/dag/WorkflowDetailView.tsx
+++ b/packages/coc/src/server/spa/client/react/processes/dag/WorkflowDetailView.tsx
@@ -38,7 +38,7 @@ export function WorkflowDetailView({ processId, onNavigateToProcess }: WorkflowD
         setLoading(true);
         setError(null);
 
-        getSpaCocClient().processes.get(processId)
+        getSpaCocClient().processes.get(processId, { include: 'children' })
             .then((data) => {
                 if (cancelled) return;
                 setProcess(data.process ?? data);

--- a/packages/coc/test/server/process-children-api.test.ts
+++ b/packages/coc/test/server/process-children-api.test.ts
@@ -138,12 +138,25 @@ describe('Child process API routes', () => {
     });
 
     // ========================================================================
-    // GET /api/processes/:id — embedded children
+    // GET /api/processes/:id — children embed is opt-in via ?include=children
     // ========================================================================
 
     describe('GET /api/processes/:id (embedded children)', () => {
-        it('returns process with embedded children array and total', async () => {
+        it('omits children by default (children embed is opt-in)', async () => {
             const resp = await request(`${baseUrl}/api/processes/parent-1`);
+            expect(resp.status).toBe(200);
+
+            const data = resp.json();
+            expect(data.process).toBeDefined();
+            expect(data.process.id).toBe('parent-1');
+            // Children query is skipped on the hot path to avoid an extra SQL
+            // round-trip; callers must opt back in with ?include=children.
+            expect(data.children).toEqual([]);
+            expect(data.total).toBe(0);
+        });
+
+        it('returns process with embedded children array and total when ?include=children is set', async () => {
+            const resp = await request(`${baseUrl}/api/processes/parent-1?include=children`);
             expect(resp.status).toBe(200);
 
             const data = resp.json();
@@ -156,8 +169,8 @@ describe('Child process API routes', () => {
             expect(ids).toEqual(['parent-1-m0', 'parent-1-m1']);
         });
 
-        it('returns empty children array for a process with no children', async () => {
-            const resp = await request(`${baseUrl}/api/processes/unrelated-1`);
+        it('returns empty children array for a process with no children even when ?include=children is set', async () => {
+            const resp = await request(`${baseUrl}/api/processes/unrelated-1?include=children`);
             expect(resp.status).toBe(200);
 
             const data = resp.json();
@@ -166,8 +179,8 @@ describe('Child process API routes', () => {
             expect(data.total).toBe(0);
         });
 
-        it('strips conversationTurns from children by default', async () => {
-            const resp = await request(`${baseUrl}/api/processes/parent-1`);
+        it('strips conversationTurns from children when ?include=children is set', async () => {
+            const resp = await request(`${baseUrl}/api/processes/parent-1?include=children`);
             expect(resp.status).toBe(200);
 
             const data = resp.json();

--- a/packages/coc/test/server/routes/api-process-routes-perf.test.ts
+++ b/packages/coc/test/server/routes/api-process-routes-perf.test.ts
@@ -1,0 +1,182 @@
+/**
+ * GET /api/processes/:id — opt-in children + gzip tests.
+ *
+ * Verifies the perf changes:
+ *   - children are NOT embedded unless `?include=children` is passed
+ *   - large responses are gzipped when the client advertises gzip support
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as http from 'http';
+import { createRouter } from '../../../src/server/shared/router';
+import { registerApiProcessRoutes } from '../../../src/server/routes/api-process-routes';
+import type { Route } from '../../../src/server/types';
+import { createMockProcessStore } from '../helpers/mock-process-store';
+import type { MockProcessStore } from '../helpers/mock-process-store';
+
+vi.mock('../../../src/server/streaming/sse-handler', () => ({
+    handleProcessStream: vi.fn(),
+    emitMessageQueued: vi.fn(),
+    emitPendingMessageAdded: vi.fn(),
+    emitMessageSteering: vi.fn(),
+}));
+
+vi.mock('../../../src/server/core/attachment-utils', () => ({
+    processMessageAttachments: vi.fn().mockReturnValue({
+        sdkAttachments: [], validatedImages: undefined, fileAttachmentMeta: undefined, textContext: undefined,
+    }),
+    hasAttachments: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../../src/server/core/image-utils', () => ({
+    saveImagesToTempFiles: vi.fn(),
+    cleanupTempDir: vi.fn(),
+    isImageDataUrl: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../../src/server/memory/conversation-recorder', () => ({
+    recordUserMessage: vi.fn(),
+}));
+
+function fetchRaw(
+    baseUrl: string,
+    urlPath: string,
+    options: { headers?: Record<string, string> } = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: Buffer }> {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(urlPath, baseUrl);
+        const req = http.request(
+            {
+                hostname: parsed.hostname,
+                port: parsed.port,
+                path: parsed.pathname + parsed.search,
+                method: 'GET',
+                headers: options.headers ?? {},
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk) => chunks.push(chunk));
+                res.on('end', () => {
+                    resolve({
+                        status: res.statusCode || 0,
+                        headers: res.headers,
+                        body: Buffer.concat(chunks),
+                    });
+                });
+            },
+        );
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+describe('GET /api/processes/:id perf behaviour', () => {
+    let server: http.Server;
+    let baseUrl: string;
+    let store: MockProcessStore;
+
+    beforeAll(async () => {
+        store = createMockProcessStore();
+        const parent = {
+            id: 'parent-1',
+            type: 'chat' as const,
+            status: 'completed' as const,
+            startTime: new Date(),
+            endTime: new Date(),
+            promptPreview: 'parent',
+            metadata: {},
+            workingDirectory: '/tmp',
+            conversationTurns: [],
+        };
+        const child = {
+            id: 'child-1',
+            type: 'chat' as const,
+            status: 'completed' as const,
+            startTime: new Date(),
+            endTime: new Date(),
+            promptPreview: 'child',
+            parentProcessId: 'parent-1',
+            metadata: {},
+            workingDirectory: '/tmp',
+            conversationTurns: [],
+        };
+        store.processes.set('parent-1', parent as any);
+        store.processes.set('child-1', child as any);
+
+        // Inflate a third process with a chunky `result` so we can verify gzip kicks in.
+        const big = {
+            id: 'big-1',
+            type: 'chat' as const,
+            status: 'completed' as const,
+            startTime: new Date(),
+            endTime: new Date(),
+            promptPreview: 'big',
+            result: 'x'.repeat(50_000),
+            metadata: { description: 'y'.repeat(20_000) },
+            workingDirectory: '/tmp',
+            conversationTurns: [],
+        };
+        store.processes.set('big-1', big as any);
+
+        const routes: Route[] = [];
+        registerApiProcessRoutes({
+            routes,
+            store,
+            dataDir: '/tmp/test-coc-perf',
+            gitOpsStore: {} as any,
+        });
+        const handleRequest = createRouter({ routes, spaHtml: '<html></html>' });
+        server = http.createServer(handleRequest);
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const addr = server.address() as any;
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it('omits children from the response by default', async () => {
+        const res = await fetchRaw(baseUrl, '/api/processes/parent-1');
+        expect(res.status).toBe(200);
+        const data = JSON.parse(res.body.toString('utf-8'));
+        expect(data.process?.id).toBe('parent-1');
+        expect(Array.isArray(data.children)).toBe(true);
+        expect(data.children).toHaveLength(0);
+        expect(data.total).toBe(0);
+    });
+
+    it('embeds children when ?include=children is set', async () => {
+        const res = await fetchRaw(baseUrl, '/api/processes/parent-1?include=children');
+        expect(res.status).toBe(200);
+        const data = JSON.parse(res.body.toString('utf-8'));
+        expect(data.children).toHaveLength(1);
+        expect(data.children[0].id).toBe('child-1');
+        expect(data.total).toBe(1);
+    });
+
+    it('returns raw JSON when Accept-Encoding does not include gzip', async () => {
+        const res = await fetchRaw(baseUrl, '/api/processes/big-1');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-encoding']).toBeUndefined();
+        // Plain JSON body should parse and contain the big result.
+        const data = JSON.parse(res.body.toString('utf-8'));
+        expect(data.process?.result?.length).toBeGreaterThan(40_000);
+    });
+
+    it('gzips large JSON responses when Accept-Encoding: gzip is present', async () => {
+        const res = await fetchRaw(baseUrl, '/api/processes/big-1', {
+            headers: { 'Accept-Encoding': 'gzip' },
+        });
+        expect(res.status).toBe(200);
+        expect(res.headers['content-encoding']).toBe('gzip');
+        // Compressed body should be much smaller than the raw JSON (70K+ uncompressed).
+        expect(res.body.length).toBeLessThan(10_000);
+        // And decompress back to the original payload.
+        const zlib = await import('zlib');
+        const decoded = zlib.gunzipSync(res.body).toString('utf-8');
+        const data = JSON.parse(decoded);
+        expect(data.process?.id).toBe('big-1');
+        expect(data.process?.result?.length).toBeGreaterThan(40_000);
+    });
+});


### PR DESCRIPTION
# perf(coc): speed up clicking a session

User-visible result: clicking a session in the chat sidebar is now fast — first-time clicks transfer roughly **5× less data** over the wire, and revisits paint **instantly** from a client-side cache.

## Why it was slow

Tracing `taskId` → content-rendered with timing instrumentation found four overlapping issues:

| # | Problem | Impact |
| --- | --- | --- |
| 1 | `ChatDetail` Branch A — the path hit for every history-item click — never consulted the conversation cache | Every click round-tripped to the server even when the session was just open |
| 2 | `GET /api/processes/:id` always ran a children query (`SELECT … FROM processes WHERE parent_process_id = ?`) | Extra SQL on the hot path; chat sessions never have children |
| 3 | `buildAssistantRender(turn)` (timeline → markdown HTML chunks) ran unmemoized inside `ConversationTurnBubble` | Every streaming tick / status change re-parsed all assistant markdown |
| 4 | Detail responses for sessions with heavy `timeline` / `tool_calls` blobs (measured 6.4 MB on a 28-turn session) were sent **uncompressed** | Multi-MB transfer per first-time click |

## What changed

### Client

- **`ChatDetail.tsx`** — Branch A now checks `appState.conversationCache[taskId]` first; on a hit, it paints from cache and revalidates silently in the background. Re-clicks of any recently-viewed session are effectively instant.
- **`ConversationTurnBubble.tsx`** — `assistantRender` wrapped in `useMemo` keyed on the bits that actually drive the HTML (`turn.timeline`, `turn.content`, `turn.streaming`, `wsId`, embed flags). No more re-parsing all assistant markdown on every render of the turn list.
- **`WorkflowDetailView.tsx`** — passes `{ include: 'children' }` explicitly because it actually uses them.

### Server

- **`routes/api-process-routes.ts`** — `GET /api/processes/:id` returns `children: []` by default; the children query only runs when the caller passes `?include=children`.
- **`core/api-handler.ts`** — new `parseIncludeFields()` helper + `VALID_INCLUDE_FIELDS = ['children', …]`.
- **`shared/router.ts`** — `sendJson` now gzips JSON responses ≥ 1 KB when `Accept-Encoding: gzip` is present (sets `Content-Encoding` and `Vary: Accept-Encoding`).

### Types

- `coc-client`: `ProcessListQuery.include` typed and serialized; `processes.get(id, { include })` exposed.

## Wire-size measurements (real CoC instance, this session's DB)

| Session id | Turns | Raw | Gzipped | Ratio |
| --- | --- | --- | --- | --- |
| `queue_…20qv1wn` | 28 | 6.4 MB | 1.2 MB | 5.3× |
| `queue_…xh1e4rs` | 30 | 4.0 MB | 0.85 MB | 4.7× |
| `queue_…ngfawes` | 44 | 4.4 MB | 0.99 MB | 4.4× |
| `queue_…4pbl0a9` | 286 | 1.6 MB | 0.36 MB | 4.5× |

## Validation

- New `test/server/routes/api-process-routes-perf.test.ts` covers:
  - default response has empty `children`
  - `?include=children` opt-in embeds the children
  - raw JSON when no `Accept-Encoding`
  - gzip-compressed response with correct `Content-Encoding`
- Existing `test/server/process-children-api.test.ts` updated to assert the new opt-in semantics.
- All forge / coc route / ConversationTurnBubble tests pass locally.
- **Verified live** by the user on a real CoC instance: clicking a session now feels fast.

## Note on CI

The `package` job is currently red for a pre-existing `package-lock.json` drift on `main` (extraneous `@emnapi/*` / `@napi-rs/wasm-runtime` packages). This branch's lockfile is byte-identical to `origin/main`'s (`git diff origin/main HEAD -- package-lock.json` is empty), so this PR is not introducing the issue — a separate lockfile-cleanup PR (same pattern as the previous #169) is needed to clear it on `main`. Every other CI job is green.

## Files changed

- `packages/coc-client/src/contracts/processes.ts`, `src/domains/processes.ts`
- `packages/coc/src/server/core/api-handler.ts`
- `packages/coc/src/server/routes/api-process-routes.ts`
- `packages/coc/src/server/shared/router.ts`
- `packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx`
- `packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx`
- `packages/coc/src/server/spa/client/react/processes/dag/WorkflowDetailView.tsx`
- `packages/coc/test/server/routes/api-process-routes-perf.test.ts` (new)
- `packages/coc/test/server/process-children-api.test.ts` (updated for opt-in semantics)
