### PR TITLE
feat(scratchpad): show .plan.md files as scratchpad tabs

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -957,17 +957,17 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         }
     }, [turns, loading]);
 
-    // Register all .md files from created files into the scratchpad tab list.
-    // The plan file is excluded — it has its own dedicated display in the header.
+    // Register all .md files from created files into the scratchpad tab list,
+    // including the plan file so it appears as a scratchpad tab (AC-01, AC-03).
     useEffect(() => {
         if (!scratchpadEnabled) return;
         const mdPaths = createdFiles
             .map(f => f.filePath)
-            .filter(p => p.endsWith('.md') && p !== effectivePlanPath);
+            .filter(p => p.endsWith('.md'));
         if (mdPaths.length > 0) {
             scratchpad.registerFiles(mdPaths);
         }
-    }, [createdFiles, effectivePlanPath, scratchpadEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [createdFiles, scratchpadEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Track scroll position
     useEffect(() => {

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -1235,6 +1235,18 @@ describe('ChatDetail', () => {
             expect(SCRATCHPAD_STATE_SOURCE).toContain('setKnownFiles(prev => prev.filter');
             expect(SCRATCHPAD_STATE_SOURCE).toContain('writeLinkedNotePath(taskId, null)');
         });
+
+        it('registers .plan.md files into the scratchpad tab list (AC-01, AC-03)', () => {
+            // The registration effect must NOT filter out the plan file so that
+            // .plan.md appears as a scratchpad tab alongside other .md files.
+            const registerBlock = source.substring(
+                source.indexOf('Register all .md files from created files into the scratchpad tab list'),
+                source.indexOf('// Track scroll position'),
+            );
+            expect(registerBlock).toContain("filter(p => p.endsWith('.md'))");
+            // Must NOT exclude the plan file any more
+            expect(registerBlock).not.toContain('effectivePlanPath');
+        });
     });
 
     describe('mobile responsiveness', () => {


### PR DESCRIPTION
Previously the registerFiles effect explicitly excluded the plan file
(effectivePlanPath) so it only appeared in the References dropdown header.

Remove the exclusion filter so all .md files from createdFiles — including
.plan.md — are registered into knownFiles and rendered as scratchpad tabs
(AC-01, AC-03). The plan file continues to appear in the References dropdown
via the separate effectivePlanPath prop path (AC-02 unaffected).

The displayFiles dedup logic already removes the plan file from the dropdown
list once it is in knownFiles, so there is no double-display regression.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
