### PR TITLE
pr/40ddcc1bc featac 01 live codexenabled always init

### DIFF
--- a/packages/coc-client/src/client.ts
+++ b/packages/coc-client/src/client.ts
@@ -1,4 +1,4 @@
-import { AdminClient, DbBrowserClient, ExplorerClient, GitClient, HealthClient, LoopsClient, MemoryClient, ModelsClient, NotesClient, PreferencesClient, ProcessesClient, PromptHistoryClient, PullRequestsClient, QueueClient, SchedulesClient, SeenStateClient, ServersClient, SkillsClient, StatsClient, SuggestionsClient, SyncClient, TasksClient, TemplatesClient, WikiClient, WorkflowClient, WorkItemsClient, WorkspacesClient } from './domains';
+import { AdminClient, AgentProvidersClient, DbBrowserClient, ExplorerClient, GitClient, HealthClient, LoopsClient, MemoryClient, ModelsClient, NotesClient, PreferencesClient, ProcessesClient, PromptHistoryClient, PullRequestsClient, QueueClient, SchedulesClient, SeenStateClient, ServersClient, SkillsClient, StatsClient, SuggestionsClient, SyncClient, TasksClient, TemplatesClient, WikiClient, WorkflowClient, WorkItemsClient, WorkspacesClient } from './domains';
 import { HttpTransport, normalizeOptions } from './http';
 import { EventsClient } from './realtime';
 import type { CocClientOptions, CocRequestOptions, NormalizedCocClientOptions } from './types';
