### PR TITLE
pr/4f1fef629 feat display supported reasoning efforts

### DIFF
--- a/packages/coc-client/src/contracts/common.ts
+++ b/packages/coc-client/src/contracts/common.ts
@@ -20,6 +20,10 @@ export interface ModelInfo {
   label?: string;
   enabled?: boolean;
   capabilities?: JsonObject;
+  /** Reasoning efforts the model accepts (e.g. ['low','medium','high','xhigh']). Empty/undefined when unknown. */
+  supportedReasoningEfforts?: string[];
+  /** Default reasoning effort the model picks when none is requested. */
+  defaultReasoningEffort?: string;
   [key: string]: unknown;
 }
 

--- a/packages/coc-client/src/contracts/common.ts
+++ b/packages/coc-client/src/contracts/common.ts
@@ -30,3 +30,7 @@ export interface ModelInfo {
 export interface EnabledModelsResponse {
   enabledModels: string[];
 }
+
+export interface ReasoningEffortsResponse {
+  reasoningEfforts: Record<string, string>;
+}

--- a/packages/coc-client/src/domains/models.ts
+++ b/packages/coc-client/src/domains/models.ts
@@ -1,4 +1,4 @@
-import type { EnabledModelsResponse, ModelInfo } from '../contracts';
+import type { EnabledModelsResponse, ModelInfo, ReasoningEffortsResponse } from '../contracts';
 import type { RequestAdapter } from '../types';
 
 export class ModelsClient {
@@ -16,6 +16,17 @@ export class ModelsClient {
     return this.transport.request<EnabledModelsResponse>('/models/enabled', {
       method: 'PUT',
       body: { enabledModels: [...enabledModels] },
+    });
+  }
+
+  getReasoningEfforts(): Promise<ReasoningEffortsResponse> {
+    return this.transport.request<ReasoningEffortsResponse>('/models/reasoning-efforts');
+  }
+
+  setReasoningEffort(modelId: string, effort: string): Promise<ReasoningEffortsResponse> {
+    return this.transport.request<ReasoningEffortsResponse>('/models/reasoning-efforts', {
+      method: 'PUT',
+      body: { modelId, effort },
     });
   }
 }

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -77,6 +77,8 @@ export interface CLIConfig {
     /** Models whitelist configuration */
     models?: {
         enabled?: string[];
+        /** Per-model reasoning effort overrides (modelId → effort). */
+        reasoningEfforts?: Record<string, string>;
     };
     /** Logging configuration */
     logging?: LoggingConfig;
@@ -248,6 +250,8 @@ export interface ResolvedCLIConfig {
     /** Models whitelist — list of enabled model IDs */
     models?: {
         enabled?: string[];
+        /** Per-model reasoning effort overrides (modelId → effort). */
+        reasoningEfforts?: Record<string, string>;
     };
     /** Logging config passed through from file (not fully resolved — use resolveLoggingConfig) */
     logging?: LoggingConfig;

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -50,6 +50,7 @@ import { saveImagesToTempFiles, cleanupTempDir, rehydrateImagesIfNeeded } from '
 import type { BroadcastWorkItemFn } from '../llm-tools/create-work-item-tool';
 import { BaseExecutor } from './base-executor';
 import { resolveDefaultModel } from '../preferences-handler';
+import { loadConfigFile } from '../../config';
 import {
     assertNoAskUserConflict,
     buildBoundedMemoryAddon,
@@ -496,9 +497,16 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
                 effectiveModel = resolveDefaultModel(this.dataDir, payload.workspaceId, defaultModelMode);
             }
 
+            // Resolve reasoning effort: explicit task config > persisted per-model preference > SDK default
+            let requestedEffort: Parameters<typeof resolveReasoningSelection>[0]['requestedEffort'] = task.config.reasoningEffort;
+            if (!requestedEffort && effectiveModel) {
+                const cfg = loadConfigFile();
+                const persisted = cfg?.models?.reasoningEfforts?.[effectiveModel];
+                if (persisted) requestedEffort = persisted as NonNullable<typeof requestedEffort>;
+            }
             const reasoningSelection = resolveReasoningSelection({
                 modelId: effectiveModel,
-                requestedEffort: task.config.reasoningEffort,
+                requestedEffort,
                 model: await this.getModelMetadataForReasoning(effectiveModel),
             });
 

--- a/packages/coc/src/server/executors/follow-up-executor.ts
+++ b/packages/coc/src/server/executors/follow-up-executor.ts
@@ -329,8 +329,17 @@ export class FollowUpExecutor extends ChatBaseExecutor {
                 const { resolveDefaultModel } = await import('../preferences-handler');
                 reasoningModel = resolveDefaultModel(this.dataDir, wsId, 'followUp');
             }
+            // Resolve reasoning effort: persisted per-model preference > SDK default
+            let requestedEffort: Parameters<typeof resolveReasoningSelection>[0]['requestedEffort'];
+            if (reasoningModel) {
+                const { loadConfigFile } = await import('../../config');
+                const cfg = loadConfigFile();
+                const persisted = cfg?.models?.reasoningEfforts?.[reasoningModel];
+                if (persisted) requestedEffort = persisted as typeof requestedEffort;
+            }
             const reasoningSelection = resolveReasoningSelection({
                 modelId: reasoningModel,
+                requestedEffort,
                 model: await this.getModelMetadataForReasoning(reasoningModel),
             });
 

--- a/packages/coc/src/server/models/model-routes.ts
+++ b/packages/coc/src/server/models/model-routes.ts
@@ -105,4 +105,57 @@ export function registerModelRoutes(routes: Route[], store: ModelStore, options?
             });
         },
     });
