### PR TITLE
feat(coc): add Ralph prompt tuning and route utilities

### DIFF
--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -270,7 +270,29 @@ export interface BuiltInPrompt {
   group: string;
   source: string;
   description: string;
+  /** Built-in default text. */
   text: string;
+  /** Whether this prompt supports admin overrides. */
+  editable?: boolean;
+  /** Required template variable names that must appear in any override (e.g. "${hint}"). */
+  templateVars?: string[];
+  /** Active override text, if set. */
+  overrideText?: string;
+  /** True when an override is currently active. */
+  hasOverride?: boolean;
 }
 
 export type AdminPromptsResponse = Record<string, BuiltInPrompt>;
+
+export interface AdminPromptUpdateRequest {
+  text: string;
+}
+
+export interface AdminPromptUpdateResponse extends BuiltInPrompt {
+  saved: true;
+}
+
+export interface AdminPromptDeleteResponse {
+  id: string;
+  reset: true;
+}

--- a/packages/coc-client/src/domains/admin.ts
+++ b/packages/coc-client/src/domains/admin.ts
@@ -6,6 +6,9 @@ import type {
   AdminImportMode,
   AdminImportPreviewResponse,
   AdminImportResponse,
+  AdminPromptDeleteResponse,
+  AdminPromptUpdateRequest,
+  AdminPromptUpdateResponse,
   AdminPromptsResponse,
   AdminRestartResponse,
   AdminStorageCancelMigrationResponse,
@@ -38,6 +41,19 @@ export class AdminClient {
 
   getPrompts(): Promise<AdminPromptsResponse> {
     return this.transport.request<AdminPromptsResponse>('/admin/prompts');
+  }
+
+  updatePrompt(id: string, update: AdminPromptUpdateRequest): Promise<AdminPromptUpdateResponse> {
+    return this.transport.request<AdminPromptUpdateResponse>(`/admin/prompts/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      body: update,
+    });
+  }
+
+  resetPromptOverride(id: string): Promise<AdminPromptDeleteResponse> {
+    return this.transport.request<AdminPromptDeleteResponse>(`/admin/prompts/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
   }
 
   getDataStats(query?: AdminDataStatsQuery, options: Pick<CocRequestOptions, 'signal' | 'timeoutMs'> = {}): Promise<AdminDataStatsResponse> {

--- a/packages/coc/src/server/admin/admin-handler.ts
+++ b/packages/coc/src/server/admin/admin-handler.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import * as url from 'url';
 import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import { parseBody, sendJSON } from '../core/api-handler';
-import { badRequest, forbidden, handleAPIError, invalidJSON } from '../errors';
+import { badRequest, forbidden, handleAPIError, invalidJSON, notFound } from '../errors';
 import { exportAllData } from '../storage/data-exporter';
 import { importData } from '../storage/data-importer';
 import { DataWiper } from '../storage/data-wiper';
@@ -30,6 +30,16 @@ import type { ProcessWebSocketServer } from '../streaming/websocket';
 import type { Route } from '../types';
 import { sendSSE } from '../wiki/ask-handler';
 import { ADMIN_CONFIG_FIELDS, ADMIN_EDITABLE_KEYS, getAdminFieldMetadata } from './admin-config-fields';
+import { RALPH_GRILL_SUFFIX } from '../executors/chat-base-executor';
+import { RALPH_BASE_INSTRUCTIONS } from '../executors/ralph-executor';
+import { RALPH_SYNTHESIS_PROMPT_BASE } from '../ralph/synthesis-prompt';
+import { RALPH_ITERATION_PROMPT_DEFAULT_HEAD } from '../ralph/iteration-prompt';
+import {
+    getAllPromptOverrides,
+    savePromptOverride as writeSavedPromptOverride,
+    deletePromptOverride as removePromptOverride,
+    RALPH_PROMPT_IDS,
+} from './ralph-prompt-overrides';
 
 // ============================================================================
 // Token Management
@@ -448,12 +458,83 @@ export function registerAdminRoutes(routes: Route[], options: AdminRouteOptions)
 
     // ------------------------------------------------------------------
     // GET /api/admin/prompts — Return built-in prompt default texts
+    // (annotated with active overrides when dataDir is available)
     // ------------------------------------------------------------------
     routes.push({
         method: 'GET',
         pattern: '/api/admin/prompts',
         handler: async (_req, res) => {
-            sendJSON(res, 200, getBuiltInPrompts());
+            sendJSON(res, 200, dataDir ? getPromptsWithOverrides(dataDir) : getBuiltInPrompts());
+        },
+    });
+
+    // ------------------------------------------------------------------
+    // PUT /api/admin/prompts/:id — Save an admin override for a prompt
+    // ------------------------------------------------------------------
+    routes.push({
+        method: 'PUT',
+        pattern: /^\/api\/admin\/prompts\/([^/]+)$/,
+        handler: async (req, res, match) => {
+            const promptId = match?.[1] ? decodeURIComponent(match[1]) : undefined;
+            if (!promptId) return handleAPIError(res, badRequest('Missing prompt ID'));
+            if (!dataDir) return handleAPIError(res, badRequest('dataDir not configured'));
+
+            const builtins = getBuiltInPrompts();
+            const prompt = builtins[promptId];
+            if (!prompt) return handleAPIError(res, notFound(`prompt '${promptId}'`));
+            if (!prompt.editable) return handleAPIError(res, forbidden(`Prompt '${promptId}' is not editable`));
+
+            let body: { text?: unknown };
+            try {
+                body = await parseBody(req);
+            } catch {
+                return handleAPIError(res, invalidJSON());
+            }
+            if (typeof body.text !== 'string' || !body.text.trim()) {
+                return handleAPIError(res, badRequest('Body must contain a non-empty "text" string'));
+            }
+
+            const validationError = validatePromptOverride(prompt, body.text);
+            if (validationError) return handleAPIError(res, badRequest(validationError));
+
+            try {
+                writeSavedPromptOverride(promptId, body.text, dataDir);
+            } catch (err) {
+                return handleAPIError(res, err);
+            }
+
+            sendJSON(res, 200, {
+                ...prompt,
+                overrideText: body.text,
+                hasOverride: true,
+                saved: true,
+            });
+        },
+    });
+
+    // ------------------------------------------------------------------
+    // DELETE /api/admin/prompts/:id — Reset a prompt to its built-in default
+    // ------------------------------------------------------------------
+    routes.push({
+        method: 'DELETE',
+        pattern: /^\/api\/admin\/prompts\/([^/]+)$/,
+        handler: async (_req, res, match) => {
+            const promptId = match?.[1] ? decodeURIComponent(match[1]) : undefined;
+            if (!promptId) return handleAPIError(res, badRequest('Missing prompt ID'));
+            if (!dataDir) return handleAPIError(res, badRequest('dataDir not configured'));
+
+            const builtins = getBuiltInPrompts();
+            const prompt = builtins[promptId];
+            if (!prompt) return handleAPIError(res, notFound(`prompt '${promptId}'`));
+            if (!prompt.editable) return handleAPIError(res, forbidden(`Prompt '${promptId}' is not editable`));
+
+            try {
+                removePromptOverride(promptId, dataDir);
+            } catch (err) {
+                return handleAPIError(res, err);
+            }
+
+            sendJSON(res, 200, { id: promptId, reset: true });
         },
     });
 
@@ -814,7 +895,16 @@ export interface BuiltInPrompt {
     group: string;
     source: string;
     description: string;
+    /** Built-in default text. */
     text: string;
+    /** Whether this prompt supports admin overrides. */
+    editable?: boolean;
+    /** Required template variable names that must appear in any override. */
+    templateVars?: string[];
+    /** Active override text, if set. */
+    overrideText?: string;
+    /** True when an override is currently active. */
+    hasOverride?: boolean;
 }
 
 /** Return all built-in prompts as a record keyed by prompt id. */
@@ -948,5 +1038,75 @@ Each entry must have this exact shape:
             description: 'Tool description controlling when/how AI calls suggest_follow_ups',
             text: 'After completing your response, call this tool to suggest 2-3 brief follow-up actions the user might want to take next. Each suggestion should be a short, direct action phrase (imperative, not a question) that continues the conversation — e.g., "Show an example", "Explain the config options", "Generate the fix". IMPORTANT: Never list follow-up suggestions in your response text. Always call this tool instead.',
         },
+        'ralph-grill-suffix': {
+            id: 'ralph-grill-suffix',
+            title: 'Ralph — Grilling Phase Suffix',
+            group: 'Ralph',
+            source: 'coc/server/executors/chat-base-executor.ts',
+            description: 'System-prompt suffix appended during the Ralph grilling phase; guides the model to interview the user via ask_user',
+            text: RALPH_GRILL_SUFFIX,
+            editable: true,
+            templateVars: [],
+        },
+        'ralph-synthesis': {
+            id: 'ralph-synthesis',
+            title: 'Ralph — Synthesis Prompt',
+            group: 'Ralph',
+            source: 'coc/server/ralph/synthesis-prompt.ts',
+            description: 'User prompt sent to synthesise the grilling conversation into a ## Goal block',
+            text: RALPH_SYNTHESIS_PROMPT_BASE,
+            editable: true,
+            templateVars: [],
+        },
+        'ralph-execution-system': {
+            id: 'ralph-execution-system',
+            title: 'Ralph — Execution System Prompt',
+            group: 'Ralph',
+            source: 'coc/server/executors/ralph-executor.ts',
+            description: 'Base system-prompt block injected at the start of every Ralph execution iteration',
+            text: RALPH_BASE_INSTRUCTIONS,
+            editable: true,
+            templateVars: [],
+        },
+        'ralph-iteration-user': {
+            id: 'ralph-iteration-user',
+            title: 'Ralph — Iteration User Prompt',
+            group: 'Ralph',
+            source: 'coc/server/ralph/iteration-prompt.ts',
+            description: 'User-turn prompt (prefix + work_intent + spec_contract) sent each iteration; the <goal> block is appended dynamically',
+            text: RALPH_ITERATION_PROMPT_DEFAULT_HEAD,
+            editable: true,
+            templateVars: [],
+        },
     };
+}
+
+/**
+ * Return all built-in prompts annotated with any active admin overrides.
+ * Called by GET /api/admin/prompts so the UI sees override state without a
+ * separate request.
+ */
+export function getPromptsWithOverrides(dataDir: string): Record<string, BuiltInPrompt> {
+    const builtins = getBuiltInPrompts();
+    const overrides = getAllPromptOverrides(dataDir);
+    for (const [id, overrideText] of Object.entries(overrides)) {
+        if (builtins[id]) {
+            builtins[id].overrideText = overrideText;
+            builtins[id].hasOverride = true;
+        }
+    }
+    return builtins;
+}
+
+/**
+ * Validate a prompt override.  Returns an error message, or undefined if valid.
+ * Currently only checks required template variables.
+ */
+export function validatePromptOverride(prompt: BuiltInPrompt, text: string): string | undefined {
+    const vars = prompt.templateVars ?? [];
+    const missing = vars.filter(v => !text.includes(v));
+    if (missing.length > 0) {
+        return `Override must contain required template variable(s): ${missing.join(', ')}`;
+    }
+    return undefined;
 }

--- a/packages/coc/src/server/admin/ralph-prompt-overrides.ts
+++ b/packages/coc/src/server/admin/ralph-prompt-overrides.ts
@@ -1,0 +1,72 @@
+/**
+ * Ralph Prompt Override Persistence
+ *
+ * Reads and writes per-prompt admin overrides from/to a global JSON file at
+ * `<dataDir>/admin-prompt-overrides.json`.  Absent file = all built-in
+ * defaults.  Any read / write failure is handled silently so the server
+ * never crashes over a missing or corrupt overrides file.
+ *
+ * Callers
+ *  - `admin-handler.ts` — GET /api/admin/prompts (read), PUT/DELETE (write)
+ *  - `chat-base-executor.ts` — grilling phase suffix
+ *  - `ralph-executor.ts` — execution system prompt
+ *  - `synthesis-prompt.ts` caller — synthesis base
+ *  - `iteration-prompt.ts` caller — iteration user prompt
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** IDs for the four tunable Ralph prompt blocks. */
+export const RALPH_PROMPT_IDS = [
+    'ralph-grill-suffix',
+    'ralph-synthesis',
+    'ralph-execution-system',
+    'ralph-iteration-user',
+] as const;
+
+export type RalphPromptId = typeof RALPH_PROMPT_IDS[number];
+
+export function getPromptOverridesPath(dataDir: string): string {
+    return path.join(dataDir, 'admin-prompt-overrides.json');
+}
+
+function readOverrides(dataDir: string): Record<string, string> {
+    try {
+        const raw = fs.readFileSync(getPromptOverridesPath(dataDir), 'utf8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as Record<string, string>;
+        }
+        return {};
+    } catch {
+        return {};
+    }
+}
+
+/** Returns the override text for the given prompt ID, or undefined if not overridden. */
+export function getPromptOverride(id: string, dataDir: string): string | undefined {
+    return readOverrides(dataDir)[id];
+}
+
+/** Read all current overrides as a plain record. */
+export function getAllPromptOverrides(dataDir: string): Record<string, string> {
+    return readOverrides(dataDir);
+}
+
+/** Save an override for the given prompt ID. Creates the file if absent. */
+export function savePromptOverride(id: string, text: string, dataDir: string): void {
+    const overridesPath = getPromptOverridesPath(dataDir);
+    const overrides = readOverrides(dataDir);
+    overrides[id] = text;
+    fs.writeFileSync(overridesPath, JSON.stringify(overrides, null, 2) + '\n', 'utf8');
+}
+
+/** Remove the override for the given prompt ID (resets to built-in default). */
+export function deletePromptOverride(id: string, dataDir: string): void {
+    const overridesPath = getPromptOverridesPath(dataDir);
+    const overrides = readOverrides(dataDir);
+    if (!(id in overrides)) return;
+    delete overrides[id];
+    fs.writeFileSync(overridesPath, JSON.stringify(overrides, null, 2) + '\n', 'utf8');
+}

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -61,6 +61,41 @@ import type { BoundedMemoryAddon } from './bounded-memory-addon';
 import { resolveAutoFolderContext } from './auto-folder-utils';
 import { systemMessageBuilder } from './system-message-builder';
 import { buildChatToolBundle } from './chat-tool-builder';
+import { getPromptOverride } from '../admin/ralph-prompt-overrides';
+
+// ============================================================================
+// Ralph grilling-phase system message suffix
+// ============================================================================
+
+/** Default system-prompt suffix appended when `payload.context.ralph.phase === 'grilling'`. */
+export const RALPH_GRILL_SUFFIX = [
+    '## Ralph Grilling Phase — Clarification Protocol',
+    '',
+    'You are in the Ralph grilling phase. Your job right now is to interactively interview the user to nail down a precise goal spec before any coding begins.',
+    '',
+    'Rules for this phase (these OVERRIDE any earlier guidance about ask_user):',
+    '- Use the `ask_user` tool for EVERY clarification, confirmation, or choice question. Do NOT write clarification questions as plain assistant text.',
+    '- Batch related questions into a SINGLE `ask_user` call by passing multiple entries in `questions[]`. Do not call the tool repeatedly for one round of clarification.',
+    '- Yes/no clarifications ARE in scope here — ignore the earlier "Do NOT use ask_user for simple yes/no" guidance during grilling. In this phase, simple yes/no clarifications MUST also go through `ask_user`.',
+    '- Keep questions concrete and answerable. Prefer choice questions with explicit options when there are a few obvious paths.',
+    '- Only after the user explicitly signals they are done (e.g. "enough", "go", "that\'s it") OR you have gathered enough answers to write a precise spec, emit the final goal-spec block as plain assistant text using the template below. Do not emit the goal spec while still asking questions.',
+    '',
+    'Final goal-spec template (emit ONLY at the end, as plain assistant text — not via ask_user):',
+    '',
+    '## Goal',
+    '<one-sentence goal>',
+    '',
+    '## Acceptance Criteria',
+    '<bullet list>',
+    '',
+    '## Constraints / Tech Context',
+    '<bullet list>',
+    '',
+    '## Out of Scope',
+    '<bullet list>',
+    '',
+    'This spec will be used to drive an automated coding loop. Be precise and concrete.',
+].join('\n');
 
 // ============================================================================
 // Types
@@ -331,34 +366,9 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
 
         // When this is a Ralph grilling session, append the goal-spec instruction.
         if (payload.context?.ralph?.phase === 'grilling' && systemMessage) {
-            const ralphGrillSuffix = [
-                '## Ralph Grilling Phase — Clarification Protocol',
-                '',
-                'You are in the Ralph grilling phase. Your job right now is to interactively interview the user to nail down a precise goal spec before any coding begins.',
-                '',
-                'Rules for this phase (these OVERRIDE any earlier guidance about ask_user):',
-                '- Use the `ask_user` tool for EVERY clarification, confirmation, or choice question. Do NOT write clarification questions as plain assistant text.',
-                '- Batch related questions into a SINGLE `ask_user` call by passing multiple entries in `questions[]`. Do not call the tool repeatedly for one round of clarification.',
-                '- Yes/no clarifications ARE in scope here — ignore the earlier "Do NOT use ask_user for simple yes/no" guidance during grilling. In this phase, simple yes/no clarifications MUST also go through `ask_user`.',
-                '- Keep questions concrete and answerable. Prefer choice questions with explicit options when there are a few obvious paths.',
-                '- Only after the user explicitly signals they are done (e.g. "enough", "go", "that\'s it") OR you have gathered enough answers to write a precise spec, emit the final goal-spec block as plain assistant text using the template below. Do not emit the goal spec while still asking questions.',
-                '',
-                'Final goal-spec template (emit ONLY at the end, as plain assistant text — not via ask_user):',
-                '',
-                '## Goal',
-                '<one-sentence goal>',
-                '',
-                '## Acceptance Criteria',
-                '<bullet list>',
-                '',
-                '## Constraints / Tech Context',
-                '<bullet list>',
-                '',
-                '## Out of Scope',
-                '<bullet list>',
-                '',
-                'This spec will be used to drive an automated coding loop. Be precise and concrete.',
-            ].join('\n');
+            const ralphGrillSuffix = (this.dataDir
+                ? (getPromptOverride('ralph-grill-suffix', this.dataDir) ?? RALPH_GRILL_SUFFIX)
+                : RALPH_GRILL_SUFFIX);
             systemMessage.content = systemMessage.content
                 ? systemMessage.content + '\n\n' + ralphGrillSuffix
                 : ralphGrillSuffix;

--- a/packages/coc/src/server/executors/ralph-executor.ts
+++ b/packages/coc/src/server/executors/ralph-executor.ts
@@ -34,12 +34,13 @@ import type { ChatModeAIOptions, ChatModeExecutorOptions } from './chat-base-exe
 import { ChatBaseExecutor } from './chat-base-executor';
 import { buildChatToolBundle } from './chat-tool-builder';
 import { RalphSessionStore } from '../ralph/ralph-session-store';
+import { getPromptOverride } from '../admin/ralph-prompt-overrides';
 
 // ============================================================================
 // System prompt template
 // ============================================================================
 
-const RALPH_BASE_INSTRUCTIONS = `\
+export const RALPH_BASE_INSTRUCTIONS = `\
 You are a focused AI coding agent running in Ralph mode.
 
 Your task each iteration:
@@ -82,8 +83,8 @@ export interface BuildRalphSystemMessageInput {
     maxIterations?: number;
 }
 
-function buildRalphSystemMessage(ralph: BuildRalphSystemMessageInput): string {
-    const parts: string[] = [RALPH_BASE_INSTRUCTIONS];
+function buildRalphSystemMessage(ralph: BuildRalphSystemMessageInput, baseInstructions?: string): string {
+    const parts: string[] = [baseInstructions ?? RALPH_BASE_INSTRUCTIONS];
 
     if (ralph.originalGoal) {
         parts.push(`## Goal Spec\n${ralph.originalGoal}`);
@@ -128,12 +129,16 @@ export class RalphExecutor extends ChatBaseExecutor {
 
         const progressPath = this.resolveProgressPath(payload.workspaceId, ralphCtx?.sessionId);
 
+        const resolvedBaseInstructions = this.dataDir
+            ? (getPromptOverride('ralph-execution-system', this.dataDir) ?? RALPH_BASE_INSTRUCTIONS)
+            : RALPH_BASE_INSTRUCTIONS;
+
         const ralphSystemPrompt = buildRalphSystemMessage({
             originalGoal: ralphCtx?.originalGoal,
             progressPath,
             currentIteration: ralphCtx?.currentIteration,
             maxIterations: ralphCtx?.maxIterations,
-        });
+        }, resolvedBaseInstructions);
 
         const boundedMemory = await this.buildMemoryAddon(payload.workspaceId, this.buildCaptureContext(task), prompt);
 

--- a/packages/coc/src/server/ralph/enqueue-iteration.ts
+++ b/packages/coc/src/server/ralph/enqueue-iteration.ts
@@ -8,6 +8,7 @@
  */
 
 import { buildRalphIterationPrompt } from './iteration-prompt';
+import { getPromptOverride } from '../admin/ralph-prompt-overrides';
 
 export interface BuildRalphIterationTaskInput {
     workspaceId?: string;
@@ -19,6 +20,8 @@ export interface BuildRalphIterationTaskInput {
     maxIterations: number;
     /** Optional pre-built prompt; when omitted, uses {@link buildRalphIterationPrompt}. */
     prompt?: string;
+    /** Repo-scoped data root; used to resolve admin prompt overrides. */
+    dataDir?: string;
     /** Optional carry-over context (e.g. previous attachments, additional ralph fields). */
     extraContext?: Record<string, unknown>;
     /** Display name for the queued task. Defaults to "Ralph iteration N (sessionId)". */
@@ -28,7 +31,13 @@ export interface BuildRalphIterationTaskInput {
 }
 
 export function buildRalphIterationTask(input: BuildRalphIterationTaskInput) {
-    const prompt = input.prompt ?? buildRalphIterationPrompt({ originalGoal: input.originalGoal });
+    const promptOverride = input.dataDir
+        ? (getPromptOverride('ralph-iteration-user', input.dataDir) ?? undefined)
+        : undefined;
+    const prompt = input.prompt ?? buildRalphIterationPrompt({
+        originalGoal: input.originalGoal,
+        promptOverride,
+    });
     const displayName = input.displayName
         ?? `Ralph iteration ${input.iteration} (${input.sessionId})`;
     return {

--- a/packages/coc/src/server/ralph/iteration-prompt.ts
+++ b/packages/coc/src/server/ralph/iteration-prompt.ts
@@ -40,9 +40,19 @@ Honor the decision-tagging convention used by the grill-me skill:
 A slice is done only when its Definition of Done is satisfied. Record evidence (test command output, demo transcript, code-search results) in progress.md before marking the iteration complete. Do not declare the overall Ralph session complete until every functional AC's Definition of Done is satisfied.
 </spec_contract>`;
 
+/** The built-in default instruction head (prefix + work_intent + spec_contract). */
+export const RALPH_ITERATION_PROMPT_DEFAULT_HEAD =
+    `${PROMPT_PREFIX}\n\n${RALPH_WORK_INTENT_PROMPT}\n\n${RALPH_SPEC_CONTRACT_PROMPT}`;
+
 export interface BuildRalphIterationPromptInput {
     /** The user's original goal text from the grilling phase. */
     originalGoal?: string;
+    /**
+     * Override text from admin prompts; replaces the default instruction head
+     * (prefix + work_intent + spec_contract) when provided. The `<goal>` block
+     * is still appended after the override.
+     */
+    promptOverride?: string;
 }
 
 /**
@@ -54,7 +64,7 @@ export function buildRalphIterationPrompt(
     input: BuildRalphIterationPromptInput,
 ): string {
     const goal = (input.originalGoal ?? '').trim();
-    const head = `${PROMPT_PREFIX}\n\n${RALPH_WORK_INTENT_PROMPT}\n\n${RALPH_SPEC_CONTRACT_PROMPT}`;
+    const head = input.promptOverride ?? RALPH_ITERATION_PROMPT_DEFAULT_HEAD;
     if (!goal) {
         return head;
     }

--- a/packages/coc/src/server/ralph/synthesis-prompt.ts
+++ b/packages/coc/src/server/ralph/synthesis-prompt.ts
@@ -11,7 +11,7 @@
  * editor before the user clicks "Start Ralph".
  */
 
-const PROMPT_BASE = `You are now in the Ralph grilling phase for this conversation.
+export const RALPH_SYNTHESIS_PROMPT_BASE = `You are now in the Ralph grilling phase for this conversation.
 
 Your single job for this turn is to synthesize the discussion above into a precise goal spec for a Ralph iterative coding loop.
 
@@ -30,13 +30,16 @@ export const RALPH_SYNTHESIS_HINT_MAX_LENGTH = 2000;
 export interface BuildRalphSynthesisPromptInput {
     /** Optional one-line hint typed by the user into the message box. */
     extraGuidance?: string;
+    /** Override text from admin prompts; replaces RALPH_SYNTHESIS_PROMPT_BASE when provided. */
+    promptOverride?: string;
 }
 
 export function buildRalphSynthesisPrompt(input: BuildRalphSynthesisPromptInput = {}): string {
+    const base = input.promptOverride ?? RALPH_SYNTHESIS_PROMPT_BASE;
     const hint = (input.extraGuidance ?? '').trim();
-    if (!hint) return PROMPT_BASE;
+    if (!hint) return base;
     const truncated = hint.length > RALPH_SYNTHESIS_HINT_MAX_LENGTH
         ? hint.slice(0, RALPH_SYNTHESIS_HINT_MAX_LENGTH).trimEnd() + '…'
         : hint;
-    return `${PROMPT_BASE}${HINT_HEADER}${truncated}`;
+    return `${base}${HINT_HEADER}${truncated}`;
 }

--- a/packages/coc/src/server/router.ts
+++ b/packages/coc/src/server/router.ts
@@ -20,6 +20,8 @@ import {
     sendJson,
     send404,
 } from './shared/router';
+import { applyCorsHeaders, getDefaultCorsPolicy } from './shared/cors';
+import type { CorsPolicy } from './shared/cors';
 
 // ============================================================================
 // Swagger UI HTML
@@ -69,6 +71,8 @@ export interface RouterOptions {
     spaETag?: string | (() => string | undefined);
     /** Optional factory for the /icon.svg favicon (hostname-derived colors). Called on each request. */
     getIconSvg?: () => string;
+    /** CORS policy forwarded to the shared router and used on error responses. Defaults to {@link getDefaultCorsPolicy}. */
+    corsPolicy?: CorsPolicy;
 }
 
 // ============================================================================
@@ -86,17 +90,11 @@ export interface RouterOptions {
  *   GET /wiki/:id/static/* → static files from wiki dir
  *   GET /*           → SPA fallback (client-side routing)
  */
-/** Set standard CORS headers on a response. */
-function setCorsHeaders(res: http.ServerResponse): void {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-}
-
 export function createRequestHandler(
     options: RouterOptions
 ): (req: http.IncomingMessage, res: http.ServerResponse) => void {
     const { spaHtml, staticDir, store, getWikiDir, spaETag, getIconSvg } = options;
+    const corsPolicy = options.corsPolicy ?? getDefaultCorsPolicy();
 
     // Prepend built-in routes (OpenAPI spec, Swagger UI, health)
     const routes: Route[] = [
@@ -158,6 +156,7 @@ export function createRequestHandler(
         spaHtml,
         staticHandlers,
         spaETag,
+        corsPolicy,
     });
 
     // Wrap with wiki static file handling (needs explicit 404 responses)
@@ -186,21 +185,21 @@ export function createRequestHandler(
             const fileSuffix = wikiStaticMatch[2];
             const wikiDir = getWikiDir?.(wikiId);
             if (!wikiDir) {
-                setCorsHeaders(res);
+                applyCorsHeaders(req, res, corsPolicy);
                 send404(res, `Wiki not found: ${wikiId}`);
                 return;
             }
             const resolved = path.resolve(wikiDir, fileSuffix);
             // Security: prevent directory traversal
             if (!isWithinDirectory(resolved, wikiDir)) {
-                setCorsHeaders(res);
+                applyCorsHeaders(req, res, corsPolicy);
                 send404(res, 'Invalid path');
                 return;
             }
             if (serveStaticFile(resolved, res)) {
                 return;
             }
-            setCorsHeaders(res);
+            applyCorsHeaders(req, res, corsPolicy);
             send404(res, `File not found: ${fileSuffix}`);
             return;
         }

--- a/packages/coc/src/server/routes/api-git-branch-routes.ts
+++ b/packages/coc/src/server/routes/api-git-branch-routes.ts
@@ -143,7 +143,8 @@ export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
             try { body = await parseBody(req); } catch { body = {}; }
             const { commitHash } = body;
             if (!commitHash || typeof commitHash !== 'string') {
-                return void handleAPIError(res, badRequest('Missing or invalid commitHash'));
+                sendJSON(res, 400, { success: false, error: 'Missing or invalid commitHash' });
+                return;
             }
             const result = await branchService.pushUpTo(ws.rootPath, commitHash);
             getWsServer?.()?.broadcastGitChanged(ws.id, 'push');

--- a/packages/coc/src/server/routes/api-git-branch-routes.ts
+++ b/packages/coc/src/server/routes/api-git-branch-routes.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Git Branch Management REST API Routes
  *
  * Endpoints for listing, creating, switching, renaming, deleting branches,
@@ -6,7 +6,6 @@
  * cherry-pick, git-ops tracking, and amending commit messages.
  */
 
-import * as url from 'url';
 import { BranchService } from '@plusplusoneplusplus/forge';
 import type { GitOpJob } from '@plusplusoneplusplus/forge';
 import { sendJSON, parseBody, execGitArgsSync } from '../core/api-handler';
@@ -14,529 +13,394 @@ import { handleAPIError, missingFields, notFound, badRequest, conflict } from '.
 import { gitCache } from '../git/git-cache';
 import { resolveWorkspaceOrFail, parseBodyOrReject } from '../shared/handler-utils';
 import type { ApiRouteContext } from './api-shared';
+import { createRoute, asString, asInt, asBool } from './route-utils';
 
 export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
     const { routes, store, getWsServer, gitOpsStore, bridge } = ctx;
     const branchService = new BranchService();
 
     // GET /api/workspaces/:id/git/branches — List branches with pagination
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/branches$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        parseQuery: (q) => ({
+            type: asString(q.type, 'all'),
+            limit: asInt(q.limit, 100, 500),
+            offset: asInt(q.offset, 0),
+            search: asString(q.search),
+        }),
+        handler: async ({ query, match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-
-            try {
-                const parsed = url.parse(req.url!, true).query;
-                const type = (parsed.type as string) || 'all';
-                const limit = Math.min(parseInt(parsed.limit as string) || 100, 500);
-                const offset = parseInt(parsed.offset as string) || 0;
-                const searchPattern = (parsed.search as string) || undefined;
-                const options = { limit, offset, searchPattern };
-
-                let result: Record<string, unknown> = {};
-                if (type === 'local') {
-                    result = { local: branchService.getLocalBranchesPaginated(ws.rootPath, options) };
-                } else if (type === 'remote') {
-                    result = { remote: branchService.getRemoteBranchesPaginated(ws.rootPath, options) };
-                } else {
-                    result = {
-                        local: branchService.getLocalBranchesPaginated(ws.rootPath, options),
-                        remote: branchService.getRemoteBranchesPaginated(ws.rootPath, options),
-                    };
-                }
-                sendJSON(res, 200, result);
-            } catch (err) {
-                return handleAPIError(res, err);
+            const { type, limit, offset, search: searchPattern } = query;
+            const options = { limit, offset, searchPattern };
+            if (type === 'local') {
+                return { local: branchService.getLocalBranchesPaginated(ws.rootPath, options) };
+            } else if (type === 'remote') {
+                return { remote: branchService.getRemoteBranchesPaginated(ws.rootPath, options) };
+            } else {
+                return {
+                    local: branchService.getLocalBranchesPaginated(ws.rootPath, options),
+                    remote: branchService.getRemoteBranchesPaginated(ws.rootPath, options),
+                };
             }
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/branch-status — Current branch status
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/branch-status$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-
-            try {
-                const uncommitted = await branchService.hasUncommittedChanges(ws.rootPath);
-                const status = await branchService.getBranchStatus(ws.rootPath, uncommitted);
-                sendJSON(res, 200, status);
-            } catch (err) {
-                return handleAPIError(res, err);
-            }
+            const uncommitted = await branchService.hasUncommittedChanges(ws.rootPath);
+            return branchService.getBranchStatus(ws.rootPath, uncommitted);
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/branches — Create a new branch
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/branches$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.name) {
-                return handleAPIError(res, missingFields(['name']));
-            }
-
+            if (!body.name) return void handleAPIError(res, missingFields(['name']));
             const checkout = body.checkout ?? false;
-            const result = await branchService.createBranch(ws.rootPath, body.name, checkout);
-            sendJSON(res, 200, result);
+            return branchService.createBranch(ws.rootPath, body.name, checkout);
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/branches/switch — Switch to a branch
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/branches\/switch$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.name) {
-                return handleAPIError(res, missingFields(['name']));
-            }
-
+            if (!body.name) return void handleAPIError(res, missingFields(['name']));
             const result = await branchService.switchBranch(ws.rootPath, body.name, { force: body.force ?? false });
-            getWsServer?.()?.broadcastGitChanged(id, 'branch-switch');
-            sendJSON(res, 200, result);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'branch-switch');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/branches/rename — Rename a branch
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/branches\/rename$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.oldName || !body.newName) {
-                return handleAPIError(res, missingFields(['oldName', 'newName']));
-            }
-
-            const result = await branchService.renameBranch(ws.rootPath, body.oldName, body.newName);
-            sendJSON(res, 200, result);
+            if (!body.oldName || !body.newName) return void handleAPIError(res, missingFields(['oldName', 'newName']));
+            return branchService.renameBranch(ws.rootPath, body.oldName, body.newName);
         },
-    });
+    }));
 
     // DELETE /api/workspaces/:id/git/branches/:name — Delete a branch
-    routes.push({
+    routes.push(createRoute({
         method: 'DELETE',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/branches\/(.+)$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        parseQuery: (q) => ({ force: asBool(q.force) }),
+        handler: async ({ query, match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-
-            const branchName = decodeURIComponent(match![2]);
-            const parsed = url.parse(req.url!, true).query;
-            const force = parsed.force === 'true';
-            const result = await branchService.deleteBranch(ws.rootPath, branchName, force);
-            sendJSON(res, 200, result);
+            const branchName = decodeURIComponent(match[2]);
+            return branchService.deleteBranch(ws.rootPath, branchName, query.force);
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/push — Push to remote
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/push$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             let body: any = {};
-            try {
-                body = await parseBody(req);
-            } catch {
-                body = {};
-            }
-
-            const setUpstream = body.setUpstream === true;
-            const result = await branchService.push(ws.rootPath, setUpstream);
-            getWsServer?.()?.broadcastGitChanged(id, 'push');
-            sendJSON(res, 200, result);
+            try { body = await parseBody(req); } catch { body = {}; }
+            const result = await branchService.push(ws.rootPath, body.setUpstream === true);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'push');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/push-to — Push up to a specific commit
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/push-to$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             let body: any = {};
-            try {
-                body = await parseBody(req);
-            } catch {
-                body = {};
-            }
-
-            const commitHash = body.commitHash;
+            try { body = await parseBody(req); } catch { body = {}; }
+            const { commitHash } = body;
             if (!commitHash || typeof commitHash !== 'string') {
-                sendJSON(res, 400, { success: false, error: 'Missing or invalid commitHash' });
-                return;
+                return void handleAPIError(res, badRequest('Missing or invalid commitHash'));
             }
-
             const result = await branchService.pushUpTo(ws.rootPath, commitHash);
-            getWsServer?.()?.broadcastGitChanged(id, 'push');
-            sendJSON(res, 200, result);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'push');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/pull — Pull from remote (async background job)
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/pull$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        statusCode: 202,
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-
             const running = await gitOpsStore.getRunning(id, 'pull');
-            if (running.length > 0) {
-                return handleAPIError(res, conflict('A pull operation is already running'));
-            }
-
+            if (running.length > 0) return void handleAPIError(res, conflict('A pull operation is already running'));
             let body: any = {};
-            try {
-                body = await parseBody(req);
-            } catch {
-                body = {};
-            }
-
+            try { body = await parseBody(req); } catch { body = {}; }
             const rebase = body.rebase === true;
             const jobId = `pull-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const job: GitOpJob = {
-                id: jobId,
-                workspaceId: id,
-                op: 'pull',
-                status: 'running',
-                startedAt: new Date().toISOString(),
-                pid: process.pid,
+                id: jobId, workspaceId: id, op: 'pull',
+                status: 'running', startedAt: new Date().toISOString(), pid: process.pid,
             };
             await gitOpsStore.create(job);
-            sendJSON(res, 202, { jobId });
-
-            branchService.pull(ws.rootPath, rebase).then(async (result) => {
+            void branchService.pull(ws.rootPath, rebase).then(async (result) => {
                 await gitOpsStore.update(id, jobId, {
                     status: result.success ? 'success' : 'failed',
-                    finishedAt: new Date().toISOString(),
-                    error: result.error,
+                    finishedAt: new Date().toISOString(), error: result.error,
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'pull');
             }).catch(async (err) => {
                 await gitOpsStore.update(id, jobId, {
-                    status: 'failed',
-                    finishedAt: new Date().toISOString(),
+                    status: 'failed', finishedAt: new Date().toISOString(),
                     error: err instanceof Error ? err.message : 'Unknown error',
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'pull');
             });
+            return { jobId };
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/rebase-autosquash — Non-interactive rebase --autosquash (async background job)
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/rebase-autosquash$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        statusCode: 202,
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-
             const running = await gitOpsStore.getRunning(id, 'rebase-autosquash');
-            if (running.length > 0) {
-                return handleAPIError(res, conflict('A rebase-autosquash operation is already running'));
-            }
-
+            if (running.length > 0) return void handleAPIError(res, conflict('A rebase-autosquash operation is already running'));
             const jobId = `rebase-autosquash-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const job: GitOpJob = {
-                id: jobId,
-                workspaceId: id,
-                op: 'rebase-autosquash',
-                status: 'running',
-                startedAt: new Date().toISOString(),
-                pid: process.pid,
+                id: jobId, workspaceId: id, op: 'rebase-autosquash',
+                status: 'running', startedAt: new Date().toISOString(), pid: process.pid,
             };
             await gitOpsStore.create(job);
-            sendJSON(res, 202, { jobId });
-
-            branchService.rebaseAutosquash(ws.rootPath).then(async (result) => {
+            void branchService.rebaseAutosquash(ws.rootPath).then(async (result) => {
                 await gitOpsStore.update(id, jobId, {
                     status: result.success ? 'success' : 'failed',
-                    finishedAt: new Date().toISOString(),
-                    error: result.error,
+                    finishedAt: new Date().toISOString(), error: result.error,
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'rebase-autosquash');
             }).catch(async (err) => {
                 await gitOpsStore.update(id, jobId, {
-                    status: 'failed',
-                    finishedAt: new Date().toISOString(),
+                    status: 'failed', finishedAt: new Date().toISOString(),
                     error: err instanceof Error ? err.message : 'Unknown error',
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'rebase-autosquash');
             });
+            return { jobId };
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/ops/latest — Most recent git op job (supports ?op=pull)
-    routes.push({
+    routes.push(createRoute({
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/ops\/latest$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
-            const parsed = url.parse(req.url || '', true);
-            const opFilter = typeof parsed.query.op === 'string' ? parsed.query.op as any : undefined;
-            const job = await gitOpsStore.getLatest(id, opFilter);
-            if (!job) {
-                return sendJSON(res, 200, null);
-            }
-            sendJSON(res, 200, job);
+        parseQuery: (q) => ({ op: asString(q.op) as any }),
+        handler: async ({ query, match, res }) => {
+            const id = decodeURIComponent(match[1]);
+            const job = await gitOpsStore.getLatest(id, query.op);
+            if (!job) { sendJSON(res, 200, null); return; }
+            return job;
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/ops/:jobId — Specific git op job by ID
-    routes.push({
+    routes.push(createRoute({
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/ops\/([^/]+)$/,
-        handler: async (req, res, match) => {
-            const wsId = decodeURIComponent(match![1]);
-            const jobId = decodeURIComponent(match![2]);
+        handler: async ({ match, res }) => {
+            const wsId = decodeURIComponent(match[1]);
+            const jobId = decodeURIComponent(match[2]);
             const job = await gitOpsStore.getById(wsId, jobId);
-            if (!job) {
-                return handleAPIError(res, notFound('Git operation'));
-            }
-            sendJSON(res, 200, job);
+            if (!job) return void handleAPIError(res, notFound('Git operation'));
+            return job;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/fetch — Fetch from remote(s)
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/fetch$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             let body: any = {};
-            try {
-                body = await parseBody(req);
-            } catch {
-                body = {};
-            }
-
+            try { body = await parseBody(req); } catch { body = {}; }
             const remote: string | undefined = typeof body.remote === 'string' ? body.remote : undefined;
             const result = await branchService.fetch(ws.rootPath, remote);
-            getWsServer?.()?.broadcastGitChanged(id, 'fetch');
-            sendJSON(res, 200, result);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'fetch');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/merge — Merge a branch
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/merge$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.branch || typeof body.branch !== 'string') {
-                return handleAPIError(res, missingFields(['branch']));
-            }
-
+            if (!body.branch || typeof body.branch !== 'string') return void handleAPIError(res, missingFields(['branch']));
             const result = await branchService.mergeBranch(ws.rootPath, body.branch);
-            getWsServer?.()?.broadcastGitChanged(id, 'merge');
-            sendJSON(res, 200, result);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'merge');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/stash — Stash changes
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/stash$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
             const message: string | undefined = typeof body.message === 'string' ? body.message : undefined;
             const result = await branchService.stashChanges(ws.rootPath, message);
-            getWsServer?.()?.broadcastGitChanged(id, 'stash');
-            sendJSON(res, 200, result);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'stash');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/stash/pop — Pop stash
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/stash\/pop$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const result = await branchService.popStash(ws.rootPath);
-            getWsServer?.()?.broadcastGitChanged(id, 'stash-pop');
-            sendJSON(res, 200, result);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'stash-pop');
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/reset — Reset HEAD to a commit
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/reset$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.hash || typeof body.hash !== 'string') {
-                return handleAPIError(res, missingFields(['hash']));
-            }
-
+            if (!body.hash || typeof body.hash !== 'string') return void handleAPIError(res, missingFields(['hash']));
             const allowedModes = ['hard', 'soft', 'mixed'];
-            const mode: string = typeof body.mode === 'string' && allowedModes.includes(body.mode)
-                ? body.mode
-                : 'hard';
-
+            const mode = typeof body.mode === 'string' && allowedModes.includes(body.mode) ? body.mode : 'hard';
             try {
                 execGitArgsSync(['reset', `--${mode}`, body.hash], ws.rootPath);
-                gitCache.invalidateMutable(id);
-                getWsServer?.()?.broadcastGitChanged(id, 'reset');
-                sendJSON(res, 200, { success: true });
             } catch (err: any) {
-                return handleAPIError(res, badRequest('Failed to reset: ' + (err.message || 'unknown error')));
+                throw badRequest('Failed to reset: ' + (err.message || 'unknown error'));
             }
+            gitCache.invalidateMutable(ws.id);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'reset');
+            return { success: true };
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/cherry-pick — Cherry-pick a commit onto the current branch
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/cherry-pick$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.hash || typeof body.hash !== 'string') {
-                return handleAPIError(res, missingFields(['hash']));
-            }
-
+            if (!body.hash || typeof body.hash !== 'string') return void handleAPIError(res, missingFields(['hash']));
             const result = await branchService.cherryPick(ws.rootPath, body.hash);
             if (result.success) {
-                gitCache.invalidateMutable(id);
-                getWsServer?.()?.broadcastGitChanged(id, 'cherry-pick');
-                return sendJSON(res, 200, { success: true });
+                gitCache.invalidateMutable(ws.id);
+                getWsServer?.()?.broadcastGitChanged(ws.id, 'cherry-pick');
+                return { success: true };
             }
             if (result.conflicts) {
-                return sendJSON(res, 409, { error: result.message, conflicts: true });
+                sendJSON(res, 409, { error: result.message, conflicts: true });
+                return;
             }
-            return handleAPIError(res, badRequest('Cherry-pick failed: ' + result.message));
+            throw badRequest('Cherry-pick failed: ' + result.message);
         },
-    });
-
-    // ------------------------------------------------------------------
-    // Amend commit message
-    // ------------------------------------------------------------------
+    }));
 
     // POST /api/workspaces/:id/git/amend — Amend the HEAD commit message
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/amend$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.title || typeof body.title !== 'string' || !body.title.trim()) {
-                return handleAPIError(res, missingFields(['title']));
-            }
-
+            if (!body.title || typeof body.title !== 'string' || !body.title.trim()) return void handleAPIError(res, missingFields(['title']));
             const result = await branchService.amendCommitMessage(
-                ws.rootPath,
-                body.title,
-                typeof body.body === 'string' ? body.body : undefined
+                ws.rootPath, body.title,
+                typeof body.body === 'string' ? body.body : undefined,
             );
-            if (!result.success) {
-                return handleAPIError(res, badRequest(result.error || 'Failed to amend commit message'));
-            }
-            gitCache.invalidateMutable(id);
-            getWsServer?.()?.broadcastGitChanged(id, 'amend');
-            sendJSON(res, 200, { hash: result.hash });
+            if (!result.success) throw badRequest(result.error || 'Failed to amend commit message');
+            gitCache.invalidateMutable(ws.id);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'amend');
+            return { hash: result.hash };
         },
-    });
-
-    // ------------------------------------------------------------------
-    // Repo state (merge/rebase/cherry-pick detection)
-    // ------------------------------------------------------------------
+    }));
 
     // GET /api/workspaces/:id/git/repo-state — Detect in-progress operations
-    routes.push({
+    routes.push(createRoute({
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/repo-state$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const repoState = branchService.getRepoState(ws.rootPath);
-            sendJSON(res, 200, repoState);
+            return branchService.getRepoState(ws.rootPath);
         },
-    });
-
-    // ------------------------------------------------------------------
-    // Rebase continue / abort
-    // ------------------------------------------------------------------
+    }));
 
     // POST /api/workspaces/:id/git/rebase-continue
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/rebase-continue$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        statusCode: 202,
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-
             const jobId = `rebase-continue-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const job: GitOpJob = {
                 id: jobId, workspaceId: id, op: 'rebase-continue',
                 status: 'running', startedAt: new Date().toISOString(), pid: process.pid,
             };
             await gitOpsStore.create(job);
-            sendJSON(res, 202, { jobId });
-
-            branchService.rebaseContinue(ws.rootPath).then(async (result) => {
+            void branchService.rebaseContinue(ws.rootPath).then(async (result) => {
                 await gitOpsStore.update(id, jobId, {
                     status: result.success ? 'success' : 'failed',
                     finishedAt: new Date().toISOString(), error: result.error,
@@ -550,49 +414,41 @@ export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'rebase-continue');
             });
+            return { jobId };
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/rebase-abort
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/rebase-abort$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
             const result = await branchService.rebaseAbort(ws.rootPath);
-            if (!result.success) {
-                return handleAPIError(res, badRequest(result.error || 'Failed to abort rebase'));
-            }
-            gitCache.invalidateMutable(id);
-            getWsServer?.()?.broadcastGitChanged(id, 'rebase-abort');
-            sendJSON(res, 200, { success: true });
+            if (!result.success) throw badRequest(result.error || 'Failed to abort rebase');
+            gitCache.invalidateMutable(ws.id);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'rebase-abort');
+            return { success: true };
         },
-    });
-
-    // ------------------------------------------------------------------
-    // Merge continue / abort
-    // ------------------------------------------------------------------
+    }));
 
     // POST /api/workspaces/:id/git/merge-continue
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/merge-continue$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        statusCode: 202,
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-
             const jobId = `merge-continue-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const job: GitOpJob = {
                 id: jobId, workspaceId: id, op: 'merge-continue',
                 status: 'running', startedAt: new Date().toISOString(), pid: process.pid,
             };
             await gitOpsStore.create(job);
-            sendJSON(res, 202, { jobId });
-
-            branchService.mergeContinue(ws.rootPath).then(async (result) => {
+            void branchService.mergeContinue(ws.rootPath).then(async (result) => {
                 await gitOpsStore.update(id, jobId, {
                     status: result.success ? 'success' : 'failed',
                     finishedAt: new Date().toISOString(), error: result.error,
@@ -606,64 +462,47 @@ export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'merge-continue');
             });
+            return { jobId };
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/merge-abort
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/merge-abort$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ match, res }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const id = ws.id;
             const result = await branchService.mergeAbort(ws.rootPath);
-            if (!result.success) {
-                return handleAPIError(res, badRequest(result.error || 'Failed to abort merge'));
-            }
-            gitCache.invalidateMutable(id);
-            getWsServer?.()?.broadcastGitChanged(id, 'merge-abort');
-            sendJSON(res, 200, { success: true });
+            if (!result.success) throw badRequest(result.error || 'Failed to abort merge');
+            gitCache.invalidateMutable(ws.id);
+            getWsServer?.()?.broadcastGitChanged(ws.id, 'merge-abort');
+            return { success: true };
         },
-    });
-
-    // ------------------------------------------------------------------
-    // Reword commit title (non-HEAD commits via interactive rebase)
-    // ------------------------------------------------------------------
+    }));
 
     // POST /api/workspaces/:id/git/reword — Reword a non-HEAD commit's title
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/reword$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        statusCode: 202,
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-
-            if (!body.hash || typeof body.hash !== 'string') {
-                return handleAPIError(res, missingFields(['hash']));
-            }
-            if (!body.title || typeof body.title !== 'string' || !body.title.trim()) {
-                return handleAPIError(res, missingFields(['title']));
-            }
-
+            if (!body.hash || typeof body.hash !== 'string') return void handleAPIError(res, missingFields(['hash']));
+            if (!body.title || typeof body.title !== 'string' || !body.title.trim()) return void handleAPIError(res, missingFields(['title']));
             const running = await gitOpsStore.getRunning(id, 'reword');
-            if (running.length > 0) {
-                return handleAPIError(res, conflict('A reword operation is already running'));
-            }
-
+            if (running.length > 0) return void handleAPIError(res, conflict('A reword operation is already running'));
             const jobId = `reword-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const job: GitOpJob = {
                 id: jobId, workspaceId: id, op: 'reword',
                 status: 'running', startedAt: new Date().toISOString(), pid: process.pid,
             };
             await gitOpsStore.create(job);
-            sendJSON(res, 202, { jobId });
-
-            branchService.rewordCommit(ws.rootPath, body.hash, body.title).then(async (result) => {
+            void branchService.rewordCommit(ws.rootPath, body.hash, body.title).then(async (result) => {
                 await gitOpsStore.update(id, jobId, {
                     status: result.success ? 'success' : 'failed',
                     finishedAt: new Date().toISOString(), error: result.error,
@@ -677,47 +516,33 @@ export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
                 });
                 getWsServer?.()?.broadcastGitChanged(id, 'reword');
             });
+            return { jobId };
         },
-    });
-
-    // ------------------------------------------------------------------
-    // Rebase reorder (drag-and-drop commit reorder)
-    // ------------------------------------------------------------------
+    }));
 
     // POST /api/workspaces/:id/git/rebase-reorder
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/rebase-reorder$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        statusCode: 202,
+        handler: async ({ match, res, req }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (!Array.isArray(body.commits) || body.commits.length === 0) {
-                return handleAPIError(res, missingFields(['commits']));
-            }
-
-            if (!bridge?.enqueue) {
-                return handleAPIError(res, conflict('Queue bridge is not available for rebase-reorder'));
-            }
-
+            if (!Array.isArray(body.commits) || body.commits.length === 0) return void handleAPIError(res, missingFields(['commits']));
+            if (!bridge?.enqueue) return void handleAPIError(res, conflict('Queue bridge is not available for rebase-reorder'));
             const running = await gitOpsStore.getRunning(id, 'rebase-reorder');
-            if (running.length > 0) {
-                return handleAPIError(res, conflict('A rebase-reorder operation is already running'));
-            }
-
+            if (running.length > 0) return void handleAPIError(res, conflict('A rebase-reorder operation is already running'));
             const commits: string[] = body.commits;
             const displayName = `Reorder ${commits.length} commit${commits.length !== 1 ? 's' : ''}`;
-
             const jobId = `rebase-reorder-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const job: GitOpJob = {
                 id: jobId, workspaceId: id, op: 'rebase-reorder',
                 status: 'running', startedAt: new Date().toISOString(), pid: process.pid,
             };
             await gitOpsStore.create(job);
-
             const taskId = await bridge.enqueue({
                 type: 'chat',
                 priority: 'normal',
@@ -731,14 +556,12 @@ export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
                 },
                 config: { retryOnFailure: false },
             });
-
             const onQueueChange = (event: Record<string, unknown>) => {
                 const eventTaskId = (event.taskId ?? (event.task as any)?.id) as string | undefined;
                 if (eventTaskId !== taskId) return;
                 if (event.type !== 'updated') return;
                 const status = (event.task as any)?.status as string | undefined;
                 if (status !== 'completed' && status !== 'failed') return;
-
                 bridge.off?.('queueChange', onQueueChange);
                 gitOpsStore.update(id, jobId, {
                     status: status === 'completed' ? 'success' : 'failed',
@@ -748,17 +571,11 @@ export function registerGitBranchRoutes(ctx: ApiRouteContext): void {
                 getWsServer?.()?.broadcastGitChanged(id, 'rebase-reorder');
             };
             bridge.on?.('queueChange', onQueueChange);
-
-            sendJSON(res, 202, { taskId, jobId });
+            return { taskId, jobId };
         },
-    });
+    }));
 }
 
-/**
- * Build the AI prompt for an interactive rebase-reorder operation.
- * The prompt instructs the AI to run git rebase -i, detect merge conflicts,
- * resolve trivial ones automatically, or abort cleanly on non-trivial conflicts.
- */
 function buildRebaseReorderPrompt(repoRoot: string, commits: string[]): string {
     const firstCommit = commits[0];
     const pickLines = commits.map(h => `pick ${h}`).join('\n');

--- a/packages/coc/src/server/routes/api-git-commit-routes.ts
+++ b/packages/coc/src/server/routes/api-git-commit-routes.ts
@@ -5,15 +5,15 @@
  * diffs, per-file diffs, and file content at a given commit.
  */
 
-import * as url from 'url';
 import * as path from 'path';
 import { BranchService } from '@plusplusoneplusplus/forge';
-import { sendJSON, execGitArgsSync, readGitFileAtCommit } from '../core/api-handler';
+import { execGitArgsSync, readGitFileAtCommit } from '../core/api-handler';
 import { handleAPIError, notFound, badRequest } from '../errors';
 import { gitCache } from '../git/git-cache';
 import { resolveWorkspaceOrFail } from '../shared/handler-utils';
 import type { ApiRouteContext } from './api-shared';
 import { truncateDiffIfNeeded } from './api-shared';
+import { createRoute, asString, asInt, asBool } from './route-utils';
 
 export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
     const { routes, store } = ctx;
@@ -26,19 +26,21 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
     }
 
     // GET /api/workspaces/:id/git/commits — List commits with pagination
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/commits$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        parseQuery: (q) => ({
+            limit: Math.min(Math.max(asInt(q.limit, 50), 1), 200),
+            skip: Math.max(asInt(q.skip, 0), 0),
+            refresh: asBool(q.refresh),
+            search: asString(q.search, '').trim(),
+        }),
+        handler: async ({ res, match, query }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
 
-            const parsed = url.parse(req.url || '/', true);
-            const limit = Math.min(Math.max(parseInt(String(parsed.query.limit || '50'), 10) || 50, 1), 200);
-            const skip = Math.max(parseInt(String(parsed.query.skip || '0'), 10) || 0, 0);
-            const refresh = parsed.query.refresh === 'true';
-            const search = parsed.query.search ? String(parsed.query.search).trim() : '';
+            const { limit, skip, refresh, search } = query;
 
             if (refresh) {
                 gitCache.invalidateMutable(id);
@@ -47,7 +49,7 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
             const cacheKey = `${id}:commits:${limit}:${skip}${search ? `:search:${search}` : ''}`;
             const cached = gitCache.get<{ commits: any[]; unpushedCount: number }>(cacheKey);
             if (cached) {
-                return sendJSON(res, 200, cached);
+                return cached;
             }
 
             try {
@@ -101,27 +103,27 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
 
                 const result = { commits, unpushedCount };
                 gitCache.set(cacheKey, result);
-                sendJSON(res, 200, result);
+                return result;
             } catch {
-                sendJSON(res, 200, { commits: [], unpushedCount: 0 });
+                return { commits: [], unpushedCount: 0 };
             }
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/commits/:hash — Single commit details
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/commits\/([a-f0-9]{4,40})$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-            const hash = match![2];
+            const hash = match[2];
 
             const cacheKey = `${id}:commit:${hash}`;
             const cached = gitCache.get<Record<string, string>>(cacheKey);
             if (cached) {
-                return sendJSON(res, 200, cached);
+                return cached;
             }
 
             try {
@@ -129,7 +131,7 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
                 const raw = execGitArgsSync(['log', '-1', `--format=${format}`, hash], ws.rootPath);
                 const lines = raw.trim().split('\n');
                 if (lines.length < 6) {
-                    return handleAPIError(res, notFound('Commit'));
+                    return void handleAPIError(res, notFound('Commit'));
                 }
                 const result = {
                     hash: lines[0],
@@ -142,27 +144,27 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
                     body: lines.slice(7).join('\n').trim(),
                 };
                 gitCache.set(cacheKey, result);
-                sendJSON(res, 200, result);
+                return result;
             } catch {
-                return handleAPIError(res, notFound('Commit'));
+                return void handleAPIError(res, notFound('Commit'));
             }
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/commits/:hash/files — Files changed in a commit
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/commits\/([a-f0-9]{4,40})\/files$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-            const hash = match![2];
+            const hash = match[2];
 
             const cacheKey = `${id}:commit-files:${hash}`;
             const cached = gitCache.get<{ files: any[] }>(cacheKey);
             if (cached) {
-                return sendJSON(res, 200, cached);
+                return cached;
             }
 
             try {
@@ -212,81 +214,81 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
                 }
                 const result = { files };
                 gitCache.set(cacheKey, result);
-                sendJSON(res, 200, result);
+                return result;
             } catch (err: any) {
-                return handleAPIError(res, badRequest('Failed to get commit files: ' + (err.message || 'unknown error')));
+                return void handleAPIError(res, badRequest('Failed to get commit files: ' + (err.message || 'unknown error')));
             }
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/commits/:hash/diff — Full diff for a commit
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/commits\/([a-f0-9]{4,40})\/diff$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-            const hash = match![2];
+            const hash = match[2];
 
             const cacheKey = `${id}:commit-diff:${hash}`;
             const cached = gitCache.get<{ diff: string }>(cacheKey);
             if (cached) {
-                return sendJSON(res, 200, cached);
+                return cached;
             }
 
             try {
                 const diff = execGitArgsSync(['show', '--format=', '--patch', hash], ws.rootPath);
                 const result = { diff };
                 gitCache.set(cacheKey, result);
-                sendJSON(res, 200, result);
+                return result;
             } catch (err: any) {
-                return handleAPIError(res, badRequest('Failed to get commit diff: ' + (err.message || 'unknown error')));
+                return void handleAPIError(res, badRequest('Failed to get commit diff: ' + (err.message || 'unknown error')));
             }
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/commits/:hash/files/*/diff — Per-file diff for a commit
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/commits\/([a-f0-9]{4,40})\/files\/(.+)\/diff$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        parseQuery: (q) => ({ full: asBool(q.full) }),
+        handler: async ({ res, match, query }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-            const hash = match![2];
-            const filePath = decodeURIComponent(match![3]);
+            const hash = match[2];
+            const filePath = decodeURIComponent(match[3]);
 
-            const parsed = url.parse(req.url || '/', true);
-            const full = parsed.query.full === 'true';
+            const full = query.full;
 
             const cacheKey = `${id}:commit-file-diff:${hash}:${filePath}${full ? ':full' : ''}`;
             const cached = gitCache.get<{ diff: string; truncated?: boolean; totalLines?: number }>(cacheKey);
             if (cached) {
-                return sendJSON(res, 200, cached);
+                return cached;
             }
 
             try {
                 const diff = execGitArgsSync(['show', '--format=', '--patch', '-U99999', hash, '--', filePath], ws.rootPath);
                 const result = truncateDiffIfNeeded(diff, full);
                 gitCache.set(cacheKey, result);
-                sendJSON(res, 200, result);
+                return result;
             } catch (err: any) {
-                return handleAPIError(res, badRequest('Failed to get commit file diff: ' + (err.message || 'unknown error')));
+                return void handleAPIError(res, badRequest('Failed to get commit file diff: ' + (err.message || 'unknown error')));
             }
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/commits/:hash/files/*/content — Full file content for a commit file
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/commits\/([a-f0-9]{4,40})\/files\/(.+)\/content$/,
-        handler: async (_req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
-            const hash = match![2];
-            const filePath = decodeURIComponent(match![3]);
+            const hash = match[2];
+            const filePath = decodeURIComponent(match[3]);
 
             const cacheKey = `${id}:commit-file-content:${hash}:${filePath}`;
             const cached = gitCache.get<{
@@ -299,13 +301,13 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
                 resolvedRef: string;
             }>(cacheKey);
             if (cached) {
-                return sendJSON(res, 200, cached);
+                return cached;
             }
 
             try {
                 const { content, resolvedRef } = readGitFileAtCommit(hash, filePath, ws.rootPath);
                 if (Buffer.byteLength(content, 'utf-8') > 10 * 1024 * 1024) {
-                    return handleAPIError(res, badRequest('Commit file is too large (max 10MB)'));
+                    return void handleAPIError(res, badRequest('Commit file is too large (max 10MB)'));
                 }
 
                 const allLines = content.split('\n');
@@ -324,10 +326,10 @@ export function registerGitCommitRoutes(ctx: ApiRouteContext): void {
                     resolvedRef,
                 };
                 gitCache.set(cacheKey, result);
-                sendJSON(res, 200, result);
+                return result;
             } catch (err: any) {
-                return handleAPIError(res, badRequest('Failed to get commit file content: ' + (err.message || 'unknown error')));
+                return void handleAPIError(res, badRequest('Failed to get commit file content: ' + (err.message || 'unknown error')));
             }
         },
-    });
+    }));
 }

--- a/packages/coc/src/server/routes/api-git-working-tree-routes.ts
+++ b/packages/coc/src/server/routes/api-git-working-tree-routes.ts
@@ -5,13 +5,12 @@
  * batch stage/unstage, deleting untracked files, and per-file working-tree diffs.
  */
 
-import * as url from 'url';
 import { WorkingTreeService, BranchService } from '@plusplusoneplusplus/forge';
-import { sendJSON } from '../core/api-handler';
 import { handleAPIError, missingFields } from '../errors';
 import { resolveWorkspaceOrFail, parseBodyOrReject } from '../shared/handler-utils';
 import type { ApiRouteContext } from './api-shared';
 import { truncateDiffIfNeeded } from './api-shared';
+import { createRoute, asBool } from './route-utils';
 
 export function registerGitWorkingTreeRoutes(ctx: ApiRouteContext): void {
     const { routes, store, getWsServer } = ctx;
@@ -31,152 +30,149 @@ export function registerGitWorkingTreeRoutes(ctx: ApiRouteContext): void {
     }
 
     // GET /api/workspaces/:id/git/changes — All working-tree changes + repo state
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
 
             const changes = await workingTreeService.getAllChanges(ws.rootPath);
             const repoState = branchService.getRepoState(ws.rootPath);
-            sendJSON(res, 200, { changes: normalizeChanges(changes), repoState });
+            return { changes: normalizeChanges(changes), repoState };
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/changes/stage — Stage a file
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/stage$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ req, res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (typeof body.filePath !== 'string') return handleAPIError(res, missingFields(['filePath']));
+            if (typeof body.filePath !== 'string') return void handleAPIError(res, missingFields(['filePath']));
 
             const result = await workingTreeService.stageFile(ws.rootPath, body.filePath);
             getWsServer?.()?.broadcastGitChanged(id, 'stage');
-            sendJSON(res, 200, result);
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/changes/unstage — Unstage a file
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/unstage$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ req, res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (typeof body.filePath !== 'string') return handleAPIError(res, missingFields(['filePath']));
+            if (typeof body.filePath !== 'string') return void handleAPIError(res, missingFields(['filePath']));
 
             const result = await workingTreeService.unstageFile(ws.rootPath, body.filePath);
             getWsServer?.()?.broadcastGitChanged(id, 'unstage');
-            sendJSON(res, 200, result);
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/changes/discard — Discard unstaged changes
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/discard$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ req, res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (typeof body.filePath !== 'string') return handleAPIError(res, missingFields(['filePath']));
+            if (typeof body.filePath !== 'string') return void handleAPIError(res, missingFields(['filePath']));
 
             const result = await workingTreeService.discardChanges(ws.rootPath, body.filePath);
             getWsServer?.()?.broadcastGitChanged(id, 'discard');
-            sendJSON(res, 200, result);
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/changes/stage-batch — Stage multiple files at once
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/stage-batch$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ req, res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (!Array.isArray(body.filePaths)) return handleAPIError(res, missingFields(['filePaths']));
+            if (!Array.isArray(body.filePaths)) return void handleAPIError(res, missingFields(['filePaths']));
 
             const result = await workingTreeService.stageFiles(ws.rootPath, body.filePaths);
             getWsServer?.()?.broadcastGitChanged(id, 'stage-batch');
-            sendJSON(res, 200, result);
+            return result;
         },
-    });
+    }));
 
     // POST /api/workspaces/:id/git/changes/unstage-batch — Unstage multiple files at once
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/unstage-batch$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ req, res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
             const id = ws.id;
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (!Array.isArray(body.filePaths)) return handleAPIError(res, missingFields(['filePaths']));
+            if (!Array.isArray(body.filePaths)) return void handleAPIError(res, missingFields(['filePaths']));
 
             const result = await workingTreeService.unstageFiles(ws.rootPath, body.filePaths);
             getWsServer?.()?.broadcastGitChanged(id, 'unstage-batch');
-            sendJSON(res, 200, result);
+            return result;
         },
-    });
+    }));
 
     // DELETE /api/workspaces/:id/git/changes/untracked — Delete an untracked file
-    routes.push({
+    routes.push(createRoute({
         method: 'DELETE',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/untracked$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        handler: async ({ req, res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
-            if (typeof body.filePath !== 'string') return handleAPIError(res, missingFields(['filePath']));
+            if (typeof body.filePath !== 'string') return void handleAPIError(res, missingFields(['filePath']));
 
-            const result = await workingTreeService.deleteUntrackedFile(ws.rootPath, body.filePath);
-            sendJSON(res, 200, result);
+            return await workingTreeService.deleteUntrackedFile(ws.rootPath, body.filePath);
         },
-    });
+    }));
 
     // GET /api/workspaces/:id/git/changes/files/*/diff — Per-file working-tree diff
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/files\/(.+)\/diff$/,
-        handler: async (req, res, match) => {
-            const ws = await resolveWorkspaceOrFail(store, match!, res);
+        parseQuery: (q) => ({ stage: q.stage as string | undefined, full: asBool(q.full) }),
+        handler: async ({ res, match, query }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
             if (!ws) return;
-            const filePath = decodeURIComponent(match![2]);
+            const filePath = decodeURIComponent(match[2]);
 
-            const parsed = url.parse(req.url!, true).query;
-            const stage = parsed.stage as string | undefined;
-            const staged = stage === 'staged';
-            const full = parsed.full === 'true';
+            const staged = query.stage === 'staged';
+            const full = query.full;
 
             try {
                 const diff = await workingTreeService.getFileDiff(ws.rootPath, filePath, staged);
-                const result = { ...truncateDiffIfNeeded(diff, full), path: filePath };
-                sendJSON(res, 200, result);
+                return { ...truncateDiffIfNeeded(diff, full), path: filePath };
             } catch {
-                sendJSON(res, 200, { diff: '', path: filePath });
+                return { diff: '', path: filePath };
             }
         },
-    });
+    }));
 }

--- a/packages/coc/src/server/routes/api-process-routes.ts
+++ b/packages/coc/src/server/routes/api-process-routes.ts
@@ -28,6 +28,7 @@ import { parseBodyOrReject } from '../shared/handler-utils';
 import { truncateDisplayName } from '../shared/queue-utils';
 import { prependSelectedSkillsDirective } from '../executors/prompt-builder';
 import type { ApiRouteContext } from './api-shared';
+import { createRoute, asString } from './route-utils';
 
 /** Valid AIProcessStatus values for validation. */
 const VALID_STATUSES: Set<string> = new Set(['queued', 'running', 'cancelling', 'completed', 'failed', 'cancelled']);
@@ -94,27 +95,27 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
     const { routes, store, bridge, dataDir, getWsServer } = ctx;
 
     // GET /api/processes/summaries — Lightweight index-only process list (no file I/O per process)
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: '/api/processes/summaries',
-        handler: async (req, res) => {
+        handler: async ({ req, res }) => {
             if (!store.getProcessSummaries) {
-                return handleAPIError(res, badRequest('Summaries not supported by this store'));
+                return void handleAPIError(res, badRequest('Summaries not supported by this store'));
             }
             const filter = parseQueryParams(req.url || '/');
             const limit = filter.limit ?? 100;
             const offset = filter.offset ?? 0;
             const paginatedFilter: ProcessFilter = { ...filter, limit, offset };
             const { entries, total } = await store.getProcessSummaries(paginatedFilter);
-            sendJSON(res, 200, { summaries: entries, total, limit, offset });
+            return { summaries: entries, total, limit, offset };
         },
-    });
+    }));
 
     // GET /api/processes — List processes with filtering + pagination
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: '/api/processes',
-        handler: async (req, res) => {
+        handler: async ({ req, res }) => {
             const parsed = url.parse(req.url || '/', true);
             const sdkSessionId = typeof parsed.query.sdkSessionId === 'string' ? parsed.query.sdkSessionId : '';
 
@@ -123,13 +124,12 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                     ? (store as any).getProcessBySdkSessionId(sdkSessionId) as AIProcess | undefined
                     : (await store.getAllProcesses()).find(p => p.sdkSessionId === sdkSessionId);
                 if (!match) {
-                    return handleAPIError(res, notFound('Process with sdkSessionId: ' + sdkSessionId));
+                    return void handleAPIError(res, notFound('Process with sdkSessionId: ' + sdkSessionId));
                 }
-                return sendJSON(res, 200, { process: match });
+                return { process: match };
             }
 
             const filter = parseQueryParams(req.url || '/');
-
             const countFilter: ProcessFilter = { ...filter };
             delete countFilter.limit;
             delete countFilter.offset;
@@ -141,25 +141,23 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             const offset = filter.offset ?? 0;
             const paginatedFilter: ProcessFilter = { ...filter, limit, offset };
             const processes = await store.getAllProcesses(paginatedFilter);
-
             const responseProcesses = filter.exclude
                 ? processes.map(p => stripExcludedFields(p, filter.exclude))
                 : processes;
-
-            sendJSON(res, 200, { processes: responseProcesses, total, limit, offset });
+            return { processes: responseProcesses, total, limit, offset };
         },
-    });
+    }));
 
     // DELETE /api/processes — Bulk-clear processes by status
-    routes.push({
+    routes.push(createRoute({
         method: 'DELETE',
         pattern: '/api/processes',
-        handler: async (req, res) => {
+        handler: async ({ req, res }) => {
             const parsed = url.parse(req.url || '/', true);
             const statusParam = parsed.query.status;
 
             if (typeof statusParam !== 'string' || !statusParam) {
-                return handleAPIError(res, badRequest('Query parameter "status" is required for bulk delete'));
+                return void handleAPIError(res, badRequest('Query parameter "status" is required for bulk delete'));
             }
 
             const statuses = statusParam
@@ -168,24 +166,25 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                 .filter(s => VALID_STATUSES.has(s)) as AIProcessStatus[];
 
             if (statuses.length === 0) {
-                return handleAPIError(res, badRequest('No valid status values provided'));
+                return void handleAPIError(res, badRequest('No valid status values provided'));
             }
 
             const removed = await store.clearProcesses({ status: statuses });
-            sendJSON(res, 200, { removed });
+            return { removed };
         },
-    });
+    }));
 
     // POST /api/processes — Create a new process
-    routes.push({
+    routes.push(createRoute({
+        statusCode: 201,
         method: 'POST',
         pattern: '/api/processes',
-        handler: async (req, res) => {
+        handler: async ({ req, res }) => {
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
 
             if (!body.id || !body.promptPreview || !body.status || !body.startTime) {
-                return handleAPIError(res, missingFields(['id', 'promptPreview', 'status', 'startTime']));
+                return void handleAPIError(res, missingFields(['id', 'promptPreview', 'status', 'startTime']));
             }
 
             const proc: AIProcess = deserializeProcess({
@@ -218,25 +217,25 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             }
 
             await store.addProcess(proc);
-            sendJSON(res, 201, proc);
+            return proc;
         },
-    });
+    }));
 
     // GET /api/processes/search — Full-text search across conversations
     // Registered before :id regex patterns to avoid "search" matching as a process ID.
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: '/api/processes/search',
-        handler: async (req, res) => {
+        handler: async ({ req, res }) => {
             const parsed = url.parse(req.url || '/', true);
             const q = typeof parsed.query.q === 'string' ? parsed.query.q.trim() : '';
 
             if (!q) {
-                return sendJSON(res, 200, { results: [], total: 0, query: '' });
+                return { results: [], total: 0, query: '' };
             }
 
             if (!store.searchConversations) {
-                return handleAPIError(res, badRequest('Full-text search not supported by this store backend'));
+                return void handleAPIError(res, badRequest('Full-text search not supported by this store backend'));
             }
 
             const filter = parseQueryParams(req.url || '/');
@@ -251,9 +250,9 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             };
 
             const { results, total } = await store.searchConversations(q, searchFilter);
-            sendJSON(res, 200, { results, total, query: q, limit: searchFilter.limit, offset: searchFilter.offset });
+            return { results, total, query: q, limit: searchFilter.limit, offset: searchFilter.offset };
         },
-    });
+    }));
 
     // GET /api/processes/:id/stream — SSE stream for real-time output
     routes.push({
@@ -269,11 +268,11 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
     });
 
     // GET /api/processes/:id/output — Persisted conversation output
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/processes\/([^/]+)\/output$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const proc = await resolveProcess(store, id, wsId);
             if (!proc) {
@@ -283,38 +282,38 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                     try {
                         const task = bridge.getTask?.(toTaskId(id));
                         if (task) {
-                            return sendJSON(res, 200, { content: '', format: 'markdown' });
+                            return { content: '', format: 'markdown' };
                         }
                     } catch { /* toTaskId may throw if prefix is wrong — fall through */ }
                 }
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
             const filePath = proc.rawStdoutFilePath;
             if (!filePath) {
-                return handleAPIError(res, notFound('Conversation output'));
+                return void handleAPIError(res, notFound('Conversation output'));
             }
             try {
                 await fs.promises.access(filePath);
                 const content = await fs.promises.readFile(filePath, 'utf-8');
-                sendJSON(res, 200, { content, format: 'markdown' });
+                return { content, format: 'markdown' };
             } catch (err: any) {
                 if (err.code === 'ENOENT') {
-                    return handleAPIError(res, notFound('Conversation output'));
+                    return void handleAPIError(res, notFound('Conversation output'));
                 }
-                return handleAPIError(res, internalError('Failed to read conversation output'));
+                return void handleAPIError(res, internalError('Failed to read conversation output'));
             }
         },
-    });
+    }));
 
     // GET /api/processes/:id — Single process detail
     // By default, children are NOT embedded (saves an extra SQL query on a hot
     // path that is overwhelmingly used for chat sessions without children).
     // Opt back in with `?include=children`.
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: /^\/api\/processes\/([^/]+)$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const filter = parseQueryParams(req.url || '/');
             const include = parseIncludeFields(req.url || '/');
             const proc = await resolveProcess(store, id, filter.workspaceId);
@@ -326,16 +325,16 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                         if (task) {
                             const synthetic = queuedTaskToProcess(task);
                             const result = filter.exclude ? stripExcludedFields(synthetic, filter.exclude) : synthetic;
-                            return sendJSON(res, 200, { process: result, children: [], total: 0 });
+                            return { process: result, children: [], total: 0 };
                         }
                     } catch { /* toTaskId may throw if prefix is wrong — fall through */ }
                 }
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
             const result = filter.exclude ? stripExcludedFields(proc, filter.exclude) : proc;
 
             if (!include.has('children')) {
-                return sendJSON(res, 200, { process: result, children: [], total: 0 });
+                return { process: result, children: [], total: 0 };
             }
 
             // Embed children using the same logic the deleted /children route used
@@ -351,20 +350,20 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                 ? children.map(p => stripExcludedFields(p, childFilter.exclude))
                 : children;
 
-            sendJSON(res, 200, { process: result, children: responseChildren, total: children.length });
+            return { process: result, children: responseChildren, total: children.length };
         },
-    });
+    }));
 
     // PATCH /api/processes/:id — Partial update
-    routes.push({
+    routes.push(createRoute({
         method: 'PATCH',
         pattern: /^\/api\/processes\/([^/]+)$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const existing = await resolveProcess(store, id, wsId);
             if (!existing) {
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
 
             const body = await parseBodyOrReject(req, res);
@@ -382,11 +381,11 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             if (body.customTitle !== undefined) {
                 const raw = body.customTitle;
                 if (raw !== null && typeof raw !== 'string') {
-                    return handleAPIError(res, badRequest('customTitle must be a string or null'));
+                    return void handleAPIError(res, badRequest('customTitle must be a string or null'));
                 }
                 const trimmed = typeof raw === 'string' ? raw.trim() : '';
                 if (trimmed.length > 80) {
-                    return handleAPIError(res, badRequest('customTitle exceeds 80 characters'));
+                    return void handleAPIError(res, badRequest('customTitle exceeds 80 characters'));
                 }
                 updates.customTitle = trimmed;
             }
@@ -400,43 +399,43 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             }
 
             const updated = await store.getProcess(existing.id, wsId);
-            sendJSON(res, 200, { process: updated });
+            return { process: updated };
         },
-    });
+    }));
 
     // DELETE /api/processes/:id — Remove a single process
     // @deprecated — does not clean up in-memory queue state or child processes.
     // Prefer DELETE /api/workspaces/:id/history/:processId instead.
-    routes.push({
+    routes.push(createRoute({
         method: 'DELETE',
         pattern: /^\/api\/processes\/([^/]+)$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const existing = await resolveProcess(store, id, wsId);
             if (!existing) {
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
             await store.removeProcess(existing.id);
             res.writeHead(204);
             res.end();
         },
-    });
+    }));
 
     // POST /api/processes/:id/cancel — Cancel a running process
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/processes\/([^/]+)\/cancel$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const existing = await resolveProcess(store, id, wsId);
             if (!existing) {
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
 
             if (TERMINAL_STATUSES.has(existing.status)) {
-                return handleAPIError(res, new APIError(409, `Process is already in terminal state: ${existing.status}`, 'CONFLICT'));
+                return void handleAPIError(res, new APIError(409, `Process is already in terminal state: ${existing.status}`, 'CONFLICT'));
             }
 
             await store.updateProcess(existing.id, {
@@ -467,26 +466,27 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             }
 
             const updated = await store.getProcess(existing.id, wsId);
-            sendJSON(res, 200, { process: updated });
+            return { process: updated };
         },
-    });
+    }));
 
     // POST /api/processes/:id/fork — Fork a completed process
-    routes.push({
+    routes.push(createRoute({
+        statusCode: 201,
         method: 'POST',
         pattern: /^\/api\/processes\/([^/]+)\/fork$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const proc = await resolveProcess(store, id, wsId);
             if (!proc) {
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
             if (!proc.sdkSessionId) {
-                return handleAPIError(res, badRequest('Process has no SDK session to fork'));
+                return void handleAPIError(res, badRequest('Process has no SDK session to fork'));
             }
             if (!store.forkProcess) {
-                return handleAPIError(res, badRequest('Fork not supported by this store'));
+                return void handleAPIError(res, badRequest('Fork not supported by this store'));
             }
 
             const newId = crypto.randomUUID();
@@ -496,7 +496,7 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                 const sdkService = sdkServiceRegistry.getOrThrow(SDK_PROVIDER_COPILOT);
                 newSdkSessionId = await sdkService.forkSession(proc.sdkSessionId);
             } catch (err: any) {
-                return handleAPIError(res, internalError(`Failed to fork SDK session: ${err?.message || err}`));
+                return void handleAPIError(res, internalError(`Failed to fork SDK session: ${err?.message || err}`));
             }
 
             try {
@@ -517,12 +517,12 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                         },
                     });
                 }
-                sendJSON(res, 201, { process: forked });
+                return { process: forked };
             } catch (err: any) {
-                return handleAPIError(res, internalError(`Failed to fork process: ${err?.message || err}`));
+                return void handleAPIError(res, internalError(`Failed to fork process: ${err?.message || err}`));
             }
         },
-    });
+    }));
 
     // POST /api/processes/:id/message — Send a follow-up message
     routes.push({
@@ -744,33 +744,33 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
     // ------------------------------------------------------------------
 
     // POST /api/processes/:id/ask-user-response — Answer or skip a pending ask-user question batch
-    routes.push({
+    routes.push(createRoute({
         method: 'POST',
         pattern: /^\/api\/processes\/([^/]+)\/ask-user-response$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
 
             if (!body.batchId || typeof body.batchId !== 'string') {
-                return handleAPIError(res, missingFields(['batchId']));
+                return void handleAPIError(res, missingFields(['batchId']));
             }
             if (!Array.isArray(body.answers) || body.answers.length === 0) {
-                return handleAPIError(res, missingFields(['answers']));
+                return void handleAPIError(res, missingFields(['answers']));
             }
             const answers = body.answers as Array<{ questionId?: unknown; answer?: unknown; skipped?: unknown }>;
             for (const answer of answers) {
                 if (!answer.questionId || typeof answer.questionId !== 'string') {
-                    return handleAPIError(res, missingFields(['answers[].questionId']));
+                    return void handleAPIError(res, missingFields(['answers[].questionId']));
                 }
                 if (answer.skipped !== true && answer.answer === undefined) {
-                    return handleAPIError(res, missingFields(['answers[].answer']));
+                    return void handleAPIError(res, missingFields(['answers[].answer']));
                 }
             }
 
             if (!bridge) {
-                return handleAPIError(res, notFound('Bridge not available'));
+                return void handleAPIError(res, notFound('Bridge not available'));
             }
 
             const resolved = await bridge.answerAskUserQuestions?.(id, body.batchId as string, answers.map(answer => ({
@@ -780,34 +780,35 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             }))) ?? false;
 
             if (!resolved) {
-                return handleAPIError(res, notFound('Question batch not found or already answered'));
+                return void handleAPIError(res, notFound('Question batch not found or already answered'));
             }
 
-            sendJSON(res, 200, { ok: true });
+            return { ok: true };
         },
-    });
+    }));
 
     // ------------------------------------------------------------------
     // Pending messages endpoints
     // ------------------------------------------------------------------
 
     // POST /api/processes/:id/pending-messages — Queue a message while AI is busy
-    routes.push({
+    routes.push(createRoute({
+        statusCode: 201,
         method: 'POST',
         pattern: /^\/api\/processes\/([^/]+)\/pending-messages$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const proc = await resolveProcess(store, id, wsId);
             if (!proc) {
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
 
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
 
             if (!body.content || typeof body.content !== 'string') {
-                return handleAPIError(res, missingFields(['content']));
+                return void handleAPIError(res, missingFields(['content']));
             }
 
             const pendingMsg = {
@@ -824,21 +825,21 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
 
             emitPendingMessageAdded(store, id, pendingMsg);
 
-            sendJSON(res, 201, { message: pendingMsg });
+            return { message: pendingMsg };
         },
-    });
+    }));
 
     // DELETE /api/processes/:id/pending-messages/:msgId — Remove a consumed pending message
-    routes.push({
+    routes.push(createRoute({
         method: 'DELETE',
         pattern: /^\/api\/processes\/([^/]+)\/pending-messages\/([^/]+)$/,
-        handler: async (req, res, match) => {
-            const id = decodeURIComponent(match![1]);
-            const msgId = decodeURIComponent(match![2]);
+        handler: async ({ req, res, match }) => {
+            const id = decodeURIComponent(match[1]);
+            const msgId = decodeURIComponent(match[2]);
             const wsId = parseQueryParams(req.url || '/').workspaceId;
             const proc = await resolveProcess(store, id, wsId);
             if (!proc) {
-                return handleAPIError(res, notFound('Process'));
+                return void handleAPIError(res, notFound('Process'));
             }
 
             const existing = proc.pendingMessages ?? [];
@@ -848,17 +849,17 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
             res.writeHead(204);
             res.end();
         },
-    });
+    }));
 
     // ------------------------------------------------------------------
     // Stats endpoint
     // ------------------------------------------------------------------
 
     // GET /api/stats — Aggregate statistics
-    routes.push({
+    routes.push(createRoute({
         method: 'GET',
         pattern: '/api/stats',
-        handler: async (_req, res) => {
+        handler: async () => {
             const allProcesses = store.getProcessSummaries
                 ? (await store.getProcessSummaries()).entries
                 : await store.getAllProcesses();
@@ -885,11 +886,11 @@ export function registerApiProcessRoutes(ctx: ApiRouteContext): void {
                 count: workspaceCounts[ws.id] || 0,
             }));
 
-            sendJSON(res, 200, {
+            return {
                 totalProcesses: allProcesses.length,
                 byStatus,
                 byWorkspace,
-            });
+            };
         },
-    });
+    }));
 }

--- a/packages/coc/src/server/routes/queue-ralph-routes.ts
+++ b/packages/coc/src/server/routes/queue-ralph-routes.ts
@@ -15,6 +15,7 @@ import { getRalphContext } from '../tasks/task-types';
 import { RalphSessionStore } from '../ralph/ralph-session-store';
 import { buildRalphIterationPrompt } from '../ralph/iteration-prompt';
 import { RALPH_DEFAULT_MAX_ITERATIONS, readRepoPreferences } from '../preferences-handler';
+import { getPromptOverride } from '../admin/ralph-prompt-overrides';
 
 export interface QueueRalphRouteContext {
     bridge: MultiRepoQueueRouter;
@@ -124,7 +125,12 @@ export function registerRalphRoutes(routes: Route[], ctx: QueueRalphRouteContext
                 payload: {
                     kind: 'chat',
                     mode: 'ralph',
-                    prompt: buildRalphIterationPrompt({ originalGoal: goalSpec }),
+                    prompt: buildRalphIterationPrompt({
+                        originalGoal: goalSpec,
+                        promptOverride: dataDir
+                            ? (getPromptOverride('ralph-iteration-user', dataDir) ?? undefined)
+                            : undefined,
+                    }),
                     workspaceId: wsId,
                     workingDirectory,
                     folderPath,

--- a/packages/coc/src/server/routes/ralph-continue-routes.ts
+++ b/packages/coc/src/server/routes/ralph-continue-routes.ts
@@ -178,6 +178,7 @@ export function registerRalphContinueRoutes(routes: Route[], ctx: RalphContinueR
                 originalGoal: record.originalGoal,
                 iteration: nextIteration,
                 maxIterations: newMax,
+                dataDir,
             });
 
             let taskId: string;

--- a/packages/coc/src/server/routes/ralph-launch-routes.ts
+++ b/packages/coc/src/server/routes/ralph-launch-routes.ts
@@ -92,6 +92,7 @@ export function registerRalphLaunchRoutes(routes: Route[], ctx: RalphLaunchRoute
                 originalGoal: goalSpec,
                 iteration: 1,
                 maxIterations,
+                dataDir,
             });
 
             const taskId = await bridge.enqueue({

--- a/packages/coc/src/server/routes/ralph-promote-routes.ts
+++ b/packages/coc/src/server/routes/ralph-promote-routes.ts
@@ -31,6 +31,7 @@ import {
     RALPH_SYNTHESIS_HINT_MAX_LENGTH,
 } from '../ralph/synthesis-prompt';
 import { RALPH_DEFAULT_MAX_ITERATIONS, readRepoPreferences } from '../preferences-handler';
+import { getPromptOverride } from '../admin/ralph-prompt-overrides';
 
 export interface RalphPromoteRouteContext {
     bridge: MultiRepoQueueRouter;
@@ -191,7 +192,12 @@ export function registerRalphPromoteRoutes(routes: Route[], ctx: RalphPromoteRou
                     payload: {
                         kind: 'chat',
                         mode: 'ask',
-                        prompt: buildRalphSynthesisPrompt({ extraGuidance }),
+                        prompt: buildRalphSynthesisPrompt({
+                            extraGuidance,
+                            promptOverride: dataDir
+                                ? (getPromptOverride('ralph-synthesis', dataDir) ?? undefined)
+                                : undefined,
+                        }),
                         processId: proc.id,
                         workspaceId: wsId,
                         workingDirectory,

--- a/packages/coc/src/server/routes/route-utils.ts
+++ b/packages/coc/src/server/routes/route-utils.ts
@@ -1,0 +1,125 @@
+/**
+ * Route creation utilities
+ *
+ * `createRoute` eliminates the repeated try/catch + url.parse + sendJSON boilerplate
+ * found in route handlers. Typed query-parser helpers (`asString`, `asInt`, `asBool`)
+ * replace ad-hoc casts from ParsedUrlQuery values.
+ */
+
+import * as url from 'url';
+import type { ParsedUrlQuery } from 'querystring';
+import type * as http from 'http';
+import type { Route } from '../types';
+import { sendJSON } from '../core/api-handler';
+import { handleAPIError } from '../errors';
+
+// ============================================================================
+// Query-param helpers
+// ============================================================================
+
+/**
+ * Extract a string value from a raw query param.
+ * Returns `fallback` (default `undefined`) when the value is absent or not a string.
+ */
+export function asString(v: string | string[] | undefined): string | undefined;
+export function asString(v: string | string[] | undefined, fallback: string): string;
+export function asString(v: string | string[] | undefined, fallback?: string): string | undefined {
+    const s = Array.isArray(v) ? v[0] : v;
+    return typeof s === 'string' ? s : fallback;
+}
+
+/**
+ * Extract an integer from a raw query param.
+ * @param v - raw query value
+ * @param fallback - value to return when absent or not parseable (default `undefined`)
+ * @param max - cap the result to at most this value
+ */
+export function asInt(v: string | string[] | undefined): number | undefined;
+export function asInt(v: string | string[] | undefined, fallback: number, max?: number): number;
+export function asInt(v: string | string[] | undefined, fallback?: number, max?: number): number | undefined {
+    const s = Array.isArray(v) ? v[0] : v;
+    if (typeof s !== 'string') return fallback;
+    const n = parseInt(s, 10);
+    if (isNaN(n)) return fallback;
+    return max !== undefined ? Math.min(n, max) : n;
+}
+
+/**
+ * Extract a boolean from a raw query param.
+ * 'true' → true, 'false' → false, otherwise → `fallback` (default `false`).
+ */
+export function asBool(v: string | string[] | undefined, fallback = false): boolean {
+    const s = Array.isArray(v) ? v[0] : v;
+    return s === 'true' ? true : s === 'false' ? false : fallback;
+}
+
+// ============================================================================
+// createRoute
+// ============================================================================
+
+/**
+ * Context passed to `createRoute` handlers.
+ * Includes typed `query` (from `parseQuery`), the regex `match`, the raw `req`,
+ * and `res` — needed for early-exit helpers like `resolveWorkspaceOrFail`.
+ * If the handler calls `sendJSON` / `handleAPIError` itself and returns `void`,
+ * the wrapper skips its own response emission.
+ */
+export interface RouteHandlerContext<TQuery = ParsedUrlQuery> {
+    query: TQuery;
+    match: RegExpMatchArray;
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+}
+
+export type TypedHandler<TQuery, TResult> = (
+    ctx: RouteHandlerContext<TQuery>
+) => Promise<TResult | void> | TResult | void;
+
+export interface CreateRouteOptions<TQuery, TResult> {
+    method?: string;
+    pattern: string | RegExp;
+    /** Transform raw ParsedUrlQuery into a typed object. */
+    parseQuery?: (raw: ParsedUrlQuery) => TQuery;
+    handler: TypedHandler<TQuery, TResult>;
+    /** HTTP status code to use when the handler returns a non-void result (default 200). */
+    statusCode?: number;
+}
+
+/**
+ * Build a `Route` that automatically:
+ *  - parses `req.url` into a typed query object (via `parseQuery`)
+ *  - wraps the handler in try/catch → `handleAPIError`
+ *  - calls `sendJSON(res, statusCode, result)` when the handler returns a non-void value
+ *
+ * If the handler returns `void` (or `undefined`) the response is assumed to have
+ * been sent already (e.g. via `resolveWorkspaceOrFail`'s built-in 404 or an early
+ * `sendJSON` call inside the handler body).
+ */
+export function createRoute<TQuery = ParsedUrlQuery, TResult = unknown>(
+    opts: CreateRouteOptions<TQuery, TResult>,
+): Route {
+    return {
+        method: opts.method,
+        pattern: opts.pattern,
+        handler: async (req, res, match) => {
+            const raw = url.parse(req.url || '/', true).query;
+            const query: TQuery = opts.parseQuery ? opts.parseQuery(raw) : raw as unknown as TQuery;
+            const ctx: RouteHandlerContext<TQuery> = {
+                query,
+                match: match ?? ([] as unknown as RegExpMatchArray),
+                req,
+                res,
+            };
+            try {
+                const result = await opts.handler(ctx);
+                if (result !== undefined && !res.headersSent) {
+                    sendJSON(res, opts.statusCode ?? 200, result);
+                }
+            } catch (err) {
+                if (!res.headersSent) {
+                    handleAPIError(res, err);
+                }
+            }
+        },
+    };
+}

--- a/packages/coc/src/server/shared/cors.ts
+++ b/packages/coc/src/server/shared/cors.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared CORS Utilities
+ *
+ * Single source of truth for CORS header logic.
+ * Reflects the request Origin when it matches the allowlist (localhost variants
+ * or explicitly configured origins). Falls back to `*` for unknown origins.
+ *
+ * Cross-platform compatible (Linux/Mac/Windows).
+ */
+
+import * as http from 'http';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CorsPolicy {
+    /**
+     * Origins to allow in addition to localhost variants.
+     * Use `'*'` to reflect any origin (permissive — avoid on public endpoints).
+     */
+    allowedOrigins: string[] | '*';
+    /** Send `Access-Control-Allow-Credentials: true` when reflecting a specific origin. */
+    credentials: boolean;
+    methods: string[];
+    headers: string[];
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
+
+const DEFAULT_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+const DEFAULT_HEADERS = ['Authorization', 'Content-Type'];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Returns true if `origin` is an HTTP origin on a well-known localhost hostname.
+ * Any port is accepted.
+ */
+function isLocalhostOrigin(origin: string): boolean {
+    try {
+        const { protocol, hostname } = new URL(origin);
+        return protocol === 'http:' && LOCALHOST_HOSTNAMES.has(hostname);
+    } catch {
+        return false;
+    }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Returns the default CORS policy:
+ * - Localhost variants are always allowed (any port).
+ * - No additional explicitly-listed origins beyond localhost.
+ * - Credentials allowed for reflected origins.
+ * - All standard HTTP methods including PUT/PATCH.
+ * - `Authorization` and `Content-Type` in allowed headers.
+ */
+export function getDefaultCorsPolicy(): CorsPolicy {
+    return {
+        allowedOrigins: [],
+        credentials: true,
+        methods: DEFAULT_METHODS,
+        headers: DEFAULT_HEADERS,
+    };
+}
+
+/**
+ * Apply CORS headers to `res` according to `policy`.
+ *
+ * - If the request carries an `Origin` that is a localhost variant, explicitly
+ *   listed in `policy.allowedOrigins`, or if `policy.allowedOrigins === '*'`,
+ *   the origin is reflected back and (optionally) credentials are enabled.
+ * - All other requests receive `Access-Control-Allow-Origin: *` with no
+ *   credentials header, which is safe for unknown / unauthenticated callers.
+ */
+export function applyCorsHeaders(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    policy: CorsPolicy,
+): void {
+    const origin = req.headers['origin'] as string | undefined;
+
+    const shouldReflect =
+        origin !== undefined &&
+        (
+            policy.allowedOrigins === '*' ||
+            isLocalhostOrigin(origin) ||
+            (Array.isArray(policy.allowedOrigins) && policy.allowedOrigins.includes(origin))
+        );
+
+    if (shouldReflect && origin) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        if (policy.credentials) {
+            res.setHeader('Access-Control-Allow-Credentials', 'true');
+        }
+    } else {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+    }
+
+    res.setHeader('Access-Control-Allow-Methods', policy.methods.join(', '));
+    res.setHeader('Access-Control-Allow-Headers', policy.headers.join(', '));
+}

--- a/packages/coc/src/server/shared/router.ts
+++ b/packages/coc/src/server/shared/router.ts
@@ -14,6 +14,9 @@ import * as path from 'path';
 import * as url from 'url';
 import * as zlib from 'zlib';
 import { getServerLogger } from '../logging/server-logger';
+import { applyCorsHeaders, getDefaultCorsPolicy } from './cors';
+export type { CorsPolicy } from './cors';
+export { getDefaultCorsPolicy } from './cors';
 
 // ============================================================================
 // Constants
@@ -89,6 +92,8 @@ export interface SharedRouterOptions {
     staticHandlers?: StaticFileHandler[];
     /** Optional ETag for the SPA HTML response. Enables conditional caching (304 Not Modified). */
     spaETag?: string | (() => string | undefined);
+    /** CORS policy. Defaults to {@link getDefaultCorsPolicy} when omitted. */
+    corsPolicy?: import('./cors').CorsPolicy;
 }
 
 // ============================================================================
@@ -105,6 +110,7 @@ export interface SharedRouterOptions {
  */
 export function createRouter(options: SharedRouterOptions): (req: http.IncomingMessage, res: http.ServerResponse) => void {
     const { routes, spaHtml, staticHandlers = [], spaETag } = options;
+    const corsPolicy = options.corsPolicy ?? getDefaultCorsPolicy();
 
     return (req: http.IncomingMessage, res: http.ServerResponse) => {
         const startTime = Date.now();
@@ -118,15 +124,7 @@ export function createRouter(options: SharedRouterOptions): (req: http.IncomingM
         const method = req.method?.toUpperCase() || 'GET';
 
         // CORS headers for every request
-        const origin = req.headers['origin'];
-        if (origin) {
-            res.setHeader('Access-Control-Allow-Origin', origin);
-            res.setHeader('Access-Control-Allow-Credentials', 'true');
-        } else {
-            res.setHeader('Access-Control-Allow-Origin', '*');
-        }
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+        applyCorsHeaders(req, res, corsPolicy);
 
         res.on('finish', () => {
             const durationMs = Date.now() - startTime;

--- a/packages/coc/src/server/spa/client/react/admin/PromptCard.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/PromptCard.tsx
@@ -1,18 +1,83 @@
 /**
- * PromptCard — read-only card displaying a single built-in prompt.
- * Shows title, source file badge, one-line description, and full prompt text.
- *
- * Visuals come from `admin-redesign.css`.
+ * PromptCard — card displaying a built-in prompt.
+ * Read-only for non-editable prompts; shows Edit/Save/Cancel/Reset for editable ones.
  */
 
+import { useState } from 'react';
+
 interface PromptCardProps {
+    id: string;
     title: string;
     source: string;
     description: string;
+    /** Built-in default text. */
     text: string;
+    editable?: boolean;
+    templateVars?: string[];
+    hasOverride?: boolean;
+    overrideText?: string;
+    onSave?: (id: string, text: string) => Promise<void>;
+    onReset?: (id: string) => Promise<void>;
 }
 
-export function PromptCard({ title, source, description, text }: PromptCardProps) {
+export function PromptCard({
+    id,
+    title,
+    source,
+    description,
+    text,
+    editable,
+    templateVars,
+    hasOverride,
+    overrideText,
+    onSave,
+    onReset,
+}: PromptCardProps) {
+    const [editing, setEditing] = useState(false);
+    const [draftText, setDraftText] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const displayText = hasOverride && overrideText ? overrideText : text;
+
+    function handleEdit() {
+        setDraftText(displayText);
+        setError(null);
+        setEditing(true);
+    }
+
+    function handleCancel() {
+        setEditing(false);
+        setError(null);
+    }
+
+    async function handleSave() {
+        if (!onSave) return;
+        setSaving(true);
+        setError(null);
+        try {
+            await onSave(id, draftText);
+            setEditing(false);
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    async function handleReset() {
+        if (!onReset) return;
+        setSaving(true);
+        setError(null);
+        try {
+            await onReset(id);
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSaving(false);
+        }
+    }
+
     return (
         <div className="ar-prompt" data-testid="prompt-card">
             <div className="ar-prompt-head">
@@ -20,13 +85,100 @@ export function PromptCard({ title, source, description, text }: PromptCardProps
                     <div className="ar-prompt-title">
                         {title}
                         <span className="ar-badge ar-mono">{source}</span>
+                        {hasOverride && (
+                            <span className="ar-badge" style={{ color: 'var(--vscode-charts-orange, #f0a31c)', borderColor: 'var(--vscode-charts-orange, #f0a31c)' }}>overridden</span>
+                        )}
                     </div>
                     <div className="ar-prompt-desc">{description}</div>
                 </div>
+                {editable && !editing && (
+                    <div className="flex gap-2 items-center flex-shrink-0 ml-2">
+                        {hasOverride && (
+                            <button
+                                className="ar-btn ar-btn-ghost text-xs"
+                                onClick={handleReset}
+                                disabled={saving}
+                                data-testid="prompt-reset-btn"
+                                title="Reset to built-in default"
+                            >
+                                Reset
+                            </button>
+                        )}
+                        <button
+                            className="ar-btn ar-btn-secondary text-xs"
+                            onClick={handleEdit}
+                            data-testid="prompt-edit-btn"
+                        >
+                            Edit
+                        </button>
+                    </div>
+                )}
             </div>
-            <div className="ar-prompt-body">
-                <pre className="ar-pre" data-testid="prompt-text">{text}</pre>
-            </div>
+
+            {id === 'ralph-iteration-user' && (
+                <div
+                    className="ar-prompt-body"
+                    style={{
+                        backgroundColor: 'var(--vscode-inputValidation-warningBackground, #352a05)',
+                        border: '1px solid var(--vscode-inputValidation-warningBorder, #cca700)',
+                        borderRadius: '4px',
+                        padding: '6px 8px',
+                        marginBottom: '4px',
+                        fontSize: '11px',
+                        color: 'var(--vscode-inputValidation-warningForeground, #cca700)',
+                    }}
+                    data-testid="prompt-retriever-warning"
+                >
+                    ⚠ This prompt contains a <code>&lt;work_intent&gt;</code> block that signals the Copilot CLI skill retriever. Overrides that remove or alter this block may prevent project skills from being surfaced.
+                </div>
+            )}
+
+            {editing ? (
+                <div className="ar-prompt-body space-y-2">
+                    {templateVars && templateVars.length > 0 && (
+                        <div className="flex flex-wrap gap-1 text-xs">
+                            <span className="text-[#848484]">Required vars:</span>
+                            {templateVars.map(v => (
+                                <span key={v} className="ar-badge ar-mono">{v}</span>
+                            ))}
+                        </div>
+                    )}
+                    <textarea
+                        className="ar-textarea w-full"
+                        rows={12}
+                        value={draftText}
+                        onChange={e => setDraftText(e.target.value)}
+                        style={{ fontFamily: 'monospace', fontSize: '12px', resize: 'vertical' }}
+                        data-testid="prompt-editor"
+                        disabled={saving}
+                    />
+                    {error && (
+                        <div className="text-xs text-red-500" data-testid="prompt-save-error">{error}</div>
+                    )}
+                    <div className="flex gap-2">
+                        <button
+                            className="ar-btn ar-btn-primary text-xs"
+                            onClick={handleSave}
+                            disabled={saving || !draftText.trim()}
+                            data-testid="prompt-save-btn"
+                        >
+                            {saving ? 'Saving…' : 'Save'}
+                        </button>
+                        <button
+                            className="ar-btn ar-btn-ghost text-xs"
+                            onClick={handleCancel}
+                            disabled={saving}
+                            data-testid="prompt-cancel-btn"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="ar-prompt-body">
+                    <pre className="ar-pre" data-testid="prompt-text">{displayText}</pre>
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/coc/src/server/spa/client/react/admin/PromptsPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/PromptsPanel.tsx
@@ -1,5 +1,6 @@
 /**
- * PromptsPanel — read-only viewer for built-in AI prompt templates.
+ * PromptsPanel — viewer for built-in AI prompt templates.
+ * Ralph prompts support admin overrides via Edit/Save/Reset.
  * Fetches from GET /api/admin/prompts and renders grouped PromptCards.
  */
 
@@ -15,13 +16,17 @@ interface BuiltInPrompt {
     source: string;
     description: string;
     text: string;
+    editable?: boolean;
+    templateVars?: string[];
+    hasOverride?: boolean;
+    overrideText?: string;
 }
 
 interface PromptsPanelProps {
     onError: (msg: string) => void;
 }
 
-const GROUP_ORDER = ['Pipeline', 'Memory', 'UI'];
+const GROUP_ORDER = ['Pipeline', 'Memory', 'UI', 'Ralph'];
 
 export function PromptsPanel({ onError }: PromptsPanelProps) {
     const [prompts, setPrompts] = useState<BuiltInPrompt[]>([]);
@@ -42,6 +47,20 @@ export function PromptsPanel({ onError }: PromptsPanelProps) {
     useEffect(() => {
         load();
     }, [load]);
+
+    const handleSave = useCallback(async (id: string, text: string) => {
+        await getSpaCocClient().admin.updatePrompt(id, { text });
+        setPrompts(prev => prev.map(p =>
+            p.id === id ? { ...p, overrideText: text, hasOverride: true } : p
+        ));
+    }, []);
+
+    const handleReset = useCallback(async (id: string) => {
+        await getSpaCocClient().admin.resetPromptOverride(id);
+        setPrompts(prev => prev.map(p =>
+            p.id === id ? { ...p, overrideText: undefined, hasOverride: false } : p
+        ));
+    }, []);
 
     if (loading) {
         return (
@@ -69,7 +88,7 @@ export function PromptsPanel({ onError }: PromptsPanelProps) {
             <div>
                 <h2 className="text-sm font-semibold text-[#1e1e1e] dark:text-[#cccccc] mb-1">Prompt Templates</h2>
                 <p className="text-xs text-[#616161] dark:text-[#9d9d9d]">
-                    These are the AI instructions used internally by CoC. They are read-only in this view.
+                    Built-in AI instructions used by CoC. Ralph prompts are editable; others are read-only.
                 </p>
             </div>
 
@@ -81,10 +100,17 @@ export function PromptsPanel({ onError }: PromptsPanelProps) {
                     {items.map(p => (
                         <PromptCard
                             key={p.id}
+                            id={p.id}
                             title={p.title}
                             source={p.source}
                             description={p.description}
                             text={p.text}
+                            editable={p.editable}
+                            templateVars={p.templateVars}
+                            hasOverride={p.hasOverride}
+                            overrideText={p.overrideText}
+                            onSave={p.editable ? handleSave : undefined}
+                            onReset={p.editable ? handleReset : undefined}
                         />
                     ))}
                 </div>

--- a/packages/coc/src/server/sync/sync-engine.ts
+++ b/packages/coc/src/server/sync/sync-engine.ts
@@ -11,8 +11,12 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { safeExistsAsync, safeReadDirAsync, safeReadFileAsync } from '@plusplusoneplusplus/forge';
 import type { AIInvoker } from '@plusplusoneplusplus/forge';
+
+const execFileAsync = promisify(execFile);
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -59,18 +63,19 @@ interface FolderMapping {
 
 // ── Git helpers ──────────────────────────────────────────────────────────────
 
-function git(args: string[], cwd: string): string {
-    return execFileSync('git', args, {
+async function git(args: string[], cwd: string): Promise<string> {
+    const { stdout } = await execFileAsync('git', args, {
         cwd,
         encoding: 'utf8',
         maxBuffer: 10 * 1024 * 1024,
         timeout: 120_000,
-    }).trim();
+    });
+    return stdout.trim();
 }
 
-function isGitRepo(dir: string): boolean {
+async function isGitRepo(dir: string): Promise<boolean> {
     try {
-        git(['rev-parse', '--is-inside-work-tree'], dir);
+        await git(['rev-parse', '--is-inside-work-tree'], dir);
         return true;
     } catch {
         return false;
@@ -79,18 +84,18 @@ function isGitRepo(dir: string): boolean {
 
 // ── Lock file helpers ────────────────────────────────────────────────────────
 
-function acquireLock(lockPath: string): boolean {
+async function acquireLock(lockPath: string): Promise<boolean> {
+    await fs.promises.mkdir(path.dirname(lockPath), { recursive: true });
     try {
-        fs.mkdirSync(path.dirname(lockPath), { recursive: true });
-        fs.writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+        await fs.promises.writeFile(lockPath, String(process.pid), { flag: 'wx' });
         return true;
     } catch {
         // Check for stale lock
         try {
-            const pid = parseInt(fs.readFileSync(lockPath, 'utf8'), 10);
+            const pid = parseInt(await fs.promises.readFile(lockPath, 'utf8'), 10);
             if (pid && !isProcessRunning(pid)) {
-                fs.unlinkSync(lockPath);
-                fs.writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+                await fs.promises.unlink(lockPath);
+                await fs.promises.writeFile(lockPath, String(process.pid), { flag: 'wx' });
                 return true;
             }
         } catch { /* lock held by active process */ }
@@ -98,8 +103,8 @@ function acquireLock(lockPath: string): boolean {
     }
 }
 
-function releaseLock(lockPath: string): void {
-    try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+async function releaseLock(lockPath: string): Promise<void> {
+    try { await fs.promises.unlink(lockPath); } catch { /* ignore */ }
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -113,33 +118,35 @@ function isProcessRunning(pid: number): boolean {
 
 // ── File sync helpers ────────────────────────────────────────────────────────
 
-function copyDirContents(src: string, dest: string): void {
-    fs.mkdirSync(dest, { recursive: true });
+async function copyDirContents(src: string, dest: string): Promise<void> {
+    await fs.promises.mkdir(dest, { recursive: true });
 
     // Remove files in dest that don't exist in src
-    if (fs.existsSync(dest)) {
-        for (const entry of fs.readdirSync(dest, { withFileTypes: true })) {
+    const destEntries = await safeReadDirAsync(dest, true);
+    if (destEntries.success) {
+        for (const entry of destEntries.data!) {
             const destPath = path.join(dest, entry.name);
-            const srcPath = path.join(src, entry.name);
-            if (!fs.existsSync(srcPath)) {
+            if (!await safeExistsAsync(path.join(src, entry.name))) {
                 if (entry.isDirectory()) {
-                    fs.rmSync(destPath, { recursive: true, force: true });
+                    await fs.promises.rm(destPath, { recursive: true, force: true });
                 } else {
-                    fs.unlinkSync(destPath);
+                    await fs.promises.unlink(destPath);
                 }
             }
         }
     }
 
-    if (!fs.existsSync(src)) return;
+    if (!await safeExistsAsync(src)) return;
 
-    for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcEntries = await safeReadDirAsync(src, true);
+    if (!srcEntries.success) return;
+    for (const entry of srcEntries.data!) {
         const srcPath = path.join(src, entry.name);
         const destPath = path.join(dest, entry.name);
         if (entry.isDirectory()) {
-            copyDirContents(srcPath, destPath);
+            await copyDirContents(srcPath, destPath);
         } else {
-            fs.copyFileSync(srcPath, destPath);
+            await fs.promises.copyFile(srcPath, destPath);
         }
     }
 }
@@ -252,7 +259,7 @@ export class SyncEngine {
             return;
         }
 
-        if (!acquireLock(this.lockPath)) {
+        if (!await acquireLock(this.lockPath)) {
             this.logger.warn('Could not acquire sync lock, skipping');
             return;
         }
@@ -263,16 +270,16 @@ export class SyncEngine {
 
         try {
             // 1. Ensure the sync repo exists (clone or verify)
-            this.ensureSyncRepo(gitRemote);
+            await this.ensureSyncRepo(gitRemote);
 
             // 2. Copy local notes → sync repo
-            this.copyLocalToRepo();
+            await this.copyLocalToRepo();
 
             // 3. Stage + commit local changes
-            this.commitLocalChanges();
+            await this.commitLocalChanges();
 
             // 4. Pull remote changes (may produce conflicts)
-            const hasConflicts = this.pullRemote();
+            const hasConflicts = await this.pullRemote();
 
             // 5. If conflicts, resolve them
             if (hasConflicts) {
@@ -280,10 +287,10 @@ export class SyncEngine {
             }
 
             // 6. Push to remote
-            this.pushToRemote();
+            await this.pushToRemote();
 
             // 7. Copy sync repo → local notes
-            this.copyRepoToLocal();
+            await this.copyRepoToLocal();
 
             this.status.lastSyncTime = new Date().toISOString();
             this.status.lastError = null;
@@ -294,55 +301,55 @@ export class SyncEngine {
             this.logger.error(`Sync failed: ${message}`);
         } finally {
             this.status.inProgress = false;
-            releaseLock(this.lockPath);
+            await releaseLock(this.lockPath);
         }
     }
 
-    private ensureSyncRepo(gitRemote: string): void {
-        if (isGitRepo(this.syncRepoDir)) {
+    private async ensureSyncRepo(gitRemote: string): Promise<void> {
+        if (await isGitRepo(this.syncRepoDir)) {
             // Verify the remote matches
             try {
-                const currentRemote = git(['remote', 'get-url', 'origin'], this.syncRepoDir);
+                const currentRemote = await git(['remote', 'get-url', 'origin'], this.syncRepoDir);
                 if (currentRemote !== gitRemote) {
-                    git(['remote', 'set-url', 'origin', gitRemote], this.syncRepoDir);
+                    await git(['remote', 'set-url', 'origin', gitRemote], this.syncRepoDir);
                     this.logger.info('Updated sync repo remote URL');
                 }
             } catch {
-                git(['remote', 'add', 'origin', gitRemote], this.syncRepoDir);
+                await git(['remote', 'add', 'origin', gitRemote], this.syncRepoDir);
             }
             return;
         }
 
         // Clone fresh
-        fs.mkdirSync(this.syncRepoDir, { recursive: true });
+        await fs.promises.mkdir(this.syncRepoDir, { recursive: true });
         try {
-            git(['clone', gitRemote, '.'], this.syncRepoDir);
+            await git(['clone', gitRemote, '.'], this.syncRepoDir);
             this.logger.info('Cloned sync repo');
         } catch {
             // Remote might be empty — init locally and add remote
-            git(['init'], this.syncRepoDir);
-            git(['remote', 'add', 'origin', gitRemote], this.syncRepoDir);
+            await git(['init'], this.syncRepoDir);
+            await git(['remote', 'add', 'origin', gitRemote], this.syncRepoDir);
             this.logger.info('Initialized empty sync repo with remote');
         }
     }
 
-    private copyLocalToRepo(): void {
-        if (fs.existsSync(this.mapping.localDir)) {
-            copyDirContents(this.mapping.localDir, this.syncRepoDir);
+    private async copyLocalToRepo(): Promise<void> {
+        if (await safeExistsAsync(this.mapping.localDir)) {
+            await copyDirContents(this.mapping.localDir, this.syncRepoDir);
         }
     }
 
-    private commitLocalChanges(): void {
-        git(['add', '-A'], this.syncRepoDir);
+    private async commitLocalChanges(): Promise<void> {
+        await git(['add', '-A'], this.syncRepoDir);
 
         // Check if there's anything to commit
         try {
-            git(['diff', '--cached', '--quiet'], this.syncRepoDir);
+            await git(['diff', '--cached', '--quiet'], this.syncRepoDir);
             // No changes staged
         } catch {
             // Changes exist — commit them
             const hostname = require('os').hostname();
-            git(
+            await git(
                 ['commit', '-m', `sync from ${hostname} at ${new Date().toISOString()}`],
                 this.syncRepoDir,
             );
@@ -350,16 +357,16 @@ export class SyncEngine {
         }
     }
 
-    private pullRemote(): boolean {
+    private async pullRemote(): Promise<boolean> {
         try {
             // Check if remote has any commits first
             try {
-                git(['ls-remote', '--heads', 'origin'], this.syncRepoDir);
+                await git(['ls-remote', '--heads', 'origin'], this.syncRepoDir);
             } catch {
                 return false; // Can't reach remote or empty
             }
 
-            git(['pull', '--no-rebase', 'origin', 'HEAD'], this.syncRepoDir);
+            await git(['pull', '--no-rebase', 'origin', 'HEAD'], this.syncRepoDir);
             return false;
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -377,7 +384,7 @@ export class SyncEngine {
 
     private async resolveConflicts(): Promise<void> {
         // Get list of conflicted files
-        const statusOutput = git(['status', '--porcelain'], this.syncRepoDir);
+        const statusOutput = await git(['status', '--porcelain'], this.syncRepoDir);
         const conflictedFiles = statusOutput
             .split('\n')
             .filter(line => line.startsWith('UU') || line.startsWith('AA') || line.startsWith('DU') || line.startsWith('UD'))
@@ -390,22 +397,23 @@ export class SyncEngine {
         for (const file of conflictedFiles) {
             const filePath = path.join(this.syncRepoDir, file);
             try {
-                const content = fs.readFileSync(filePath, 'utf8');
-                const resolved = await this.resolveFileConflict(file, content);
-                fs.writeFileSync(filePath, resolved, 'utf8');
-                git(['add', file], this.syncRepoDir);
+                const readResult = await safeReadFileAsync(filePath);
+                if (!readResult.success) throw readResult.error!;
+                const resolved = await this.resolveFileConflict(file, readResult.data!);
+                await fs.promises.writeFile(filePath, resolved, 'utf8');
+                await git(['add', file], this.syncRepoDir);
             } catch (err) {
                 this.logger.error(`Failed to resolve conflict in ${file}: ${err}`);
                 // Accept theirs as fallback
                 try {
-                    git(['checkout', '--theirs', file], this.syncRepoDir);
-                    git(['add', file], this.syncRepoDir);
+                    await git(['checkout', '--theirs', file], this.syncRepoDir);
+                    await git(['add', file], this.syncRepoDir);
                 } catch { /* last resort: skip */ }
             }
         }
 
         try {
-            git(['commit', '--no-edit'], this.syncRepoDir);
+            await git(['commit', '--no-edit'], this.syncRepoDir);
             this.logger.info('Committed conflict resolution');
         } catch {
             // May already be committed
@@ -431,9 +439,9 @@ export class SyncEngine {
         }
     }
 
-    private pushToRemote(): void {
+    private async pushToRemote(): Promise<void> {
         try {
-            git(['push', '-u', 'origin', 'HEAD'], this.syncRepoDir);
+            await git(['push', '-u', 'origin', 'HEAD'], this.syncRepoDir);
             this.logger.info('Pushed to remote');
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -441,18 +449,20 @@ export class SyncEngine {
         }
     }
 
-    private copyRepoToLocal(): void {
-        if (fs.existsSync(this.syncRepoDir)) {
-            fs.mkdirSync(this.mapping.localDir, { recursive: true });
+    private async copyRepoToLocal(): Promise<void> {
+        if (await safeExistsAsync(this.syncRepoDir)) {
+            await fs.promises.mkdir(this.mapping.localDir, { recursive: true });
             // Copy everything except .git and .lock
-            for (const entry of fs.readdirSync(this.syncRepoDir, { withFileTypes: true })) {
+            const entries = await safeReadDirAsync(this.syncRepoDir, true);
+            if (!entries.success) return;
+            for (const entry of entries.data!) {
                 if (entry.name === '.git' || entry.name === '.lock') continue;
                 const src = path.join(this.syncRepoDir, entry.name);
                 const dest = path.join(this.mapping.localDir, entry.name);
                 if (entry.isDirectory()) {
-                    copyDirContents(src, dest);
+                    await copyDirContents(src, dest);
                 } else {
-                    fs.copyFileSync(src, dest);
+                    await fs.promises.copyFile(src, dest);
                 }
             }
         }

--- a/packages/coc/src/server/wiki/router.ts
+++ b/packages/coc/src/server/wiki/router.ts
@@ -18,6 +18,7 @@ import type { ContextBuilder } from './context-builder';
 import type { AskAIFunction } from './types';
 import type { ConversationSessionManager } from './conversation-session-manager';
 import type { WebSocketServer } from './websocket';
+import { applyCorsHeaders, getDefaultCorsPolicy } from '../shared/cors';
 
 // ============================================================================
 // Constants
@@ -92,9 +93,7 @@ export function createRequestHandler(
         const method = req.method?.toUpperCase() || 'GET';
 
         // CORS headers for API requests
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+        applyCorsHeaders(req, res, getDefaultCorsPolicy());
 
         // Handle CORS preflight
         if (method === 'OPTIONS') {

--- a/packages/coc/test/server/admin-handler.test.ts
+++ b/packages/coc/test/server/admin-handler.test.ts
@@ -390,7 +390,7 @@ describe('Admin Handler', () => {
 
             expect(res.status).toBe(200);
             const body = JSON.parse(res.body);
-            expect(Object.keys(body)).toHaveLength(9);
+            expect(Object.keys(body)).toHaveLength(13);
             expect(body['read-only-mode']).toBeDefined();
             expect(body['read-only-mode'].title).toBe('Read-only Mode');
             expect(body['read-only-mode'].group).toBe('Pipeline');

--- a/packages/coc/test/server/admin-prompts.test.ts
+++ b/packages/coc/test/server/admin-prompts.test.ts
@@ -6,10 +6,10 @@ import { describe, it, expect } from 'vitest';
 import { getBuiltInPrompts } from '../../src/server/admin/admin-handler';
 
 describe('getBuiltInPrompts', () => {
-    it('returns all 9 built-in prompts', () => {
+    it('returns all 13 built-in prompts', () => {
         const prompts = getBuiltInPrompts();
         const ids = Object.keys(prompts);
-        expect(ids).toHaveLength(9);
+        expect(ids).toHaveLength(13);
         expect(ids).toContain('read-only-mode');
         expect(ids).toContain('task-creation');
         expect(ids).toContain('plan-generation');
@@ -19,6 +19,10 @@ describe('getBuiltInPrompts', () => {
         expect(ids).toContain('memory-security-patterns');
         expect(ids).toContain('tool-call-cache');
         expect(ids).toContain('follow-up-suggestions');
+        expect(ids).toContain('ralph-grill-suffix');
+        expect(ids).toContain('ralph-synthesis');
+        expect(ids).toContain('ralph-execution-system');
+        expect(ids).toContain('ralph-iteration-user');
     });
 
     it('each prompt has all required fields', () => {
@@ -35,9 +39,9 @@ describe('getBuiltInPrompts', () => {
         }
     });
 
-    it('groups are Pipeline, Memory, or UI', () => {
+    it('groups are Pipeline, Memory, UI, or Ralph', () => {
         const prompts = getBuiltInPrompts();
-        const validGroups = new Set(['Pipeline', 'Memory', 'UI']);
+        const validGroups = new Set(['Pipeline', 'Memory', 'UI', 'Ralph']);
         for (const p of Object.values(prompts)) {
             expect(validGroups.has(p.group)).toBe(true);
         }
@@ -59,6 +63,24 @@ describe('getBuiltInPrompts', () => {
         const prompts = getBuiltInPrompts();
         const uiPrompts = Object.values(prompts).filter(p => p.group === 'UI');
         expect(uiPrompts).toHaveLength(1);
+    });
+
+    it('Ralph group contains 4 editable prompts', () => {
+        const prompts = getBuiltInPrompts();
+        const ralphPrompts = Object.values(prompts).filter(p => p.group === 'Ralph');
+        expect(ralphPrompts).toHaveLength(4);
+        for (const p of ralphPrompts) {
+            expect(p.editable).toBe(true);
+            expect(Array.isArray(p.templateVars)).toBe(true);
+        }
+    });
+
+    it('non-Ralph prompts are not editable', () => {
+        const prompts = getBuiltInPrompts();
+        const nonRalph = Object.values(prompts).filter(p => p.group !== 'Ralph');
+        for (const p of nonRalph) {
+            expect(p.editable).toBeFalsy();
+        }
     });
 
     it('read-only-mode prompt contains key phrases', () => {

--- a/packages/coc/test/server/cors.test.ts
+++ b/packages/coc/test/server/cors.test.ts
@@ -45,17 +45,19 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
 function rawRequest(
     baseUrl: string,
     path: string,
-    opts: { method?: string; body?: string } = {},
+    opts: { method?: string; body?: string; origin?: string } = {},
 ): Promise<{ status: number; headers: Record<string, string | string[] | undefined> }> {
     return new Promise((resolve, reject) => {
         const parsed = new URL(`${baseUrl}${path}`);
+        const reqHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (opts.origin) reqHeaders['Origin'] = opts.origin;
         const req = http.request(
             {
                 hostname: parsed.hostname,
                 port: parsed.port,
                 path: parsed.pathname + parsed.search,
                 method: opts.method ?? 'GET',
-                headers: { 'Content-Type': 'application/json' },
+                headers: reqHeaders,
             },
             (res) => {
                 const chunks: Buffer[] = [];
@@ -161,5 +163,48 @@ describe('CORS headers', () => {
     it('Access-Control-Allow-Headers is set on all responses', async () => {
         const { headers } = await rawRequest(baseUrl, '/api/processes');
         expect(headers['access-control-allow-headers']).toBeDefined();
+    });
+
+    it('Access-Control-Allow-Headers always includes Authorization', async () => {
+        const { headers } = await rawRequest(baseUrl, '/api/processes');
+        expect(String(headers['access-control-allow-headers'])).toContain('Authorization');
+    });
+
+    it('OPTIONS response includes PUT method', async () => {
+        const { headers } = await rawRequest(baseUrl, '/api/processes', { method: 'OPTIONS' });
+        expect(String(headers['access-control-allow-methods'])).toContain('PUT');
+    });
+
+    it('reflects localhost origin and sets credentials header', async () => {
+        const localhostOrigin = `http://localhost:${new URL(baseUrl).port}`;
+        const { headers } = await rawRequest(baseUrl, '/api/processes', { origin: localhostOrigin });
+        expect(headers['access-control-allow-origin']).toBe(localhostOrigin);
+        expect(headers['access-control-allow-credentials']).toBe('true');
+    });
+
+    it('reflects 127.0.0.1 origin and sets credentials header', async () => {
+        const loopback = `http://127.0.0.1:${new URL(baseUrl).port}`;
+        const { headers } = await rawRequest(baseUrl, '/api/processes', { origin: loopback });
+        expect(headers['access-control-allow-origin']).toBe(loopback);
+        expect(headers['access-control-allow-credentials']).toBe('true');
+    });
+
+    it('unknown origin gets wildcard (no credentials)', async () => {
+        const { headers } = await rawRequest(baseUrl, '/api/processes', { origin: 'https://evil.example.com' });
+        expect(headers['access-control-allow-origin']).toBe('*');
+        expect(headers['access-control-allow-credentials']).toBeUndefined();
+    });
+
+    it('OPTIONS preflight from localhost reflects origin', async () => {
+        const localhostOrigin = `http://localhost:${new URL(baseUrl).port}`;
+        const { status, headers } = await rawRequest(baseUrl, '/api/processes', { method: 'OPTIONS', origin: localhostOrigin });
+        expect(status).toBe(204);
+        expect(headers['access-control-allow-origin']).toBe(localhostOrigin);
+    });
+
+    it('OPTIONS preflight from unknown origin gets wildcard', async () => {
+        const { status, headers } = await rawRequest(baseUrl, '/api/processes', { method: 'OPTIONS', origin: 'https://remote.devtunnels.ms' });
+        expect(status).toBe(204);
+        expect(headers['access-control-allow-origin']).toBe('*');
     });
 });

--- a/packages/coc/test/server/route-utils.test.ts
+++ b/packages/coc/test/server/route-utils.test.ts
@@ -1,0 +1,334 @@
+/**
+ * route-utils unit tests
+ *
+ * Covers: asString, asInt, asBool, and the createRoute() wrapper.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as http from 'http';
+import { asString, asInt, asBool, createRoute } from '../../src/server/routes/route-utils';
+
+// ============================================================================
+// asString
+// ============================================================================
+
+describe('asString', () => {
+    it('returns the string value when given a string', () => {
+        expect(asString('hello')).toBe('hello');
+    });
+
+    it('returns the first element when given a string array', () => {
+        expect(asString(['a', 'b'])).toBe('a');
+    });
+
+    it('returns undefined when given undefined and no fallback', () => {
+        expect(asString(undefined)).toBeUndefined();
+    });
+
+    it('returns fallback when given undefined', () => {
+        expect(asString(undefined, 'default')).toBe('default');
+    });
+
+    it('returns fallback when given an empty array', () => {
+        // empty array: Array.isArray is true, v[0] is undefined
+        expect(asString([], 'default')).toBe('default');
+    });
+
+    it('returns the string even when a fallback is provided', () => {
+        expect(asString('value', 'fallback')).toBe('value');
+    });
+});
+
+// ============================================================================
+// asInt
+// ============================================================================
+
+describe('asInt', () => {
+    it('parses a valid integer string', () => {
+        expect(asInt('42', 0)).toBe(42);
+    });
+
+    it('returns fallback when given undefined', () => {
+        expect(asInt(undefined, 99)).toBe(99);
+    });
+
+    it('returns fallback when the string is NaN', () => {
+        expect(asInt('not-a-number', 5)).toBe(5);
+    });
+
+    it('applies max cap when provided', () => {
+        expect(asInt('1000', 100, 500)).toBe(500);
+    });
+
+    it('does not cap when value is below max', () => {
+        expect(asInt('200', 100, 500)).toBe(200);
+    });
+
+    it('returns undefined (no overload) when value is absent and no fallback given', () => {
+        expect(asInt(undefined)).toBeUndefined();
+    });
+
+    it('uses the first element of an array', () => {
+        expect(asInt(['7', '99'], 0)).toBe(7);
+    });
+
+    it('returns fallback when array is empty', () => {
+        expect(asInt([], 3)).toBe(3);
+    });
+
+    it('handles negative integers', () => {
+        expect(asInt('-5', 0)).toBe(-5);
+    });
+});
+
+// ============================================================================
+// asBool
+// ============================================================================
+
+describe('asBool', () => {
+    it("returns true for 'true'", () => {
+        expect(asBool('true')).toBe(true);
+    });
+
+    it("returns false for 'false'", () => {
+        expect(asBool('false')).toBe(false);
+    });
+
+    it('returns the fallback (default false) for undefined', () => {
+        expect(asBool(undefined)).toBe(false);
+    });
+
+    it('returns custom fallback for undefined', () => {
+        expect(asBool(undefined, true)).toBe(true);
+    });
+
+    it('returns the fallback for an unrecognised string', () => {
+        expect(asBool('yes')).toBe(false);
+        expect(asBool('1')).toBe(false);
+    });
+
+    it('uses the first element of an array', () => {
+        expect(asBool(['true', 'false'])).toBe(true);
+    });
+});
+
+// ============================================================================
+// createRoute — helpers
+// ============================================================================
+
+/** Build a minimal fake IncomingMessage with the given url. */
+function fakeReq(url: string): http.IncomingMessage {
+    return { url } as unknown as http.IncomingMessage;
+}
+
+interface ResponseCapture {
+    statusCode: number | undefined;
+    body: string | undefined;
+    headers: Record<string, string | number>;
+    ended: boolean;
+}
+
+/** Build a fake ServerResponse that captures writes. */
+function fakeRes(): { res: http.ServerResponse; capture: ResponseCapture } {
+    const capture: ResponseCapture = {
+        statusCode: undefined,
+        body: undefined,
+        headers: {},
+        ended: false,
+    };
+    const res = {
+        headersSent: false,
+        writeHead(code: number, hdrs?: Record<string, string | number>) {
+            capture.statusCode = code;
+            if (hdrs) Object.assign(capture.headers, hdrs);
+            (this as any).headersSent = true;
+        },
+        end(data?: string | Buffer) {
+            if (data !== undefined) {
+                capture.body = typeof data === 'string' ? data : data.toString('utf-8');
+            }
+            capture.ended = true;
+        },
+        write() {},
+        // attach req so gzip logic works
+        req: fakeReq('/'),
+    } as unknown as http.ServerResponse;
+    return { res, capture };
+}
+
+// ============================================================================
+// createRoute — behaviour tests
+// ============================================================================
+
+describe('createRoute', () => {
+    it('sends a JSON 200 response when handler returns a value', async () => {
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/test',
+            handler: async () => ({ ok: true }),
+        });
+
+        const { res, capture } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/test'), res, undefined);
+
+        expect(capture.statusCode).toBe(200);
+        expect(JSON.parse(capture.body!)).toEqual({ ok: true });
+    });
+
+    it('uses the provided statusCode', async () => {
+        const route = createRoute({
+            method: 'POST',
+            pattern: '/api/jobs',
+            statusCode: 202,
+            handler: async () => ({ jobId: 'j1' }),
+        });
+
+        const { res, capture } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/jobs'), res, undefined);
+
+        expect(capture.statusCode).toBe(202);
+        expect(JSON.parse(capture.body!)).toEqual({ jobId: 'j1' });
+    });
+
+    it('does not send a response when handler returns void', async () => {
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/void',
+            handler: async ({ res }) => {
+                // manually send the response
+                res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end('{"manual":true}');
+            },
+        });
+
+        const { res, capture } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/void'), res, undefined);
+
+        // The wrapper must not overwrite the manually-sent response
+        expect(capture.statusCode).toBe(200);
+        expect(JSON.parse(capture.body!)).toEqual({ manual: true });
+    });
+
+    it('calls handleAPIError when the handler throws an Error', async () => {
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/throw',
+            handler: async () => {
+                throw new Error('something went wrong');
+            },
+        });
+
+        const { res, capture } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/throw'), res, undefined);
+
+        expect(capture.statusCode).toBe(500);
+        const body = JSON.parse(capture.body!);
+        expect(body).toHaveProperty('error');
+    });
+
+    it('returns the API error statusCode when the handler throws an APIError', async () => {
+        // Dynamically import to get the real APIError class
+        const { APIError } = await import('../../src/server/errors');
+
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/missing',
+            handler: async () => {
+                throw new APIError(404, 'Resource not found', 'NOT_FOUND');
+            },
+        });
+
+        const { res, capture } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/missing'), res, undefined);
+
+        expect(capture.statusCode).toBe(404);
+        const body = JSON.parse(capture.body!);
+        expect(body.error).toBe('Resource not found');
+        expect(body.code).toBe('NOT_FOUND');
+    });
+
+    it('passes typed query params from parseQuery to the handler', async () => {
+        let received: { limit: number; search: string | undefined } | undefined;
+
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/items',
+            parseQuery: (q) => ({
+                limit: asInt(q.limit, 10, 100),
+                search: asString(q.search),
+            }),
+            handler: async ({ query }) => {
+                received = query;
+                return { ok: true };
+            },
+        });
+
+        const { res } = fakeRes();
+        await (route.handler as Function)(
+            fakeReq('/api/items?limit=50&search=hello'),
+            res,
+            undefined,
+        );
+
+        expect(received?.limit).toBe(50);
+        expect(received?.search).toBe('hello');
+    });
+
+    it('caps the integer via asInt max when provided', async () => {
+        let received: { limit: number } | undefined;
+
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/items',
+            parseQuery: (q) => ({ limit: asInt(q.limit, 10, 100) }),
+            handler: async ({ query }) => {
+                received = query;
+                return {};
+            },
+        });
+
+        const { res } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/items?limit=9999'), res, undefined);
+
+        expect(received?.limit).toBe(100);
+    });
+
+    it('passes the match array to the handler', async () => {
+        let capturedMatch: RegExpMatchArray | undefined;
+
+        const route = createRoute({
+            pattern: /^\/api\/items\/([^/]+)$/,
+            handler: async ({ match }) => {
+                capturedMatch = match;
+                return { id: match[1] };
+            },
+        });
+
+        const match = '/api/items/abc123'.match(/^\/api\/items\/([^/]+)$/)!;
+        const { res } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/items/abc123'), res, match);
+
+        expect(capturedMatch![1]).toBe('abc123');
+    });
+
+    it('does not double-send when headersSent is already true', async () => {
+        const writeSpy = vi.fn();
+
+        const route = createRoute({
+            method: 'GET',
+            pattern: '/api/test',
+            handler: async ({ res }) => {
+                res.writeHead(200, {});
+                res.end('{"first":true}');
+                return { second: true }; // should be ignored
+            },
+        });
+
+        const { res, capture } = fakeRes();
+        await (route.handler as Function)(fakeReq('/api/test'), res, undefined);
+
+        // writeHead was called once (manually); the wrapper must not call it again
+        expect(capture.statusCode).toBe(200);
+        expect(capture.body).toBe('{"first":true}');
+    });
+});