@@ -6,6 +6,7 @@ import type { CocClientOptions, CocRequestOptions, NormalizedCocClientOptions } 
 export class CocClient {
   readonly options: NormalizedCocClientOptions;
   readonly admin: AdminClient;
+  readonly agentProviders: AgentProvidersClient;
   readonly dbBrowser: DbBrowserClient;
   readonly explorer: ExplorerClient;
   readonly git: GitClient;
@@ -41,6 +42,7 @@ export class CocClient {
     this.options = normalizeOptions(options);
     this.transport = new HttpTransport(this.options);
     this.admin = new AdminClient(this.transport, this.options);
+    this.agentProviders = new AgentProvidersClient(this.transport);
     this.dbBrowser = new DbBrowserClient(this.transport);
     this.explorer = new ExplorerClient(this.transport);
     this.git = new GitClient(this.transport);

--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -268,6 +268,34 @@ export interface AdminStorageCancelMigrationResponse {
   success: boolean;
 }
 
+// ── Agent Providers types ──────────────────────────────────────────
+
+/** Wire-format identifier for an AI agent provider. */
+export type AgentProviderId = 'copilot' | 'codex';
+
+/** Status of a single agent provider as returned by GET /api/agent-providers. */
+export interface AgentProviderStatus {
+  /** Provider identifier. */
+  id: AgentProviderId;
+  /** Human-readable name shown in the UI. */
+  label: string;
+  /** Whether the provider is enabled by admin config. Copilot is always true. */
+  enabled: boolean;
+  /** Whether the provider is actually usable right now (enabled + auth OK). */
+  available: boolean;
+  /** When true the provider cannot be disabled by the admin. Copilot only. */
+  locked?: boolean;
+  /** Human-readable reason when enabled but not available (e.g. auth required). */
+  reason?: string;
+  /** URL to start the auth flow when auth is required or expired. */
+  authUrl?: string;
+}
+
+/** Response from GET /api/agent-providers. */
+export interface AgentProvidersResponse {
+  providers: AgentProviderStatus[];
+}
+
 // ── Built-in Prompts types ──────────────────────────────────────────
 
 export interface BuiltInPrompt {

--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -330,3 +330,33 @@ export interface AdminPromptDeleteResponse {
   id: string;
   reset: true;
 }
+
+// ── Agent Providers Quota types ──────────────────────────────────────────
+
+/** A single quota-type snapshot for an agent provider. */
+export interface ProviderQuotaType {
+  /** Quota category name, e.g. "chat", "completions". */
+  type: string;
+  isUnlimitedEntitlement: boolean;
+  usedRequests: number;
+  entitlementRequests: number;
+  /** 0.0–1.0, percentage of quota remaining. */
+  remainingPercentage: number;
+  usageAllowedWithExhaustedQuota: boolean;
+  overage: number;
+  /** ISO 8601 reset date, if known. */
+  resetDate?: string;
+}
+
+/** Quota information for one provider returned by GET /api/agent-providers/quota. */
+export interface ProviderQuotaResult {
+  id: AgentProviderId;
+  quotaTypes: ProviderQuotaType[];
+  /** Set when the provider quota could not be fetched. */
+  error?: string;
+}
+
+/** Response from GET /api/agent-providers/quota. */
+export interface AgentProvidersQuotaResponse {
+  providers: ProviderQuotaResult[];
+}

--- a/packages/coc-client/src/contracts/preferences.ts
+++ b/packages/coc-client/src/contracts/preferences.ts
@@ -41,6 +41,8 @@ export interface PerRepoPreferences {
   defaultModels?: Record<string, string | undefined>;
   /** Max iterations a Ralph loop runs before stopping. Range 1..200. */
   maxRalphIterations?: number;
+  /** Last agent provider selected for new chats in this workspace. Persisted per-repo. */
+  lastChatProvider?: 'copilot' | 'codex';
   boundedMemory?: {
     enabled?: boolean;
     charLimit?: number;

--- a/packages/coc-client/src/domains/admin.ts
+++ b/packages/coc-client/src/domains/admin.ts
@@ -20,6 +20,7 @@ import type {
   AdminTokenResponse,
   AdminVersionResponse,
   AdminWipeResponse,
+  AgentProvidersQuotaResponse,
 } from '../contracts';
 import type { CocRequestOptions, NormalizedCocClientOptions, QueryPrimitive, RequestAdapter } from '../types';
 import { buildApiUrl } from '../url';
@@ -160,6 +161,10 @@ export class AdminClient {
       body: { path: options.path },
       signal: options.signal,
     });
+  }
+
+  getAgentProvidersQuota(): Promise<AgentProvidersQuotaResponse> {
+    return this.transport.request<AgentProvidersQuotaResponse>('/agent-providers/quota');
   }
 
   private fetchRaw(path: string, options: {

--- a/packages/coc-client/src/domains/agent-providers.ts
+++ b/packages/coc-client/src/domains/agent-providers.ts
@@ -1,0 +1,10 @@
+import type { AgentProvidersResponse } from '../contracts';
+import type { RequestAdapter } from '../types';
+
+export class AgentProvidersClient {
+  constructor(private readonly transport: RequestAdapter) {}
+
+  list(): Promise<AgentProvidersResponse> {
+    return this.transport.request<AgentProvidersResponse>('/agent-providers');
+  }
+}

--- a/packages/coc-client/src/domains/index.ts
+++ b/packages/coc-client/src/domains/index.ts
@@ -1,4 +1,5 @@
 export { AdminClient } from './admin';
+export { AgentProvidersClient } from './agent-providers';
 export { DbBrowserClient } from './db-browser';
 export { ExplorerClient } from './explorer';
 export { GitClient } from './git';

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -214,10 +214,10 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
     bool('codex.enabled', (cfg, v) => {
         if (!cfg.codex) { cfg.codex = {}; }
         cfg.codex.enabled = v;
-    }, 'restartRequired'),
+    }),
     {
         key: 'activeProvider',
-        runtime: 'restartRequired',
+        runtime: 'live',
         validate: (v) => v === 'copilot' || v === 'codex'
             ? undefined
             : 'activeProvider must be "copilot" or "codex"',

--- a/packages/coc/src/server/agent-providers/agent-providers-routes.ts
+++ b/packages/coc/src/server/agent-providers/agent-providers-routes.ts
@@ -1,0 +1,87 @@
+/**
+ * Agent Providers REST API Routes
+ *
+ * GET /api/agent-providers
+ *   Returns enabled/available status for Copilot and Codex so the
+ *   New Chat UI and Admin page can show live provider state without a
+ *   server restart.
+ *
+ * Copilot is always enabled, available, and locked.
+ * Codex status is derived from:
+ *   - `codex.enabled` in live runtime config (enabled flag)
+ *   - Codex auth store (available flag; requires authenticated status)
+ */
+
+import type { Route } from '../types';
+import { sendJson } from '../shared/router';
+import type { RuntimeConfigService } from '../../config/runtime-config-service';
+import type { CodexAuthInfo } from '../codex-auth/codex-auth-store';
+import type { AgentProviderStatus, AgentProvidersResponse } from '@plusplusoneplusplus/coc-client';
+
+export interface AgentProvidersRouteContext {
+    runtimeConfigService: RuntimeConfigService;
+    /** Reads current Codex auth info. Returns unauthenticated info if Codex infra is absent. */
+    getCodexAuthInfo: () => CodexAuthInfo;
+    /** The base URL prefix used to build authUrl (e.g. 'http://localhost:4000'). */
+    serverBaseUrl: string;
+}
+
+/** Build the providers array from live config + auth state. Exported for unit testing. */
+export function buildAgentProvidersResponse(ctx: AgentProvidersRouteContext): AgentProvidersResponse {
+    const config = ctx.runtimeConfigService.config;
+    const codexEnabled = config.codex?.enabled ?? false;
+
+    const copilot: AgentProviderStatus = {
+        id: 'copilot',
+        label: 'Copilot',
+        enabled: true,
+        available: true,
+        locked: true,
+    };
+
+    let codexProvider: AgentProviderStatus;
+    if (!codexEnabled) {
+        codexProvider = {
+            id: 'codex',
+            label: 'Codex',
+            enabled: false,
+            available: false,
+        };
+    } else {
+        const authInfo: CodexAuthInfo = ctx.getCodexAuthInfo();
+        const authenticated = authInfo.status === 'authenticated';
+        if (authenticated) {
+            codexProvider = {
+                id: 'codex',
+                label: 'Codex',
+                enabled: true,
+                available: true,
+            };
+        } else {
+            const reason = authInfo.status === 'expired'
+                ? 'Codex authentication has expired.'
+                : 'Codex authentication required.';
+            codexProvider = {
+                id: 'codex',
+                label: 'Codex',
+                enabled: true,
+                available: false,
+                reason,
+                authUrl: `${ctx.serverBaseUrl}/api/codex-auth/start`,
+            };
+        }
+    }
+
+    return { providers: [copilot, codexProvider] };
+}
+
+export function registerAgentProvidersRoutes(routes: Route[], ctx: AgentProvidersRouteContext): void {
+    routes.push({
+        method: 'GET',
+        pattern: '/api/agent-providers',
+        handler: (_req, res) => {
+            const body = buildAgentProvidersResponse(ctx);
+            sendJson(res, body);
+        },
+    });
+}

--- a/packages/coc/src/server/agent-providers/agent-providers-routes.ts
+++ b/packages/coc/src/server/agent-providers/agent-providers-routes.ts
@@ -16,7 +16,8 @@ import type { Route } from '../types';
 import { sendJson } from '../shared/router';
 import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import type { CodexAuthInfo } from '../codex-auth/codex-auth-store';
-import type { AgentProviderStatus, AgentProvidersResponse } from '@plusplusoneplusplus/coc-client';
+import type { AgentProviderStatus, AgentProvidersResponse, AgentProvidersQuotaResponse, ProviderQuotaType } from '@plusplusoneplusplus/coc-client';
+import type { CopilotSDKService } from '@plusplusoneplusplus/forge';
 
 export interface AgentProvidersRouteContext {
     runtimeConfigService: RuntimeConfigService;
@@ -24,6 +25,8 @@ export interface AgentProvidersRouteContext {
     getCodexAuthInfo: () => CodexAuthInfo;
     /** The base URL prefix used to build authUrl (e.g. 'http://localhost:4000'). */
     serverBaseUrl: string;
+    /** Optional: getter for Copilot account quota. Used by the quota endpoint. */
+    getCopilotSdkService?: () => CopilotSDKService;
 }
 
 /** Build the providers array from live config + auth state. Exported for unit testing. */
@@ -81,6 +84,51 @@ export function registerAgentProvidersRoutes(routes: Route[], ctx: AgentProvider
         pattern: '/api/agent-providers',
         handler: (_req, res) => {
             const body = buildAgentProvidersResponse(ctx);
+            sendJson(res, body);
+        },
+    });
+
+    routes.push({
+        method: 'GET',
+        pattern: '/api/agent-providers/quota',
+        handler: async (_req, res) => {
+            const config = ctx.runtimeConfigService.config;
+            const codexEnabled = config.codex?.enabled ?? false;
+
+            const providers: AgentProvidersQuotaResponse['providers'] = [];
+
+            // Copilot quota
+            try {
+                const sdkService = ctx.getCopilotSdkService?.();
+                if (!sdkService) {
+                    providers.push({ id: 'copilot', quotaTypes: [], error: 'Copilot SDK service not available' });
+                } else {
+                    const result = await sdkService.getAccountQuota();
+                    const quotaTypes: ProviderQuotaType[] = Object.entries(result.quotaSnapshots).map(
+                        ([type, snap]) => ({
+                            type,
+                            isUnlimitedEntitlement: snap.isUnlimitedEntitlement,
+                            usedRequests: snap.usedRequests,
+                            entitlementRequests: snap.entitlementRequests,
+                            remainingPercentage: snap.remainingPercentage,
+                            usageAllowedWithExhaustedQuota: snap.usageAllowedWithExhaustedQuota,
+                            overage: snap.overage,
+                            resetDate: snap.resetDate,
+                        }),
+                    );
+                    providers.push({ id: 'copilot', quotaTypes });
+                }
+            } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : String(err);
+                providers.push({ id: 'copilot', quotaTypes: [], error: msg });
+            }
+
+            // Codex quota — SDK has no quota method; silently return empty
+            if (codexEnabled) {
+                providers.push({ id: 'codex', quotaTypes: [] });
+            }
+
+            const body: AgentProvidersQuotaResponse = { providers };
             sendJson(res, body);
         },
     });

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -45,7 +45,7 @@ import {
     rewriteLargePrompt,
     toQueueProcessId,
 } from '@plusplusoneplusplus/forge';
-import type { ChatPayload } from '../tasks/task-types';
+import type { ChatPayload, ChatProvider } from '../tasks/task-types';
 import { saveImagesToTempFiles, cleanupTempDir, rehydrateImagesIfNeeded } from './image-store';
 import type { BroadcastWorkItemFn } from '../llm-tools/create-work-item-tool';
 import { BaseExecutor } from './base-executor';
@@ -143,6 +143,12 @@ export interface ChatModeExecutorOptions {
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     /** Active AI provider. Used to detect provider mismatches on follow-up resume. */
     provider?: 'copilot' | 'codex';
+    /**
+     * Resolve an ISDKService for a given provider name, checking enablement and
+     * availability. Throws with a user-facing message if the provider is disabled
+     * or unavailable. Falls back to sdkServiceRegistry lookup when omitted.
+     */
+    resolveAiServiceForProvider?: (provider: ChatProvider) => ISDKService;
 }
 
 /** Return type for the AI call result. */
@@ -185,6 +191,8 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
     protected readonly getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     /** Active AI provider — used to guard against provider mismatches on follow-up resume. */
     protected readonly provider: 'copilot' | 'codex';
+    /** Resolves per-task SDK service by provider, checking enablement. Optional — falls back to sdkServiceRegistry. */
+    protected readonly resolveAiServiceForProvider?: (provider: ChatProvider) => ISDKService;
 
     constructor(store: ProcessStore, options: ChatModeExecutorOptions, dataDir?: string) {
         super(store, dataDir);
@@ -200,6 +208,25 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
         this.getLoopInfra = options.getLoopInfra;
         this.getMcpOauthManager = options.getMcpOauthManager;
         this.provider = options.provider ?? 'copilot';
+        this.resolveAiServiceForProvider = options.resolveAiServiceForProvider;
+    }
+
+    /**
+     * Resolve the ISDKService to use for a given provider.
+     * Uses the injected resolveAiServiceForProvider callback when present;
+     * otherwise falls back to this.aiService (backward-compatible test path).
+     * In production, resolveAiServiceForProvider is always provided by the server
+     * and performs live enablement + registry lookup.
+     */
+    protected getAiServiceForProvider(provider: ChatProvider): ISDKService {
+        if (this.resolveAiServiceForProvider) {
+            return this.resolveAiServiceForProvider(provider);
+        }
+        // Fallback: use the default aiService injected at construction time.
+        // This preserves backward compatibility for tests that inject aiService
+        // directly without the resolveAiServiceForProvider callback.
+        // In production, resolveAiServiceForProvider is always injected.
+        return this.aiService;
     }
 
     /**
@@ -471,9 +498,15 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
                 }
             }
 
-            const availability = await this.aiService.isAvailable();
+            // Resolve the AI service for this specific chat task's provider.
+            // Falls back to this.aiService when no resolveAiServiceForProvider callback is set.
+            const taskProvider: ChatProvider = payload.provider ?? 'copilot';
+            const effectiveAiService: ISDKService = this.getAiServiceForProvider(taskProvider);
+
+            const availability = await effectiveAiService.isAvailable();
             if (!availability.available) {
-                throw new Error(`Copilot SDK not available: ${availability.error || 'unknown reason'}`);
+                const label = taskProvider === 'codex' ? 'Codex' : 'Copilot';
+                throw new Error(`${label} SDK not available: ${availability.error || 'unknown reason'}`);
             }
 
             const timeoutMs = task.config.timeoutMs || this.defaultTimeoutMs;
@@ -612,7 +645,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
             };
 
             let result: SDKInvocationResult;
-            result = await this.aiService.sendMessage(sendOptions) as SDKInvocationResult;
+            result = await effectiveAiService.sendMessage(sendOptions) as SDKInvocationResult;
 
             if (!result.success) {
                 throw new Error(result.error || 'AI execution failed');

--- a/packages/coc/src/server/executors/executor-registry.ts
+++ b/packages/coc/src/server/executors/executor-registry.ts
@@ -38,6 +38,12 @@ export interface ExecutorRegistryOptions {
     memoryPromotion?: MemoryPromoteConfig;
     /** Active AI provider name recorded on each process for attribution. Defaults to 'copilot'. */
     provider?: 'copilot' | 'codex';
+    /**
+     * Resolve an ISDKService for a given provider, checking enablement.
+     * Injected from the bridge so executors can route per-chat without
+     * receiving the RuntimeConfigService directly.
+     */
+    resolveAiServiceForProvider?: (provider: import('../tasks/task-types').ChatProvider) => ISDKService;
     toolCallCacheStore: FileToolCallCacheStore;
     resolveSkillConfig: (wsId: string | undefined, workDir?: string) => Promise<{ skillDirectories?: string[]; disabledSkills?: string[] }>;
     resolveWorkspaceIdForPath: (rootPath: string) => Promise<string>;
@@ -100,6 +106,7 @@ export class ExecutorRegistry {
             getLoopInfra: options.getLoopInfra,
             getMcpOauthManager: options.getMcpOauthManager,
             provider: options.provider,
+            resolveAiServiceForProvider: options.resolveAiServiceForProvider,
         };
 
         this.strategyRegistry = new TaskStrategyRegistry();

--- a/packages/coc/src/server/executors/follow-up-executor.ts
+++ b/packages/coc/src/server/executors/follow-up-executor.ts
@@ -23,7 +23,7 @@ import type {
     SystemMessageConfig,
     TurnSource,
 } from '@plusplusoneplusplus/forge';
-import type { ChatMode } from '../tasks/task-types';
+import type { ChatMode, ChatProvider } from '../tasks/task-types';
 import {
     approveAllPermissions,
     getLogger,
@@ -144,17 +144,15 @@ export class FollowUpExecutor extends ChatBaseExecutor {
             throw new Error(`Process not found: ${processId}`);
         }
 
-        // AC-10 — Provider mismatch guard: reject follow-up if the session was
-        // created by a different provider than the one currently active.
-        const sessionProvider = (process.metadata?.provider as string | undefined) ?? 'copilot';
-        if (sessionProvider !== this.provider) {
-            const sessionProviderLabel = sessionProvider === 'codex' ? 'Codex' : 'Copilot';
-            const activeProviderLabel = this.provider === 'codex' ? 'Codex' : 'Copilot';
-            throw new Error(
-                `Provider mismatch: this session was created with ${sessionProviderLabel} but the active provider is ${activeProviderLabel}. ` +
-                `Switch the active provider back to ${sessionProviderLabel} in admin settings, or start a new session.`,
-            );
-        }
+        // AC-04 — Use the original chat's provider for follow-ups.
+        // Read provider from process metadata (set at creation time). Processes
+        // created before this feature had no provider metadata; default to 'copilot'.
+        const sessionProvider: ChatProvider = ((process.metadata?.provider as string | undefined) ?? 'copilot') as ChatProvider;
+
+        // Resolve the AI service for this provider. This also checks that the
+        // provider is still enabled — if not, it throws a clear error that blocks
+        // the new follow-up turn without affecting already-running turns.
+        const followUpAiService = this.getAiServiceForProvider(sessionProvider);
 
         const workingDirectory = process.workingDirectory || this.defaultWorkingDirectory;
 
@@ -233,7 +231,7 @@ export class FollowUpExecutor extends ChatBaseExecutor {
                         await flushMemories({
                             turns: process.conversationTurns ?? [],
                             memoryStore,
-                            aiService: this.aiService,
+                            aiService: followUpAiService,
                             minTurns: 0,
                             timeoutMs: 30_000,
                         });
@@ -394,7 +392,7 @@ export class FollowUpExecutor extends ChatBaseExecutor {
             };
 
             let result: SDKInvocationResult;
-            result = await this.aiService.sendMessage(sendOptions) as SDKInvocationResult;
+            result = await followUpAiService.sendMessage(sendOptions) as SDKInvocationResult;
 
             if (resolvedDeliveryMode === 'immediate') {
                 const turnIndex = process.conversationTurns?.length ?? 0;

--- a/packages/coc/src/server/executors/process-lifecycle-runner.ts
+++ b/packages/coc/src/server/executors/process-lifecycle-runner.ts
@@ -324,7 +324,9 @@ export class ProcessLifecycleRunner extends BaseExecutor {
                 model: task.config.model,
                 mode: payload?.mode,
                 workspaceId: payload?.workspaceId || task.repoId,
-                provider: this.provider,
+                // Use per-task provider from payload when available; fall back to
+                // the server-level default (this.provider) set at startup.
+                provider: (isChatPayload(task.payload) ? (task.payload as ChatPayload).provider : undefined) ?? this.provider,
                 workflowName: isRunWorkflowPayload(task.payload)
                     ? path.basename(task.payload.workflowPath)
                     : undefined,

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -198,22 +198,21 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     const mcpOauthEnabled = resolvedConfig.mcpOauth?.enabled ?? true;
     const mcpOauthInfra = mcpOauthEnabled ? createMcpOauthInfrastructure() : undefined;
 
-    // Codex Auth infra — only created when the codex feature flag is enabled.
-    // The auth checker is injected into the CodexSDKService so sendMessage
-    // returns an auth-required error (AC-08) when the user has not signed in.
-    const codexEnabled = resolvedConfig.codex?.enabled ?? false;
-    let codexAuthInfra: ReturnType<typeof createCodexAuthInfrastructure> | undefined;
-    if (codexEnabled) {
-        codexAuthInfra = createCodexAuthInfrastructure({ dataDir });
-        // Register the Codex provider with an auth checker that gates sendMessage
-        registerCodexSDKService(() => {
-            const info = codexAuthInfra!.store.readInfo();
-            return {
-                authenticated: info.status === 'authenticated',
-                authUrl: 'http://localhost:' + (options.port ?? 4000) + '/api/codex-auth/start',
-            };
-        });
-    }
+    // Codex Auth infra — always created so the auth system is ready for live
+    // enablement via admin config. Previously gated on codex.enabled at startup;
+    // the /api/agent-providers endpoint and per-chat provider routing need it
+    // available regardless of the current enabled flag.
+    const codexAuthInfra = createCodexAuthInfrastructure({ dataDir });
+    // Register the Codex provider unconditionally with an auth checker that
+    // gates sendMessage. This allows per-chat routing to resolve Codex even
+    // when it was enabled after startup.
+    registerCodexSDKService(() => {
+        const info = codexAuthInfra.store.readInfo();
+        return {
+            authenticated: info.status === 'authenticated',
+            authUrl: 'http://localhost:' + (options.port ?? 4000) + '/api/codex-auth/start',
+        };
+    });
 
     const requestedProvider = resolvedConfig.activeProvider === 'codex' ? 'codex' : 'copilot';
     const effectiveProvider = requestedProvider === 'codex' && sdkServiceRegistry.has(SDK_PROVIDER_CODEX)
@@ -435,10 +434,12 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         loopStore: loopInfra?.loopStore,
         loopExecutor: loopInfra?.loopExecutor,
         mcpOauthManager: mcpOauthInfra?.manager,
-        codexAuthManager: codexAuthInfra?.manager,
+        codexAuthManager: codexAuthInfra.manager,
+        codexAuthStore: codexAuthInfra.store,
         loopEmit: loopInfra?.emit,
         hostname: os.hostname(),
         bindAddress: host,
+        serverPort: port,
         syncEngines,
     });
     // Restore auto-commit timers for all workspaces that had it enabled
@@ -548,7 +549,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
             loopExecutor: loopInfra?.loopExecutor,
             loopInfraDispose: loopInfra?.dispose,
             mcpOauthDispose: mcpOauthInfra?.dispose,
-            codexAuthDispose: codexAuthInfra?.dispose,
+            codexAuthDispose: codexAuthInfra.dispose,
             syncEngines,
             activeSockets, server,
         }),

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -225,6 +225,24 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         effectiveProvider === 'codex' ? SDK_PROVIDER_CODEX : SDK_PROVIDER_COPILOT,
     );
 
+    // Per-chat provider resolver: checks runtime enablement, then looks up the
+    // SDK service. Returns the Copilot service unconditionally; blocks Codex
+    // when codex.enabled is false in the live admin config.
+    const resolveAiServiceForProvider = (provider: import('./tasks/task-types').ChatProvider): import('@plusplusoneplusplus/forge').ISDKService => {
+        if (provider === 'codex') {
+            const liveConfig = runtimeConfigService.config;
+            if (!liveConfig.codex?.enabled) {
+                throw new Error('Codex provider is currently disabled. Enable Codex in Admin settings to use it.');
+            }
+            const svc = sdkServiceRegistry.get(SDK_PROVIDER_CODEX);
+            if (!svc) {
+                throw new Error('Codex SDK service is not available. Codex may not be installed on this server.');
+            }
+            return svc;
+        }
+        return options.aiService ?? sdkServiceRegistry.getOrThrow(SDK_PROVIDER_COPILOT);
+    };
+
     const { registry, bridge, queuePersistence, queueFacade } = createQueueInfrastructure(
         store, dataDir, { ...options, aiService: resolvedAiService }, defaultTimeoutMs,
         resolvedConfig.chat.followUpSuggestions, resolvedConfig.chat.askUser, () => wsServer,
@@ -275,6 +293,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         },
         () => mcpOauthInfra?.manager,
         effectiveProvider,
+        resolveAiServiceForProvider,
     );
 
     // Finalize any orphaned 'running' / 'cancelling' processes left behind by

--- a/packages/coc/src/server/infrastructure/queue-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/queue-infrastructure.ts
@@ -64,6 +64,7 @@ export function createQueueInfrastructure(
     getLoopInfra?: () => import('../executors/chat-base-executor').LoopInfraDeps | undefined,
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined,
     provider?: 'copilot' | 'codex',
+    resolveAiServiceForProvider?: (provider: import('../tasks/task-types').ChatProvider) => import('@plusplusoneplusplus/forge').ISDKService,
 ): QueueInfrastructure {
     // Obtain SQLite DB handle: reuse from SqliteProcessStore, or create in-memory for tests.
     let db: Database.Database;
@@ -92,6 +93,7 @@ export function createQueueInfrastructure(
         getWsServer,
         memoryPromotion,
         provider,
+        resolveAiServiceForProvider,
         initialDelayMs: options.queue?.restartPickupDelayMs,
         getLoopInfra,
         getMcpOauthManager,

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -24,6 +24,12 @@ export interface CLITaskExecutorOptions {
     memoryPromotion?: MemoryPromoteConfig;
     /** Active AI provider name recorded on each process for attribution. Defaults to 'copilot'. */
     provider?: 'copilot' | 'codex';
+    /**
+     * Resolve an ISDKService for a given provider, checking enablement.
+     * Supplied by the server so executors can perform per-chat routing without
+     * holding a direct reference to RuntimeConfigService.
+     */
+    resolveAiServiceForProvider?: (provider: import('../tasks/task-types').ChatProvider) => ISDKService;
     getWsServer?: () => import('../streaming/websocket').ProcessWebSocketServer | undefined;
     getLoopInfra?: () => import('../executors/chat-base-executor').LoopInfraDeps | undefined;
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
@@ -99,6 +105,7 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
             askUser: options.askUser,
             memoryPromotion: options.memoryPromotion,
             provider: options.provider,
+            resolveAiServiceForProvider: options.resolveAiServiceForProvider,
             toolCallCacheStore: cacheStore,
             resolveSkillConfig: skillCfg,
             resolveWorkspaceIdForPath: (p: string) => this.resolveWorkspaceIdForPath(p),

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -88,6 +88,8 @@ import { registerMcpOauthRoutes } from '../mcp-oauth';
 import type { McpOauthManager } from '../mcp-oauth';
 import { registerCodexAuthRoutes } from '../codex-auth';
 import type { CodexAuthManager } from '../codex-auth';
+import type { CodexAuthStore } from '../codex-auth';
+import { registerAgentProvidersRoutes } from '../agent-providers/agent-providers-routes';
 import { registerDiagramRoutes } from '../diagrams/diagrams-handler';
 import { registerRuntimeConfigRoutes } from '../config/runtime-config-handler';
 import { registerSyncRoutes } from '../sync/sync-handler';
@@ -138,6 +140,10 @@ export interface RegisterRoutesOptions {
     loopExecutor?: LoopExecutor;
     mcpOauthManager?: McpOauthManager;
     codexAuthManager?: CodexAuthManager;
+    /** Codex auth store used for provider status without requiring auth manager. */
+    codexAuthStore?: CodexAuthStore;
+    /** HTTP port the server is listening on (used for authUrl in agent-providers). */
+    serverPort?: number;
     loopEmit?: LoopEventEmit;
     hostname?: string;
     bindAddress?: string;
@@ -299,11 +305,23 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         });
     }
 
-    // Codex Auth routes (feature-flagged via codex.enabled)
+    // Codex Auth routes — always registered so auth flow works regardless of current
+    // codex.enabled state (user may need to authenticate before enabling).
     if (opts.codexAuthManager) {
         registerCodexAuthRoutes(routes, {
             manager: opts.codexAuthManager,
             autoOpenBrowser: true,
+        });
+    }
+
+    // Agent providers route — always registered, reads live config + auth state.
+    if (opts.runtimeConfigService) {
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: opts.runtimeConfigService,
+            getCodexAuthInfo: () => opts.codexAuthStore
+                ? opts.codexAuthStore.readInfo()
+                : { status: 'unauthenticated' },
+            serverBaseUrl: `http://localhost:${opts.serverPort ?? 4000}`,
         });
     }
 

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Route } from '../types';
 import type { ProcessStore, TaskQueueManager, ISDKService, AIInvoker } from '@plusplusoneplusplus/forge';
