### PR TITLE
fix(notes): allow absolute paths within workspace rootPath in notes c…

### DIFF
--- a/packages/coc/src/server/notes/notes-comments-handler.ts
+++ b/packages/coc/src/server/notes/notes-comments-handler.ts
@@ -50,8 +50,10 @@ function getCopilotDir(): string {
     return path.join(os.homedir(), '.copilot');
 }
 
-function isAllowedPath(resolved: string, wsDataDir: string): boolean {
-    return isWithinDirectory(resolved, wsDataDir) || isWithinDirectory(resolved, getCopilotDir());
+function isAllowedPath(resolved: string, wsDataDir: string, wsRootPath?: string): boolean {
+    return isWithinDirectory(resolved, wsDataDir)
+        || isWithinDirectory(resolved, getCopilotDir())
+        || (!!wsRootPath && isWithinDirectory(resolved, wsRootPath));
 }
 
 /**

--- a/packages/coc/src/server/notes/notes-read-handler.ts
+++ b/packages/coc/src/server/notes/notes-read-handler.ts
@@ -62,8 +62,10 @@ function getCopilotDir(): string {
     return path.join(os.homedir(), '.copilot');
 }
 
-function isAllowedPath(resolved: string, wsDataDir: string): boolean {
-    return isWithinDirectory(resolved, wsDataDir) || isWithinDirectory(resolved, getCopilotDir());
+function isAllowedPath(resolved: string, wsDataDir: string, wsRootPath?: string): boolean {
+    return isWithinDirectory(resolved, wsDataDir)
+        || isWithinDirectory(resolved, getCopilotDir())
+        || (!!wsRootPath && isWithinDirectory(resolved, wsRootPath));
 }
 
 async function ensureNotesRoot(notesRoot: string): Promise<void> {
@@ -271,7 +273,7 @@ export function registerNotesRoutes(
 
             // For non-default roots, allow paths within the resolved root directory
             const allowed = rootResult.isDefault
-                ? isAllowedPath(resolved, wsDataDir)
+                ? isAllowedPath(resolved, wsDataDir, ws.rootPath)
                 : isWithinDirectory(resolved, notesRoot);
             if (!allowed) {
                 return sendError(res, 403, 'Access denied: path is outside workspace data directory');

--- a/packages/coc/src/server/notes/notes-write-handler.ts
+++ b/packages/coc/src/server/notes/notes-write-handler.ts
@@ -35,8 +35,10 @@ function getCopilotDir(): string {
     return path.join(os.homedir(), '.copilot');
 }
 
-function isAllowedPath(resolved: string, wsDataDir: string): boolean {
-    return isWithinDirectory(resolved, wsDataDir) || isWithinDirectory(resolved, getCopilotDir());
+function isAllowedPath(resolved: string, wsDataDir: string, wsRootPath?: string): boolean {
+    return isWithinDirectory(resolved, wsDataDir)
+        || isWithinDirectory(resolved, getCopilotDir())
+        || (!!wsRootPath && isWithinDirectory(resolved, wsRootPath));
 }
 
 function isSystemFolder(notesRoot: string, resolvedPath: string): boolean {
@@ -217,7 +219,7 @@ export function registerNotesWriteRoutes(
 
             // For non-default roots, allow paths within the resolved root directory
             const allowed = rootResult.isDefault
-                ? isAllowedPath(resolved, wsDataDir)
+                ? isAllowedPath(resolved, wsDataDir, ws.rootPath)
                 : isWithinDirectory(resolved, notesRoot);
             if (!allowed) {
                 return sendError(res, 403, 'Access denied: path is outside workspace data directory');

--- a/packages/coc/test/server/notes-read-handler.test.ts
+++ b/packages/coc/test/server/notes-read-handler.test.ts
@@ -202,6 +202,25 @@ describe('Notes Read Handler — GET /notes/content security', { timeout: 30_000
     });
 
     // -------------------------------------------------------------------------
+    // Happy path — workspace root directory (repo files via absolute path)
+    // -------------------------------------------------------------------------
+
+    it('returns 200 for an absolute path inside the workspace rootPath (regression: repo skill files)', async () => {
+        const srv = await startServer();
+        await registerWorkspace(srv);
+
+        // Create a file inside the workspace root directory (simulating a repo file)
+        const skillFile = path.join(workspaceDir, '.github', 'skills', 'help-me-review', 'SKILL.md');
+        fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+        fs.writeFileSync(skillFile, '# Help Me Review\n\nSkill content.', 'utf-8');
+
+        const res = await request(contentUrl(srv, skillFile));
+        expect(res.status).toBe(200);
+        const data = JSON.parse(res.body);
+        expect(data.content).toBe('# Help Me Review\n\nSkill content.');
+    });
+
+    // -------------------------------------------------------------------------
     // Security — reject paths outside workspace data directory
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
…ontent API

The isAllowedPath check only permitted paths within the workspace data directory (~/.coc/repos/<wsId>/) and ~/.copilot/. Absolute paths pointing to files inside the workspace root (e.g. repo skill files) were rejected with 403.

Add ws.rootPath to the allowlist in all three notes handlers (read, write, comments) so files within the registered workspace directory are accessible.