+
+    // -- GET /api/models/reasoning-efforts ------------------------------------
+    routes.push({
+        method: 'GET',
+        pattern: '/api/models/reasoning-efforts',
+        handler: (_req: http.IncomingMessage, res: http.ServerResponse) => {
+            try {
+                const cfg = options.loadConfigFile(options.configPath);
+                sendJson(res, { reasoningEfforts: cfg?.models?.reasoningEfforts ?? {} });
+            } catch (err) {
+                send500(res, err instanceof Error ? err.message : 'Failed to retrieve reasoning efforts');
+            }
+        },
+    });
+
+    // -- PUT /api/models/reasoning-efforts ------------------------------------
+    routes.push({
+        method: 'PUT',
+        pattern: '/api/models/reasoning-efforts',
+        handler: (req: http.IncomingMessage, res: http.ServerResponse) => {
+            let body = '';
+            req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+            req.on('end', () => {
+                try {
+                    const parsed = JSON.parse(body || '{}');
+                    if (typeof parsed.modelId !== 'string' || !parsed.modelId) {
+                        res.writeHead(400);
+                        res.end(JSON.stringify({ error: 'modelId is required' }));
+                        return;
+                    }
+                    if (typeof parsed.effort !== 'string') {
+                        res.writeHead(400);
+                        res.end(JSON.stringify({ error: 'effort must be a string (or empty string to clear)' }));
+                        return;
+                    }
+                    const { modelId, effort } = parsed as { modelId: string; effort: string };
+                    const filePath = options.getConfigFilePath();
+                    const cfg = options.loadConfigFile(options.configPath) ?? {};
+                    const existing = { ...(cfg.models?.reasoningEfforts ?? {}) };
+                    if (effort === '') {
+                        delete existing[modelId];
+                    } else {
+                        existing[modelId] = effort;
+                    }
+                    const updated: CLIConfig = { ...cfg, models: { ...cfg.models, reasoningEfforts: existing } };
+                    options.writeConfigFile(filePath, updated);
+                    sendJson(res, { reasoningEfforts: existing });
+                } catch (err) {
+                    send500(res, err instanceof Error ? err.message : 'Failed to update reasoning effort');
+                }
+            });
+        },
+    });
 }