--- a/packages/coc/test/server/wiki-static-cors.test.ts
+++ b/packages/coc/test/server/wiki-static-cors.test.ts
@@ -66,8 +66,13 @@ function request(
 
 function assertCorsHeaders(headers: Record<string, string>): void {
     expect(headers['access-control-allow-origin']).toBe('*');
-    expect(headers['access-control-allow-methods']).toBe('GET, POST, PATCH, DELETE, OPTIONS');
-    expect(headers['access-control-allow-headers']).toBe('Content-Type');
+    expect(headers['access-control-allow-methods']).toContain('GET');
+    expect(headers['access-control-allow-methods']).toContain('POST');
+    expect(headers['access-control-allow-methods']).toContain('DELETE');
+    expect(headers['access-control-allow-methods']).toContain('OPTIONS');
+    expect(headers['access-control-allow-methods']).toContain('PUT');
+    expect(headers['access-control-allow-headers']).toContain('Content-Type');
+    expect(headers['access-control-allow-headers']).toContain('Authorization');
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/coc/test/spa/react/admin/PromptsPanel.test.tsx
+++ b/packages/coc/test/spa/react/admin/PromptsPanel.test.tsx
@@ -100,7 +100,7 @@ describe('PromptsPanel', () => {
 
         await waitFor(() => {
             expect(screen.getByText('Prompt Templates')).toBeDefined();
-            expect(screen.getByText(/read-only in this view/)).toBeDefined();
+            expect(screen.getByText(/Ralph prompts are editable/)).toBeDefined();
         });
     });
 


### PR DESCRIPTION
## Summary
- add admin-configurable Ralph prompt overrides and wire them through Ralph execution
- refactor server route handlers onto shared route utilities and CORS helpers
- make sync-engine file operations async and update related tests

## Included commits
- fe00e630452a1671230473d48b72bd027a876d75 refactor(coc): extract createRoute utility and migrate route handlers
- d5a76b5597390a4626c9059a78feee0a6662c2c2 refactor(coc): migrate api-git-commit-routes to createRoute
- 051e06e2bfde427ab6ba95dfe95c1e487e2bfec8 refactor(cors): consolidate CORS into shared/cors.ts
- 9a5eaf93c3b2a7d4c75fa5dcd569a731db2f05e5 refactor(sync-engine): replace blocking I/O with async equivalents
- e9962648bf6d78138d4c415854008df65f6b6307 fix: update PromptsPanel test for new header description text
- c23388da2f103f990ceeeabfd7136afac07e5bf5 feat: tunable Ralph prompts via admin UI

## Testing
- Not run; submitting existing requested commits as a PR.