### PR TITLE
fix(coc): add optional chaining for status.stats in StorageSection

### DIFF
--- a/packages/coc/src/server/spa/client/react/admin/StorageSection.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/StorageSection.tsx
@@ -609,7 +609,7 @@ export default function StorageSection() {
                     <div className="flex flex-col gap-1">
                         <span className={statusTextClass}>
                             Current: {status.backend === 'sqlite' ? 'SQLite' : 'JSON files'}
-                            {' '}({status.stats.processes} processes, {status.stats.workspaces} workspaces)
+                            {' '}({status.stats?.processes ?? 0} processes, {status.stats?.workspaces ?? 0} workspaces)
                         </span>
                         {status.backend === 'sqlite' && status.dbPath && (
                             <span className={statusTextClass}>Database: {status.dbPath}</span>


### PR DESCRIPTION
The 'renders export section with Export button' test was flaky because
the mock fetch returned {} for the storage status endpoint. When
StorageSection rendered, status was truthy but status.stats was
undefined, causing 'Cannot read properties of undefined (reading
processes)'.

Add optional chaining (?.) and nullish coalescing (?? 0) so missing
stats gracefully default to 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