--- a/packages/coc/src/server/routes/queue-shared.ts
+++ b/packages/coc/src/server/routes/queue-shared.ts
@@ -324,7 +324,7 @@ export function validateAndParseTask(taskSpec: any): TaskValidationResult {
         priority,
         payload,
         config: {
-            model: taskSpec.config?.model,
+            model: taskSpec.config?.model ?? (typeof payload.model === 'string' ? payload.model : undefined),
             timeoutMs: taskSpec.config?.timeoutMs,
             retryOnFailure: taskSpec.config?.retryOnFailure ?? false,
             retryAttempts: taskSpec.config?.retryAttempts,

--- a/packages/coc/src/server/spa/client/react/features/models/ModelsView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/models/ModelsView.tsx
@@ -34,6 +34,8 @@ function ModelCard({ model, onToggle, saving }: { model: ModelInfo; onToggle: (i
     const vision = model.capabilities?.supports?.vision;
     const reasoning = model.capabilities?.supports?.reasoningEffort;
     const ctx = model.capabilities?.limits?.max_context_window_tokens ?? model.tokenLimit;
+    const supportedEfforts = model.supportedReasoningEfforts ?? [];
+    const defaultEffort = model.defaultReasoningEffort;
 
     const borderClass = model.enabled
         ? 'border-[#4caf50] dark:border-[#388e3c]'
@@ -79,6 +81,31 @@ function ModelCard({ model, onToggle, saving }: { model: ModelInfo; onToggle: (i
                 {vision && <span className="text-xs bg-[#e8f5e9] dark:bg-[#1b3a26] text-[#2e7d32] dark:text-[#81c784] px-1.5 py-0.5 rounded" data-testid="badge-vision">👁 Vision</span>}
                 {reasoning && <span className="text-xs bg-[#e3f2fd] dark:bg-[#1a2e45] text-[#1565c0] dark:text-[#64b5f6] px-1.5 py-0.5 rounded" data-testid="badge-reasoning">🧠 Reasoning</span>}
             </div>
+            {supportedEfforts.length > 0 && (
+                <div
+                    className="flex gap-1 mt-1.5 flex-wrap items-center"
+                    data-testid="reasoning-efforts"
+                >
+                    <span className="text-xs text-[#666] dark:text-[#999]">Effort:</span>
+                    {supportedEfforts.map(effort => {
+                        const isDefault = effort === defaultEffort;
+                        const badgeClass = isDefault
+                            ? 'bg-[#1565c0] dark:bg-[#1976d2] text-white'
+                            : 'bg-[#e3f2fd] dark:bg-[#1a2e45] text-[#1565c0] dark:text-[#64b5f6]';
+                        return (
+                            <span
+                                key={effort}
+                                className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${badgeClass}`}
+                                data-testid={`effort-${effort}`}
+                                data-default={isDefault ? 'true' : 'false'}
+                                title={isDefault ? `${effort} (default)` : effort}
+                            >
+                                {effort}{isDefault ? '★' : ''}
+                            </span>
+                        );
+                    })}
+                </div>
+            )}
         </button>
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/models/ModelsView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/models/ModelsView.tsx
@@ -13,7 +13,15 @@ function fmt(n: number): string {
     return String(n);
 }
 
-function ModelCard({ model, onToggle, saving }: { model: ModelInfo; onToggle: (id: string, enabled: boolean) => void; saving: boolean }) {
+interface ModelCardProps {
+    model: ModelInfo;
+    onToggle: (id: string, enabled: boolean) => void;
+    saving: boolean;
+    selectedEffort?: string;
+    onSelectEffort: (modelId: string, effort: string) => void;
+}
+
+function ModelCard({ model, onToggle, saving, selectedEffort, onSelectEffort }: ModelCardProps) {
     const [copied, setCopied] = useState(false);
 
     const handleClick = () => {
@@ -36,6 +44,8 @@ function ModelCard({ model, onToggle, saving }: { model: ModelInfo; onToggle: (i
     const ctx = model.capabilities?.limits?.max_context_window_tokens ?? model.tokenLimit;
     const supportedEfforts = model.supportedReasoningEfforts ?? [];
     const defaultEffort = model.defaultReasoningEffort;
+    // The active effort is the user's persisted override, falling back to the model's default
+    const activeEffort = selectedEffort ?? defaultEffort;
 
     const borderClass = model.enabled
         ? 'border-[#4caf50] dark:border-[#388e3c]'
@@ -88,22 +98,49 @@ function ModelCard({ model, onToggle, saving }: { model: ModelInfo; onToggle: (i
                 >
                     <span className="text-xs text-[#666] dark:text-[#999]">Effort:</span>
                     {supportedEfforts.map(effort => {
+                        const isActive = effort === activeEffort;
                         const isDefault = effort === defaultEffort;
-                        const badgeClass = isDefault
+                        const badgeClass = isActive
                             ? 'bg-[#1565c0] dark:bg-[#1976d2] text-white'
                             : 'bg-[#e3f2fd] dark:bg-[#1a2e45] text-[#1565c0] dark:text-[#64b5f6]';
+                        const handleEffortClick = (e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            if (effort === defaultEffort && !selectedEffort) return;
+                            if (effort === selectedEffort) {
+                                // Clicking the already-selected effort resets to default
+                                onSelectEffort(model.id, '');
+                            } else {
+                                onSelectEffort(model.id, effort);
+                            }
+                        };
+                        let title = effort;
+                        if (isDefault) title += ' (default)';
+                        if (selectedEffort === effort) title += ' (selected — click to reset)';
                         return (
                             <span
                                 key={effort}
-                                className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${badgeClass}`}
+                                role="button"
+                                tabIndex={0}
+                                className={`text-[10px] px-1.5 py-0.5 rounded font-mono cursor-pointer hover:opacity-80 transition-opacity ${badgeClass}`}
                                 data-testid={`effort-${effort}`}
+                                data-active={isActive ? 'true' : 'false'}
                                 data-default={isDefault ? 'true' : 'false'}
-                                title={isDefault ? `${effort} (default)` : effort}
+                                title={title}
+                                onClick={handleEffortClick}
+                                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleEffortClick(e as unknown as React.MouseEvent); }}
                             >
-                                {effort}{isDefault ? '★' : ''}
+                                {effort}{isActive ? '★' : ''}
                             </span>
                         );
                     })}
+                    {selectedEffort && (
+                        <span
+                            className="text-[10px] text-[#888] italic ml-0.5"
+                            data-testid="effort-override-indicator"
+                        >
+                            (custom)
+                        </span>
+                    )}
                 </div>
             )}
         </button>
@@ -111,7 +148,7 @@ function ModelCard({ model, onToggle, saving }: { model: ModelInfo; onToggle: (i
 }
 
 export function ModelsView() {
-    const { models, loading, error, saving, reload, toggleModel } = useModelConfig();
+    const { models, loading, error, saving, reload, toggleModel, reasoningEfforts, setReasoningEffort } = useModelConfig();
     const [search, setSearch] = useState('');
     const [capFilter, setCapFilter] = useState<CapFilter>('all');
 
@@ -186,7 +223,16 @@ export function ModelsView() {
                 </div>
             ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4" data-testid="models-grid">
-                    {filtered.map(m => <ModelCard key={m.id} model={m} onToggle={toggleModel} saving={saving} />)}
+                    {filtered.map(m => (
+                        <ModelCard
+                            key={m.id}
+                            model={m}
+                            onToggle={toggleModel}
+                            saving={saving}
+                            selectedEffort={reasoningEfforts[m.id]}
+                            onSelectEffort={setReasoningEffort}
+                        />
+                    ))}
                 </div>
             )}
         </div>

--- a/packages/coc/src/server/spa/client/react/hooks/useModels.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useModels.ts
@@ -14,6 +14,10 @@ export interface ModelInfo {
         supports: { vision: boolean; reasoningEffort: boolean };
         limits: { max_context_window_tokens: number; max_prompt_tokens?: number };
     };
+    /** Reasoning efforts the model accepts (e.g. ['low','medium','high','xhigh']). Empty when unknown. */
+    supportedReasoningEfforts: string[];
+    /** Default reasoning effort the model picks when none is requested. */
+    defaultReasoningEffort?: string;
 }
 
 interface RawModel {
@@ -21,12 +25,55 @@ interface RawModel {
     name?: string;
     enabled?: boolean;
     capabilities?: {
-        supports?: { vision?: boolean; reasoningEffort?: boolean };
+        supports?: {
+            vision?: boolean;
+            reasoningEffort?: boolean;
+            /** Raw CAPI metadata: list of accepted reasoning_effort values. Authoritative when present. */
+            reasoning_effort?: unknown;
+        };
         limits?: { max_context_window_tokens?: number; max_prompt_tokens?: number };
     };
+    /** SDK contract field with the supported reasoning efforts. */
+    supportedReasoningEfforts?: unknown;
+    defaultReasoningEffort?: unknown;
+}
+
+const KNOWN_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
+type KnownReasoningEffort = typeof KNOWN_REASONING_EFFORTS[number];
+
+function normalizeReasoningEfforts(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const item of value) {
+        if (typeof item !== 'string') continue;
+        if (!(KNOWN_REASONING_EFFORTS as readonly string[]).includes(item)) continue;
+        if (seen.has(item)) continue;
+        seen.add(item);
+        result.push(item);
+    }
+    // Preserve canonical ordering for stable rendering
+    return KNOWN_REASONING_EFFORTS.filter(e => seen.has(e));
+}
+
+function normalizeDefaultReasoningEffort(value: unknown, supported: string[]): string | undefined {
+    if (typeof value !== 'string') return undefined;
+    if (!supported.includes(value)) return undefined;
+    return value as KnownReasoningEffort;
 }
 
 function mapModel(m: RawModel): ModelInfo {
+    // Raw CAPI capability metadata wins over the SDK contract field — it is the
+    // direct source for the values CAPI actually accepts.
+    const supportedReasoningEfforts = normalizeReasoningEfforts(
+        m.capabilities?.supports?.reasoning_effort ?? m.supportedReasoningEfforts,
+    );
+    const defaultReasoningEffort = normalizeDefaultReasoningEffort(m.defaultReasoningEffort, supportedReasoningEfforts);
+    // Treat the presence of a non-empty supported list as definitive proof
+    // the model exposes reasoning, even if the boolean flag is missing.
+    const reasoningEffort = supportedReasoningEfforts.length > 0
+        ? true
+        : (m.capabilities?.supports?.reasoningEffort ?? false);
     return {
         id: m.id,
         tokenLimit: m.capabilities?.limits?.max_context_window_tokens ?? 0,
@@ -35,13 +82,15 @@ function mapModel(m: RawModel): ModelInfo {
         capabilities: {
             supports: {
                 vision: m.capabilities?.supports?.vision ?? false,
-                reasoningEffort: m.capabilities?.supports?.reasoningEffort ?? false,
+                reasoningEffort,
             },
             limits: {
                 max_context_window_tokens: m.capabilities?.limits?.max_context_window_tokens ?? 0,
                 max_prompt_tokens: m.capabilities?.limits?.max_prompt_tokens,
             },
         },
+        supportedReasoningEfforts,
+        defaultReasoningEffort,
     };
 }
 

--- a/packages/coc/src/server/spa/client/react/hooks/useModels.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useModels.ts
@@ -123,15 +123,31 @@ export function useModelConfig(): {
     saving: boolean;
     reload: () => void;
     toggleModel: (modelId: string, enabled: boolean) => Promise<void>;
+    /** Per-model persisted reasoning effort overrides (modelId → effort). */
+    reasoningEfforts: Record<string, string>;
+    /** Persist a reasoning effort override for a model. Empty string clears it. */
+    setReasoningEffort: (modelId: string, effort: string) => Promise<void>;
 } {
     const { models, loading, error, reload } = useModels();
     const [localModels, setLocalModels] = useState<ModelInfo[]>([]);
     const [saving, setSaving] = useState(false);
+    const [reasoningEfforts, setReasoningEfforts] = useState<Record<string, string>>({});
 
     // Keep localModels in sync with fetched models
     useEffect(() => {
         setLocalModels(models);
     }, [models]);
+
+    // Load persisted reasoning efforts on mount
+    useEffect(() => {
+        getSpaCocClient().models.getReasoningEfforts()
+            .then((data: { reasoningEfforts: Record<string, string> }) => {
+                if (data?.reasoningEfforts && typeof data.reasoningEfforts === 'object') {
+                    setReasoningEfforts(data.reasoningEfforts);
+                }
+            })
+            .catch(() => { /* reasoning efforts are optional */ });
+    }, []);
 
     const toggleModel = useCallback(async (modelId: string, enabled: boolean) => {
         // Optimistic update
@@ -149,5 +165,22 @@ export function useModelConfig(): {
         }
     }, [localModels, models]);
 
-    return { models: localModels, loading, error, saving, reload, toggleModel };
+    const setReasoningEffortFn = useCallback(async (modelId: string, effort: string) => {
+        const prev = { ...reasoningEfforts };
+        // Optimistic update
+        if (effort === '') {
+            const next = { ...reasoningEfforts };
+            delete next[modelId];
+            setReasoningEfforts(next);
+        } else {
+            setReasoningEfforts({ ...reasoningEfforts, [modelId]: effort });
+        }
+        try {
+            await getSpaCocClient().models.setReasoningEffort(modelId, effort);
+        } catch {
+            setReasoningEfforts(prev);
+        }
+    }, [reasoningEfforts]);
+
+    return { models: localModels, loading, error, saving, reload, toggleModel, reasoningEfforts, setReasoningEffort: setReasoningEffortFn };
 }

--- a/packages/coc/test/server/model-routes.test.ts
+++ b/packages/coc/test/server/model-routes.test.ts
@@ -298,3 +298,114 @@ describe('PUT /api/models/enabled', () => {
         expect(res.status).toBe(404);
     });
 });
+
+describe('GET /api/models/reasoning-efforts', () => {
+    afterEach(async () => {
+        await stopServer();
+    });
+
+    it('returns empty map when no config exists', async () => {
+        const opts = makeOptions(undefined);
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status, body } = await apiGet('/api/models/reasoning-efforts');
+        expect(status).toBe(200);
+        expect((body as { reasoningEfforts: Record<string, string> }).reasoningEfforts).toEqual({});
+    });
+
+    it('returns persisted reasoning efforts', async () => {
+        const opts = makeOptions({ models: { reasoningEfforts: { 'model-a': 'high', 'model-b': 'low' } } });
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status, body } = await apiGet('/api/models/reasoning-efforts');
+        expect(status).toBe(200);
+        expect((body as { reasoningEfforts: Record<string, string> }).reasoningEfforts).toEqual({ 'model-a': 'high', 'model-b': 'low' });
+    });
+
+    it('not registered when no options provided', async () => {
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store);
+        await startServer();
+
+        const res = await fetch(`${baseUrl}/api/models/reasoning-efforts`);
+        expect(res.status).toBe(404);
+    });
+});
+
+describe('PUT /api/models/reasoning-efforts', () => {
+    afterEach(async () => {
+        await stopServer();
+    });
+
+    it('sets a reasoning effort for a model', async () => {
+        const opts = makeOptions(undefined);
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status, body } = await apiPut('/api/models/reasoning-efforts', { modelId: 'model-a', effort: 'high' });
+        expect(status).toBe(200);
+        expect((body as { reasoningEfforts: Record<string, string> }).reasoningEfforts).toEqual({ 'model-a': 'high' });
+        expect(opts.writtenConfig?.models?.reasoningEfforts).toEqual({ 'model-a': 'high' });
+    });
+
+    it('clears a reasoning effort when effort is empty string', async () => {
+        const opts = makeOptions({ models: { reasoningEfforts: { 'model-a': 'high', 'model-b': 'low' } } });
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status, body } = await apiPut('/api/models/reasoning-efforts', { modelId: 'model-a', effort: '' });
+        expect(status).toBe(200);
+        expect((body as { reasoningEfforts: Record<string, string> }).reasoningEfforts).toEqual({ 'model-b': 'low' });
+        expect(opts.writtenConfig?.models?.reasoningEfforts).toEqual({ 'model-b': 'low' });
+    });
+
+    it('merges with existing reasoning efforts', async () => {
+        const opts = makeOptions({ models: { reasoningEfforts: { 'model-a': 'high' } } });
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status, body } = await apiPut('/api/models/reasoning-efforts', { modelId: 'model-b', effort: 'xhigh' });
+        expect(status).toBe(200);
+        const efforts = (body as { reasoningEfforts: Record<string, string> }).reasoningEfforts;
+        expect(efforts).toEqual({ 'model-a': 'high', 'model-b': 'xhigh' });
+    });
+
+    it('preserves other config fields when writing', async () => {
+        const opts = makeOptions({ model: 'gpt-4', models: { enabled: ['model-a'] } });
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        await apiPut('/api/models/reasoning-efforts', { modelId: 'model-a', effort: 'low' });
+        expect(opts.writtenConfig?.model).toBe('gpt-4');
+        expect(opts.writtenConfig?.models?.enabled).toEqual(['model-a']);
+        expect(opts.writtenConfig?.models?.reasoningEfforts).toEqual({ 'model-a': 'low' });
+    });
+
+    it('returns 400 when modelId is missing', async () => {
+        const opts = makeOptions(undefined);
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status } = await apiPut('/api/models/reasoning-efforts', { effort: 'high' });
+        expect(status).toBe(400);
+    });
+
+    it('returns 400 when effort is missing', async () => {
+        const opts = makeOptions(undefined);
+        const store: ModelStore = { getAll: () => THREE_MODELS };
+        server = makeServer(store, opts);
+        await startServer();
+
+        const { status } = await apiPut('/api/models/reasoning-efforts', { modelId: 'model-a' });
+        expect(status).toBe(400);
+    });
+});