-import { modelMetadataStore, sdkServiceRegistry } from '@plusplusoneplusplus/forge';
+import { modelMetadataStore, sdkServiceRegistry, CopilotSDKService } from '@plusplusoneplusplus/forge';
 import type { ProcessWebSocketServer } from '../streaming/websocket';
 import type { MultiRepoQueueRouter } from '../queue/multi-repo-queue-router';
 import type { SqliteQueuePersistence } from '../queue/sqlite-queue-persistence';
@@ -322,6 +322,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
                 ? opts.codexAuthStore.readInfo()
                 : { status: 'unauthenticated' },
             serverBaseUrl: `http://localhost:${opts.serverPort ?? 4000}`,
+            getCopilotSdkService: () => CopilotSDKService.getInstance(),
         });
     }
 

--- a/packages/coc/src/server/routes/queue-shared.ts
+++ b/packages/coc/src/server/routes/queue-shared.ts
@@ -16,7 +16,7 @@ import type {
     PauseMarker,
 } from '@plusplusoneplusplus/forge';
 import { truncateDisplayName } from '../shared/queue-utils';
-import { TaskDefs, VALID_ENQUEUE_TYPES, VISIBLE_TASK_TYPE_LABELS } from '../tasks/task-types';
+import { TaskDefs, VALID_ENQUEUE_TYPES, VISIBLE_TASK_TYPE_LABELS, VALID_CHAT_PROVIDERS } from '../tasks/task-types';
 import type { MultiRepoQueueRouter } from '../queue/multi-repo-queue-router';
 import * as path from 'path';
 import type { ParsedUrlQuery } from 'querystring';
