### PR TITLE
feat(dashboard): show process error reason in conversation UI for fai…

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1254,6 +1254,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         mcpOAuthPrompts={mcpOAuthPrompts}
                         onMcpOAuthCompleted={(requestId) => setMcpOAuthPrompts(prev => prev.filter(p => p.requestId !== requestId))}
                         onMcpOAuthFailed={(requestId) => setMcpOAuthPrompts(prev => prev.filter(p => p.requestId !== requestId))}
+                        processError={processDetails?.error ?? null}
                     />
                     {variant !== 'floating' && !isMobile && (
                         <ConversationMiniMap

--- a/packages/coc/src/server/spa/client/react/features/chat/ConversationArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ConversationArea.tsx
@@ -80,6 +80,13 @@ export interface ConversationAreaProps {
     /** Called when the user cancels a queued/pending follow-up message. */
     onCancelPendingMessage?: (messageId: string) => void;
     /**
+     * Process-level failure reason (from `processDetails.error`). When set and
+     * the task status is `failed`, shown as an error banner — either replacing
+     * the "No conversation data" placeholder (0 turns) or appended after the
+     * last conversation turn.
+     */
+    processError?: string | null;
+    /**
      * Optional handle to the chat follow-up input. When provided,
      * vim-style `i` re-focuses the input from nav mode.
      */
@@ -131,6 +138,7 @@ export function ConversationArea({
     mcpOAuthPrompts,
     onMcpOAuthCompleted,
     onMcpOAuthFailed,
+    processError,
 }: ConversationAreaProps) {
     const [showArchived, setShowArchived] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -172,7 +180,21 @@ export function ConversationArea({
                         <Spinner size="sm" /> Loading conversation...
                     </div>
                 ) : turns.length === 0 ? (
-                    <div className="text-[#848484] text-sm">No conversation data available.</div>
+                    processError ? (
+                        <div
+                            className="flex items-start gap-3 p-3 rounded-lg bg-[#fdf3f3] dark:bg-[#3a1a1a] border border-[#f1707050] dark:border-[#f1707040]"
+                            data-testid="process-error-banner"
+                            role="alert"
+                        >
+                            <span className="text-[#d32f2f] dark:text-[#f48771] flex-shrink-0 text-base leading-5">⚠</span>
+                            <div className="min-w-0">
+                                <div className="text-sm font-semibold text-[#d32f2f] dark:text-[#f48771] mb-1">Task failed</div>
+                                <pre className="text-xs text-[#1f2328] dark:text-[#cccccc] whitespace-pre-wrap break-words font-mono">{processError}</pre>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="text-[#848484] text-sm">No conversation data available.</div>
+                    )
                 ) : (
                     <div className="space-y-3" ref={turnsContainerRef}>
                         {/* Pinned messages section */}
@@ -357,6 +379,19 @@ export function ConversationArea({
                         )}
                         {backgroundTasks && backgroundTasks.backgroundTotalActive > 0 && (
                             <BackgroundTasksIndicator backgroundTasks={backgroundTasks} />
+                        )}
+                        {processError && task?.status === 'failed' && (
+                            <div
+                                className="flex items-start gap-3 p-3 rounded-lg bg-[#fdf3f3] dark:bg-[#3a1a1a] border border-[#f1707050] dark:border-[#f1707040]"
+                                data-testid="process-error-banner"
+                                role="alert"
+                            >
+                                <span className="text-[#d32f2f] dark:text-[#f48771] flex-shrink-0 text-base leading-5">⚠</span>
+                                <div className="min-w-0">
+                                    <div className="text-sm font-semibold text-[#d32f2f] dark:text-[#f48771] mb-1">Task failed</div>
+                                    <pre className="text-xs text-[#1f2328] dark:text-[#cccccc] whitespace-pre-wrap break-words font-mono">{processError}</pre>
+                                </div>
+                            </div>
                         )}
                     </div>
                 )}

--- a/packages/coc/test/spa/react/repos/ConversationArea-sort-order.test.tsx
+++ b/packages/coc/test/spa/react/repos/ConversationArea-sort-order.test.tsx
@@ -53,3 +53,39 @@ describe('ConversationArea: turn ordering', () => {
         expect(CONVERSATION_AREA_SOURCE).toContain('nextTurnIndex');
     });
 });
+
+describe('ConversationArea: process error banner', () => {
+    it('accepts a processError prop in ConversationAreaProps', () => {
+        expect(CONVERSATION_AREA_SOURCE).toContain('processError?:');
+    });
+
+    it('renders a process-error-banner when processError is provided', () => {
+        expect(CONVERSATION_AREA_SOURCE).toContain('process-error-banner');
+    });
+
+    it('shows the error banner in the zero-turns case when processError is set', () => {
+        // The banner should replace the generic "No conversation data available." message
+        // when a processError is provided (failed task with no turns).
+        expect(CONVERSATION_AREA_SOURCE).toContain('processError ?');
+        // Generic fallback must still exist for the no-error zero-turns case
+        expect(CONVERSATION_AREA_SOURCE).toContain('No conversation data available.');
+    });
+
+    it('shows the error banner after turns when the task failed with an error', () => {
+        // The banner is also rendered inside the turns branch for failed tasks
+        // that produced some turns before failing.
+        expect(CONVERSATION_AREA_SOURCE).toContain("task?.status === 'failed'");
+    });
+
+    it('labels the banner with "Task failed" heading', () => {
+        expect(CONVERSATION_AREA_SOURCE).toContain('Task failed');
+    });
+
+    it('passes processError from ChatDetail to ConversationArea', () => {
+        const chatDetailSource = fs.readFileSync(
+            path.join(REPOS_DIR, 'ChatDetail.tsx'), 'utf-8'
+        );
+        expect(chatDetailSource).toContain('processError={processDetails?.error');
+    });
+});
+


### PR DESCRIPTION
…led tasks

When a task fails, the chat detail view now displays a styled error banner with the process-level failure reason (processDetails.error):

- Zero turns + failed: replaces the generic 'No conversation data available.' placeholder with a red error card showing the failure reason.
- Has turns + failed: appends the error card after the last conversation turn so the user can see why the task stopped.

ConversationArea accepts a new optional processError prop and renders the banner in both cases. ChatDetail passes processDetails?.error ?? null.