--- a/packages/coc/test/server/model-routes.test.ts
+++ b/packages/coc/test/server/model-routes.test.ts
@@ -67,6 +67,23 @@ function makeModelInfo(id: string, name: string, contextWindow = 128_000): Model
     };
 }
 
+function makeReasoningModelInfo(id: string, supportedReasoningEfforts: string[], defaultReasoningEffort: string): ModelInfo {
+    return {
+        id,
+        name: id,
+        capabilities: {
+            supports: {
+                vision: false,
+                reasoningEffort: true,
+                reasoning_effort: supportedReasoningEfforts,
+            },
+            limits: { max_context_window_tokens: 128_000 },
+        },
+        supportedReasoningEfforts,
+        defaultReasoningEffort,
+    };
+}
+
 const THREE_MODELS: ModelInfo[] = [
     makeModelInfo('model-a', 'Model A'),
     makeModelInfo('model-b', 'Model B'),
@@ -156,6 +173,29 @@ describe('GET /api/models', () => {
         const models = body as Array<ModelInfo & { enabled: boolean }>;
         expect(models).toHaveLength(3);
         expect(models.every(m => m.enabled === false)).toBe(true);
+    });
+
+    it('passes supportedReasoningEfforts and defaultReasoningEffort from the SDK store through verbatim', async () => {
+        const store: ModelStore = {
+            getAll: () => [
+                makeReasoningModelInfo('reasoning-a', ['low', 'medium', 'high'], 'medium'),
+                makeReasoningModelInfo('reasoning-b', ['high', 'xhigh'], 'high'),
+            ],
+        };
+        server = makeServer(store);
+        await startServer();
+
+        const { status, body } = await apiGet('/api/models');
+
+        expect(status).toBe(200);
+        const models = body as Array<ModelInfo & { id: string }>;
+        expect(models).toHaveLength(2);
+        const byId = Object.fromEntries(models.map(m => [m.id, m]));
+        expect(byId['reasoning-a'].supportedReasoningEfforts).toEqual(['low', 'medium', 'high']);
+        expect(byId['reasoning-a'].defaultReasoningEffort).toBe('medium');
+        expect(byId['reasoning-a'].capabilities.supports.reasoning_effort).toEqual(['low', 'medium', 'high']);
+        expect(byId['reasoning-b'].supportedReasoningEfforts).toEqual(['high', 'xhigh']);
+        expect(byId['reasoning-b'].defaultReasoningEffort).toBe('high');
     });
 
     it('marks only whitelisted models as enabled', async () => {

--- a/packages/coc/test/server/queue-shared-validate.test.ts
+++ b/packages/coc/test/server/queue-shared-validate.test.ts
@@ -131,6 +131,63 @@ describe('validateAndParseTask – chat kind injection (existing behavior)', () 
 });
 
 // ============================================================================
+// payload.model → config.model promotion
+// ============================================================================
+
+describe('validateAndParseTask – payload.model promotion to config.model', () => {
+    it('promotes payload.model to config.model when config.model is absent', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', model: 'claude-sonnet-4.6' },
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.input!.config.model).toBe('claude-sonnet-4.6');
+    });
+
+    it('config.model takes precedence over payload.model', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', model: 'claude-sonnet-4.6' },
+            config: { model: 'gpt-4.1' },
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.input!.config.model).toBe('gpt-4.1');
+    });
+
+    it('config.model is undefined when neither config nor payload supply a model', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello' },
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.input!.config.model).toBeUndefined();
+    });
+
+    it('ignores non-string payload.model values', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', model: 42 },
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.input!.config.model).toBeUndefined();
+    });
+
+    it('works for non-chat task types with payload.model', () => {
+        const result = validateAndParseTask({
+            type: 'run-script',
+            payload: { script: 'echo hi', workingDirectory: '/ws', model: 'claude-sonnet-4.6' },
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.input!.config.model).toBe('claude-sonnet-4.6');
+    });
+});
+
+// ============================================================================
 // Dispatch correctness end-to-end guard check
 // ============================================================================
 