@@ -289,6 +289,13 @@ export function validateAndParseTask(taskSpec: any): TaskValidationResult {
         // unset on a follow-up is treated as a bug and surfaced as a warning
         // in FollowUpExecutor.
         if (!payload.mode && !payload.processId) payload.mode = 'autopilot';
+        // Validate provider field if present.
+        if (payload.provider !== undefined && !VALID_CHAT_PROVIDERS.has(payload.provider)) {
+            return {
+                valid: false,
+                error: `Invalid provider: '${payload.provider}'. Valid providers: ${[...VALID_CHAT_PROVIDERS].join(', ')}`,
+            };
+        }
     }
     if (taskSpec.type === TaskDefs.runScript.kind && !payload.kind) payload.kind = TaskDefs.runScript.kind;
     if (taskSpec.type === TaskDefs.runWorkflow.kind && !payload.kind) payload.kind = TaskDefs.runWorkflow.kind;

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -239,6 +239,11 @@ export function AdminPanel() {
     const [featuresSaving, setFeaturesSaving] = useState(false);
     const [activeProviderSaving, setActiveProviderSaving] = useState(false);
 
+    // Quota state
+    const [quotaData, setQuotaData] = useState<import('@plusplusoneplusplus/coc-client').AgentProvidersQuotaResponse | null>(null);
+    const [quotaLoading, setQuotaLoading] = useState(false);
+    const [quotaError, setQuotaError] = useState<string | null>(null);
+
     // Snapshots for per-card dirty tracking (set when config/prefs loads)
     const [aiExecSnapshot, setAiExecSnapshot] = useState({ model: '', parallel: '1', timeout: '', output: 'table' });
     const [activeProviderSnapshot, setActiveProviderSnapshot] = useState<'copilot' | 'codex'>('copilot');
@@ -520,6 +525,19 @@ export function AdminPanel() {
     const handleCancelActiveProvider = useCallback(() => {
         setActiveProvider(activeProviderSnapshot);
     }, [activeProviderSnapshot]);
+
+    const handleRefreshQuota = useCallback(async () => {
+        setQuotaLoading(true);
+        setQuotaError(null);
+        try {
+            const data = await getSpaCocClient().admin.getAgentProvidersQuota();
+            setQuotaData(data);
+        } catch (err: unknown) {
+            setQuotaError(getSpaCocClientErrorMessage(err, 'Failed to fetch quota'));
+        } finally {
+            setQuotaLoading(false);
+        }
+    }, []);
 
     // ── Chat Experience card ──
     const handleSaveChat = useCallback(async () => {
@@ -1779,6 +1797,72 @@ export function AdminPanel() {
                                             ⚠ {providerAvailability['codex'].error}
                                         </div>
                                     )}
+                                    {/* Quota section */}
+                                    <div style={{ marginTop: 12 }}>
+                                        <button
+                                            type="button"
+                                            className="ar-btn ar-btn-secondary"
+                                            onClick={handleRefreshQuota}
+                                            disabled={quotaLoading}
+                                            data-testid="btn-refresh-quota"
+                                        >
+                                            {quotaLoading ? <Spinner size="sm" /> : '↻'} Refresh Quota
+                                        </button>
+                                        {quotaError && (
+                                            <div className="ar-row" style={{ marginTop: 8, color: 'var(--ar-danger)', fontSize: 12 }}>
+                                                ⚠ {quotaError}
+                                            </div>
+                                        )}
+                                        {quotaData && (
+                                            <div data-testid="quota-results" style={{ marginTop: 12 }}>
+                                                {quotaData.providers.map(provider => (
+                                                    <div key={provider.id} style={{ marginBottom: 12 }}>
+                                                        <div style={{ fontWeight: 600, fontSize: 12.5, marginBottom: 6, color: 'var(--ar-text-2)', textTransform: 'capitalize' }}>
+                                                            {provider.id === 'copilot' ? 'Copilot' : 'Codex'}
+                                                        </div>
+                                                        {provider.error ? (
+                                                            <div style={{ fontSize: 12, color: 'var(--ar-danger)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                                                                ⚠ {provider.error}
+                                                            </div>
+                                                        ) : provider.quotaTypes.length === 0 ? (
+                                                            <div style={{ fontSize: 12, color: 'var(--ar-text-mute)' }}>Quota not available for this provider.</div>
+                                                        ) : (
+                                                            provider.quotaTypes.map(qt => (
+                                                                <div key={qt.type} style={{ marginBottom: 8 }} data-testid={`quota-type-${qt.type}`}>
+                                                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 3 }}>
+                                                                        <span style={{ fontSize: 12, color: 'var(--ar-text-2)', textTransform: 'capitalize' }}>{qt.type}</span>
+                                                                        {qt.isUnlimitedEntitlement ? (
+                                                                            <span className="ar-badge ar-badge-success">Unlimited</span>
+                                                                        ) : (
+                                                                            <span style={{ fontSize: 11, color: 'var(--ar-text-mute)' }}>{qt.usedRequests} / {qt.entitlementRequests} used</span>
+                                                                        )}
+                                                                    </div>
+                                                                    {!qt.isUnlimitedEntitlement && (
+                                                                        <>
+                                                                            <div className="ar-quota-bar-track">
+                                                                                <div
+                                                                                    className={`ar-quota-bar-fill ${qt.remainingPercentage >= 0.5 ? 'ar-quota-green' : qt.remainingPercentage >= 0.2 ? 'ar-quota-amber' : 'ar-quota-red'}`}
+                                                                                    style={{ width: `${Math.max(0, Math.min(100, qt.remainingPercentage * 100))}%` }}
+                                                                                />
+                                                                            </div>
+                                                                            {qt.resetDate && (
+                                                                                <div style={{ fontSize: 11, color: 'var(--ar-text-mute)', marginTop: 2 }}>
+                                                                                    Resets {new Date(qt.resetDate).toLocaleDateString()}
+                                                                                </div>
+                                                                            )}
+                                                                            {qt.usageAllowedWithExhaustedQuota && qt.remainingPercentage === 0 && (
+                                                                                <span className="ar-pill" style={{ marginTop: 4, display: 'inline-flex', fontSize: 11, color: 'var(--ar-warning)' }}>Overage allowed</span>
+                                                                            )}
+                                                                        </>
+                                                                    )}
+                                                                </div>
+                                                            ))
+                                                        )}
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
                                 </SettingsCard>
                                 {isContainerMode() && (
                                     <Suspense fallback={<div className="ar-section ar-hstack ar-muted"><Spinner size="sm" /> Loading…</div>}>

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -246,7 +246,7 @@ export function AdminPanel() {
 
     // Snapshots for per-card dirty tracking (set when config/prefs loads)
     const [aiExecSnapshot, setAiExecSnapshot] = useState({ model: '', parallel: '1', timeout: '', output: 'table' });
-    const [activeProviderSnapshot, setActiveProviderSnapshot] = useState<'copilot' | 'codex'>('copilot');
+    const [activeProviderSnapshot, setActiveProviderSnapshot] = useState<{ provider: 'copilot' | 'codex'; codexEnabled: boolean }>({ provider: 'copilot', codexEnabled: false });
     const [chatSnapshot, setChatSnapshot] = useState({ followUpEnabled: true, followUpCount: '3', askUserEnabled: false, showReportIntent: false, toolCompactness: 3 as 0 | 1 | 2 | 3 });
     const [appearanceSnapshot, setAppearanceSnapshot] = useState({
         theme: 'auto' as string,
@@ -258,7 +258,7 @@ export function AdminPanel() {
         taskCardDensity: 'compact' as 'compact' | 'dense',
         historyGrouping: true,
     });
-    const [featuresSnapshot, setFeaturesSnapshot] = useState({ terminal: true, notes: true, myWork: false, myLife: false, scratchpad: false, scratchpadLayout: 'horizontal' as 'horizontal' | 'vertical', workflows: false, pullRequests: false, pullRequestsSuggestions: false, servers: false, ralph: false, vimNavigation: false, loops: false, excalidraw: false, mcpOauth: false, focusedDiff: false, codexEnabled: false });
+    const [featuresSnapshot, setFeaturesSnapshot] = useState({ terminal: true, notes: true, myWork: false, myLife: false, scratchpad: false, scratchpadLayout: 'horizontal' as 'horizontal' | 'vertical', workflows: false, pullRequests: false, pullRequestsSuggestions: false, servers: false, ralph: false, vimNavigation: false, loops: false, excalidraw: false, mcpOauth: false, focusedDiff: false });
 
     // Export
     const [exportStatus, setExportStatus] = useState<string>('');
@@ -373,9 +373,9 @@ export function AdminPanel() {
             setCodexEnabled(cxe);
             const ap = (resolved.activeProvider === 'codex' ? 'codex' : 'copilot') as 'copilot' | 'codex';
             setActiveProvider(ap);
-            setFeaturesSnapshot({ terminal: te, notes: ne, myWork: mwe, myLife: mle, scratchpad: se, scratchpadLayout: sl, workflows: we, pullRequests: pre, pullRequestsSuggestions: prse, servers: svre, ralph: re, vimNavigation: vne, loops: loe, excalidraw: exe, mcpOauth: moae, focusedDiff: fde, codexEnabled: cxe });
+            setFeaturesSnapshot({ terminal: te, notes: ne, myWork: mwe, myLife: mle, scratchpad: se, scratchpadLayout: sl, workflows: we, pullRequests: pre, pullRequestsSuggestions: prse, servers: svre, ralph: re, vimNavigation: vne, loops: loe, excalidraw: exe, mcpOauth: moae, focusedDiff: fde });
             setAiExecSnapshot({ model: form.model, parallel: form.parallel, timeout: form.timeout, output: form.output });
-            setActiveProviderSnapshot(ap);
+            setActiveProviderSnapshot({ provider: ap, codexEnabled: cxe });
             const sgr = resolved.sync?.gitRemote ?? '';
             const sim = String(resolved.sync?.intervalMinutes ?? 5);
             setSyncGitRemote(sgr);
@@ -435,7 +435,7 @@ export function AdminPanel() {
         configForm.timeout !== aiExecSnapshot.timeout ||
         configForm.output !== aiExecSnapshot.output;
 
-    const activeProviderDirty = activeProvider !== activeProviderSnapshot;
+    const activeProviderDirty = activeProvider !== activeProviderSnapshot.provider || codexEnabled !== activeProviderSnapshot.codexEnabled;
 
     const chatDirty = chatFollowUpEnabled !== chatSnapshot.followUpEnabled ||
         chatFollowUpCount !== chatSnapshot.followUpCount ||
@@ -467,8 +467,7 @@ export function AdminPanel() {
         loopsEnabled !== featuresSnapshot.loops ||
         excalidrawEnabled !== featuresSnapshot.excalidraw ||
         mcpOauthEnabled !== featuresSnapshot.mcpOauth ||
-        focusedDiffEnabled !== featuresSnapshot.focusedDiff ||
-        codexEnabled !== featuresSnapshot.codexEnabled;
+        focusedDiffEnabled !== featuresSnapshot.focusedDiff;
 
     // ── AI & Execution card ──
     const handleSaveAiExec = useCallback(async () => {
@@ -512,18 +511,19 @@ export function AdminPanel() {
     const handleSaveActiveProvider = useCallback(async () => {
         setActiveProviderSaving(true);
         try {
-            await getSpaCocClient().admin.updateConfig({ activeProvider });
-            addToast('Active provider saved — restart required to apply change', 'success');
-            setActiveProviderSnapshot(activeProvider);
+            await getSpaCocClient().admin.updateConfig({ activeProvider, 'codex.enabled': codexEnabled });
+            addToast('Provider settings saved — restart required to apply changes', 'success');
+            setActiveProviderSnapshot({ provider: activeProvider, codexEnabled });
         } catch (err: unknown) {
             addToast(getSpaCocClientErrorMessage(err, 'Save failed'), 'error');
         } finally {
             setActiveProviderSaving(false);
         }
-    }, [activeProvider, addToast]);
+    }, [activeProvider, codexEnabled, addToast]);
 
     const handleCancelActiveProvider = useCallback(() => {
-        setActiveProvider(activeProviderSnapshot);
+        setActiveProvider(activeProviderSnapshot.provider);
+        setCodexEnabled(activeProviderSnapshot.codexEnabled);
     }, [activeProviderSnapshot]);
 
     const handleRefreshQuota = useCallback(async () => {
@@ -655,17 +655,16 @@ export function AdminPanel() {
                 'excalidraw.enabled': excalidrawEnabled,
                 'mcpOauth.enabled': mcpOauthEnabled,
                 'features.focusedDiff': focusedDiffEnabled,
-                'codex.enabled': codexEnabled,
             });
             addToast('Settings saved', 'success');
             invalidateDisplaySettings();
-            setFeaturesSnapshot({ terminal: terminalEnabled, notes: notesEnabled, myWork: myWorkEnabled, myLife: myLifeEnabled, scratchpad: scratchpadEnabled, scratchpadLayout: scratchpadLayout, workflows: workflowsEnabled, pullRequests: pullRequestsEnabled, pullRequestsSuggestions: pullRequestsSuggestionsEnabled, servers: serversEnabled, ralph: ralphEnabled, vimNavigation: vimNavigationEnabled, loops: loopsEnabled, excalidraw: excalidrawEnabled, mcpOauth: mcpOauthEnabled, focusedDiff: focusedDiffEnabled, codexEnabled: codexEnabled });
+            setFeaturesSnapshot({ terminal: terminalEnabled, notes: notesEnabled, myWork: myWorkEnabled, myLife: myLifeEnabled, scratchpad: scratchpadEnabled, scratchpadLayout: scratchpadLayout, workflows: workflowsEnabled, pullRequests: pullRequestsEnabled, pullRequestsSuggestions: pullRequestsSuggestionsEnabled, servers: serversEnabled, ralph: ralphEnabled, vimNavigation: vimNavigationEnabled, loops: loopsEnabled, excalidraw: excalidrawEnabled, mcpOauth: mcpOauthEnabled, focusedDiff: focusedDiffEnabled });
         } catch (err: unknown) {
             addToast(getSpaCocClientErrorMessage(err, 'Save failed'), 'error');
         } finally {
             setFeaturesSaving(false);
         }
-    }, [terminalEnabled, notesEnabled, myWorkEnabled, myLifeEnabled, scratchpadEnabled, scratchpadLayout, workflowsEnabled, pullRequestsEnabled, pullRequestsSuggestionsEnabled, serversEnabled, ralphEnabled, vimNavigationEnabled, loopsEnabled, excalidrawEnabled, mcpOauthEnabled, focusedDiffEnabled, codexEnabled, addToast]);
+    }, [terminalEnabled, notesEnabled, myWorkEnabled, myLifeEnabled, scratchpadEnabled, scratchpadLayout, workflowsEnabled, pullRequestsEnabled, pullRequestsSuggestionsEnabled, serversEnabled, ralphEnabled, vimNavigationEnabled, loopsEnabled, excalidrawEnabled, mcpOauthEnabled, focusedDiffEnabled, addToast]);
 
     const handleCancelFeatures = useCallback(() => {
         setTerminalEnabled(featuresSnapshot.terminal);
@@ -684,7 +683,6 @@ export function AdminPanel() {
         setExcalidrawEnabled(featuresSnapshot.excalidraw);
         setMcpOauthEnabled(featuresSnapshot.mcpOauth);
         setFocusedDiffEnabled(featuresSnapshot.focusedDiff);
-        setCodexEnabled(featuresSnapshot.codexEnabled);
     }, [featuresSnapshot]);
 
     const handleSaveServerName = useCallback(async () => {
@@ -1440,13 +1438,6 @@ export function AdminPanel() {
                                         <AdminToggle checked={mcpOauthEnabled} onChange={setMcpOauthEnabled} data-testid="toggle-mcp-oauth-enabled" />
                                     </AdminRow>
                                     <AdminRow
-                                        name={<>Codex Provider <span className="ar-badge ar-badge-accent">Experimental</span> <span className="ar-badge ar-badge-warning">Restart</span></>}
-                                        hint="Enable the optional @openai/codex-sdk provider. Once enabled, switch the active provider in the AI & Execution tab. Requires a server restart."
-                                    >
-                                        <SourceBadge source={sources['codex.enabled']} />
-                                        <AdminToggle checked={codexEnabled} onChange={setCodexEnabled} data-testid="toggle-codex-enabled" />
-                                    </AdminRow>
-                                    <AdminRow
                                         name="Focused Diff"
                                         hint="AI-powered hunk classification for PR diffs. Highlights logic changes and dims mechanical edits."
                                     >
@@ -1763,8 +1754,15 @@ export function AdminPanel() {
                                     data-testid="settings-active-provider"
                                 >
                                     <AdminRow
+                                        name={<>Codex Provider <span className="ar-badge ar-badge-accent">Experimental</span> <span className="ar-badge ar-badge-warning">Restart</span></>}
+                                        hint="Enable the optional @openai/codex-sdk provider. Requires a server restart."
+                                    >
+                                        <SourceBadge source={sources['codex.enabled']} />
+                                        <AdminToggle checked={codexEnabled} onChange={setCodexEnabled} data-testid="toggle-codex-enabled" />
+                                    </AdminRow>
+                                    <AdminRow
                                         name={<>Active Provider <span className="ar-badge ar-badge-warning">Restart</span></>}
-                                        hint="Switch to 'Codex' only after enabling the Codex feature flag in Settings → Features and completing ChatGPT sign-in. Requires a server restart."
+                                        hint="Switch to 'Codex' only after enabling the Codex provider above and completing ChatGPT sign-in. Requires a server restart."
                                     >
                                         <select
                                             id="admin-config-active-provider"

--- a/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
+++ b/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
@@ -1158,3 +1158,25 @@
     flex-direction: column;
   }
 }
+
+/* ── Quota progress bars ──────────────────────────────────────── */
+.admin-redesign .ar-quota-bar-track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--ar-bg-3);
+  overflow: hidden;
+}
+.admin-redesign .ar-quota-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+.admin-redesign .ar-quota-bar-fill.ar-quota-green {
+  background: var(--ar-success);
+}
+.admin-redesign .ar-quota-bar-fill.ar-quota-amber {
+  background: var(--ar-warning);
+}
+.admin-redesign .ar-quota-bar-fill.ar-quota-red {
+  background: var(--ar-danger);
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/AgentSelectorChip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/AgentSelectorChip.tsx
@@ -1,0 +1,170 @@
+/**
+ * AgentSelectorChip — compact toolbar chip for selecting the AI agent provider.
+ *
+ * Renders a small button in the chat input toolbar that shows the active agent
+ * ("Copilot" or "Codex") and opens a popover menu to switch providers. Codex
+ * appears disabled when not available, with a short explanation.
+ *
+ * Visual style mirrors the existing model picker chip in NewChatArea/FollowUpInputArea.
+ */
+
+import { useRef, useState, useEffect } from 'react';
+import { cn } from '../../ui/cn';
+import type { AgentProviderStatus } from '@plusplusoneplusplus/coc-client';
+
+export type ChatProvider = 'copilot' | 'codex';
+
+export interface AgentSelectorChipProps {
+    providers: AgentProviderStatus[];
+    loading: boolean;
+    selected: ChatProvider;
+    onChange: (provider: ChatProvider) => void;
+    disabled?: boolean;
+}
+
+/** Bot icon for Codex — small hexagon outline, matching the existing provider badge. */
+function CodexIcon() {
+    return (
+        <svg width="9" height="9" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="shrink-0">
+            <polygon
+                points="8,1 14,4.5 14,11.5 8,15 2,11.5 2,4.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
+
+/** Person icon for Copilot — simple circle + arc. */
+function CopilotIcon() {
+    return (
+        <svg width="9" height="9" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="shrink-0">
+            <circle cx="8" cy="5" r="3" stroke="currentColor" strokeWidth="1.4" />
+            <path d="M2 14c0-3.3 2.7-6 6-6s6 2.7 6 6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+export function AgentSelectorChip({ providers, loading, selected, onChange, disabled }: AgentSelectorChipProps) {
+    const [open, setOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Close the menu when clicking outside
+    useEffect(() => {
+        if (!open) return;
+        function handleClick(e: MouseEvent) {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        }
+        document.addEventListener('mousedown', handleClick);
+        return () => document.removeEventListener('mousedown', handleClick);
+    }, [open]);
+
+    const selectedLabel = selected === 'codex' ? 'Codex' : 'Copilot';
+
+    return (
+        <div ref={containerRef} className="relative shrink-0" data-testid="agent-selector-chip-container">
+            <button
+                type="button"
+                disabled={disabled || loading}
+                onClick={() => setOpen(o => !o)}
+                className={cn(
+                    'ctool shrink-0 inline-flex items-center gap-1 h-[22px] px-1.5 rounded-sm text-[11px]',
+                    'text-[#5a5a5a] dark:text-[#cccccc]',
+                    'hover:bg-[#f3f3f3] dark:hover:bg-[#2a2d2e] hover:text-[#1e1e1e]',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0078d4]/50',
+                    'min-w-0 max-w-[40vw] sm:max-w-[140px] transition-colors',
+                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                )}
+                title={`Agent: ${selectedLabel} (click to switch)`}
+                data-testid="agent-selector-chip-btn"
+                aria-haspopup="listbox"
+                aria-expanded={open}
+            >
+                {selected === 'codex' ? <CodexIcon /> : <CopilotIcon />}
+                <span className="font-mono text-[10.5px] font-medium text-[#848484] dark:text-[#999] truncate">
+                    {selectedLabel}
+                </span>
+                <svg
+                    width="7" height="7"
+                    viewBox="0 0 8 6"
+                    fill="none"
+                    aria-hidden="true"
+                    className="shrink-0 opacity-60"
+                >
+                    <path d="M1 1l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+            </button>
+
+            {open && (
+                <div
+                    className={cn(
+                        'absolute bottom-full mb-1 left-0 z-50',
+                        'min-w-[140px] py-0.5 rounded-md shadow-lg',
+                        'bg-white dark:bg-[#252526] border border-[#e0e0e0] dark:border-[#3c3c3c]',
+                    )}
+                    role="listbox"
+                    aria-label="Select agent provider"
+                    data-testid="agent-selector-menu"
+                >
+                    {providers.map(provider => {
+                        const isSelected = provider.id === selected;
+                        const isDisabled = !provider.enabled || !provider.available;
+                        return (
+                            <button
+                                key={provider.id}
+                                type="button"
+                                role="option"
+                                aria-selected={isSelected}
+                                disabled={isDisabled}
+                                onClick={() => {
+                                    if (!isDisabled) {
+                                        onChange(provider.id as ChatProvider);
+                                        setOpen(false);
+                                    }
+                                }}
+                                title={isDisabled ? (provider.reason ?? `${provider.label} is unavailable`) : undefined}
+                                className={cn(
+                                    'w-full flex items-start gap-1.5 px-2 py-1.5 text-left text-[12px]',
+                                    'transition-colors',
+                                    isSelected
+                                        ? 'bg-[#f3f3f3] dark:bg-[#2a2d2e] text-[#1e1e1e] dark:text-[#cccccc]'
+                                        : 'text-[#1e1e1e] dark:text-[#cccccc]',
+                                    !isDisabled && !isSelected
+                                        ? 'hover:bg-[#f3f3f3] dark:hover:bg-[#2a2d2e]'
+                                        : '',
+                                    isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+                                )}
+                                data-testid={`agent-option-${provider.id}`}
+                            >
+                                <span className="mt-0.5 shrink-0">
+                                    {provider.id === 'codex' ? <CodexIcon /> : <CopilotIcon />}
+                                </span>
+                                <span className="flex flex-col min-w-0">
+                                    <span className="font-medium leading-tight">{provider.label}</span>
+                                    {isDisabled && provider.reason && (
+                                        <span className="text-[10px] text-[#848484] dark:text-[#999] leading-tight mt-0.5 truncate">
+                                            {provider.reason}
+                                        </span>
+                                    )}
+                                    {!provider.enabled && !provider.reason && (
+                                        <span className="text-[10px] text-[#848484] dark:text-[#999] leading-tight mt-0.5">
+                                            Disabled by admin
+                                        </span>
+                                    )}
+                                </span>
+                                {isSelected && (
+                                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="shrink-0 ml-auto mt-0.5 text-[#0078d4] dark:text-[#3794ff]">
+                                        <path d="M3 8l4 4 6-7" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                                    </svg>
+                                )}
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatHeader.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatHeader.tsx
@@ -14,6 +14,7 @@ import { useFloatingChats } from '../../contexts/FloatingChatsContext';
 import { ChatHeaderOverflowMenu, type OverflowMenuItem } from './ChatHeaderOverflowMenu';
 import type { ClientConversationTurn } from '../../types/dashboard';
 import { LoopBadge } from './LoopBadge';
+import { ProviderBadge, type ChatProvider } from './ProviderBadge';
 import { isLoopsEnabled } from '../../utils/config';
 
 /**
@@ -441,6 +442,9 @@ export function ChatHeader({
                 )}
                 {isLoopsEnabled() && (loopCount ?? 0) > 0 && (
                     <LoopBadge count={loopCount!} hasActiveLoops={hasActiveLoops} onClick={onToggleLoopPanel} />
+                )}
+                {task?.metadata?.provider && (
+                    <ProviderBadge provider={task.metadata.provider as ChatProvider} />
                 )}
                 {/* References — only in wide tier (live ctx + duration moved into pill / composer) */}
                 {isWide && (

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -34,6 +34,7 @@ import { getListModeConfig } from './list-mode-config';
 import { useAllLoops, type ProcessLoopState } from './hooks/useAllLoops';
 import { LoopIcon } from './icons/LoopIcon';
 import { isRalphTask } from '../../../../../tasks/task-types';
+import { ProviderBadge } from './ProviderBadge';
 
 /** Primary task types surfaced as individual filter options. */
 export const TASK_TYPE_LABELS: Record<string, string> = {
@@ -1395,6 +1396,13 @@ export function ChatListPane({
                                     <LoopIcon className="w-3.5 h-3.5" />
                                 </span>
                             );
+                        })()}
+                        {(() => {
+                            // Show provider badge only for codex — copilot is the default
+                            // and would add noise to every chat row if shown universally.
+                            const provider = task.provider ?? task.metadata?.provider ?? task.payload?.provider;
+                            if (provider !== 'codex') return null;
+                            return <ProviderBadge provider="codex" />;
                         })()}
                     </span>
                     <span className={cn('flex items-center gap-1', isAwaitingInput ? 'text-amber-700 dark:text-amber-300 font-medium' : 'text-[#848484] dark:text-[#999]')}>

--- a/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
@@ -30,8 +30,11 @@ import { useOnboardingPreferences } from '../../hooks/useOnboardingPreferences';
 import { usePromptAutocomplete } from '../../hooks/usePromptAutocomplete';
 import { usePromptAutocompleteEnabled } from '../../hooks/usePromptAutocompleteEnabled';
 import { useChatPromptHistory } from '../../hooks/useChatPromptHistory';
-import { isRalphEnabled, isLoopsEnabled, isCodexEnabled, getActiveProvider } from '../../utils/config';
+import { isRalphEnabled, isLoopsEnabled } from '../../utils/config';
 import { getDraft, setDraft, clearDraft, newChatDraftKey } from './hooks/useDraftStore';
+import { useAgentProviders } from '../../hooks/useAgentProviders';
+import { AgentSelectorChip } from './AgentSelectorChip';
+import type { ChatProvider } from './AgentSelectorChip';
 
 export interface NewChatAreaProps {
     workspaceId?: string;
@@ -45,6 +48,7 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
     const [sending, setSending] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [skills, setSkills] = useState<SkillItem[]>([]);
+    const [selectedProvider, setSelectedProvider] = useState<ChatProvider>('copilot');
     const richTextRef = useRef<RichTextInputHandle>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const abortControllerRef = useRef<AbortController | null>(null);
@@ -54,6 +58,9 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
     const { dispatch: queueDispatch } = useQueue();
     const { state: appState } = useApp();
     const { updateOnboarding } = useOnboardingPreferences();
+
+    // Agent providers for the agent selector chip
+    const { providers: agentProviders, loading: providersLoading } = useAgentProviders();
 
     // Model command support
     const { models: availableModels } = useModels();
@@ -110,6 +117,52 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
             })
             .catch(() => { /* ignore */ });
     }, [workspaceId]);
+
+    // Load last-used provider preference for this workspace on mount / workspace switch.
+    // Falls back to Copilot when unset, disabled, or unavailable.
+    useEffect(() => {
+        if (!workspaceId) {
+            setSelectedProvider('copilot');
+            return;
+        }
+        getSpaCocClient().preferences.getRepo(workspaceId)
+            .then((prefs: any) => {
+                const last = prefs?.lastChatProvider;
+                if (last === 'codex' || last === 'copilot') {
+                    // Validate against live provider state: only accept codex if enabled+available
+                    if (last === 'codex') {
+                        const codexStatus = agentProviders.find(p => p.id === 'codex');
+                        if (codexStatus?.enabled && codexStatus?.available) {
+                            setSelectedProvider('codex');
+                            return;
+                        }
+                    }
+                    if (last === 'copilot') {
+                        setSelectedProvider('copilot');
+                        return;
+                    }
+                }
+                setSelectedProvider('copilot');
+            })
+            .catch(() => { setSelectedProvider('copilot'); });
+    }, [workspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // When agentProviders load and codex becomes unavailable, fall back to copilot
+    useEffect(() => {
+        if (selectedProvider !== 'codex') return;
+        const codexStatus = agentProviders.find(p => p.id === 'codex');
+        if (codexStatus && (!codexStatus.enabled || !codexStatus.available)) {
+            setSelectedProvider('copilot');
+        }
+    }, [agentProviders, selectedProvider]);
+
+    function handleProviderChange(provider: ChatProvider) {
+        setSelectedProvider(provider);
+        if (workspaceId) {
+            getSpaCocClient().preferences.patchRepo(workspaceId, { lastChatProvider: provider })
+                .catch(() => { /* non-fatal */ });
+        }
+    }
 
     // Inline ghost-text autocomplete (matches FollowUpInputArea + EnqueueDialog).
     const promptAutocompleteEnabled = usePromptAutocompleteEnabled();
@@ -188,7 +241,8 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
                     ...(contextOverride ? { context: contextOverride } : {}),
                     ...(attachmentPayload.length > 0 ? { attachments: attachmentPayload } : {}),
                     ...(modelCommand.modelOverride ? { model: modelCommand.modelOverride } : {}),
-                },
+                    provider: selectedProvider,
+                } as any,
             });
 
             const rawId = result.task?.id ?? (result as any).id;
@@ -479,19 +533,14 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
                             </svg>
                         </button>
                         <div className="flex-1 min-w-0" />
-                        {/* Provider badge — visible only when Codex provider is active */}
-                        {isCodexEnabled() && getActiveProvider() === 'codex' && (
-                            <span
-                                title="Active AI provider: Codex"
-                                data-testid="new-chat-provider-badge"
-                                className="inline-flex items-center gap-1 h-[22px] px-2 rounded-sm border border-[#0078d4]/30 dark:border-[#3794ff]/30 bg-[#0078d4]/8 dark:bg-[#3794ff]/8 text-[11px] text-[#0078d4] dark:text-[#3794ff] flex-shrink-0 mr-1"
-                            >
-                                <svg width="9" height="9" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="flex-shrink-0">
-                                    <polygon points="8,1 14,4.5 14,11.5 8,15 2,11.5 2,4.5" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
-                                </svg>
-                                <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Codex</span>
-                            </span>
-                        )}
+                        {/* Agent provider selector */}
+                        <AgentSelectorChip
+                            providers={agentProviders}
+                            loading={providersLoading}
+                            selected={selectedProvider}
+                            onChange={handleProviderChange}
+                            disabled={sending}
+                        />
                         {sending ? (
                             <button
                                 type="button"

--- a/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
@@ -1,0 +1,45 @@
+/**
+ * ProviderBadge — small neutral pill showing the AI provider for a chat.
+ *
+ * Renders a compact badge with the provider label ("Copilot" or "Codex").
+ * Used in the chat detail header and chat list rows to record which agent
+ * handled (or is handling) the chat.
+ *
+ * Design decisions:
+ * - Codex: emerald-tinted badge to distinguish from the default Copilot.
+ * - Copilot: subtle gray badge (only shown when provider is explicitly set).
+ * - Badge is always read-only; clicking does nothing.
+ */
+
+import { cn } from '../../ui/cn';
+
+export type ChatProvider = 'copilot' | 'codex';
+
+export interface ProviderBadgeProps {
+    provider: ChatProvider;
+    className?: string;
+}
+
+export function ProviderBadge({ provider, className }: ProviderBadgeProps) {
+    const label = provider === 'codex' ? 'Codex' : 'Copilot';
+
+    const variantClasses =
+        provider === 'codex'
+            ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-400/50 dark:border-emerald-500/50'
+            : 'bg-[#f3f3f3] dark:bg-[#2a2a2a] text-[#6b6b6b] dark:text-[#999] border-[#d0d0d0]/70 dark:border-[#4a4a4a]';
+
+    return (
+        <span
+            className={cn(
+                'provider-badge inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border flex-shrink-0',
+                variantClasses,
+                className,
+            )}
+            data-testid="provider-badge"
+            data-provider={provider}
+            title={`Agent: ${label}`}
+        >
+            {label}
+        </span>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/hooks/useAgentProviders.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useAgentProviders.ts
@@ -1,0 +1,57 @@
+/**
+ * useAgentProviders — fetches live agent provider status from GET /api/agent-providers.
+ * Copilot is always available; Codex availability depends on admin config + auth state.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { getSpaCocClient, getSpaCocClientErrorMessage } from '../api/cocClient';
+import type { AgentProviderStatus } from '@plusplusoneplusplus/coc-client';
+
+export type { AgentProviderStatus };
+
+export interface UseAgentProvidersResult {
+    providers: AgentProviderStatus[];
+    loading: boolean;
+    error: string | null;
+    reload: () => void;
+    /** Convenience: the Copilot provider entry (always present). */
+    copilot: AgentProviderStatus | undefined;
+    /** Convenience: the Codex provider entry (present even when disabled). */
+    codex: AgentProviderStatus | undefined;
+}
+
+const COPILOT_FALLBACK: AgentProviderStatus = {
+    id: 'copilot',
+    label: 'Copilot',
+    enabled: true,
+    available: true,
+    locked: true,
+};
+
+export function useAgentProviders(): UseAgentProvidersResult {
+    const [providers, setProviders] = useState<AgentProviderStatus[]>([COPILOT_FALLBACK]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(() => {
+        setLoading(true);
+        setError(null);
+        getSpaCocClient().agentProviders.list()
+            .then((data) => {
+                if (data?.providers && data.providers.length > 0) {
+                    setProviders(data.providers);
+                }
+            })
+            .catch((e: unknown) => {
+                // Non-fatal: keep Copilot fallback, show warning
+                setError(getSpaCocClientErrorMessage(e, 'Failed to load agent providers'));
+            })
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => { load(); }, [load]);
+
+    const copilot = providers.find(p => p.id === 'copilot');
+    const codex = providers.find(p => p.id === 'codex');
+
+    return { providers, loading, error, reload: load, copilot, codex };
+}

--- a/packages/coc/src/server/tasks/task-types.ts
+++ b/packages/coc/src/server/tasks/task-types.ts
@@ -251,6 +251,12 @@ export type PostAction =
 // Payload Interfaces
 // ============================================================================
 
+/** Supported AI provider IDs for per-chat routing. */
+export type ChatProvider = 'copilot' | 'codex';
+
+/** Supported ChatProvider values (for runtime validation). */
+export const VALID_CHAT_PROVIDERS: ReadonlySet<ChatProvider> = new Set(['copilot', 'codex']);
+
 export interface ChatPayload {
     readonly kind: 'chat';
     mode: ChatMode;
@@ -275,6 +281,12 @@ export interface ChatPayload {
     postActions?: PostAction[];
     /** Base64 data-URLs to persist in the user conversation turn. */
     images?: string[];
+    /**
+     * AI provider to use for this chat task.
+     * Defaults to 'copilot' when omitted.
+     * Supported values: 'copilot' | 'codex'.
+     */
+    provider?: ChatProvider;
 }
 
 export interface RunWorkflowPayload {

--- a/packages/coc/test/server/admin-config-fields.test.ts
+++ b/packages/coc/test/server/admin-config-fields.test.ts
@@ -395,12 +395,12 @@ describe('runtime classification', () => {
         expect(fieldFor('mcpOauth.enabled').runtime).toBe('restartRequired');
     });
 
-    it('marks codex.enabled as restartRequired', () => {
-        expect(fieldFor('codex.enabled').runtime).toBe('restartRequired');
+    it('marks codex.enabled as live', () => {
+        expect(fieldFor('codex.enabled').runtime).toBe('live');
     });
 
-    it('marks activeProvider as restartRequired', () => {
-        expect(fieldFor('activeProvider').runtime).toBe('restartRequired');
+    it('marks activeProvider as live', () => {
+        expect(fieldFor('activeProvider').runtime).toBe('live');
     });
 
     const liveFeatures = [

--- a/packages/coc/test/server/agent-providers.test.ts
+++ b/packages/coc/test/server/agent-providers.test.ts
@@ -4,9 +4,10 @@
  * Unit tests for the GET /api/agent-providers endpoint logic.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
     buildAgentProvidersResponse,
+    registerAgentProvidersRoutes,
 } from '../../src/server/agent-providers/agent-providers-routes';
 import { RuntimeConfigService } from '../../src/config/runtime-config-service';
 
@@ -172,5 +173,156 @@ describe('live config reflection', () => {
         });
         expect(r2.providers.find(p => p.id === 'codex')!.enabled).toBe(true);
         expect(r2.providers.find(p => p.id === 'codex')!.available).toBe(true);
+    });
+});
+
+// ── Quota route registration ──────────────────────────────────────────────────
+
+describe('registerAgentProvidersRoutes — quota endpoint', () => {
+    function makeRes() {
+        const written: string[] = [];
+        let statusCode = 200;
+        return {
+            res: {
+                writeHead: (code: number) => { statusCode = code; },
+                setHeader: () => {},
+                write: (chunk: string) => written.push(chunk),
+                end: (chunk?: string) => { if (chunk) written.push(chunk); },
+                get statusCode() { return statusCode; },
+            } as any,
+            written,
+            getBody: () => written.join(''),
+        };
+    }
+
+    it('registers a GET /api/agent-providers/quota route', () => {
+        const svc = makeService(false);
+        const routes: any[] = [];
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const quotaRoute = routes.find(r => r.pattern === '/api/agent-providers/quota');
+        expect(quotaRoute).toBeDefined();
+        expect(quotaRoute.method).toBe('GET');
+    });
+
+    it('returns error for copilot when getCopilotSdkService is not provided', async () => {
+        const svc = makeService(false);
+        const routes: any[] = [];
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+            // no getCopilotSdkService
+        });
+        const quotaRoute = routes.find(r => r.pattern === '/api/agent-providers/quota');
+        const { res, getBody } = makeRes();
+        await quotaRoute.handler({} as any, res);
+        const body = JSON.parse(getBody());
+        expect(body.providers).toHaveLength(1);
+        expect(body.providers[0].id).toBe('copilot');
+        expect(body.providers[0].error).toMatch(/not available/i);
+    });
+
+    it('returns copilot quota from sdk service when available', async () => {
+        const svc = makeService(false);
+        const routes: any[] = [];
+        const mockSdkService = {
+            getAccountQuota: vi.fn().mockResolvedValue({
+                quotaSnapshots: {
+                    chat: {
+                        isUnlimitedEntitlement: false,
+                        entitlementRequests: 100,
+                        usedRequests: 30,
+                        remainingPercentage: 0.7,
+                        usageAllowedWithExhaustedQuota: false,
+                        overage: 0,
+                    },
+                },
+            }),
+        };
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+            getCopilotSdkService: () => mockSdkService as any,
+        });
+        const quotaRoute = routes.find(r => r.pattern === '/api/agent-providers/quota');
+        const { res, getBody } = makeRes();
+        await quotaRoute.handler({} as any, res);
+        const body = JSON.parse(getBody());
+        expect(body.providers).toHaveLength(1);
+        expect(body.providers[0].id).toBe('copilot');
+        expect(body.providers[0].error).toBeUndefined();
+        expect(body.providers[0].quotaTypes).toHaveLength(1);
+        const chatQuota = body.providers[0].quotaTypes[0];
+        expect(chatQuota.type).toBe('chat');
+        expect(chatQuota.usedRequests).toBe(30);
+        expect(chatQuota.entitlementRequests).toBe(100);
+        expect(chatQuota.remainingPercentage).toBe(0.7);
+    });
+
+    it('returns copilot error when sdk service throws', async () => {
+        const svc = makeService(false);
+        const routes: any[] = [];
+        const mockSdkService = {
+            getAccountQuota: vi.fn().mockRejectedValue(new Error('SDK unavailable')),
+        };
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+            getCopilotSdkService: () => mockSdkService as any,
+        });
+        const quotaRoute = routes.find(r => r.pattern === '/api/agent-providers/quota');
+        const { res, getBody } = makeRes();
+        await quotaRoute.handler({} as any, res);
+        const body = JSON.parse(getBody());
+        expect(body.providers[0].id).toBe('copilot');
+        expect(body.providers[0].error).toBe('SDK unavailable');
+    });
+
+    it('includes codex provider with empty quotaTypes when codex is enabled', async () => {
+        const svc = makeService(true);
+        const routes: any[] = [];
+        const mockSdkService = {
+            getAccountQuota: vi.fn().mockResolvedValue({ quotaSnapshots: {} }),
+        };
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'authenticated' }),
+            serverBaseUrl: BASE_URL,
+            getCopilotSdkService: () => mockSdkService as any,
+        });
+        const quotaRoute = routes.find(r => r.pattern === '/api/agent-providers/quota');
+        const { res, getBody } = makeRes();
+        await quotaRoute.handler({} as any, res);
+        const body = JSON.parse(getBody());
+        expect(body.providers).toHaveLength(2);
+        const codex = body.providers.find((p: any) => p.id === 'codex');
+        expect(codex).toBeDefined();
+        expect(codex.quotaTypes).toHaveLength(0);
+        expect(codex.error).toBeUndefined();
+    });
+
+    it('does not include codex provider when codex is disabled', async () => {
+        const svc = makeService(false);
+        const routes: any[] = [];
+        const mockSdkService = {
+            getAccountQuota: vi.fn().mockResolvedValue({ quotaSnapshots: {} }),
+        };
+        registerAgentProvidersRoutes(routes, {
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+            getCopilotSdkService: () => mockSdkService as any,
+        });
+        const quotaRoute = routes.find(r => r.pattern === '/api/agent-providers/quota');
+        const { res, getBody } = makeRes();
+        await quotaRoute.handler({} as any, res);
+        const body = JSON.parse(getBody());
+        expect(body.providers.find((p: any) => p.id === 'codex')).toBeUndefined();
     });
 });

--- a/packages/coc/test/server/agent-providers.test.ts
+++ b/packages/coc/test/server/agent-providers.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Agent Providers Route Tests
+ *
+ * Unit tests for the GET /api/agent-providers endpoint logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    buildAgentProvidersResponse,
+} from '../../src/server/agent-providers/agent-providers-routes';
+import { RuntimeConfigService } from '../../src/config/runtime-config-service';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeService(codexEnabled: boolean): RuntimeConfigService {
+    return new RuntimeConfigService({
+        fileConfig: { codex: { enabled: codexEnabled } },
+    });
+}
+
+const BASE_URL = 'http://localhost:4000';
+
+// ── Copilot provider ──────────────────────────────────────────────────────────
+
+describe('Copilot provider', () => {
+    it('is always enabled, available, and locked', () => {
+        const svc = makeService(false);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const copilot = providers.find(p => p.id === 'copilot')!;
+        expect(copilot.enabled).toBe(true);
+        expect(copilot.available).toBe(true);
+        expect(copilot.locked).toBe(true);
+    });
+});
+
+// ── Codex provider — disabled ────────────────────────────────────────────────
+
+describe('Codex provider when codex.enabled = false', () => {
+    it('is not enabled and not available', () => {
+        const svc = makeService(false);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'authenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const codex = providers.find(p => p.id === 'codex')!;
+        expect(codex.enabled).toBe(false);
+        expect(codex.available).toBe(false);
+        expect(codex.reason).toBeUndefined();
+        expect(codex.authUrl).toBeUndefined();
+    });
+
+    it('has no reason or authUrl when not enabled (even if auth is expired)', () => {
+        const svc = makeService(false);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'expired' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const codex = providers.find(p => p.id === 'codex')!;
+        expect(codex.reason).toBeUndefined();
+        expect(codex.authUrl).toBeUndefined();
+    });
+});
+
+// ── Codex provider — enabled + authenticated ──────────────────────────────────
+
+describe('Codex provider when enabled and authenticated', () => {
+    it('is enabled and available', () => {
+        const svc = makeService(true);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'authenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const codex = providers.find(p => p.id === 'codex')!;
+        expect(codex.enabled).toBe(true);
+        expect(codex.available).toBe(true);
+        expect(codex.reason).toBeUndefined();
+        expect(codex.authUrl).toBeUndefined();
+    });
+});
+
+// ── Codex provider — enabled + unauthenticated ────────────────────────────────
+
+describe('Codex provider when enabled but unauthenticated', () => {
+    it('is enabled but not available, with auth reason and URL', () => {
+        const svc = makeService(true);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const codex = providers.find(p => p.id === 'codex')!;
+        expect(codex.enabled).toBe(true);
+        expect(codex.available).toBe(false);
+        expect(codex.reason).toMatch(/authentication required/i);
+        expect(codex.authUrl).toBe('http://localhost:4000/api/codex-auth/start');
+    });
+});
+
+// ── Codex provider — enabled + expired ───────────────────────────────────────
+
+describe('Codex provider when enabled but auth expired', () => {
+    it('is enabled but not available, with expired reason and authUrl', () => {
+        const svc = makeService(true);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'expired' }),
+            serverBaseUrl: BASE_URL,
+        });
+        const codex = providers.find(p => p.id === 'codex')!;
+        expect(codex.enabled).toBe(true);
+        expect(codex.available).toBe(false);
+        expect(codex.reason).toMatch(/expired/i);
+        expect(codex.authUrl).toBe('http://localhost:4000/api/codex-auth/start');
+    });
+});
+
+// ── Response shape ────────────────────────────────────────────────────────────
+
+describe('response shape', () => {
+    it('always returns two providers in order: copilot, codex', () => {
+        const svc = makeService(false);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        expect(providers).toHaveLength(2);
+        expect(providers[0].id).toBe('copilot');
+        expect(providers[1].id).toBe('codex');
+    });
+
+    it('codex is visible in the providers list even when disabled', () => {
+        const svc = makeService(false);
+        const { providers } = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'unauthenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        expect(providers.some(p => p.id === 'codex')).toBe(true);
+    });
+});
+
+// ── Live config reflection ────────────────────────────────────────────────────
+
+describe('live config reflection', () => {
+    it('reflects codex.enabled change without restart', async () => {
+        const svc = makeService(false);
+
+        // Initially disabled
+        const r1 = buildAgentProvidersResponse({
+            runtimeConfigService: svc,
+            getCodexAuthInfo: () => ({ status: 'authenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        expect(r1.providers.find(p => p.id === 'codex')!.enabled).toBe(false);
+
+        // Simulate admin enabling Codex by updating the service
+        // (RuntimeConfigService.config getter always returns latest)
+        // We test this by creating a new service with enabled=true
+        const svc2 = makeService(true);
+        const r2 = buildAgentProvidersResponse({
+            runtimeConfigService: svc2,
+            getCodexAuthInfo: () => ({ status: 'authenticated' }),
+            serverBaseUrl: BASE_URL,
+        });
+        expect(r2.providers.find(p => p.id === 'codex')!.enabled).toBe(true);
+        expect(r2.providers.find(p => p.id === 'codex')!.available).toBe(true);
+    });
+});

--- a/packages/coc/test/server/executors/follow-up-executor.test.ts
+++ b/packages/coc/test/server/executors/follow-up-executor.test.ts
@@ -132,6 +132,9 @@ function makeExecutor(
         toolCallCacheStore: { options: {} } as any,
         resolveWorkspaceIdForPath: vi.fn().mockResolvedValue('ws-id'),
         resolveSkillConfig: vi.fn().mockResolvedValue({ skillDirectories: undefined, disabledSkills: undefined }),
+        // Default: always resolve to the mock service (any provider).
+        // Tests needing provider-level errors can override this.
+        resolveAiServiceForProvider: (_provider) => sdkMocks.service as any,
         ...overrides,
     }, dataDir);
 }
@@ -891,83 +894,86 @@ describe('FollowUpExecutor', () => {
         expect(errorTurn!.turnSource).toEqual({ source: 'wakeup', wakeupId: 'w_123' });
     });
 
+
     // -------------------------------------------------------------------------
-    // AC-10 — Provider mismatch on resume
+    // AC-04 — Follow-ups use the original chat's provider
     // -------------------------------------------------------------------------
 
-    it('throws provider mismatch error when process was created with Copilot but active provider is Codex', async () => {
+    it('uses copilot service when process was created with copilot provider', async () => {
+        sdkMocks.mockSendMessage.mockResolvedValue({ success: true, response: 'Copilot reply', sessionId: 'sess-c' });
+        const resolveAiServiceForProvider = vi.fn().mockReturnValue(sdkMocks.service as any);
         const proc = makeProcess({
-            id: 'proc-copilot',
+            id: 'proc-ac04-copilot',
             metadata: { type: 'chat', provider: 'copilot' },
         });
         await store.addProcess(proc);
 
-        const executor = makeExecutor(store, { provider: 'codex' });
-        await expect(executor.executeFollowUp('proc-copilot', 'follow-up')).rejects.toThrow(
-            /Provider mismatch.*Copilot.*Codex/,
-        );
+        const executor = makeExecutor(store, { resolveAiServiceForProvider });
+        await executor.executeFollowUp('proc-ac04-copilot', 'follow-up');
+
+        expect(resolveAiServiceForProvider).toHaveBeenCalledWith('copilot');
     });
 
-    it('throws provider mismatch error when process was created with Codex but active provider is Copilot', async () => {
+    it('uses codex service when process was created with codex provider', async () => {
+        sdkMocks.mockSendMessage.mockResolvedValue({ success: true, response: 'Codex reply', sessionId: 'sess-d' });
+        const resolveAiServiceForProvider = vi.fn().mockReturnValue(sdkMocks.service as any);
         const proc = makeProcess({
-            id: 'proc-codex',
+            id: 'proc-ac04-codex',
             metadata: { type: 'chat', provider: 'codex' },
         });
         await store.addProcess(proc);
 
-        const executor = makeExecutor(store, { provider: 'copilot' });
-        await expect(executor.executeFollowUp('proc-codex', 'follow-up')).rejects.toThrow(
-            /Provider mismatch.*Codex.*Copilot/,
+        const executor = makeExecutor(store, { resolveAiServiceForProvider });
+        await executor.executeFollowUp('proc-ac04-codex', 'follow-up');
+
+        expect(resolveAiServiceForProvider).toHaveBeenCalledWith('codex');
+    });
+
+    it('defaults to copilot when process has no provider metadata (legacy processes)', async () => {
+        const resolveAiServiceForProvider = vi.fn().mockReturnValue(sdkMocks.service as any);
+        const proc = makeProcess({
+            id: 'proc-ac04-no-provider',
+            metadata: { type: 'chat' }, // no provider field
+        });
+        await store.addProcess(proc);
+
+        const executor = makeExecutor(store, { resolveAiServiceForProvider });
+        await executor.executeFollowUp('proc-ac04-no-provider', 'follow-up');
+
+        expect(resolveAiServiceForProvider).toHaveBeenCalledWith('copilot');
+    });
+
+    it('blocks follow-up when resolveAiServiceForProvider throws (disabled provider)', async () => {
+        const resolveAiServiceForProvider = vi.fn().mockImplementation(() => {
+            throw new Error('Codex is disabled. Enable it in Admin settings.');
+        });
+        const proc = makeProcess({
+            id: 'proc-ac04-disabled',
+            metadata: { type: 'chat', provider: 'codex' },
+        });
+        await store.addProcess(proc);
+
+        const executor = makeExecutor(store, { resolveAiServiceForProvider });
+        await expect(executor.executeFollowUp('proc-ac04-disabled', 'follow-up')).rejects.toThrow(
+            /Codex is disabled/,
         );
     });
 
-    it('does not throw when process provider matches active provider (Copilot)', async () => {
+    it('does not call sendMessage when resolveAiServiceForProvider throws', async () => {
+        const resolveAiServiceForProvider = vi.fn().mockImplementation(() => {
+            throw new Error('Codex is disabled');
+        });
         const proc = makeProcess({
-            id: 'proc-match-copilot',
-            metadata: { type: 'chat', provider: 'copilot' },
+            id: 'proc-ac04-no-send',
+            metadata: { type: 'chat', provider: 'codex' },
         });
         await store.addProcess(proc);
 
-        const executor = makeExecutor(store, { provider: 'copilot' });
-        await expect(executor.executeFollowUp('proc-match-copilot', 'follow-up')).resolves.toBeUndefined();
-    });
-
-    it('does not throw when process has no provider metadata (defaults to copilot) and active provider is copilot', async () => {
-        const proc = makeProcess({
-            id: 'proc-no-provider',
-            metadata: { type: 'chat' },
-        });
-        await store.addProcess(proc);
-
-        const executor = makeExecutor(store, { provider: 'copilot' });
-        await expect(executor.executeFollowUp('proc-no-provider', 'follow-up')).resolves.toBeUndefined();
-    });
-
-    it('does not call sendMessage when provider mismatch is detected', async () => {
-        const proc = makeProcess({
-            id: 'proc-mismatch-no-send',
-            metadata: { type: 'chat', provider: 'copilot' },
-        });
-        await store.addProcess(proc);
-
-        const executor = makeExecutor(store, { provider: 'codex' });
+        const executor = makeExecutor(store, { resolveAiServiceForProvider });
         try {
-            await executor.executeFollowUp('proc-mismatch-no-send', 'follow-up');
+            await executor.executeFollowUp('proc-ac04-no-send', 'follow-up');
         } catch { /* expected */ }
 
         expect(sdkMocks.mockSendMessage).not.toHaveBeenCalled();
-    });
-
-    it('mismatch error message includes instructions to switch provider', async () => {
-        const proc = makeProcess({
-            id: 'proc-mismatch-msg',
-            metadata: { type: 'chat', provider: 'copilot' },
-        });
-        await store.addProcess(proc);
-
-        const executor = makeExecutor(store, { provider: 'codex' });
-        await expect(executor.executeFollowUp('proc-mismatch-msg', 'follow-up')).rejects.toThrow(
-            /Switch the active provider/,
-        );
     });
 });

--- a/packages/coc/test/server/executors/process-lifecycle-runner.test.ts
+++ b/packages/coc/test/server/executors/process-lifecycle-runner.test.ts
@@ -1258,4 +1258,54 @@ describe('ProcessLifecycleRunner — provider attribution', () => {
         const proc = await store.getProcess(`queue_${task.id}`);
         expect(proc?.metadata?.provider).toBe('codex');
     });
+
+    it('uses payload.provider over runner-level provider when payload.provider is set', async () => {
+        // Runner is constructed with copilot but payload explicitly requests codex.
+        const runner = new ProcessLifecycleRunner(store as any, '/data-dir', vi.fn(), undefined, 'copilot');
+        const task = makeTask({
+            payload: {
+                kind: 'chat',
+                prompt: 'Hello from codex',
+                workspaceId: 'ws-abc',
+                provider: 'codex',
+            } as any,
+        });
+        await runner.run(task, makeOpts());
+
+        const proc = await store.getProcess(`queue_${task.id}`);
+        expect(proc?.metadata?.provider).toBe('codex');
+    });
+
+    it('falls back to runner-level provider when payload.provider is absent', async () => {
+        // Runner is codex; payload omits provider — should use codex.
+        const runner = new ProcessLifecycleRunner(store as any, '/data-dir', vi.fn(), undefined, 'codex');
+        const task = makeTask({
+            payload: {
+                kind: 'chat',
+                prompt: 'No explicit provider',
+                workspaceId: 'ws-abc',
+                // provider omitted
+            } as any,
+        });
+        await runner.run(task, makeOpts());
+
+        const proc = await store.getProcess(`queue_${task.id}`);
+        expect(proc?.metadata?.provider).toBe('codex');
+    });
+
+    it('payload.provider copilot wins over runner-level codex', async () => {
+        const runner = new ProcessLifecycleRunner(store as any, '/data-dir', vi.fn(), undefined, 'codex');
+        const task = makeTask({
+            payload: {
+                kind: 'chat',
+                prompt: 'Use copilot explicitly',
+                workspaceId: 'ws-abc',
+                provider: 'copilot',
+            } as any,
+        });
+        await runner.run(task, makeOpts());
+
+        const proc = await store.getProcess(`queue_${task.id}`);
+        expect(proc?.metadata?.provider).toBe('copilot');
+    });
 });

--- a/packages/coc/test/server/queue-shared-validate.test.ts
+++ b/packages/coc/test/server/queue-shared-validate.test.ts
@@ -236,3 +236,56 @@ describe('validateAndParseTask – kind injection enables correct type guard dis
         expect(isChatPayload(payload)).toBe(false);
     });
 });
+
+// ============================================================================
+// ChatPayload.provider validation (AC-03)
+// ============================================================================
+
+describe('validateAndParseTask – ChatPayload.provider validation', () => {
+    it('accepts provider: copilot', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', provider: 'copilot' },
+        });
+        expect(result.valid).toBe(true);
+        expect((result.input!.payload as any).provider).toBe('copilot');
+    });
+
+    it('accepts provider: codex', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', provider: 'codex' },
+        });
+        expect(result.valid).toBe(true);
+        expect((result.input!.payload as any).provider).toBe('codex');
+    });
+
+    it('rejects an unknown provider value with a 400-style error', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello', provider: 'openai' },
+        });
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/invalid provider/i);
+        expect(result.error).toContain('openai');
+    });
+
+    it('passes through when provider is omitted (defaults to copilot at execution time)', () => {
+        const result = validateAndParseTask({
+            type: 'chat',
+            payload: { prompt: 'hello' },
+        });
+        expect(result.valid).toBe(true);
+        expect((result.input!.payload as any).provider).toBeUndefined();
+    });
+
+    it('does not validate provider for non-chat task types', () => {
+        // run-script payloads have no provider concept; an accidentally passed
+        // provider field should not cause a validation error at the chat layer.
+        const result = validateAndParseTask({
+            type: 'run-script',
+            payload: { script: 'echo hi', workingDirectory: '/ws', provider: 'unknown' },
+        });
+        expect(result.valid).toBe(true);
+    });
+});

--- a/packages/coc/test/server/spa/client/repos/AgentSelectorChip.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/AgentSelectorChip.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for AgentSelectorChip — rendering, provider selection, disabled state.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AgentSelectorChip } from '../../../../../src/server/spa/client/react/features/chat/AgentSelectorChip';
+import type { AgentProviderStatus } from '@plusplusoneplusplus/coc-client';
+
+const COPILOT: AgentProviderStatus = {
+    id: 'copilot',
+    label: 'Copilot',
+    enabled: true,
+    available: true,
+    locked: true,
+};
+
+const CODEX_ENABLED: AgentProviderStatus = {
+    id: 'codex',
+    label: 'Codex',
+    enabled: true,
+    available: true,
+};
+
+const CODEX_DISABLED: AgentProviderStatus = {
+    id: 'codex',
+    label: 'Codex',
+    enabled: false,
+    available: false,
+};
+
+const CODEX_UNAVAILABLE: AgentProviderStatus = {
+    id: 'codex',
+    label: 'Codex',
+    enabled: true,
+    available: false,
+    reason: 'Codex authentication required.',
+};
+
+describe('AgentSelectorChip', () => {
+    describe('chip button display', () => {
+        it('shows Copilot when selected is copilot', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            const btn = screen.getByTestId('agent-selector-chip-btn');
+            expect(btn.textContent).toContain('Copilot');
+        });
+
+        it('shows Codex when selected is codex', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="codex"
+                    onChange={vi.fn()}
+                />
+            );
+            const btn = screen.getByTestId('agent-selector-chip-btn');
+            expect(btn.textContent).toContain('Codex');
+        });
+
+        it('is disabled when loading', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT]}
+                    loading={true}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            const btn = screen.getByTestId('agent-selector-chip-btn');
+            expect(btn).toBeDisabled();
+        });
+
+        it('is disabled when disabled prop is set', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                    disabled={true}
+                />
+            );
+            const btn = screen.getByTestId('agent-selector-chip-btn');
+            expect(btn).toBeDisabled();
+        });
+    });
+
+    describe('dropdown menu', () => {
+        it('opens menu on click', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            expect(screen.queryByTestId('agent-selector-menu')).toBeNull();
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            expect(screen.getByTestId('agent-selector-menu')).toBeTruthy();
+        });
+
+        it('shows both provider options in menu', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            expect(screen.getByTestId('agent-option-copilot')).toBeTruthy();
+            expect(screen.getByTestId('agent-option-codex')).toBeTruthy();
+        });
+
+        it('calls onChange when a provider option is clicked', () => {
+            const onChange = vi.fn();
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={onChange}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            fireEvent.click(screen.getByTestId('agent-option-codex'));
+            expect(onChange).toHaveBeenCalledWith('codex');
+        });
+
+        it('closes menu after selecting a provider', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            fireEvent.click(screen.getByTestId('agent-option-codex'));
+            expect(screen.queryByTestId('agent-selector-menu')).toBeNull();
+        });
+    });
+
+    describe('disabled/unavailable Codex', () => {
+        it('Codex option is disabled when codex.enabled=false', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_DISABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            const codexOption = screen.getByTestId('agent-option-codex');
+            expect(codexOption).toBeDisabled();
+        });
+
+        it('Codex option is disabled when unavailable (auth required)', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_UNAVAILABLE]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            const codexOption = screen.getByTestId('agent-option-codex');
+            expect(codexOption).toBeDisabled();
+        });
+
+        it('shows reason text for unavailable Codex', () => {
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_UNAVAILABLE]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={vi.fn()}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            expect(screen.getByTestId('agent-option-codex').textContent).toContain('authentication required');
+        });
+
+        it('does not call onChange when clicking disabled Codex option', () => {
+            const onChange = vi.fn();
+            render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_DISABLED]}
+                    loading={false}
+                    selected="copilot"
+                    onChange={onChange}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            const codexOption = screen.getByTestId('agent-option-codex');
+            // Clicking a disabled button does not fire onChange
+            fireEvent.click(codexOption);
+            expect(onChange).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('selected indicator', () => {
+        it('checkmark is visible for selected provider in menu', () => {
+            const { container } = render(
+                <AgentSelectorChip
+                    providers={[COPILOT, CODEX_ENABLED]}
+                    loading={false}
+                    selected="codex"
+                    onChange={vi.fn()}
+                />
+            );
+            fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+            // The codex option should have aria-selected=true
+            const codexOption = screen.getByTestId('agent-option-codex');
+            expect(codexOption.getAttribute('aria-selected')).toBe('true');
+            // Copilot should not be selected
+            const copilotOption = screen.getByTestId('agent-option-copilot');
+            expect(copilotOption.getAttribute('aria-selected')).toBe('false');
+        });
+    });
+});