--- a/packages/coc/test/spa/react/features/models/ModelsView.test.tsx
+++ b/packages/coc/test/spa/react/features/models/ModelsView.test.tsx
@@ -60,6 +60,8 @@ function makeDefaultReturn(overrides: Partial<ReturnType<typeof mockUseModelConf
         saving: false,
         reload: vi.fn(),
         toggleModel: vi.fn(),
+        reasoningEfforts: {} as Record<string, string>,
+        setReasoningEffort: vi.fn(),
         ...overrides,
     };
 }
@@ -69,14 +71,14 @@ describe('ModelsView', () => {
     afterEach(() => { vi.clearAllMocks(); });
 
     it('shows loading state', () => {
-        mockUseModelConfig.mockReturnValue({ models: [], loading: true, error: null, saving: false, reload: vi.fn(), toggleModel: vi.fn() });
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({ models: [], loading: true }));
         render(<ModelsView />);
         expect(screen.getByTestId('models-loading')).toBeTruthy();
     });
 
     it('shows error state with retry button', () => {
         const reload = vi.fn();
-        mockUseModelConfig.mockReturnValue({ models: [], loading: false, error: 'HTTP 500', saving: false, reload, toggleModel: vi.fn() });
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({ models: [], loading: false, error: 'HTTP 500', reload }));
         render(<ModelsView />);
         expect(screen.getByTestId('models-error')).toBeTruthy();
         fireEvent.click(screen.getByTestId('models-retry'));
@@ -247,5 +249,64 @@ describe('ModelsView', () => {
         render(<ModelsView />);
         fireEvent.click(screen.getByTestId('models-refresh-btn'));
         expect(reload).toHaveBeenCalled();
+    });
+
+    it('highlights the default effort as active when no persisted override', () => {
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn());
+        render(<ModelsView />);
+        expect(screen.getByTestId('effort-medium').getAttribute('data-active')).toBe('true');
+        expect(screen.getByTestId('effort-low').getAttribute('data-active')).toBe('false');
+        expect(screen.getByTestId('effort-high').getAttribute('data-active')).toBe('false');
+    });
+
+    it('highlights persisted effort override instead of default', () => {
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({
+            reasoningEfforts: { 'claude-sonnet-4.6': 'high' },
+        }));
+        render(<ModelsView />);
+        expect(screen.getByTestId('effort-high').getAttribute('data-active')).toBe('true');
+        expect(screen.getByTestId('effort-medium').getAttribute('data-active')).toBe('false');
+        expect(screen.getByTestId('effort-low').getAttribute('data-active')).toBe('false');
+    });
+
+    it('shows override indicator when effort is persisted', () => {
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({
+            reasoningEfforts: { 'claude-sonnet-4.6': 'high' },
+        }));
+        render(<ModelsView />);
+        expect(screen.getByTestId('effort-override-indicator')).toBeTruthy();
+    });
+
+    it('does not show override indicator when no effort is persisted', () => {
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn());
+        render(<ModelsView />);
+        expect(screen.queryByTestId('effort-override-indicator')).toBeNull();
+    });
+
+    it('calls setReasoningEffort when an effort badge is clicked', () => {
+        const setReasoningEffort = vi.fn();
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({ setReasoningEffort }));
+        render(<ModelsView />);
+        fireEvent.click(screen.getByTestId('effort-high'));
+        expect(setReasoningEffort).toHaveBeenCalledWith('claude-sonnet-4.6', 'high');
+    });
+
+    it('calls setReasoningEffort with empty string to reset when clicking already-selected effort', () => {
+        const setReasoningEffort = vi.fn();
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({
+            setReasoningEffort,
+            reasoningEfforts: { 'claude-sonnet-4.6': 'high' },
+        }));
+        render(<ModelsView />);
+        fireEvent.click(screen.getByTestId('effort-high'));
+        expect(setReasoningEffort).toHaveBeenCalledWith('claude-sonnet-4.6', '');
+    });
+
+    it('does not call setReasoningEffort when clicking the default effort with no override', () => {
+        const setReasoningEffort = vi.fn();
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({ setReasoningEffort }));
+        render(<ModelsView />);
+        fireEvent.click(screen.getByTestId('effort-medium'));
+        expect(setReasoningEffort).not.toHaveBeenCalled();
     });
 });

--- a/packages/coc/test/spa/react/features/models/ModelsView.test.tsx
+++ b/packages/coc/test/spa/react/features/models/ModelsView.test.tsx
@@ -24,6 +24,8 @@ function makeModels() {
                 supports: { vision: true, reasoningEffort: true },
                 limits: { max_context_window_tokens: 200000 },
             },
+            supportedReasoningEfforts: ['low', 'medium', 'high'],
+            defaultReasoningEffort: 'medium',
         },
         {
             id: 'claude-haiku-4.5',
@@ -34,6 +36,7 @@ function makeModels() {
                 supports: { vision: true, reasoningEffort: false },
                 limits: { max_context_window_tokens: 200000 },
             },
+            supportedReasoningEfforts: [],
         },
         {
             id: 'gpt-5.1',
@@ -44,6 +47,7 @@ function makeModels() {
                 supports: { vision: false, reasoningEffort: false },
                 limits: { max_context_window_tokens: 128000 },
             },
+            supportedReasoningEfforts: [],
         },
     ];
 }
@@ -133,6 +137,53 @@ describe('ModelsView', () => {
         const reasoningBadges = screen.getAllByTestId('badge-reasoning');
         expect(visionBadges).toHaveLength(2); // sonnet + haiku
         expect(reasoningBadges).toHaveLength(1); // sonnet only
+    });
+
+    it('shows supported reasoning effort badges for models that expose them', () => {
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn());
+        render(<ModelsView />);
+        const effortContainers = screen.getAllByTestId('reasoning-efforts');
+        // Only sonnet has supported efforts
+        expect(effortContainers).toHaveLength(1);
+        expect(screen.getByTestId('effort-low')).toBeTruthy();
+        expect(screen.getByTestId('effort-medium')).toBeTruthy();
+        expect(screen.getByTestId('effort-high')).toBeTruthy();
+    });
+
+    it('marks the default reasoning effort with data-default="true"', () => {
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn());
+        render(<ModelsView />);
+        expect(screen.getByTestId('effort-medium').getAttribute('data-default')).toBe('true');
+        expect(screen.getByTestId('effort-low').getAttribute('data-default')).toBe('false');
+        expect(screen.getByTestId('effort-high').getAttribute('data-default')).toBe('false');
+    });
+
+    it('renders no reasoning-efforts container when the supported list is empty', () => {
+        const models = makeModels();
+        // Strip reasoning info from all models
+        for (const m of models) {
+            m.supportedReasoningEfforts = [];
+            m.defaultReasoningEffort = undefined as unknown as string;
+            m.capabilities.supports.reasoningEffort = false;
+        }
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({ models }));
+        render(<ModelsView />);
+        expect(screen.queryByTestId('reasoning-efforts')).toBeNull();
+    });
+
+    it('renders all four known reasoning efforts in canonical order', () => {
+        const models = makeModels();
+        models[0].supportedReasoningEfforts = ['xhigh', 'low', 'high', 'medium'];
+        models[0].defaultReasoningEffort = 'high';
+        mockUseModelConfig.mockReturnValue(makeDefaultReturn({ models }));
+        render(<ModelsView />);
+        const efforts = screen.getAllByTestId(/^effort-/);
+        // Order is the order the model exposes them (which is preserved by the hook,
+        // but here we are passing them through ModelsView directly so the order
+        // is whatever the test fixture provides).
+        const ids = efforts.map(el => el.getAttribute('data-testid'));
+        expect(ids).toEqual(['effort-xhigh', 'effort-low', 'effort-high', 'effort-medium']);
+        expect(screen.getByTestId('effort-high').getAttribute('data-default')).toBe('true');
     });
 
     it('copies model id to clipboard on card click', async () => {

--- a/packages/coc/test/spa/react/hooks/useModels.test.ts
+++ b/packages/coc/test/spa/react/hooks/useModels.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
     models: {
         list: vi.fn(),
         setEnabled: vi.fn(),
+        getReasoningEfforts: vi.fn(),
+        setReasoningEffort: vi.fn(),
     },
 }));
 