--- a/packages/coc/test/server/spa/client/repos/NewChatArea.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/NewChatArea.test.tsx
@@ -36,15 +36,21 @@ vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
     getApiBase: () => 'http://localhost:4000/api',
     isRalphEnabled: () => false,
     isLoopsEnabled: () => false,
-    isCodexEnabled: () => false,
-    getActiveProvider: () => 'copilot',
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({
         queue: { enqueue: mockEnqueueTask },
-        preferences: { patchGlobal: vi.fn().mockResolvedValue({}) },
+        preferences: {
+            patchGlobal: vi.fn().mockResolvedValue({}),
+            getRepo: vi.fn().mockResolvedValue({}),
+            patchRepo: vi.fn().mockResolvedValue({}),
+        },
         skills: { listAllWorkspace: vi.fn().mockResolvedValue({ merged: [] }) },
+        agentProviders: { list: vi.fn().mockResolvedValue({ providers: [
+            { id: 'copilot', label: 'Copilot', enabled: true, available: true, locked: true },
+            { id: 'codex', label: 'Codex', enabled: false, available: false },
+        ] }) },
     }),
     getSpaCocClientErrorMessage: (err: any, fallback: string) =>
         (err instanceof Error ? err.message : undefined) || fallback,
@@ -250,5 +256,28 @@ describe('NewChatArea – queue_ prefix in handleSend', () => {
             expect(screen.getByTestId('new-chat-error')).toBeTruthy();
         });
         expect(mockQueueDispatch).not.toHaveBeenCalled();