@@ -237,7 +239,13 @@ describe('useModels', () => {
 });
 
 describe('useModelConfig', () => {
-    beforeEach(() => { mocks.models.list.mockReset(); mocks.models.setEnabled.mockReset(); });
+    beforeEach(() => {
+        mocks.models.list.mockReset();
+        mocks.models.setEnabled.mockReset();
+        mocks.models.getReasoningEfforts.mockReset();
+        mocks.models.setReasoningEffort.mockReset();
+        mocks.models.getReasoningEfforts.mockResolvedValue({ reasoningEfforts: {} });
+    });
     afterEach(() => { vi.clearAllMocks(); });
 
     it('toggleModel calls models.setEnabled with PUT semantics', async () => {
@@ -257,5 +265,72 @@ describe('useModelConfig', () => {
         expect(mocks.models.setEnabled).toHaveBeenCalledWith(
             expect.arrayContaining(['a', 'b'])
         );
+    });
+
+    it('loads persisted reasoning efforts on mount', async () => {
+        mocks.models.list.mockResolvedValue([]);
+        mocks.models.getReasoningEfforts.mockResolvedValue({ reasoningEfforts: { 'model-a': 'high' } });
+
+        const { result } = renderHook(() => useModelConfig());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        await waitFor(() => expect(result.current.reasoningEfforts).toEqual({ 'model-a': 'high' }));
+    });
+
+    it('setReasoningEffort calls models.setReasoningEffort and updates local state', async () => {
+        mocks.models.list.mockResolvedValue([
+            { id: 'model-a', name: 'A', enabled: true },
+        ]);
+        mocks.models.setReasoningEffort.mockResolvedValue({ reasoningEfforts: { 'model-a': 'xhigh' } });
+
+        const { result } = renderHook(() => useModelConfig());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        await act(async () => {
+            await result.current.setReasoningEffort('model-a', 'xhigh');
+        });
+
+        expect(mocks.models.setReasoningEffort).toHaveBeenCalledWith('model-a', 'xhigh');
+        expect(result.current.reasoningEfforts['model-a']).toBe('xhigh');
+    });
+
+    it('setReasoningEffort with empty string removes the override', async () => {
+        mocks.models.list.mockResolvedValue([]);
+        mocks.models.getReasoningEfforts.mockResolvedValue({ reasoningEfforts: { 'model-a': 'high' } });
+        mocks.models.setReasoningEffort.mockResolvedValue({ reasoningEfforts: {} });
+
+        const { result } = renderHook(() => useModelConfig());
+        await waitFor(() => expect(result.current.reasoningEfforts).toEqual({ 'model-a': 'high' }));
+
+        await act(async () => {
+            await result.current.setReasoningEffort('model-a', '');
+        });
+
+        expect(mocks.models.setReasoningEffort).toHaveBeenCalledWith('model-a', '');
+        expect(result.current.reasoningEfforts['model-a']).toBeUndefined();
+    });
+
+    it('reverts optimistic update on setReasoningEffort failure', async () => {
+        mocks.models.list.mockResolvedValue([]);
+        mocks.models.getReasoningEfforts.mockResolvedValue({ reasoningEfforts: {} });
+        mocks.models.setReasoningEffort.mockRejectedValue(new Error('fail'));
+
+        const { result } = renderHook(() => useModelConfig());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        await act(async () => {
+            await result.current.setReasoningEffort('model-a', 'high');
+        });
+
+        // Should revert to empty since that was the state before the call
+        expect(result.current.reasoningEfforts['model-a']).toBeUndefined();
+    });
+
+    it('returns empty reasoningEfforts when getReasoningEfforts fails', async () => {
+        mocks.models.list.mockResolvedValue([]);
+        mocks.models.getReasoningEfforts.mockRejectedValue(new Error('fail'));
+
+        const { result } = renderHook(() => useModelConfig());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.reasoningEfforts).toEqual({});
     });
 });

--- a/packages/coc/test/spa/react/hooks/useModels.test.ts
+++ b/packages/coc/test/spa/react/hooks/useModels.test.ts
@@ -61,6 +61,8 @@ describe('useModels', () => {
                 supports: { vision: false, reasoningEffort: false },
                 limits: { max_context_window_tokens: 8192, max_prompt_tokens: undefined },
             },
+            supportedReasoningEfforts: [],
+            defaultReasoningEffort: undefined,
         });
     });
 