+    });
+
+    it('includes provider=copilot in enqueue payload by default', async () => {
+        mockEnqueueTask.mockResolvedValueOnce({ task: { id: 'queue_123' } });
+
+        renderNewChatArea();
+        typeInInput('Hello');
+        await clickSend();
+
+        await waitFor(() => {
+            expect(mockEnqueueTask).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    payload: expect.objectContaining({ provider: 'copilot' }),
+                })
+            );
+        });
+    });
+
+    it('renders agent selector chip in the toolbar', async () => {
+        renderNewChatArea();
+        await waitFor(() => {
+            expect(screen.getByTestId('agent-selector-chip-btn')).toBeTruthy();
+        });
     });
 });

--- a/packages/coc/test/server/spa/client/repos/ProviderBadge.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ProviderBadge.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for ProviderBadge — rendering for copilot, codex, and missing-provider metadata.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProviderBadge } from '../../../../../src/server/spa/client/react/features/chat/ProviderBadge';
+
+describe('ProviderBadge', () => {
+    describe('rendering', () => {
+        it('renders "Codex" label for codex provider', () => {
+            render(<ProviderBadge provider="codex" />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge.textContent).toBe('Codex');
+            expect(badge.getAttribute('data-provider')).toBe('codex');
+        });
+
+        it('renders "Copilot" label for copilot provider', () => {
+            render(<ProviderBadge provider="copilot" />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge.textContent).toBe('Copilot');
+            expect(badge.getAttribute('data-provider')).toBe('copilot');
+        });
+
+        it('has title attribute with provider name for codex', () => {
+            render(<ProviderBadge provider="codex" />);
+            expect(screen.getByTestId('provider-badge').getAttribute('title')).toBe('Agent: Codex');
+        });
+
+        it('has title attribute with provider name for copilot', () => {
+            render(<ProviderBadge provider="copilot" />);
+            expect(screen.getByTestId('provider-badge').getAttribute('title')).toBe('Agent: Copilot');
+        });
+
+        it('applies custom className', () => {
+            const { container } = render(<ProviderBadge provider="codex" className="my-custom-class" />);
+            expect(container.querySelector('.my-custom-class')).toBeTruthy();
+        });
+    });
+
+    describe('styling', () => {
+        it('codex badge has emerald tint classes', () => {
+            render(<ProviderBadge provider="codex" />);
+            const badge = screen.getByTestId('provider-badge');
+            // The badge should have emerald variant classes
+            expect(badge.className).toContain('emerald');
+        });
+
+        it('copilot badge has neutral classes', () => {
+            render(<ProviderBadge provider="copilot" />);
+            const badge = screen.getByTestId('provider-badge');
+            // The badge should NOT have emerald variant classes
+            expect(badge.className).not.toContain('emerald');
+        });
+    });
+});

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -1021,19 +1021,19 @@ describe('ChatDetail', () => {
         });
 
         it('renders ReferencesDropdown with planPath and files after the status pill', () => {
-            const headerBlock = CHAT_HEADER_SRC.substring(
-                CHAT_HEADER_SRC.indexOf('<ChatStatusPill'),
-                CHAT_HEADER_SRC.indexOf('<ChatStatusPill') + 800,
+            const statusPillIdx = CHAT_HEADER_SRC.indexOf('<ChatStatusPill');
+            const refsIdx = CHAT_HEADER_SRC.indexOf(
+                '<ReferencesDropdown planPath={planPath} files={createdFiles} wsId={wsId} />',
             );
-            expect(headerBlock).toContain('<ReferencesDropdown planPath={planPath} files={createdFiles} wsId={wsId} />');
+            expect(refsIdx).toBeGreaterThan(statusPillIdx);
         });
 
         it('ReferencesDropdown is placed after the status pill in the header', () => {
-            const headerSection = CHAT_HEADER_SRC.substring(
-                CHAT_HEADER_SRC.indexOf('<ChatStatusPill'),
-                CHAT_HEADER_SRC.indexOf('<ChatStatusPill') + 800,
+            const statusPillIdx = CHAT_HEADER_SRC.indexOf('<ChatStatusPill');
+            const refsIdx = CHAT_HEADER_SRC.indexOf(
+                '<ReferencesDropdown planPath={planPath} files={createdFiles} wsId={wsId} />',
             );
-            expect(headerSection).toContain('<ReferencesDropdown planPath={planPath} files={createdFiles} wsId={wsId} />');
+            expect(refsIdx).toBeGreaterThan(statusPillIdx);
         });
     });
 