@@ -123,6 +125,114 @@ describe('useModels', () => {
         await waitFor(() => expect(result.current.loading).toBe(false));
         expect(result.current.models[0].capabilities?.supports?.vision).toBe(true);
         expect(result.current.models[0].capabilities?.supports?.reasoningEffort).toBe(true);
+    });
+
+    it('exposes supportedReasoningEfforts from raw CAPI capability metadata', async () => {
+        mocks.models.list.mockResolvedValue([{
+            id: 'reasoning-model',
+            name: 'Reasoning',
+            capabilities: {
+                supports: {
+                    vision: false,
+                    reasoningEffort: true,
+                    reasoning_effort: ['low', 'medium', 'high'],
+                },
+                limits: { max_context_window_tokens: 200000 },
+            },
+            defaultReasoningEffort: 'high',
+        }]);
+        const { result } = renderHook(() => useModels());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.models[0].supportedReasoningEfforts).toEqual(['low', 'medium', 'high']);
+        expect(result.current.models[0].defaultReasoningEffort).toBe('high');
+    });
+
+    it('falls back to top-level supportedReasoningEfforts when raw metadata is absent', async () => {
+        mocks.models.list.mockResolvedValue([{
+            id: 'reasoning-model',
+            name: 'Reasoning',
+            capabilities: {
+                supports: { vision: false, reasoningEffort: true },
+                limits: { max_context_window_tokens: 200000 },
+            },
+            supportedReasoningEfforts: ['medium', 'high', 'xhigh'],
+            defaultReasoningEffort: 'medium',
+        }]);
+        const { result } = renderHook(() => useModels());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.models[0].supportedReasoningEfforts).toEqual(['medium', 'high', 'xhigh']);
+        expect(result.current.models[0].defaultReasoningEffort).toBe('medium');
+    });
+
+    it('canonicalizes reasoning effort order, dedupes, and ignores unknown values', async () => {
+        mocks.models.list.mockResolvedValue([{
+            id: 'noisy-model',
+            name: 'Noisy',
+            capabilities: {
+                supports: {
+                    vision: false,
+                    reasoningEffort: true,
+                    reasoning_effort: ['high', 'low', 'bogus', 'medium', 'high', 42],
+                },
+                limits: { max_context_window_tokens: 200000 },
+            },
+        }]);
+        const { result } = renderHook(() => useModels());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.models[0].supportedReasoningEfforts).toEqual(['low', 'medium', 'high']);
+    });
+
+    it('infers reasoningEffort=true when the supported list is non-empty', async () => {
+        mocks.models.list.mockResolvedValue([{
+            id: 'implicit-reasoning',
+            name: 'Implicit',
+            capabilities: {
+                supports: {
+                    vision: false,
+                    reasoningEffort: false,
+                    reasoning_effort: ['low', 'high'],
+                },
+                limits: { max_context_window_tokens: 128000 },
+            },
+        }]);
+        const { result } = renderHook(() => useModels());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.models[0].capabilities?.supports?.reasoningEffort).toBe(true);
+        expect(result.current.models[0].supportedReasoningEfforts).toEqual(['low', 'high']);
+    });
+
+    it('drops defaultReasoningEffort when it is not in the supported list', async () => {
+        mocks.models.list.mockResolvedValue([{
+            id: 'misconfigured',
+            name: 'Misconfigured',
+            capabilities: {
+                supports: {
+                    vision: false,
+                    reasoningEffort: true,
+                    reasoning_effort: ['low', 'medium'],
+                },
+                limits: { max_context_window_tokens: 128000 },
+            },
+            defaultReasoningEffort: 'xhigh',
+        }]);
+        const { result } = renderHook(() => useModels());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.models[0].defaultReasoningEffort).toBeUndefined();
+    });
+
+    it('returns empty supportedReasoningEfforts when no reasoning metadata is present', async () => {
+        mocks.models.list.mockResolvedValue([{
+            id: 'plain',
+            name: 'Plain',
+            capabilities: {
+                supports: { vision: false, reasoningEffort: false },
+                limits: { max_context_window_tokens: 8192 },
+            },
+        }]);
+        const { result } = renderHook(() => useModels());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.models[0].supportedReasoningEfforts).toEqual([]);
+        expect(result.current.models[0].defaultReasoningEffort).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
- **feat: display supported reasoning efforts on the Models page**
- **feat: persist per-model reasoning effort overrides**
- **fix(coc): promote payload.model to config.model in task validation**