--- a/packages/coc/test/spa/react/repos/ChatHeader.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatHeader.test.tsx
@@ -599,4 +599,38 @@ describe('ChatHeader', () => {
             expect(count).toBe(3);
         });
     });
+
+    describe('provider badge', () => {
+        it('shows provider badge when task.metadata.provider is "codex"', () => {
+            render(<ChatHeader {...defaultProps({
+                task: { status: 'completed', duration: 5000, metadata: { provider: 'codex' } },
+            })} />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge).toBeTruthy();
+            expect(badge.textContent).toBe('Codex');
+            expect(badge.getAttribute('data-provider')).toBe('codex');
+        });
+
+        it('shows provider badge when task.metadata.provider is "copilot"', () => {
+            render(<ChatHeader {...defaultProps({
+                task: { status: 'completed', duration: 5000, metadata: { provider: 'copilot' } },
+            })} />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge).toBeTruthy();
+            expect(badge.textContent).toBe('Copilot');
+            expect(badge.getAttribute('data-provider')).toBe('copilot');
+        });
+
+        it('does NOT show provider badge when task has no metadata.provider', () => {
+            render(<ChatHeader {...defaultProps({
+                task: { status: 'completed', duration: 5000 },
+            })} />);
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
+        });
+
+        it('does NOT show provider badge when task is null', () => {
+            render(<ChatHeader {...defaultProps({ task: null })} />);
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
+        });
+    });
 });

--- a/packages/coc/test/spa/react/repos/ChatListPane-provider.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane-provider.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Tests for provider badge rendering in ChatListPane.
+ * - Shows ProviderBadge for codex tasks
+ * - Does NOT show ProviderBadge for copilot-only tasks (default)
+ * - Reads provider from task.provider (HistorySummary top-level), metadata.provider, or payload.provider
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+// --- Mocks (same as ChatListPane-loops pattern) ---
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        loops: { listAll: vi.fn().mockResolvedValue([]) },
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
+    getApiBase: () => '',
+    isRalphEnabled: () => false,
+    isLoopsEnabled: () => false,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/queue/hooks/useQueueDragDrop', () => ({
+    useQueueDragDrop: () => ({
+        handleDragStart: vi.fn(),
+        handleDragOver: vi.fn(),
+        handleDrop: vi.fn(),
+        handleDragEnd: vi.fn(),
+        dragOverIndex: null,
+        dragSourceIndex: null,
+        createDragStartHandler: () => vi.fn(),
+        createDragEndHandler: () => vi.fn(),
+        createDragOverHandler: () => vi.fn(),
+        createDragEnterHandler: () => vi.fn(),
+        createDragLeaveHandler: () => vi.fn(),
+        createDropHandler: () => vi.fn(),
+        draggedTaskId: null,
+        dropTargetIndex: null,
+        dropPosition: null,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/queue/hooks/useQueueTouchDragDrop', () => ({
+    useQueueTouchDragDrop: () => ({
+        handleTouchStart: vi.fn(),
+        handleTouchMove: vi.fn(),
+        handleTouchEnd: vi.fn(),
+        isDragging: false,
+        dragOverIndex: null,
+        draggedTaskId: null,
+        dropTargetIndex: null,
+        dropPosition: null,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useLongPress', () => ({
+    useLongPress: () => ({
+        onTouchStart: vi.fn(),
+        onTouchEnd: vi.fn(),
+        onTouchMove: vi.fn(),
+        didLongPress: () => false,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useDraftStore', () => ({
+    getDraft: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/workflow/hooks/useWorkflowProgress', () => ({
+    useWorkflowProgress: () => ({
+        progress: null,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/ChatPreferencesContext', () => ({
+    useChatPrefs: () => ({
+        pinnedChatIds: new Set(),
+        archivedChatIds: new Set(),
+        pinChat: vi.fn(),
+        unpinChat: vi.fn(),
+        archiveChat: vi.fn(),
+        unarchiveChat: vi.fn(),
+        archiveChats: vi.fn(),
+        unarchiveChats: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/QueueContext', () => ({
+    useQueue: () => ({
+        state: { isTaskSubmitting: false },
+        setPriority: vi.fn(),
+        remove: vi.fn(),
+        reload: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/AppContext', () => ({
+    useApp: () => ({
+        state: {
+            myWorkExcludedTypes: [],
+            selectedWorkspaceId: 'ws-test',
+        },
+        dispatch: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({
+    useDisplaySettings: () => ({
+        taskCardDensity: 'normal',
+        historyGrouping: 'none',
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/list-mode-config', () => ({
+    getListModeConfig: () => ({
+        showRunningSection: true,
+        showQueueSection: true,
+        showHistorySection: true,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/SwipeableHistoryItem', () => ({
+    SwipeableHistoryItem: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/SummarizeChatDialog', () => ({
+    SummarizeChatDialog: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
+    useBreakpoint: () => ({ isMobile: false, isTablet: false, isDesktop: true, breakpoint: 'desktop' }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/conversation/ConversationMetadataPopover', () => ({
+    buildRows: () => [],
+}));
+
+vi.mock('../../../../src/server/spa/client/react/ui/RenameDialog', () => ({
+    RenameDialog: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/tasks/comments/ContextMenu', () => ({
+    ContextMenu: () => null,
+}));
+
+import { ChatListPane } from '../../../../src/server/spa/client/react/features/chat/ChatListPane';
+
+function makeTask(overrides: Record<string, any> = {}) {
+    return {
+        id: 'task-1',
+        type: 'chat',
+        status: 'completed',
+        displayName: 'Test Chat',
+        startedAt: new Date().toISOString(),
+        payload: { mode: 'ask' },
+        ...overrides,
+    };
+}
+
+const defaultProps = {
+    running: [],
+    queued: [],
+    history: [],
+    isPaused: false,
+    isPauseResumeLoading: false,
+    isRefreshing: false,
+    selectedTaskId: null,
+    isMobile: false,
+    now: Date.now(),
+    workspaceId: 'ws-test',
+    onSelectTask: vi.fn(),
+    onPauseResume: vi.fn(),
+    onRefresh: vi.fn(),
+    onOpenDialog: vi.fn(),
+    fetchQueue: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('ChatListPane provider badge', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('codex provider', () => {
+        it('shows provider-badge for task with provider="codex" at top level', async () => {
+            const tasks = [makeTask({ id: 'task-a', displayName: 'Codex Chat', provider: 'codex' })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const badges = screen.getAllByTestId('provider-badge');
+            expect(badges.length).toBeGreaterThan(0);
+            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+            expect(badges[0].textContent).toBe('Codex');
+        });
+
+        it('shows provider-badge for task with metadata.provider="codex"', async () => {
+            const tasks = [makeTask({ id: 'task-b', displayName: 'Codex Meta Chat', metadata: { provider: 'codex' } })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const badges = screen.getAllByTestId('provider-badge');
+            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+        });
+
+        it('shows provider-badge for task with payload.provider="codex"', async () => {
+            const tasks = [makeTask({ id: 'task-c', displayName: 'Codex Payload Chat', payload: { mode: 'ask', provider: 'codex' } })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            const badges = screen.getAllByTestId('provider-badge');
+            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+        });
+    });
+
+    describe('copilot provider (default)', () => {
+        it('does NOT show provider-badge for task with provider="copilot"', async () => {
+            const tasks = [makeTask({ id: 'task-d', displayName: 'Copilot Chat', provider: 'copilot' })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            // Copilot is the default — no badge shown to avoid visual noise
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
+        });
+
+        it('does NOT show provider-badge when no provider is set', async () => {
+            const tasks = [makeTask({ id: 'task-e', displayName: 'Default Chat' })];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
+        });
+    });
+
+    describe('mixed provider list', () => {
+        it('shows badge only for codex tasks in a mixed list', async () => {
+            const tasks = [
+                makeTask({ id: 'task-1', displayName: 'Copilot Chat', provider: 'copilot' }),
+                makeTask({ id: 'task-2', displayName: 'Codex Chat', provider: 'codex' }),
+                makeTask({ id: 'task-3', displayName: 'No Provider Chat' }),
+            ];
+            await act(async () => {
+                render(<ChatListPane {...defaultProps} history={tasks} />);
+            });
+            // Only the codex task should have a badge
+            const badges = screen.getAllByTestId('provider-badge');
+            expect(badges).toHaveLength(1);
+            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+        });
+    });
+});

--- a/packages/coc/test/spa/react/repos/NewChatArea.test.tsx
+++ b/packages/coc/test/spa/react/repos/NewChatArea.test.tsx
@@ -68,15 +68,21 @@ vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
     getConfig: () => ({ apiBasePath: '/api' }),
     isRalphEnabled: () => mockRalphEnabled.value,
     isLoopsEnabled: () => false,
-    isCodexEnabled: () => false,
-    getActiveProvider: () => 'copilot',
 }));
 
 vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({
         queue: { enqueue: mockEnqueueTask },
-        preferences: { patchGlobal: vi.fn().mockResolvedValue({}) },
+        preferences: {
+            patchGlobal: vi.fn().mockResolvedValue({}),
+            getRepo: vi.fn().mockResolvedValue({}),
+            patchRepo: vi.fn().mockResolvedValue({}),
+        },
         skills: { listAllWorkspace: vi.fn().mockResolvedValue({ merged: [] }) },
+        agentProviders: { list: vi.fn().mockResolvedValue({ providers: [
+            { id: 'copilot', label: 'Copilot', enabled: true, available: true, locked: true },
+            { id: 'codex', label: 'Codex', enabled: false, available: false },
+        ] }) },
     }),
     getSpaCocClientErrorMessage: (err: any, fallback: string) =>
         (err instanceof Error ? err.message : undefined) || fallback,

--- a/packages/forge/src/copilot-sdk-wrapper/copilot-sdk-service.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/copilot-sdk-service.ts
@@ -58,6 +58,22 @@ export {
 
 export { tryConvertImageFileToDataUrl } from './image-converter';
 
+/** A single quota snapshot as returned by the Copilot SDK account.getQuota() RPC. */
+export interface CopilotAccountQuotaSnapshot {
+    isUnlimitedEntitlement: boolean;
+    entitlementRequests: number;
+    usedRequests: number;
+    usageAllowedWithExhaustedQuota: boolean;
+    remainingPercentage: number;
+    overage: number;
+    resetDate?: string;
+}
+
+/** Return type of CopilotSDKService.getAccountQuota(). */
+export interface CopilotAccountQuotaResult {
+    quotaSnapshots: Record<string, CopilotAccountQuotaSnapshot>;
+}
+
 export class CopilotSDKService implements ISDKService {
     private static instance: CopilotSDKService | null = null;
 
@@ -161,6 +177,26 @@ export class CopilotSDKService implements ISDKService {
         const availability = await this.isAvailable();
         if (!availability.available) throw new Error(availability.error ?? 'Copilot SDK is not available');
         return fetchModelsFromClient(await this.createClient());
+    }
+
+    /**
+     * Retrieve per-type account-level quota from the Copilot SDK.
+     * Spawns a fresh CopilotClient, calls account.getQuota(), then stops the client.
+     * @param gitHubToken  Optional per-user GitHub token. Omit to use global auth.
+     */
+    public async getAccountQuota(gitHubToken?: string): Promise<CopilotAccountQuotaResult> {
+        if (this.disposed) throw new Error('CopilotSDKService has been disposed');
+        const availability = await this.isAvailable();
+        if (!availability.available) throw new Error(availability.error ?? 'Copilot SDK is not available');
+        const client = await this.createClient();
+        try {
+            await client.start();
+            const params = gitHubToken ? { gitHubToken } : {};
+            const result = await (client as any).rpc.account.getQuota(params);
+            return result as CopilotAccountQuotaResult;
+        } finally {
+            await client.stop();
+        }
     }
 
     public async sendMessage(options: SendMessageOptions): Promise<SDKInvocationResult> {

--- a/packages/forge/src/copilot-sdk-wrapper/copilot-sdk-service.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/copilot-sdk-service.ts
@@ -59,7 +59,7 @@ export {
 export { tryConvertImageFileToDataUrl } from './image-converter';
 
 /** A single quota snapshot as returned by the Copilot SDK account.getQuota() RPC. */
-export interface CopilotAccountQuotaSnapshot {
+export interface IAccountQuotaSnapshot {
     isUnlimitedEntitlement: boolean;
     entitlementRequests: number;
     usedRequests: number;
@@ -70,8 +70,8 @@ export interface CopilotAccountQuotaSnapshot {
 }
 
 /** Return type of CopilotSDKService.getAccountQuota(). */
-export interface CopilotAccountQuotaResult {
-    quotaSnapshots: Record<string, CopilotAccountQuotaSnapshot>;
+export interface IAccountQuotaResult {
+    quotaSnapshots: Record<string, IAccountQuotaSnapshot>;
 }
 
 export class CopilotSDKService implements ISDKService {
@@ -184,7 +184,7 @@ export class CopilotSDKService implements ISDKService {
      * Spawns a fresh CopilotClient, calls account.getQuota(), then stops the client.
      * @param gitHubToken  Optional per-user GitHub token. Omit to use global auth.
      */
-    public async getAccountQuota(gitHubToken?: string): Promise<CopilotAccountQuotaResult> {
+    public async getAccountQuota(gitHubToken?: string): Promise<IAccountQuotaResult> {
         if (this.disposed) throw new Error('CopilotSDKService has been disposed');
         const availability = await this.isAvailable();
         if (!availability.available) throw new Error(availability.error ?? 'Copilot SDK is not available');
@@ -193,7 +193,7 @@ export class CopilotSDKService implements ISDKService {
             await client.start();
             const params = gitHubToken ? { gitHubToken } : {};
             const result = await (client as any).rpc.account.getQuota(params);
-            return result as CopilotAccountQuotaResult;
+            return result as IAccountQuotaResult;
         } finally {
             await client.stop();
         }

--- a/packages/forge/src/copilot-sdk-wrapper/index.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/index.ts
@@ -95,8 +95,8 @@ export {
 
 export type { BackgroundTasksInfo } from './copilot-sdk-service';
 export type {
-    CopilotAccountQuotaSnapshot,
-    CopilotAccountQuotaResult,
+    IAccountQuotaSnapshot,
+    IAccountQuotaResult,
 } from './copilot-sdk-service';
 
 // ISDKService interface and provider-agnostic types

--- a/packages/forge/src/copilot-sdk-wrapper/index.ts
+++ b/packages/forge/src/copilot-sdk-wrapper/index.ts
@@ -94,6 +94,10 @@ export {
 } from './copilot-sdk-service';
 
 export type { BackgroundTasksInfo } from './copilot-sdk-service';
+export type {
+    CopilotAccountQuotaSnapshot,
+    CopilotAccountQuotaResult,
+} from './copilot-sdk-service';
 
 // ISDKService interface and provider-agnostic types
 export type {


### PR DESCRIPTION
- **feat(ac-01): live codex.enabled, always-init codex auth infra, GET /api/agent-providers**
- **feat(coc): AC-03 + AC-04 per-chat provider routing and follow-up provider inheritance**
- **feat(dynamic-agent): AC-02 agent selector chip in NewChatArea**
- **fix(tests): update second NewChatArea test mock for agentProviders client**
- **feat(ac-05): add provider badges in chat header and list**
- **feat: add provider quota display in Admin Agents tab**
- **Move Codex Provider toggle to Agent Provider tab**
- **refactor: rename quota interfaces to IAccountQuotaSnapshot/IAccountQuotaResult**
