### PR TITLE
feat(coccontainer): teams-bridge send only last timeline chunk on com…

### DIFF
--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -149,6 +149,7 @@ export interface RuntimeDashboardConfig {
     excalidrawEnabled: boolean;
     mcpOauthEnabled: boolean;
     focusedDiffEnabled: boolean;
+    containerDefaultAgentEnabled: boolean;
     codexEnabled: boolean;
     activeProvider: 'copilot' | 'codex';
   };

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -137,6 +137,10 @@ export interface CLIConfig {
     excalidraw?: {
         enabled?: boolean;
     };
+    /** Container default agent — smart routing session. Disabled by default. */
+    containerDefaultAgent?: {
+        enabled?: boolean;
+    };
     /** Codex SDK provider support. Disabled by default. */
     codex?: {
         enabled?: boolean;
@@ -318,6 +322,10 @@ export interface ResolvedCLIConfig {
     excalidraw: {
         enabled: boolean;
     };
+    /** Container default agent — smart routing session. */
+    containerDefaultAgent: {
+        enabled: boolean;
+    };
     /** Codex SDK provider support. Disabled by default. */
     codex: {
         enabled: boolean;
@@ -455,6 +463,9 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
         enabled: false,
     },
     excalidraw: {
+        enabled: false,
+    },
+    containerDefaultAgent: {
         enabled: false,
     },
     codex: {

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -34,6 +34,7 @@ export type ResolvedConfigNamespaceValues = Pick<
     | 'loops'
     | 'mcpOauth'
     | 'excalidraw'
+    | 'containerDefaultAgent'
     | 'codex'
     | 'features'
     | 'memoryPromotion'
@@ -72,6 +73,7 @@ const VIM_NAVIGATION_SOURCE_KEYS = ['vimNavigation.enabled'] as const;
 const LOOPS_SOURCE_KEYS = ['loops.enabled'] as const;
 const MCP_OAUTH_SOURCE_KEYS = ['mcpOauth.enabled'] as const;
 const EXCALIDRAW_SOURCE_KEYS = ['excalidraw.enabled'] as const;
+const CONTAINER_DEFAULT_AGENT_SOURCE_KEYS = ['containerDefaultAgent.enabled'] as const;
 const CODEX_SOURCE_KEYS = ['codex.enabled'] as const;
 const FEATURES_SOURCE_KEYS = ['features.autoMemoryPromotion', 'features.focusedDiff'] as const;
 
@@ -104,6 +106,7 @@ export const CONFIG_NAMESPACE_SOURCE_KEYS = [
     ...LOOPS_SOURCE_KEYS,
     ...MCP_OAUTH_SOURCE_KEYS,
     ...EXCALIDRAW_SOURCE_KEYS,
+    ...CONTAINER_DEFAULT_AGENT_SOURCE_KEYS,
     ...CODEX_SOURCE_KEYS,
     ...FEATURES_SOURCE_KEYS,
     ...MEMORY_PROMOTION_SOURCE_KEYS,
@@ -256,6 +259,11 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
             name: 'excalidraw',
             sourceDescriptors: [source('excalidraw.', ['excalidraw'], EXCALIDRAW_SOURCE_KEYS)],
             merge: (base, override) => ({ excalidraw: { enabled: override?.excalidraw?.enabled ?? base.excalidraw?.enabled ?? false } }),
+        },
+        {
+            name: 'containerDefaultAgent',
+            sourceDescriptors: [source('containerDefaultAgent.', ['containerDefaultAgent'], CONTAINER_DEFAULT_AGENT_SOURCE_KEYS)],
+            merge: (base, override) => ({ containerDefaultAgent: { enabled: override?.containerDefaultAgent?.enabled ?? base.containerDefaultAgent?.enabled ?? false } }),
         },
         {
             name: 'codex',

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -211,6 +211,10 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
         if (!cfg.mcpOauth) { cfg.mcpOauth = {}; }
         cfg.mcpOauth.enabled = v;
     }, 'restartRequired'),
+    bool('containerDefaultAgent.enabled', (cfg, v) => {
+        if (!cfg.containerDefaultAgent) { cfg.containerDefaultAgent = {}; }
+        cfg.containerDefaultAgent.enabled = v;
+    }),
     bool('codex.enabled', (cfg, v) => {
         if (!cfg.codex) { cfg.codex = {}; }
         cfg.codex.enabled = v;

--- a/packages/coc/src/server/config/runtime-config-handler.ts
+++ b/packages/coc/src/server/config/runtime-config-handler.ts
@@ -46,6 +46,7 @@ export function buildRuntimeDashboardConfig(
             excalidrawEnabled: config.excalidraw?.enabled ?? false,
             mcpOauthEnabled: config.mcpOauth?.enabled ?? false,
             focusedDiffEnabled: config.features?.focusedDiff ?? false,
+            containerDefaultAgentEnabled: config.containerDefaultAgent?.enabled ?? false,
             codexEnabled: config.codex?.enabled ?? false,
             activeProvider: config.activeProvider ?? 'copilot',
         },

--- a/packages/coc/src/server/container-sessions/container-session-handler.ts
+++ b/packages/coc/src/server/container-sessions/container-session-handler.ts
@@ -1,0 +1,197 @@
+/**
+ * Container Session Handler
+ *
+ * REST API routes for container sessions:
+ *   POST   /api/container/sessions          — Create a new container session
+ *   GET    /api/container/sessions           — List container sessions
+ *   GET    /api/container/sessions/:id       — Get session detail with turns
+ *   POST   /api/container/sessions/:id/message — Send a message (triggers routing)
+ *   PATCH  /api/container/sessions/:id/routing — Set/clear routing override
+ *   DELETE /api/container/sessions/:id       — Delete a container session
+ */
+
+import { randomBytes } from 'crypto';
+import type { Route } from '../types';
+import { sendJson, readBody, sendError } from '../shared/router';
+import type { ContainerSessionStore } from './container-session-store';
+import type { RoutingClassifierDeps } from './routing-classifier';
+import type { ContainerAgentInfo, RoutingDecision } from './container-session-types';
+import { classifyRouting } from './routing-classifier';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ContainerSessionRouteOptions {
+    store: ContainerSessionStore;
+    classifierDeps: RoutingClassifierDeps;
+    /** Returns available agents and their workspaces for routing. */
+    getAgents: () => Promise<ContainerAgentInfo[]>;
+    /** Forwards a message to a specific agent's queue. Returns downstream process ID. */
+    forwardMessage: (agentId: string, workspaceId: string, message: string, existingProcessId?: string | null) => Promise<string>;
+}
+
+// ============================================================================
+// Route Registration
+// ============================================================================
+
+export function registerContainerSessionRoutes(
+    routes: Route[],
+    options: ContainerSessionRouteOptions,
+): void {
+    const { store, classifierDeps, getAgents, forwardMessage } = options;
+
+    // POST /api/container/sessions — create session
+    routes.push({
+        method: 'POST',
+        pattern: '/api/container/sessions',
+        handler: (_req, res) => {
+            const id = `csess_${randomBytes(8).toString('hex')}`;
+            const session = store.create(id);
+            sendJson(res, session, 201);
+        },
+    });
+
+    // GET /api/container/sessions — list sessions
+    routes.push({
+        method: 'GET',
+        pattern: '/api/container/sessions',
+        handler: (req, res) => {
+            const url = new URL(req.url ?? '', 'http://localhost');
+            const limit = parseInt(url.searchParams.get('limit') ?? '50', 10);
+            const offset = parseInt(url.searchParams.get('offset') ?? '0', 10);
+            const sessions = store.list(limit, offset);
+            sendJson(res, sessions);
+        },
+    });
+
+    // GET /api/container/sessions/:id — get session detail
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/container\/sessions\/([^/]+)$/,
+        handler: (_req, res, match) => {
+            const id = decodeURIComponent(match![1]);
+            const session = store.get(id);
+            if (!session) return sendError(res, 404, 'Session not found');
+            sendJson(res, session);
+        },
+    });
+
+    // POST /api/container/sessions/:id/message — send message
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/container\/sessions\/([^/]+)\/message$/,
+        handler: async (req, res, match) => {
+            try {
+                const id = decodeURIComponent(match![1]);
+                const session = store.get(id);
+                if (!session) return sendError(res, 404, 'Session not found');
+                if (session.status === 'closed') return sendError(res, 400, 'Session is closed');
+
+                const body = await readBody(req);
+                const { content } = JSON.parse(body);
+                if (!content || typeof content !== 'string') {
+                    return sendError(res, 400, 'content is required');
+                }
+
+                // Classify routing
+                const agents = await getAgents();
+                const routing: RoutingDecision = await classifyRouting(
+                    {
+                        agents,
+                        history: session.turns,
+                        message: content,
+                        override: session.routingOverride,
+                    },
+                    classifierDeps,
+                );
+
+                // Find existing downstream process for this agent:workspace
+                const existingProcessId = findExistingDownstreamProcess(session.turns, routing);
+
+                // Forward message to target agent
+                const downstreamProcessId = await forwardMessage(
+                    routing.agentId,
+                    routing.workspaceId,
+                    content,
+                    existingProcessId,
+                );
+
+                // Record user turn
+                const turnIndex = session.turns.length;
+                const userTurn = {
+                    index: turnIndex,
+                    role: 'user' as const,
+                    content,
+                    routing,
+                    downstreamProcessId,
+                    timestamp: new Date().toISOString(),
+                };
+                store.addTurn(id, userTurn);
+
+                sendJson(res, {
+                    turn: userTurn,
+                    routing,
+                    downstreamProcessId,
+                });
+            } catch (err: any) {
+                sendError(res, 500, err.message ?? 'Internal error');
+            }
+        },
+    });
+
+    // PATCH /api/container/sessions/:id/routing — set/clear override
+    routes.push({
+        method: 'PATCH',
+        pattern: /^\/api\/container\/sessions\/([^/]+)\/routing$/,
+        handler: async (req, res, match) => {
+            try {
+                const id = decodeURIComponent(match![1]);
+                const session = store.get(id);
+                if (!session) return sendError(res, 404, 'Session not found');
+
+                const body = await readBody(req);
+                const { agentId, workspaceId } = JSON.parse(body);
+
+                const override = agentId && workspaceId
+                    ? { agentId, workspaceId }
+                    : null;
+
+                store.setRoutingOverride(id, override);
+                sendJson(res, { routingOverride: override });
+            } catch (err: any) {
+                sendError(res, 500, err.message ?? 'Internal error');
+            }
+        },
+    });
+
+    // DELETE /api/container/sessions/:id — delete session
+    routes.push({
+        method: 'DELETE',
+        pattern: /^\/api\/container\/sessions\/([^/]+)$/,
+        handler: (_req, res, match) => {
+            const id = decodeURIComponent(match![1]);
+            const deleted = store.delete(id);
+            if (!deleted) return sendError(res, 404, 'Session not found');
+            res.writeHead(204);
+            res.end();
+        },
+    });
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function findExistingDownstreamProcess(
+    turns: Array<{ routing: RoutingDecision; downstreamProcessId: string | null }>,
+    routing: RoutingDecision,
+): string | null {
+    for (let i = turns.length - 1; i >= 0; i--) {
+        const t = turns[i];
+        if (t.routing.agentId === routing.agentId && t.routing.workspaceId === routing.workspaceId && t.downstreamProcessId) {
+            return t.downstreamProcessId;
+        }
+    }
+    return null;
+}

--- a/packages/coc/src/server/container-sessions/container-session-store.ts
+++ b/packages/coc/src/server/container-sessions/container-session-store.ts
@@ -1,0 +1,186 @@
+/**
+ * Container Session Store
+ *
+ * SQLite-backed persistence for container sessions. Stores session metadata
+ * and turns with per-turn routing decisions. Uses an in-process SQLite
+ * database (same pattern as LoopStore).
+ */
+
+import type Database from 'better-sqlite3';
+import type {
+    ContainerSession,
+    ContainerSessionTurn,
+    ContainerSessionStatus,
+    RoutingDecision,
+} from './container-session-types';
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+const CREATE_SESSIONS_TABLE = `
+CREATE TABLE IF NOT EXISTS container_sessions (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'active',
+    routing_override_agent_id TEXT,
+    routing_override_workspace_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+)`;
+
+const CREATE_TURNS_TABLE = `
+CREATE TABLE IF NOT EXISTS container_session_turns (
+    session_id TEXT NOT NULL,
+    turn_index INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    routing_agent_id TEXT NOT NULL,
+    routing_workspace_id TEXT NOT NULL,
+    routing_confidence REAL NOT NULL DEFAULT 1.0,
+    routing_reason TEXT NOT NULL DEFAULT '',
+    downstream_process_id TEXT,
+    timestamp TEXT NOT NULL,
+    PRIMARY KEY (session_id, turn_index),
+    FOREIGN KEY (session_id) REFERENCES container_sessions(id) ON DELETE CASCADE
+)`;
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export class ContainerSessionStore {
+    private readonly db: Database.Database;
+
+    constructor(db: Database.Database) {
+        this.db = db;
+        this.db.exec(CREATE_SESSIONS_TABLE);
+        this.db.exec(CREATE_TURNS_TABLE);
+    }
+
+    /** Create a new container session. */
+    create(id: string): ContainerSession {
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `INSERT INTO container_sessions (id, status, created_at, updated_at) VALUES (?, 'active', ?, ?)`,
+        ).run(id, now, now);
+        return { id, status: 'active', routingOverride: null, createdAt: now, updatedAt: now, turns: [] };
+    }
+
+    /** Get a session by ID (with all turns). Returns null if not found. */
+    get(id: string): ContainerSession | null {
+        const row = this.db.prepare(`SELECT * FROM container_sessions WHERE id = ?`).get(id) as any;
+        if (!row) return null;
+        const turns = this.getTurns(id);
+        return {
+            id: row.id,
+            status: row.status as ContainerSessionStatus,
+            routingOverride: row.routing_override_agent_id
+                ? { agentId: row.routing_override_agent_id, workspaceId: row.routing_override_workspace_id }
+                : null,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+            turns,
+        };
+    }
+
+    /** List sessions ordered by most recent activity. */
+    list(limit = 50, offset = 0): ContainerSession[] {
+        const rows = this.db.prepare(
+            `SELECT * FROM container_sessions ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
+        ).all(limit, offset) as any[];
+        return rows.map(row => ({
+            id: row.id,
+            status: row.status as ContainerSessionStatus,
+            routingOverride: row.routing_override_agent_id
+                ? { agentId: row.routing_override_agent_id, workspaceId: row.routing_override_workspace_id }
+                : null,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+            turns: [], // turns loaded lazily
+        }));
+    }
+
+    /** Add a turn to a session. */
+    addTurn(sessionId: string, turn: ContainerSessionTurn): void {
+        this.db.prepare(
+            `INSERT INTO container_session_turns
+             (session_id, turn_index, role, content, routing_agent_id, routing_workspace_id, routing_confidence, routing_reason, downstream_process_id, timestamp)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+            sessionId,
+            turn.index,
+            turn.role,
+            turn.content,
+            turn.routing.agentId,
+            turn.routing.workspaceId,
+            turn.routing.confidence,
+            turn.routing.reason,
+            turn.downstreamProcessId,
+            turn.timestamp,
+        );
+        this.db.prepare(`UPDATE container_sessions SET updated_at = ? WHERE id = ?`).run(turn.timestamp, sessionId);
+    }
+
+    /** Update the downstream process ID for a turn. */
+    updateTurnProcessId(sessionId: string, turnIndex: number, processId: string): void {
+        this.db.prepare(
+            `UPDATE container_session_turns SET downstream_process_id = ? WHERE session_id = ? AND turn_index = ?`,
+        ).run(processId, sessionId, turnIndex);
+    }
+
+    /** Set or clear the routing override for a session. */
+    setRoutingOverride(sessionId: string, override: { agentId: string; workspaceId: string } | null): void {
+        const now = new Date().toISOString();
+        if (override) {
+            this.db.prepare(
+                `UPDATE container_sessions SET routing_override_agent_id = ?, routing_override_workspace_id = ?, updated_at = ? WHERE id = ?`,
+            ).run(override.agentId, override.workspaceId, now, sessionId);
+        } else {
+            this.db.prepare(
+                `UPDATE container_sessions SET routing_override_agent_id = NULL, routing_override_workspace_id = NULL, updated_at = ? WHERE id = ?`,
+            ).run(now, sessionId);
+        }
+    }
+
+    /** Close a session. */
+    close(sessionId: string): void {
+        const now = new Date().toISOString();
+        this.db.prepare(`UPDATE container_sessions SET status = 'closed', updated_at = ? WHERE id = ?`).run(now, sessionId);
+    }
+
+    /** Delete a session and all its turns. */
+    delete(sessionId: string): boolean {
+        const result = this.db.prepare(`DELETE FROM container_sessions WHERE id = ?`).run(sessionId);
+        this.db.prepare(`DELETE FROM container_session_turns WHERE session_id = ?`).run(sessionId);
+        return result.changes > 0;
+    }
+
+    /** Get the turn count for a session. */
+    turnCount(sessionId: string): number {
+        const row = this.db.prepare(
+            `SELECT COUNT(*) as cnt FROM container_session_turns WHERE session_id = ?`,
+        ).get(sessionId) as any;
+        return row?.cnt ?? 0;
+    }
+
+    // ── Private ─────────────────────────────────────────────────────────────
+
+    private getTurns(sessionId: string): ContainerSessionTurn[] {
+        const rows = this.db.prepare(
+            `SELECT * FROM container_session_turns WHERE session_id = ? ORDER BY turn_index ASC`,
+        ).all(sessionId) as any[];
+        return rows.map(row => ({
+            index: row.turn_index,
+            role: row.role,
+            content: row.content,
+            routing: {
+                agentId: row.routing_agent_id,
+                workspaceId: row.routing_workspace_id,
+                confidence: row.routing_confidence,
+                reason: row.routing_reason,
+            },
+            downstreamProcessId: row.downstream_process_id,
+            timestamp: row.timestamp,
+        }));
+    }
+}

--- a/packages/coc/src/server/container-sessions/container-session-types.ts
+++ b/packages/coc/src/server/container-sessions/container-session-types.ts
@@ -1,0 +1,80 @@
+/**
+ * Container Session Types
+ *
+ * A container session is a meta-level chat that routes each user message
+ * to the appropriate agent:repo based on context. It tracks per-turn
+ * routing decisions and linked downstream process IDs.
+ */
+
+// ============================================================================
+// Routing Decision
+// ============================================================================
+
+export interface RoutingDecision {
+    /** Target agent ID. */
+    agentId: string;
+    /** Target workspace ID. */
+    workspaceId: string;
+    /** Confidence score (0–1). */
+    confidence: number;
+    /** Brief explanation of why this agent was chosen. */
+    reason: string;
+}
+
+// ============================================================================
+// Container Session Turn
+// ============================================================================
+
+export interface ContainerSessionTurn {
+    /** Zero-based turn index. */
+    index: number;
+    /** 'user' or 'assistant'. */
+    role: 'user' | 'assistant';
+    /** Message content. */
+    content: string;
+    /** Routing decision for this turn (set on user turns, inherited on assistant turns). */
+    routing: RoutingDecision;
+    /** Downstream process ID on the target agent (created when first message routed there). */
+    downstreamProcessId: string | null;
+    /** ISO timestamp. */
+    timestamp: string;
+}
+
+// ============================================================================
+// Container Session
+// ============================================================================
+
+export type ContainerSessionStatus = 'active' | 'closed';
+
+export interface ContainerSession {
+    /** Unique session ID (e.g. `csess_<random>`). */
+    id: string;
+    /** Current status. */
+    status: ContainerSessionStatus;
+    /** Manual routing override — when set, skips the classifier. */
+    routingOverride: { agentId: string; workspaceId: string } | null;
+    /** ISO timestamp of creation. */
+    createdAt: string;
+    /** ISO timestamp of last activity. */
+    updatedAt: string;
+    /** Session turns (in-memory representation). */
+    turns: ContainerSessionTurn[];
+}
+
+// ============================================================================
+// Agent Info (for routing)
+// ============================================================================
+
+export interface ContainerAgentInfo {
+    /** Agent ID. */
+    id: string;
+    /** Agent display name. */
+    name: string;
+    /** Workspaces managed by this agent. */
+    workspaces: Array<{
+        id: string;
+        name: string;
+        rootPath: string;
+        description?: string;
+    }>;
+}

--- a/packages/coc/src/server/container-sessions/index.ts
+++ b/packages/coc/src/server/container-sessions/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Container Sessions — barrel export.
+ */
+
+export { ContainerSessionStore } from './container-session-store';
+export { registerContainerSessionRoutes } from './container-session-handler';
+export { classifyRouting, parseClassifierResponse } from './routing-classifier';
+export type {
+    ContainerSession,
+    ContainerSessionTurn,
+    ContainerSessionStatus,
+    RoutingDecision,
+    ContainerAgentInfo,
+} from './container-session-types';
+export type { RoutingClassifierDeps, RoutingClassifierOptions } from './routing-classifier';
+export type { ContainerSessionRouteOptions } from './container-session-handler';

--- a/packages/coc/src/server/container-sessions/routing-classifier.ts
+++ b/packages/coc/src/server/container-sessions/routing-classifier.ts
@@ -1,0 +1,210 @@
+/**
+ * Container Session Routing Classifier
+ *
+ * Determines which agent:workspace should handle a user message based on
+ * message content, conversation history, and available agents.
+ *
+ * Strategy:
+ * 1. If a routing override is set, use it immediately (confidence 1.0).
+ * 2. Otherwise, call the LLM with a concise system prompt listing agents/repos.
+ * 3. If the LLM's confidence is below threshold, fall back to the last-used route.
+ */
+
+import type { RoutingDecision, ContainerAgentInfo, ContainerSessionTurn } from './container-session-types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RoutingClassifierOptions {
+    /** Available agents with their workspaces. */
+    agents: ContainerAgentInfo[];
+    /** Conversation history (recent turns for context). */
+    history: ContainerSessionTurn[];
+    /** User's new message. */
+    message: string;
+    /** Manual override (if set, skip classification). */
+    override?: { agentId: string; workspaceId: string } | null;
+}
+
+export interface RoutingClassifierDeps {
+    /** Invoke the LLM for routing classification. Returns raw text response. */
+    invokeClassifier: (systemPrompt: string, userPrompt: string) => Promise<string>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Minimum confidence to accept a routing decision. Below this, fall back. */
+const CONFIDENCE_THRESHOLD = 0.5;
+
+/** Maximum history turns to include in the classifier prompt. */
+const MAX_HISTORY_TURNS = 6;
+
+// ============================================================================
+// Classifier
+// ============================================================================
+
+/**
+ * Classify which agent:workspace should handle the user's message.
+ */
+export async function classifyRouting(
+    options: RoutingClassifierOptions,
+    deps: RoutingClassifierDeps,
+): Promise<RoutingDecision> {
+    const { agents, history, message, override } = options;
+
+    // Fast path: manual override
+    if (override?.agentId && override?.workspaceId) {
+        return {
+            agentId: override.agentId,
+            workspaceId: override.workspaceId,
+            confidence: 1.0,
+            reason: 'Manual override',
+        };
+    }
+
+    // If only one agent with one workspace, skip LLM
+    const allWorkspaces = agents.flatMap(a => a.workspaces.map(w => ({ agentId: a.id, ...w })));
+    if (allWorkspaces.length === 1) {
+        const only = allWorkspaces[0];
+        return {
+            agentId: only.agentId,
+            workspaceId: only.id,
+            confidence: 1.0,
+            reason: `Only one workspace available: ${only.name}`,
+        };
+    }
+
+    if (allWorkspaces.length === 0) {
+        throw new Error('No agents or workspaces available for routing');
+    }
+
+    // Build classifier prompt
+    const systemPrompt = buildSystemPrompt(agents);
+    const userPrompt = buildUserPrompt(message, history);
+
+    // Call LLM
+    const rawResponse = await deps.invokeClassifier(systemPrompt, userPrompt);
+
+    // Parse response
+    const decision = parseClassifierResponse(rawResponse, agents);
+
+    // If confidence is below threshold, fall back to last-used route
+    if (decision.confidence < CONFIDENCE_THRESHOLD) {
+        const fallback = getLastUsedRoute(history);
+        if (fallback) {
+            return { ...fallback, confidence: 0.6, reason: `Low confidence (${decision.confidence.toFixed(2)}); using last-used route` };
+        }
+    }
+
+    return decision;
+}
+
+// ============================================================================
+// Prompt Building
+// ============================================================================
+
+function buildSystemPrompt(agents: ContainerAgentInfo[]): string {
+    const agentList = agents.map(a => {
+        const workspaces = a.workspaces.map(w =>
+            `  - workspace_id: "${w.id}", name: "${w.name}", path: "${w.rootPath}"${w.description ? `, description: "${w.description}"` : ''}`,
+        ).join('\n');
+        return `Agent "${a.name}" (id: "${a.id}"):\n${workspaces}`;
+    }).join('\n\n');
+
+    return `You are a routing classifier for a multi-agent system. Your job is to decide which agent and workspace should handle the user's message.
+
+Available agents and their workspaces:
+${agentList}
+
+Respond with EXACTLY one line in this format:
+ROUTE: agent_id=<agent_id> workspace_id=<workspace_id> confidence=<0.0-1.0> reason=<brief reason>
+
+Rules:
+- Pick the most relevant workspace based on the message content and conversation context.
+- If the message mentions a specific project, repo, or file path, route to the matching workspace.
+- If ambiguous, pick the workspace most recently discussed in the history.
+- Confidence should reflect how certain you are (1.0 = perfect match, 0.5 = uncertain).`;
+}
+
+function buildUserPrompt(message: string, history: ContainerSessionTurn[]): string {
+    const recentHistory = history.slice(-MAX_HISTORY_TURNS);
+    const historyText = recentHistory.length > 0
+        ? 'Recent conversation:\n' + recentHistory.map(t =>
+            `[${t.role}→${t.routing.agentId}/${t.routing.workspaceId}] ${t.content.slice(0, 200)}`,
+        ).join('\n') + '\n\n'
+        : '';
+
+    return `${historyText}New message from user:\n${message}`;
+}
+
+// ============================================================================
+// Response Parsing
+// ============================================================================
+
+const ROUTE_PATTERN = /ROUTE:\s*agent_id=([^\s]+)\s+workspace_id=([^\s]+)\s+confidence=([\d.]+)\s+reason=(.+)/i;
+
+export function parseClassifierResponse(
+    response: string,
+    agents: ContainerAgentInfo[],
+): RoutingDecision {
+    const match = response.match(ROUTE_PATTERN);
+    if (!match) {
+        // Fall back to first available workspace
+        const first = agents[0];
+        const ws = first.workspaces[0];
+        return {
+            agentId: first.id,
+            workspaceId: ws.id,
+            confidence: 0.3,
+            reason: 'Could not parse classifier response; defaulting to first workspace',
+        };
+    }
+
+    const [, agentId, workspaceId, confidenceStr, reason] = match;
+    const confidence = Math.min(1.0, Math.max(0.0, parseFloat(confidenceStr) || 0.5));
+
+    // Validate that the agent/workspace exist
+    const agent = agents.find(a => a.id === agentId);
+    if (!agent) {
+        return {
+            agentId: agents[0].id,
+            workspaceId: agents[0].workspaces[0].id,
+            confidence: 0.3,
+            reason: `Agent "${agentId}" not found; defaulting`,
+        };
+    }
+
+    const workspace = agent.workspaces.find(w => w.id === workspaceId);
+    if (!workspace) {
+        return {
+            agentId: agent.id,
+            workspaceId: agent.workspaces[0]?.id ?? agents[0].workspaces[0].id,
+            confidence: 0.4,
+            reason: `Workspace "${workspaceId}" not found on agent "${agentId}"; using first`,
+        };
+    }
+
+    return { agentId, workspaceId, confidence, reason: reason.trim() };
+}
+
+// ============================================================================
+// Fallback
+// ============================================================================
+
+function getLastUsedRoute(history: ContainerSessionTurn[]): RoutingDecision | null {
+    for (let i = history.length - 1; i >= 0; i--) {
+        const turn = history[i];
+        if (turn.routing.agentId && turn.routing.workspaceId) {
+            return {
+                agentId: turn.routing.agentId,
+                workspaceId: turn.routing.workspaceId,
+                confidence: turn.routing.confidence,
+                reason: turn.routing.reason,
+            };
+        }
+    }
+    return null;
+}

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -93,6 +93,9 @@ import { registerRuntimeConfigRoutes } from '../config/runtime-config-handler';
 import { registerSyncRoutes } from '../sync/sync-handler';
 import type { SyncEngine } from '../sync/sync-engine';
 import { registerTeamsMessagingRoutes } from '../messaging/teams-messaging-handler';
+import { registerContainerSessionRoutes } from '../container-sessions/container-session-handler';
+import { ContainerSessionStore } from '../container-sessions/container-session-store';
+import type { ContainerAgentInfo } from '../container-sessions/container-session-types';
 
 /** Collect git commits made between headBefore and current HEAD. Non-fatal — returns [] on error. */
 function collectWorkItemCommits(
@@ -329,6 +332,48 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerHeapRoutes(routes);
     registerMyWorkRoutes(routes, store, dataDir);
     registerMyLifeRoutes(routes, store, dataDir);
+
+    // Container default agent session routes (feature-flagged)
+    if (opts.resolvedConfig?.containerDefaultAgent?.enabled) {
+        const Database = require('better-sqlite3');
+        fs.mkdirSync(path.join(dataDir, 'container-sessions'), { recursive: true });
+        const containerDb = new Database(path.join(dataDir, 'container-sessions', 'sessions.db'));
+        const containerSessionStore = new ContainerSessionStore(containerDb);
+        registerContainerSessionRoutes(routes, {
+            store: containerSessionStore,
+            classifierDeps: {
+                invokeClassifier: async (systemPrompt: string, userPrompt: string) => {
+                    const combinedPrompt = `${systemPrompt}\n\n${userPrompt}`;
+                    const result = await aiInvoker(combinedPrompt);
+                    return result.response ?? '';
+                },
+            },
+            getAgents: async (): Promise<ContainerAgentInfo[]> => {
+                const workspaces = await store.getWorkspaces();
+                // Group workspaces by name or treat each as its own "agent"
+                return workspaces.map(w => ({
+                    id: w.id,
+                    name: w.name ?? w.id,
+                    workspaces: [{
+                        id: w.id,
+                        name: w.name ?? w.id,
+                        rootPath: w.rootPath ?? '',
+                        description: w.rootPath ?? '',
+                    }],
+                }));
+            },
+            forwardMessage: async (_agentId, workspaceId, message, _existingProcessId) => {
+                const taskId = await bridge.enqueue({
+                    type: 'chat',
+                    repoId: workspaceId,
+                    payload: { message, workspaceId },
+                    config: {},
+                    priority: 'normal' as const,
+                });
+                return taskId;
+            },
+        });
+    }
 
     // Teams messaging routes (container-mode)
     registerTeamsMessagingRoutes(routes, { dataDir });

--- a/packages/coc/src/server/spa/client/react/features/container-session/ContainerSessionView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/container-session/ContainerSessionView.tsx
@@ -1,0 +1,181 @@
+/**
+ * ContainerSessionView — Chat UI for the Default container agent.
+ *
+ * Renders a chat interface where each message is routed to the appropriate
+ * agent:repo. Shows routing badges on turns and a routing override selector.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { isContainerMode } from '../../utils/config';
+
+const CONTAINER_DEFAULT_REPO_ID = '__container_default__';
+
+interface ContainerSessionTurn {
+    index: number;
+    role: 'user' | 'assistant';
+    content: string;
+    routing: { agentId: string; workspaceId: string; confidence: number; reason: string };
+    downstreamProcessId: string | null;
+    timestamp: string;
+}
+
+interface ContainerSessionState {
+    id: string | null;
+    turns: ContainerSessionTurn[];
+    loading: boolean;
+    routingOverride: { agentId: string; workspaceId: string } | null;
+}
+
+export { CONTAINER_DEFAULT_REPO_ID };
+
+export function ContainerSessionView() {
+    const [session, setSession] = useState<ContainerSessionState>({
+        id: null,
+        turns: [],
+        loading: false,
+        routingOverride: null,
+    });
+    const [input, setInput] = useState('');
+    const [sending, setSending] = useState(false);
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    // Auto-scroll to bottom on new turns
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
+    }, [session.turns]);
+
+    const sendMessage = useCallback(async () => {
+        if (!input.trim() || sending) return;
+        const content = input.trim();
+        setInput('');
+        setSending(true);
+
+        try {
+            let sessionId = session.id;
+
+            // Create session if needed
+            if (!sessionId) {
+                const resp = await fetch('/api/container/sessions', { method: 'POST' });
+                if (!resp.ok) throw new Error('Failed to create session');
+                const data = await resp.json();
+                sessionId = data.id;
+                setSession(prev => ({ ...prev, id: sessionId! }));
+            }
+
+            // Send message
+            const resp = await fetch(`/api/container/sessions/${sessionId}/message`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content }),
+            });
+            if (!resp.ok) throw new Error('Failed to send message');
+            const data = await resp.json();
+
+            // Add turn to local state
+            setSession(prev => ({
+                ...prev,
+                turns: [...prev.turns, data.turn],
+            }));
+        } catch (err) {
+            console.error('Container session error:', err);
+        } finally {
+            setSending(false);
+        }
+    }, [input, sending, session.id]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendMessage();
+        }
+    }, [sendMessage]);
+
+    if (!isContainerMode()) return null;
+
+    return (
+        <div className="flex flex-col h-full bg-white dark:bg-[#1e1e1e]">
+            {/* Header */}
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-[#e0e0e0] dark:border-[#3c3c3c]">
+                <span className="text-base">🌐</span>
+                <h2 className="text-sm font-semibold text-[#1e1e1e] dark:text-[#cccccc]">
+                    Default — Smart Routing
+                </h2>
+                {session.routingOverride && (
+                    <span className="ml-2 text-[10px] bg-[#0078d4]/10 text-[#0078d4] dark:bg-[#3794ff]/15 dark:text-[#3794ff] px-2 py-0.5 rounded">
+                        Pinned: {session.routingOverride.agentId}
+                    </span>
+                )}
+            </div>
+
+            {/* Chat area */}
+            <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+                {session.turns.length === 0 && !sending && (
+                    <div className="flex flex-col items-center justify-center h-full text-center text-[#848484] space-y-2">
+                        <span className="text-3xl">🌐</span>
+                        <p className="text-sm">Start typing — your message will be routed to the right agent automatically.</p>
+                        <p className="text-xs text-[#a0a0a0]">The AI decides which repository should handle each message based on context.</p>
+                    </div>
+                )}
+
+                {session.turns.map((turn) => (
+                    <div key={turn.index} className={`flex flex-col ${turn.role === 'user' ? 'items-end' : 'items-start'}`}>
+                        {/* Routing badge */}
+                        {turn.role === 'user' && (
+                            <span className="text-[10px] text-[#848484] mb-0.5 flex items-center gap-1">
+                                <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#0078d4]" />
+                                → {turn.routing.agentId}/{turn.routing.workspaceId}
+                                {turn.routing.confidence < 0.7 && (
+                                    <span className="text-[#d4a200]" title={turn.routing.reason}>⚠</span>
+                                )}
+                            </span>
+                        )}
+                        {/* Message bubble */}
+                        <div className={`max-w-[80%] rounded-lg px-3 py-2 text-sm ${
+                            turn.role === 'user'
+                                ? 'bg-[#e8e8e8] dark:bg-[#3c3c3c] text-[#1e1e1e] dark:text-[#cccccc]'
+                                : 'bg-[#f3f9ff] dark:bg-[#1a2a3a] text-[#1e1e1e] dark:text-[#cccccc] border border-[#d0e4ff] dark:border-[#2a4a6a]'
+                        }`}>
+                            {turn.content}
+                        </div>
+                    </div>
+                ))}
+
+                {sending && (
+                    <div className="flex items-center gap-2 text-xs text-[#848484]">
+                        <span className="animate-pulse">●</span>
+                        Routing message...
+                    </div>
+                )}
+            </div>
+
+            {/* Input area */}
+            <div className="border-t border-[#e0e0e0] dark:border-[#3c3c3c] px-4 py-3">
+                <div className="flex items-center gap-2">
+                    <input
+                        type="text"
+                        className="flex-1 rounded-md border border-[#d0d0d0] dark:border-[#555] bg-white dark:bg-[#2d2d2d] px-3 py-2 text-sm text-[#1e1e1e] dark:text-[#cccccc] placeholder-[#a0a0a0] focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                        placeholder="Type a message..."
+                        value={input}
+                        onChange={(e) => setInput(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        disabled={sending}
+                        data-testid="container-session-input"
+                    />
+                    <button
+                        className="px-3 py-2 bg-[#0078d4] hover:bg-[#006cc1] text-white text-sm rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+                        onClick={sendMessage}
+                        disabled={sending || !input.trim()}
+                        data-testid="container-session-send"
+                    >
+                        Send
+                    </button>
+                </div>
+                <div className="mt-1 text-[10px] text-[#a0a0a0] flex items-center gap-2">
+                    <span>Route: {session.routingOverride ? `${session.routingOverride.agentId}` : 'Auto'}</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/repos/ReposGrid.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/ReposGrid.tsx
@@ -18,7 +18,7 @@ import { AddFolderDialog } from './AddFolderDialog';
 import { groupReposByRemote, groupReposByAgent, applyGroupOrder, groupKey } from './repoGrouping';
 import type { RepoData, RepoGroup } from './repoGrouping';
 import { getGlobalPreferences, updateGlobalPreferences } from './repositoryService';
-import { isContainerMode } from '../utils/config';
+import { isContainerMode, isContainerDefaultAgentEnabled } from '../utils/config';
 
 const GROUP_DRAG_MIME = 'application/x-git-group-drag';
 const GROUP_EXPANDED_KEY = 'coc-git-group-expanded-state';
@@ -374,7 +374,29 @@ export function ReposGrid({ repos, onRefresh }: ReposGridProps) {
                     )
                 ) : agentGroups ? (
                     /* Container mode: agent sections wrapping remote groups */
-                    agentGroups.map((ag) => {
+                    <>
+                        {/* Default container agent entry — pinned at top */}
+                        {isContainerDefaultAgentEnabled() && (
+                            <button
+                                data-testid="default-container-agent-entry"
+                                className={cn(
+                                    'flex items-center gap-2 w-full text-left px-3 py-2 rounded transition-colors mb-2',
+                                    state.selectedRepoId === '__container_default__'
+                                        ? 'bg-[#0078d4]/10 dark:bg-[#3794ff]/15 border border-[#0078d4]/40 dark:border-[#3794ff]/40'
+                                        : 'bg-[#f8f8f8] dark:bg-[#252526] hover:bg-[#e8e8e8] dark:hover:bg-[#2a2a2a] border border-[#e0e0e0] dark:border-[#3c3c3c]',
+                                )}
+                                onClick={() => {
+                                    dispatch({ type: 'SET_CURRENT_AGENT', agentId: null });
+                                    dispatch({ type: 'SET_SELECTED_REPO', id: '__container_default__' });
+                                    location.hash = '#container-session';
+                                }}
+                            >
+                                <span className="text-base">🌐</span>
+                                <span className="text-xs font-semibold text-[#1e1e1e] dark:text-[#cccccc]">Default</span>
+                                <span className="ml-auto text-[10px] text-[#848484] italic">smart routing</span>
+                            </button>
+                        )}
+                        {agentGroups.map((ag) => {
                         const agentKey = ag.normalizedUrl ?? 'unknown';
                         const isExpanded = expandedState[`agent:${agentKey}`] !== false;
                         // Sub-group this agent's repos by remote
@@ -405,7 +427,8 @@ export function ReposGrid({ repos, onRefresh }: ReposGridProps) {
                                 )}
                             </div>
                         );
-                    })
+                    })}
+                    </>
                 ) : (
                     groups.map((group, idx) => renderGroup(group, idx))
                 )}

--- a/packages/coc/src/server/spa/client/react/repos/ReposView.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/ReposView.tsx
@@ -13,6 +13,7 @@ import { useMyWorkEnabled } from '../hooks/feature-flags/useMyWorkEnabled';
 import { useMyLifeEnabled } from '../hooks/feature-flags/useMyLifeEnabled';
 import { ReposGrid } from './ReposGrid';
 import { RepoDetail } from '../features/repo-detail/RepoDetail';
+import { ContainerSessionView, CONTAINER_DEFAULT_REPO_ID } from '../features/container-session/ContainerSessionView';
 import { MyWorkView, MY_WORK_WORKSPACE_ID } from './MyWorkView';
 import { MyLifeView, MY_LIFE_WORKSPACE_ID } from './MyLifeView';
 
@@ -64,6 +65,9 @@ export function ReposView() {
     // My Life virtual workspace — personal goals, journal, life admin
     const isMyLife = myLifeEnabled && state.selectedRepoId === MY_LIFE_WORKSPACE_ID;
 
+    // Container default session — smart routing chat
+    const isContainerDefault = state.selectedRepoId === CONTAINER_DEFAULT_REPO_ID;
+
     const selectedRepo = repos.find(r =>
         r.workspace.id === state.selectedRepoId &&
         (!state.currentAgentId || !r.workspace.agentId || r.workspace.agentId === state.currentAgentId)
@@ -71,7 +75,12 @@ export function ReposView() {
 
     return (
         <div id="view-repos" className={`flex ${heightClass} overflow-hidden`}>
-            {isMyWork ? (
+            {isContainerDefault ? (
+                // ── Container Default: smart routing chat ──
+                <main className="flex-1 min-w-0 min-h-0 flex flex-col bg-white dark:bg-[#1e1e1e] overflow-hidden">
+                    <ContainerSessionView />
+                </main>
+            ) : isMyWork ? (
                 // ── My Work: notes-based workspace with sync/summary toolbar ──
                 <main className="flex-1 min-w-0 min-h-0 flex flex-col bg-white dark:bg-[#1e1e1e] overflow-hidden">
                     <MyWorkView />

--- a/packages/coc/src/server/spa/client/react/utils/config.ts
+++ b/packages/coc/src/server/spa/client/react/utils/config.ts
@@ -28,6 +28,7 @@ interface DashboardConfig {
     excalidrawEnabled?: boolean;
     mcpOauthEnabled?: boolean;
     focusedDiffEnabled?: boolean;
+    containerDefaultAgentEnabled?: boolean;
     bindAddress?: string;
     /** Whether the Codex SDK provider is enabled (feature flag). */
     codexEnabled?: boolean;
@@ -90,6 +91,7 @@ async function _doLoadRuntimeConfig(): Promise<void> {
             excalidrawEnabled: data.features.excalidrawEnabled,
             mcpOauthEnabled: data.features.mcpOauthEnabled,
             focusedDiffEnabled: data.features.focusedDiffEnabled,
+            containerDefaultAgentEnabled: data.features.containerDefaultAgentEnabled,
             codexEnabled: data.features.codexEnabled,
             activeProvider: data.features.activeProvider,
             hostname: data.hostname ?? bootstrap.hostname,
@@ -213,6 +215,10 @@ export function isMcpOauthEnabled(): boolean {
 
 export function isFocusedDiffEnabled(): boolean {
     return getConfig().focusedDiffEnabled === true;
+}
+
+export function isContainerDefaultAgentEnabled(): boolean {
+    return getConfig().containerDefaultAgentEnabled === true;
 }
 
 /** Returns true when the Codex SDK provider feature flag is enabled. */

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -940,6 +940,9 @@ timeout: 300
                       "enabled": false,
                     },
                   },
+                  "containerDefaultAgent": {
+                    "enabled": false,
+                  },
                   "codex": {
                     "enabled": false,
                   },

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -807,6 +807,8 @@ timeout: 300
                 '  enabled: true',
                 'excalidraw:',
                 '  enabled: true',
+                'containerDefaultAgent:',
+                '  enabled: true',
                 'codex:',
                 '  enabled: true',
                 'activeProvider: codex',
@@ -940,10 +942,10 @@ timeout: 300
                       "enabled": false,
                     },
                   },
-                  "containerDefaultAgent": {
+                  "codex": {
                     "enabled": false,
                   },
-                  "codex": {
+                  "containerDefaultAgent": {
                     "enabled": false,
                   },
                   "excalidraw": {
@@ -1066,6 +1068,7 @@ timeout: 300
                   "chat.followUpSuggestions.count": "file",
                   "chat.followUpSuggestions.enabled": "file",
                   "codex.enabled": "default",
+                  "containerDefaultAgent.enabled": "default",
                   "excalidraw.enabled": "default",
                   "features.autoMemoryPromotion": "file",
                   "features.focusedDiff": "file",

--- a/packages/coc/test/server/container-sessions/container-session-store.test.ts
+++ b/packages/coc/test/server/container-sessions/container-session-store.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Container Session Store Tests
+ *
+ * Unit tests for `ContainerSessionStore` — SQLite CRUD operations.
+ * Uses in-memory SQLite databases (no file I/O, cross-platform safe).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { ContainerSessionStore } from '../../../src/server/container-sessions/container-session-store';
+import type { ContainerSessionTurn } from '../../../src/server/container-sessions/container-session-types';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createDb(): Database.Database {
+    return new Database(':memory:');
+}
+
+function makeTurn(overrides: Partial<ContainerSessionTurn> = {}): ContainerSessionTurn {
+    return {
+        index: overrides.index ?? 0,
+        role: overrides.role ?? 'user',
+        content: overrides.content ?? 'Hello',
+        routing: overrides.routing ?? {
+            agentId: 'agent-1',
+            workspaceId: 'ws-1',
+            confidence: 0.9,
+            reason: 'test',
+        },
+        downstreamProcessId: overrides.downstreamProcessId ?? null,
+        timestamp: overrides.timestamp ?? '2026-01-01T00:00:00.000Z',
+    };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ContainerSessionStore', () => {
+    let db: Database.Database;
+    let store: ContainerSessionStore;
+
+    beforeEach(() => {
+        db = createDb();
+        store = new ContainerSessionStore(db);
+    });
+
+    describe('create', () => {
+        it('creates a session with active status', () => {
+            const session = store.create('csess_test1');
+            expect(session.id).toBe('csess_test1');
+            expect(session.status).toBe('active');
+            expect(session.routingOverride).toBeNull();
+            expect(session.turns).toEqual([]);
+            expect(session.createdAt).toBeTruthy();
+            expect(session.updatedAt).toBeTruthy();
+        });
+
+        it('rejects duplicate IDs', () => {
+            store.create('csess_dup');
+            expect(() => store.create('csess_dup')).toThrow();
+        });
+    });
+
+    describe('get', () => {
+        it('returns null for non-existent session', () => {
+            expect(store.get('nonexistent')).toBeNull();
+        });
+
+        it('returns session with turns', () => {
+            store.create('csess_turns');
+            store.addTurn('csess_turns', makeTurn({ index: 0, content: 'Hello' }));
+            store.addTurn('csess_turns', makeTurn({ index: 1, role: 'assistant', content: 'Hi there' }));
+
+            const session = store.get('csess_turns');
+            expect(session).not.toBeNull();
+            expect(session!.turns).toHaveLength(2);
+            expect(session!.turns[0].content).toBe('Hello');
+            expect(session!.turns[1].content).toBe('Hi there');
+        });
+    });
+
+    describe('list', () => {
+        it('returns sessions ordered by most recent', () => {
+            store.create('csess_old');
+            store.create('csess_new');
+            // Update csess_new to have a later timestamp
+            store.addTurn('csess_new', makeTurn({ timestamp: '2026-12-01T00:00:00.000Z' }));
+
+            const sessions = store.list();
+            expect(sessions.length).toBe(2);
+            // Most recent first (csess_new has later updatedAt)
+            expect(sessions[0].id).toBe('csess_new');
+        });
+
+        it('respects limit and offset', () => {
+            store.create('csess_1');
+            store.create('csess_2');
+            store.create('csess_3');
+
+            const page = store.list(2, 1);
+            expect(page.length).toBe(2);
+        });
+    });
+
+    describe('addTurn', () => {
+        it('adds a turn and updates session timestamp', () => {
+            const session = store.create('csess_addturn');
+            const originalUpdated = session.updatedAt;
+
+            // Small delay to ensure timestamp differs
+            const turn = makeTurn({ timestamp: '2026-06-01T00:00:00.000Z' });
+            store.addTurn('csess_addturn', turn);
+
+            const updated = store.get('csess_addturn');
+            expect(updated!.turns).toHaveLength(1);
+            expect(updated!.updatedAt).toBe('2026-06-01T00:00:00.000Z');
+        });
+
+        it('stores routing metadata', () => {
+            store.create('csess_routing');
+            store.addTurn('csess_routing', makeTurn({
+                routing: { agentId: 'a1', workspaceId: 'w1', confidence: 0.85, reason: 'matched path' },
+            }));
+
+            const session = store.get('csess_routing');
+            expect(session!.turns[0].routing.agentId).toBe('a1');
+            expect(session!.turns[0].routing.confidence).toBe(0.85);
+            expect(session!.turns[0].routing.reason).toBe('matched path');
+        });
+    });
+
+    describe('updateTurnProcessId', () => {
+        it('updates downstream process ID on a turn', () => {
+            store.create('csess_pid');
+            store.addTurn('csess_pid', makeTurn({ index: 0 }));
+            store.updateTurnProcessId('csess_pid', 0, 'proc_downstream');
+
+            const session = store.get('csess_pid');
+            expect(session!.turns[0].downstreamProcessId).toBe('proc_downstream');
+        });
+    });
+
+    describe('setRoutingOverride', () => {
+        it('sets a routing override', () => {
+            store.create('csess_override');
+            store.setRoutingOverride('csess_override', { agentId: 'a2', workspaceId: 'w2' });
+
+            const session = store.get('csess_override');
+            expect(session!.routingOverride).toEqual({ agentId: 'a2', workspaceId: 'w2' });
+        });
+
+        it('clears a routing override', () => {
+            store.create('csess_clear');
+            store.setRoutingOverride('csess_clear', { agentId: 'a2', workspaceId: 'w2' });
+            store.setRoutingOverride('csess_clear', null);
+
+            const session = store.get('csess_clear');
+            expect(session!.routingOverride).toBeNull();
+        });
+    });
+
+    describe('close', () => {
+        it('closes a session', () => {
+            store.create('csess_close');
+            store.close('csess_close');
+
+            const session = store.get('csess_close');
+            expect(session!.status).toBe('closed');
+        });
+    });
+
+    describe('delete', () => {
+        it('deletes a session and returns true', () => {
+            store.create('csess_del');
+            store.addTurn('csess_del', makeTurn());
+
+            const deleted = store.delete('csess_del');
+            expect(deleted).toBe(true);
+            expect(store.get('csess_del')).toBeNull();
+        });
+
+        it('returns false for non-existent session', () => {
+            expect(store.delete('nonexistent')).toBe(false);
+        });
+    });
+
+    describe('turnCount', () => {
+        it('returns 0 for empty session', () => {
+            store.create('csess_empty');
+            expect(store.turnCount('csess_empty')).toBe(0);
+        });
+
+        it('returns correct count', () => {
+            store.create('csess_cnt');
+            store.addTurn('csess_cnt', makeTurn({ index: 0 }));
+            store.addTurn('csess_cnt', makeTurn({ index: 1 }));
+            store.addTurn('csess_cnt', makeTurn({ index: 2 }));
+            expect(store.turnCount('csess_cnt')).toBe(3);
+        });
+    });
+});

--- a/packages/coc/test/server/container-sessions/routing-classifier.test.ts
+++ b/packages/coc/test/server/container-sessions/routing-classifier.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Routing Classifier Tests
+ *
+ * Unit tests for the container session routing classifier.
+ * Tests parsing, classification logic, and fallback behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyRouting, parseClassifierResponse } from '../../../src/server/container-sessions/routing-classifier';
+import type { ContainerAgentInfo, ContainerSessionTurn } from '../../../src/server/container-sessions/container-session-types';
+import type { RoutingClassifierDeps } from '../../../src/server/container-sessions/routing-classifier';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const AGENTS: ContainerAgentInfo[] = [
+    {
+        id: 'agent-shortcuts',
+        name: 'shortcuts',
+        workspaces: [
+            { id: 'ws-short', name: 'shortcuts', rootPath: '/repos/shortcuts' },
+        ],
+    },
+    {
+        id: 'agent-docs',
+        name: 'docs-site',
+        workspaces: [
+            { id: 'ws-docs', name: 'docs', rootPath: '/repos/docs' },
+            { id: 'ws-blog', name: 'blog', rootPath: '/repos/blog' },
+        ],
+    },
+];
+
+function makeDeps(response: string): RoutingClassifierDeps {
+    return {
+        invokeClassifier: async () => response,
+    };
+}
+
+function makeTurn(overrides: Partial<ContainerSessionTurn> = {}): ContainerSessionTurn {
+    return {
+        index: overrides.index ?? 0,
+        role: overrides.role ?? 'user',
+        content: overrides.content ?? 'hello',
+        routing: overrides.routing ?? { agentId: 'agent-shortcuts', workspaceId: 'ws-short', confidence: 0.9, reason: 'test' },
+        downstreamProcessId: overrides.downstreamProcessId ?? null,
+        timestamp: overrides.timestamp ?? '2026-01-01T00:00:00.000Z',
+    };
+}
+
+// ============================================================================
+// parseClassifierResponse
+// ============================================================================
+
+describe('parseClassifierResponse', () => {
+    it('parses a well-formed ROUTE response', () => {
+        const response = 'ROUTE: agent_id=agent-docs workspace_id=ws-docs confidence=0.95 reason=mentions documentation';
+        const result = parseClassifierResponse(response, AGENTS);
+        expect(result.agentId).toBe('agent-docs');
+        expect(result.workspaceId).toBe('ws-docs');
+        expect(result.confidence).toBe(0.95);
+        expect(result.reason).toBe('mentions documentation');
+    });
+
+    it('handles case-insensitive ROUTE prefix', () => {
+        const response = 'route: agent_id=agent-shortcuts workspace_id=ws-short confidence=0.8 reason=code fix';
+        const result = parseClassifierResponse(response, AGENTS);
+        expect(result.agentId).toBe('agent-shortcuts');
+    });
+
+    it('falls back when response is unparseable', () => {
+        const result = parseClassifierResponse('I cannot determine the route', AGENTS);
+        expect(result.agentId).toBe('agent-shortcuts'); // first agent
+        expect(result.confidence).toBe(0.3);
+        expect(result.reason).toContain('Could not parse');
+    });
+
+    it('falls back when agent ID is invalid', () => {
+        const response = 'ROUTE: agent_id=nonexistent workspace_id=ws-docs confidence=0.9 reason=test';
+        const result = parseClassifierResponse(response, AGENTS);
+        expect(result.agentId).toBe('agent-shortcuts'); // first agent
+        expect(result.confidence).toBe(0.3);
+    });
+
+    it('falls back when workspace ID is invalid but agent is valid', () => {
+        const response = 'ROUTE: agent_id=agent-docs workspace_id=nonexistent confidence=0.9 reason=test';
+        const result = parseClassifierResponse(response, AGENTS);
+        expect(result.agentId).toBe('agent-docs');
+        expect(result.workspaceId).toBe('ws-docs'); // first workspace of valid agent
+        expect(result.confidence).toBe(0.4);
+    });
+
+    it('clamps confidence to [0, 1]', () => {
+        const response = 'ROUTE: agent_id=agent-docs workspace_id=ws-docs confidence=1.5 reason=test';
+        const result = parseClassifierResponse(response, AGENTS);
+        expect(result.confidence).toBe(1.0);
+    });
+});
+
+// ============================================================================
+// classifyRouting
+// ============================================================================
+
+describe('classifyRouting', () => {
+    it('returns override immediately when set', async () => {
+        const deps = makeDeps('should not be called');
+        const result = await classifyRouting(
+            {
+                agents: AGENTS,
+                history: [],
+                message: 'fix auth',
+                override: { agentId: 'agent-docs', workspaceId: 'ws-blog' },
+            },
+            deps,
+        );
+        expect(result.agentId).toBe('agent-docs');
+        expect(result.workspaceId).toBe('ws-blog');
+        expect(result.confidence).toBe(1.0);
+        expect(result.reason).toBe('Manual override');
+    });
+
+    it('skips LLM when only one workspace exists', async () => {
+        const singleAgent: ContainerAgentInfo[] = [
+            { id: 'only', name: 'Only Agent', workspaces: [{ id: 'ws-only', name: 'only', rootPath: '/only' }] },
+        ];
+        const deps = makeDeps('should not be called');
+        const result = await classifyRouting(
+            { agents: singleAgent, history: [], message: 'anything' },
+            deps,
+        );
+        expect(result.agentId).toBe('only');
+        expect(result.workspaceId).toBe('ws-only');
+        expect(result.confidence).toBe(1.0);
+    });
+
+    it('throws when no agents available', async () => {
+        const deps = makeDeps('');
+        await expect(
+            classifyRouting({ agents: [], history: [], message: 'test' }, deps),
+        ).rejects.toThrow('No agents or workspaces available');
+    });
+
+    it('calls LLM and parses response for multiple workspaces', async () => {
+        const deps = makeDeps('ROUTE: agent_id=agent-docs workspace_id=ws-blog confidence=0.88 reason=mentions blog post');
+        const result = await classifyRouting(
+            { agents: AGENTS, history: [], message: 'write a blog post' },
+            deps,
+        );
+        expect(result.agentId).toBe('agent-docs');
+        expect(result.workspaceId).toBe('ws-blog');
+        expect(result.confidence).toBe(0.88);
+    });
+
+    it('falls back to last-used route on low confidence', async () => {
+        const deps = makeDeps('ROUTE: agent_id=agent-docs workspace_id=ws-docs confidence=0.3 reason=unsure');
+        const history: ContainerSessionTurn[] = [
+            makeTurn({ routing: { agentId: 'agent-shortcuts', workspaceId: 'ws-short', confidence: 0.9, reason: 'previous' } }),
+        ];
+        const result = await classifyRouting(
+            { agents: AGENTS, history, message: 'do something vague' },
+            deps,
+        );
+        expect(result.agentId).toBe('agent-shortcuts');
+        expect(result.workspaceId).toBe('ws-short');
+        expect(result.confidence).toBe(0.6);
+        expect(result.reason).toContain('last-used');
+    });
+
+    it('accepts low confidence when no history exists', async () => {
+        const deps = makeDeps('ROUTE: agent_id=agent-docs workspace_id=ws-docs confidence=0.3 reason=unsure');
+        const result = await classifyRouting(
+            { agents: AGENTS, history: [], message: 'do something vague' },
+            deps,
+        );
+        // No fallback available, so accepts the low-confidence result
+        expect(result.agentId).toBe('agent-docs');
+        expect(result.confidence).toBe(0.3);
+    });
+});

--- a/packages/coc/test/spa/react/repos/ReposGrid-agent-switch.test.tsx
+++ b/packages/coc/test/spa/react/repos/ReposGrid-agent-switch.test.tsx
@@ -62,6 +62,7 @@ vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
     getApiBase: () => '',
     getHostname: () => 'localhost',
     isServersEnabled: () => false,
+    isContainerDefaultAgentEnabled: () => false,
 }));
 
 vi.mock('../../../../src/server/spa/client/react/repos/repositoryService', () => ({

--- a/packages/coccontainer/ARCHITECTURE.md
+++ b/packages/coccontainer/ARCHITECTURE.md
@@ -1,0 +1,236 @@
+# CoCContainer Architecture
+
+CoCContainer is a lightweight gateway that aggregates multiple CoC agents behind a single endpoint, serving the CoC dashboard SPA and proxying all API calls to the appropriate agent.
+
+## High-Level Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          CoC AGENTS (1..N)                                   │
+│                                                                             │
+│  Each agent runs independently with its own processes, workspaces, and API  │
+│  • HTTP REST API: /api/processes, /api/workspaces, /api/queue, etc.         │
+│  • WebSocket /ws: emits process-updated, process-created events             │
+│  • SSE /api/events: global event stream (chat streaming)                    │
+│  • SSE /processes/:id/stream: per-process content streaming                 │
+└──────┬──────────────────────────────┬──────────────────────┬────────────────┘
+       │                              │                      │
+       │ HTTP (REST)                  │ WebSocket /ws        │ SSE (streaming)
+       │                              │                      │
+       ▼                              ▼                      ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           COC CONTAINER                                      │
+│                                                                             │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │                      WS RELAY ENGINE                                   │  │
+│  │                                                                       │  │
+│  │  Ingests process lifecycle events from agents via WebSocket,          │  │
+│  │  then dispatches to all subscribers.                                  │  │
+│  │                                                                       │  │
+│  │  ┌─────────────────────────────────────────────────────────────┐     │  │
+│  │  │  WS Relay (ws-relay.ts)                                      │     │  │
+│  │  │  • Connects to each agent's /ws                              │     │  │
+│  │  │  • Receives: process-updated, process-created                │     │  │
+│  │  │  • emit('message') to all subscribers                        │     │  │
+│  │  └──────────────────────────┬──────────────────────────────────┘     │  │
+│  │                             │                                         │  │
+│  │                     DISPATCH TO SUBSCRIBERS                            │  │
+│  │                             │                                         │  │
+│  └─────────────────────────────┼─────────────────────────────────────────┘  │
+│                                │                                            │
+│              ┌─────────────────┼──────────────────┐                         │
+│              ▼                 ▼                   ▼                         │
+│  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐                │
+│  │  Web Client     │  │  Teams Bridge   │  │  WhatsApp      │                │
+│  │  (via WS)       │  │  (subscriber)   │  │  Bridge        │                │
+│  │                 │  │                 │  │  (subscriber)  │                │
+│  │  Browser opens  │  │  On completion: │  │  Same pattern  │                │
+│  │  container /ws  │  │  fetch process, │  │  as Teams      │                │
+│  │  for process    │  │  send last      │  │                │                │
+│  │  list updates   │  │  chunk to Teams │  │                │                │
+│  └────────┬────────┘  └───────┬─────────┘  └───────┬────────┘                │
+│           │                   │                     │                        │
+│  ┌────────┴───────────────────┴─────────────────────┴─────────────────────┐  │
+│  │  HTTP Proxy (http.ts) — transparent proxy to agents for REST + SSE     │  │
+│  │  • REST: /api/* (processes, workspaces, queue, chat)                   │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                             │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │  SSE Relay (transparent proxy)                                        │   │
+│  │  • Browser ↔ CoC agent direct connection (container just routes)      │   │
+│  │  • /api/events: global chat streaming                                 │   │
+│  │  • /processes/:id/stream: per-process content streaming               │   │
+│  │  • No buffering, no dispatching to bridges                            │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  ┌──────────────────────────────┐  ┌──────────────────────────────────────┐  │
+│  │  Tunnel Bridge                │  │  Health Monitor                      │  │
+│  │  Local proxy for devtunnel    │  │  Periodic health checks              │  │
+│  │  agents (auth + port mapping) │  │  Updates agent online/offline status │  │
+│  └───────────────────────────────┘  └──────────────────────────────────────┘  │
+│                                                                             │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │  SPA (CoC Dashboard in containerMode)                                 │   │
+│  │  • Reuses CoC's compiled HTML template                                │   │
+│  │  • Served at / for all non-API routes                                 │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+       │                    │                     │
+       │ HTTP + WS + SSE    │ MCP Transport       │ Baileys
+       ▼                    ▼                     ▼
+┌──────────────┐    ┌──────────────┐    ┌──────────────────┐
+│  Browser     │    │  Microsoft   │    │  WhatsApp        │
+│              │    │  Teams       │    │                  │
+│  • WS: live  │    │              │    │  • Final message │
+│    updates   │    │  • Final msg │    │    only          │
+│  • SSE: chat │    │    only      │    │                  │
+│    streaming │    │              │    │                  │
+│  (direct to  │    │              │    │                  │
+│   agent)     │    │              │    │                  │
+└──────────────┘    └──────────────┘    └──────────────────┘
+```
+
+## WS Relay Engine
+
+The WS relay engine is the core event dispatch mechanism for process lifecycle events. It ingests events from all connected agents via WebSocket and dispatches them to subscribers:
+
+| Ingress | Component | What it receives |
+|---------|-----------|-----------------|
+| WebSocket `/ws` | WS Relay | `process-updated`, `process-created` events |
+
+| Subscriber | How it connects | What it does with events |
+|------------|----------------|------------------------|
+| **Browser** | Opens container `/ws` (WebSocket) | Real-time sidebar/process list updates |
+| **Teams Bridge** | `wsRelay.on('message')` | On completion: fetch process, send last chunk |
+| **WhatsApp Bridge** | `wsRelay.on('message')` | Same pattern as Teams |
+
+## SSE Relay (Transparent Proxy)
+
+The SSE relay is a **transparent proxy** — it builds a direct connection between the browser client and the CoC agent. The container only handles routing (selecting the correct agent) and adds auth headers. It does NOT:
+- Buffer or parse SSE events
+- Dispatch events to messaging bridges
+- Store any streamed content
+
+```
+Browser opens: /api/agent/:agentId/processes/:id/stream
+  → Container routes to correct agent (transparent proxy)
+  → Agent streams: conversation-snapshot, chunk, tool-start, tool-complete, done
+  → Browser receives directly, renders content in real-time
+```
+
+The browser uses SSE for chat content streaming while using WebSocket (via WS relay) for process list/sidebar updates. These are two separate concerns:
+- **WS relay**: process lifecycle events → dispatched to all subscribers (browser, bridges)
+- **SSE relay**: chat content streaming → direct browser ↔ agent connection (no bridges involved)
+
+## Conversation Turn Storage & Timeline Chunks
+
+Each assistant response in a CoC process is stored as a single **conversation turn** row in SQLite (`conversation_turns` table):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `content` | TEXT | Full concatenated text of all content chunks |
+| `tool_calls` | JSON | Array of tool call objects |
+| `timeline` | JSON | Ordered array of `TimelineItem` events preserving chunk boundaries |
+
+### TimelineItem structure
+
+```typescript
+type TimelineItem =
+  | { type: 'content'; content: string }       // one text chunk
+  | { type: 'tool-start'; toolCall: {...} }    // tool invocation started
+  | { type: 'tool-complete'; toolCall: {...} } // tool invocation finished
+  | { type: 'tool-failed'; toolCall: {...} }   // tool invocation failed
+```
+
+### How chunks relate to turns
+
+During streaming, the agent emits multiple `chunk` SSE events for a single assistant turn. Each chunk becomes one `{ type: 'content', content: '...' }` entry in the `timeline` array. After streaming completes:
+
+- **`content`** = concatenation of all content chunks (what the user reads in full)
+- **`timeline`** = ordered interleaving of content + tool events (preserves structure)
+
+### Reconstructing individual chunks from stored data
+
+To recover the N separate "messages" (chunks) from a completed turn:
+
+```typescript
+const chunks = turn.timeline
+  .filter(item => item.type === 'content')
+  .map(item => item.content);
+// chunks.length === N (e.g., 16 for the "16 messages" shown in the UI)
+```
+
+The dashboard SPA uses this to display "84 tool calls · 16 messages" in collapsed turn headers — it counts timeline items by type.
+
+### Teams/WhatsApp bridge: last chunk only
+
+When delivering to external platforms, the bridge extracts only the **last** content chunk:
+
+```typescript
+const contentChunks = extractTimelineContentChunks(lastTurn.timeline);
+const lastChunk = contentChunks[contentChunks.length - 1];
+// Send only lastChunk to Teams/WhatsApp
+```
+
+This is the final prose after all tool calls — the actionable answer. Intermediate chunks are reasoning between tool executions and not useful to the external recipient. Falls back to full `content` when timeline is unavailable or has ≤1 items.
+
+## Message Dispatch (Outbound — Agent → Consumers)
+
+```
+Agent completes task execution
+       │
+       ▼ emits process-updated (status=completed) via WebSocket
+       │
+  WS Relay receives, dispatches to subscribers
+       │
+       ├──→ Browser (via container /ws): updates process list/sidebar
+       │
+       ├──→ Teams Bridge:
+       │      • "completed" → fetch full process via REST
+       │      • Extract last timeline chunk → send to Teams
+       │
+       └──→ WhatsApp Bridge: same as Teams
+
+Meanwhile (streaming, independent path):
+  Agent streams chunks via SSE /processes/:id/stream
+       │
+       └──→ Browser (transparent proxy, direct connection)
+            Renders content in real-time during execution
+```
+
+## Message Dispatch (Inbound — External → Agent)
+
+```
+External message arrives (Teams / WhatsApp / Browser)
+       │
+       ▼
+  Bridge/Browser → HTTP POST /api/workspaces/:wsId/chat
+       │
+       ▼ (via Container HTTP Proxy)
+       │
+  Agent creates new process or follows up on existing one
+```
+
+## Module Responsibilities
+
+| Module | File | Purpose |
+|--------|------|---------|
+| **WS Relay** | `proxy/ws-relay.ts` | Connects to agent `/ws`, dispatches lifecycle events to subscribers |
+| **SSE Relay** | `proxy/sse-relay.ts` | Transparent proxy: browser ↔ agent SSE streaming |
+| **HTTP Proxy** | `proxy/http.ts` | Transparent proxy for REST calls |
+| **Tunnel Bridge** | `proxy/tunnel-bridge.ts` | Local proxy for devtunnel agents (auth + port) |
+| **Health Monitor** | `server/health-monitor.ts` | Periodic agent health checks |
+| **Agent Store** | `store/agent-store.ts` | Persists agent registry |
+| **Teams Bridge** | `messaging/teams-bridge.ts` | WS relay subscriber → Teams (last chunk only) |
+| **WhatsApp Bridge** | `messaging/whatsapp-bridge.ts` | WS relay subscriber → WhatsApp (last chunk only) |
+| **Messaging Store** | `messaging/messaging-store.ts` | SQLite store for sent/received messages |
+| **Server** | `server/index.ts` | HTTP server, SPA, routes, orchestration |
+
+## Design Principles
+
+- **WS relay for lifecycle**: Process lifecycle events (created/updated/completed) flow through the WS relay to all subscribers
+- **SSE as transparent proxy**: Chat content streaming is a direct browser ↔ agent connection; container only routes
+- **Thin gateway**: Container has no business logic — aggregates, proxies, dispatches
+- **Multi-agent**: All components handle N agents simultaneously
+- **Final-only messaging**: External platforms receive only the last content chunk, not intermediate streaming updates
+- **Two separate concerns**: WS relay (lifecycle dispatch) and SSE relay (content streaming) serve different purposes and never cross

--- a/packages/coccontainer/src/messaging/teams-bridge.ts
+++ b/packages/coccontainer/src/messaging/teams-bridge.ts
@@ -2,16 +2,20 @@
  * TeamsBridge — glue between WS relay / agent proxy and TeamsBot.
  *
  * Only imported via dynamic import when messaging.teams.enabled is true.
- * Uses Graph API (default) or MCP server for communication, selected via config.mode.
+ * Uses MCP server for communication (Graph API disabled — az CLI tokens lack Chat permissions).
  * The transport is abstracted behind the TeamsTransport interface.
- * On startup, resolves team/channel names to IDs via the transport.
- * Auth tokens are acquired via browser OAuth (acquireTokenViaBrowser) and
- * cached/refreshed via acquireMcpOAuthToken.
+ *
+ * Outbound flow:
+ * - Subscribes to the same WS relay that feeds the web client (no extra connections).
+ * - On process-updated (running): HTTP-fetches process, forwards new user turns,
+ *   tracks last assistant content.
+ * - On process-updated (completed): sends the last tracked message to Teams.
  */
 
 import type { InboundTeamsMessage, BotStatus, TeamsTransport } from '@plusplusoneplusplus/teams-bot';
 import { TeamsBot, createTransport, acquireMcpOAuthToken } from '@plusplusoneplusplus/teams-bot';
 import type { WebSocketRelay, WSRelayMessage } from '../proxy/ws-relay';
+import type { SSERelay, SSEEvent } from '../proxy/sse-relay';
 import type { AgentStore } from '../store/agent-store';
 import type { TunnelBridge } from '../proxy/tunnel-bridge';
 import type { ResolvedTeamsConfig } from '../config';
@@ -21,6 +25,7 @@ export interface TeamsBridgeOptions {
     config: ResolvedTeamsConfig;
     dataDir: string;
     wsRelay: WebSocketRelay;
+    sseRelay: SSERelay;
     agentStore: AgentStore;
     tunnelBridge: TunnelBridge;
 }
@@ -42,7 +47,12 @@ export class TeamsBridge {
     private bot: TeamsBot | null = null;
     private transport: TeamsTransport;
     private wsHandler: ((msg: WSRelayMessage) => void) | null = null;
-    private _runningLocks: Set<string> | undefined;
+    private sseHandler: ((event: SSEEvent) => void) | null = null;
+    private _completionSent = new Set<string>();
+    /** Track latest assistant content per process (updated on each WS event) */
+    private _lastAssistantContent = new Map<string, string>();
+    /** Track user turn count per process to detect new user turns */
+    private _userTurnCount = new Map<string, number>();
     private _workspaceNameCache = new Map<string, string>();
     private _azToken: string | null = null;
 
@@ -113,12 +123,19 @@ export class TeamsBridge {
 
         this.wsHandler = (msg) => this.onWsMessage(msg);
         this.opts.wsRelay.on('message', this.wsHandler);
+
+        this.sseHandler = (event) => this.onSSEEvent(event);
+        this.opts.sseRelay.on('event', this.sseHandler);
     }
 
     async stop(): Promise<void> {
         if (this.wsHandler) {
             this.opts.wsRelay.off('message', this.wsHandler);
             this.wsHandler = null;
+        }
+        if (this.sseHandler) {
+            this.opts.sseRelay.off('event', this.sseHandler);
+            this.sseHandler = null;
         }
         await this.bot?.stop();
         this.bot = null;
@@ -316,8 +333,31 @@ export class TeamsBridge {
     }
 
     // ── Outbound: CoC process update → Teams ────────────
+    // Teams-bridge subscribes to BOTH the WS relay and the SSE relay.
+    // Each relay carries different data:
+    //
+    // WS Relay (WSRelayMessage):
+    //   - data: JSON string with { type, process: ProcessSummary }
+    //   - ProcessSummary has: id, status, title, lastMessagePreview (~120 chars)
+    //   - Used for: detecting status changes (running → completed)
+    //
+    // SSE Relay (SSEEvent):
+    //   - event: SSE event name (e.g., "process-updated", "chunk")
+    //   - data: JSON string payload (varies by event type)
+    //   - id: optional event ID for resumability
+    //   - Used for: future per-event-type handling (e.g., streaming chunks)
+    //
+    // On process-updated events (from either relay):
+    // - running: fetch process, forward new user turns, track last assistant content
+    // - completed: send the last tracked assistant content (or task_complete summary) to Teams
+
+    /**
+     * Handle WS relay messages.
+     * WS relay delivers: { agentId, agentName, data: "<JSON>" }
+     * where data contains { type: "process-updated", process: ProcessSummary }
+     */
     private async onWsMessage(msg: WSRelayMessage): Promise<void> {
-        if (!this.bot) { console.log('[teams-bridge] WS ignored: bot is null'); return; }
+        if (!this.bot) return;
         if (!this.store) return;
 
         let parsed: Record<string, unknown>;
@@ -335,150 +375,362 @@ export class TeamsBridge {
         const processId = proc.id as string;
         if (!processId) return;
 
+        console.log(`[teams-bridge] 📥 WS event: process=${processId} status=${status}`);
+
         if (status !== 'completed' && status !== 'running') return;
 
-        // Prevent concurrent processing of the same process (watermark prevents duplicate sends)
-        if (!this._runningLocks) this._runningLocks = new Set();
-        if (this._runningLocks.has(processId)) return;
-        this._runningLocks.add(processId);
+        if (status === 'completed') {
+            await this.handleCompletion(processId, msg, proc);
+        } else {
+            await this.handleRunning(processId, msg, proc);
+        }
+    }
 
-        let target = this.bot.getChannelId() ?? this.opts.config.channelId;
-        if (!target) {
-            console.warn('[teams-bridge] No target (chatId/channelId) available — skipping outbound');
-            this._runningLocks.delete(processId);
+    /**
+     * Handle SSE relay events.
+     * SSE relay delivers: { agentId, agentName, event?: string, data: string, id?: string }
+     * The `event` field is the SSE event name (e.g., "process-updated").
+     * The `data` field is the JSON payload.
+     * The `id` field is the SSE event ID for resumability.
+     *
+     * Currently SSE relay carries the same process-updated events as WS.
+     * In the future, it could carry per-process streaming chunks directly.
+     */
+    private async onSSEEvent(event: SSEEvent): Promise<void> {
+        if (!this.bot) return;
+        if (!this.store) return;
+
+        let parsed: Record<string, unknown>;
+        try {
+            parsed = JSON.parse(event.data);
+        } catch {
             return;
         }
 
-        // Skip if Teams bot is not connected
-        if (!this.bot || this.bot.getStatus() !== 'connected') {
-            this._runningLocks.delete(processId);
-            return;
-        }
+        // SSE events have an explicit event name field
+        const eventType = event.event || (parsed.type as string) || 'unknown';
+        if (eventType !== 'process-updated') return;
 
-        const agentId = msg.agentId;
-        const agentAddr = this.getAgentAddress(agentId);
-        if (!agentAddr) {
-            console.warn(`[teams-bridge] No address for agent ${agentId} (${msg.agentName}) — skipping outbound`);
-            this._runningLocks.delete(processId);
-            return;
-        }
+        const proc = parsed.process as Record<string, unknown> | undefined;
+        if (!proc) return;
 
-        console.log(`[teams-bridge] Process ${processId} status=${status} from=${msg.agentName}, target=${target}`);
+        const status = proc.status as string;
+        const processId = proc.id as string;
+        if (!processId) return;
+
+        console.log(`[teams-bridge] 📥 SSE event: type=${eventType} process=${processId} status=${status}`);
+
+        if (status !== 'completed' && status !== 'running') return;
+
+        // Construct a WSRelayMessage to reuse existing handlers
+        const msg: WSRelayMessage = {
+            agentId: event.agentId,
+            agentName: event.agentName,
+            data: event.data,
+        };
+
+        if (status === 'completed') {
+            await this.handleCompletion(processId, msg, proc);
+        } else {
+            await this.handleRunning(processId, msg, proc);
+        }
+    }
+
+    /**
+     * Handle running status: fetch process, forward new user turns,
+     * track latest assistant content for when completion arrives.
+     */
+    private async handleRunning(
+        processId: string,
+        msg: WSRelayMessage,
+        proc: Record<string, unknown>,
+    ): Promise<void> {
+        const agentAddr = this.getAgentAddress(msg.agentId);
+        if (!agentAddr) return;
+        if (!this.bot || this.bot.getStatus() !== 'connected') return;
+
+        const workspaceId = (proc.workspaceId ?? proc.workspace) as string || '';
 
         try {
-            const workspaceId = (proc.workspaceId ?? proc.workspace) as string || '';
             const url = `${agentAddr}/api/processes/${processId}?workspaceId=${encodeURIComponent(workspaceId)}`;
+            console.log(`[teams-bridge] 🔍 Fetching process: ${url}`);
             const res = await fetch(url);
             if (!res.ok) {
-                console.warn(`[teams-bridge] Process fetch failed: ${res.status} from ${url}`);
-                this._runningLocks.delete(processId);
+                console.log(`[teams-bridge] ⚠️ Fetch failed: ${res.status}`);
                 return;
             }
+
             const body = await res.json() as Record<string, unknown>;
             const processData = (body.process ?? body) as Record<string, unknown>;
             const turns = (processData.conversationTurns ?? processData.conversation ?? processData.turns) as Array<{ role: string; content?: string; text?: string; streaming?: boolean }> | undefined;
             if (!turns || turns.length === 0) {
-                console.log(`[teams-bridge] Process ${processId}: no turns found`);
-                this._runningLocks.delete(processId);
+                console.log(`[teams-bridge] ⚠️ No turns in response for ${processId}`);
                 return;
             }
 
-            const lastSeen = this.store!.getWatermark(processId);
-            console.log(`[teams-bridge] Process ${processId}: ${turns.length} turns, watermark=${lastSeen}`);
-
-            // Skip streaming turns
-            let sendableEnd = turns.length;
-            for (let i = turns.length - 1; i >= lastSeen; i--) {
-                if (turns[i].streaming) { sendableEnd = i; continue; }
-                break;
+            // Log all turns received
+            console.log(`[teams-bridge] 📋 Process ${processId}: got ${turns.length} turn(s):`);
+            for (let i = 0; i < turns.length; i++) {
+                const t = turns[i];
+                const content = (t.content ?? t.text ?? '').trim();
+                const streaming = t.streaming ? ' [streaming]' : '';
+                console.log(`[teams-bridge]   turn[${i}] role=${t.role}${streaming} (${content.length} chars): ${content.substring(0, 80)}`);
             }
 
-            const newTurns = turns.slice(lastSeen, sendableEnd);
-            if (newTurns.length === 0) {
-                console.log(`[teams-bridge] Process ${processId}: no new turns to send (lastSeen=${lastSeen}, sendableEnd=${sendableEnd})`);
-                this._runningLocks.delete(processId);
-                return;
+            // Forward new user turns
+            let currentUserCount = 0;
+            for (const turn of turns) {
+                if (turn.role === 'user') currentUserCount++;
             }
+            const prevUserCount = this._userTurnCount.get(processId) ?? 0;
+            if (currentUserCount > prevUserCount) {
+                this._userTurnCount.set(processId, currentUserCount);
+                this._completionSent.delete(processId);
+                this._lastAssistantContent.delete(processId);
 
-            console.log(`[teams-bridge] Process ${processId}: sending ${newTurns.length} new turn(s) to target=${target}`);
-
-            // Advance watermark BEFORE sending — prevents infinite retry on send failure
-            if (sendableEnd > lastSeen) {
-                this.store!.setWatermark(processId, sendableEnd);
-            }
-
-            const repoName = await this.resolveWorkspaceName(
-                proc.workspaceName as string | undefined,
-                (processData.metadata as Record<string, unknown> | undefined)?.workspaceName as string | undefined,
-                workspaceId,
-                agentAddr,
-            );
-            const title = (processData.title ?? proc.title ?? '') as string;
-
-            // Retrieve sender info for @mention notifications
-            const sender = this.store!.getProcessSender(processId);
-
-            for (const turn of newTurns) {
-                const content = (turn.content ?? turn.text ?? '') as string;
-                if (!content.trim()) continue;
-
-                const teamsText = this.formatOutboundMessage({
-                    role: turn.role,
-                    agent: msg.agentName,
-                    repo: repoName,
-                    title,
-                    content,
-                    botName: this.opts.config.botName,
-                    mentionName: sender?.senderName,
-                    processId,
-                });
-
-                try {
-                    const mentions = sender
-                        ? [{ aadId: sender.senderAadId, displayName: sender.senderName }]
-                        : undefined;
-                    const messageId = await this.bot!.send(target, teamsText, { mentions });
-                    console.log(`[teams-bridge] Sent message ${messageId} for process ${processId} (role=${turn.role})`);
-                    this.store!.bindMessage(messageId, processId, agentId, `${msg.agentName}:${repoName}`, workspaceId);
-                } catch (err: any) {
-                    // If NotFound, channel may be stale — re-resolve and retry once
-                    if (err?.message?.includes('NotFound') && this.opts.config.teamName) {
-                        console.warn(`[teams-bridge] Channel NotFound — re-resolving team/channel...`);
-                        this.opts.config.channelId = undefined;
-                        this.opts.config.teamId = undefined;
-                        await this.resolveTeamAndChannel();
-                        const newTarget = this.bot!.getChannelId();
-                        if (newTarget && newTarget !== target) {
-                            target = newTarget;
-                            try {
-                                const mentions = sender
-                                    ? [{ aadId: sender.senderAadId, displayName: sender.senderName }]
-                                    : undefined;
-                                const messageId = await this.bot!.send(target, teamsText, { mentions });
-                                console.log(`[teams-bridge] Sent message ${messageId} (after re-resolve) for process ${processId}`);
-                                this.store!.bindMessage(messageId, processId, agentId, `${msg.agentName}:${repoName}`, workspaceId);
-                            } catch (retryErr) {
-                                console.error('[teams-bridge] Retry after re-resolve also failed:', retryErr);
-                            }
-                        } else {
-                            console.error('[teams-bridge] Re-resolve did not produce a new channelId');
+                for (let i = turns.length - 1; i >= 0; i--) {
+                    if (turns[i].role === 'user') {
+                        const content = (turns[i].content ?? turns[i].text ?? '').trim();
+                        if (content) {
+                            console.log(`[teams-bridge] 📝 New user turn for ${processId} (${content.length} chars): ${content.substring(0, 100)}`);
+                            await this.sendToTeams(processId, 'user', content, msg.agentId, msg.agentName, workspaceId);
                         }
-                    } else {
-                        // Detect Graph API scope permission errors and suggest MCP mode
-                        if (err?.message?.includes('403') && err?.message?.includes('Missing scope permissions')) {
-                            console.error('[teams-bridge] ❌ Graph API 403: Token lacks ChatMessage.Send or Chat.ReadWrite scope.');
-                            console.error('[teams-bridge] 💡 Switch to MCP Server mode in Teams settings — az CLI tokens do not have Teams chat permissions.');
-                        } else {
-                            console.error('[teams-bridge] Failed to send outbound message:', err);
-                        }
+                        break;
                     }
                 }
             }
+
+            // Track latest assistant content — only keep the LAST non-streaming assistant message
+            for (let i = turns.length - 1; i >= 0; i--) {
+                const turn = turns[i];
+                if (turn.role === 'user') break;
+                if (turn.role === 'assistant' && !turn.streaming) {
+                    const content = (turn.content ?? turn.text ?? '').trim();
+                    if (content) {
+                        const prev = this._lastAssistantContent.get(processId);
+                        if (prev !== content) {
+                            this._lastAssistantContent.set(processId, content);
+                            console.log(`[teams-bridge] ✅ Kept as LAST message for ${processId} (turn[${i}], ${content.length} chars): ${content.substring(0, 120)}`);
+                        } else {
+                            console.log(`[teams-bridge] ⏭️ Same as previous last message, skipping update`);
+                        }
+                    }
+                    break;
+                }
+            }
         } catch (err) {
-            console.error('[teams-bridge] Failed to fetch process turns:', err);
-        } finally {
-            // Always release lock so future events can be processed
-            this._runningLocks.delete(processId);
+            console.log(`[teams-bridge] ❌ Error in handleRunning for ${processId}:`, err);
+        }
+    }
+
+    /**
+     * Handle completion: send final message to Teams.
+     * Uses tracked last assistant content or task_complete summary.
+     */
+    private async handleCompletion(
+        processId: string,
+        msg: WSRelayMessage,
+        proc: Record<string, unknown>,
+    ): Promise<void> {
+        const agentAddr = this.getAgentAddress(msg.agentId);
+        if (!agentAddr) return;
+        if (!this.bot || this.bot.getStatus() !== 'connected') return;
+
+        const workspaceId = (proc.workspaceId ?? proc.workspace) as string || '';
+
+        try {
+            const url = `${agentAddr}/api/processes/${processId}?workspaceId=${encodeURIComponent(workspaceId)}`;
+            console.log(`[teams-bridge] 🏁 Completion: fetching process ${processId}`);
+            const res = await fetch(url);
+            if (!res.ok) {
+                console.log(`[teams-bridge] ⚠️ Completion fetch failed: ${res.status}`);
+                return;
+            }
+
+            const body = await res.json() as Record<string, unknown>;
+            const processData = (body.process ?? body) as Record<string, unknown>;
+            const turns = (processData.conversationTurns ?? processData.conversation ?? processData.turns) as Array<{ role: string; content?: string; text?: string; streaming?: boolean; toolCalls?: Array<{ name: string; toolName?: string; args?: { summary?: string } }>; timeline?: Array<{ type: string; content?: string }> }> | undefined;
+            if (!turns || turns.length === 0) {
+                console.log(`[teams-bridge] ⚠️ No turns in completion response for ${processId}`);
+                return;
+            }
+
+            // Log all turns received on completion
+            console.log(`[teams-bridge] 🏁 Process ${processId} COMPLETED: got ${turns.length} turn(s):`);
+            for (let i = 0; i < turns.length; i++) {
+                const t = turns[i];
+                const content = (t.content ?? t.text ?? '').trim();
+                const streaming = t.streaming ? ' [streaming]' : '';
+                const hasToolCalls = t.toolCalls?.length ? ` [${t.toolCalls.length} tool call(s)]` : '';
+                console.log(`[teams-bridge]   turn[${i}] role=${t.role}${streaming}${hasToolCalls} (${content.length} chars): ${content.substring(0, 80)}`);
+            }
+
+            // Detect new user turns → reset completion tracking for new round
+            let currentUserCount = 0;
+            for (const turn of turns) {
+                if (turn.role === 'user') currentUserCount++;
+            }
+            const prevUserCount = this._userTurnCount.get(processId) ?? 0;
+            if (currentUserCount > prevUserCount) {
+                this._userTurnCount.set(processId, currentUserCount);
+                this._completionSent.delete(processId);
+                this._lastAssistantContent.delete(processId);
+
+                // Forward the new user turn
+                for (let i = turns.length - 1; i >= 0; i--) {
+                    if (turns[i].role === 'user') {
+                        const content = (turns[i].content ?? turns[i].text ?? '').trim();
+                        if (content) {
+                            await this.sendToTeams(processId, 'user', content, msg.agentId, msg.agentName, workspaceId);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if (this._completionSent.has(processId)) return;
+
+            // Find last user turn (start of current round)
+            let lastUserIdx = -1;
+            for (let i = turns.length - 1; i >= 0; i--) {
+                if (turns[i].role === 'user') { lastUserIdx = i; break; }
+            }
+
+            // Try task_complete summary first
+            let content: string | undefined;
+            for (let i = turns.length - 1; i > lastUserIdx; i--) {
+                const turn = turns[i];
+                if (turn.role === 'assistant' && turn.toolCalls) {
+                    const tc = turn.toolCalls.find(t => (t.name || t.toolName) === 'task_complete');
+                    if (tc?.args?.summary) {
+                        content = tc.args.summary;
+                        console.log(`[teams-bridge] Process ${processId}: found task_complete summary (${content.length} chars)`);
+                        break;
+                    }
+                }
+            }
+
+            // Fallback: last non-streaming assistant turn after last user turn
+            if (!content) {
+                for (let i = turns.length - 1; i > lastUserIdx; i--) {
+                    if (turns[i].role === 'assistant' && !turns[i].streaming) {
+                        content = (turns[i].content ?? turns[i].text ?? '').trim();
+                        if (content) break;
+                    }
+                }
+            }
+
+            // Final fallback: use tracked content from running events
+            if (!content) {
+                content = this._lastAssistantContent.get(processId);
+            }
+
+            if (content) {
+                this._completionSent.add(processId);
+                this._lastAssistantContent.delete(processId);
+
+                // Extract content chunks from the timeline of the last assistant turn.
+                // Only send the last chunk — it's the final prose the user cares about;
+                // intermediate chunks are just reasoning between tool calls.
+                const lastAssistantTurn = (() => {
+                    for (let i = turns.length - 1; i > lastUserIdx; i--) {
+                        if (turns[i].role === 'assistant' && !turns[i].streaming) return turns[i];
+                    }
+                    return undefined;
+                })();
+
+                const contentChunks = extractTimelineContentChunks(lastAssistantTurn?.timeline);
+                const messageToSend = contentChunks.length > 1
+                    ? contentChunks[contentChunks.length - 1]
+                    : content;
+
+                console.log(`[teams-bridge] *** SENDING FINAL MESSAGE for process ${processId} (${messageToSend.length} chars, from ${contentChunks.length > 1 ? 'last of ' + contentChunks.length + ' chunks' : 'full content'}):\n${messageToSend.substring(0, 300)}`);
+                await this.sendToTeams(processId, 'assistant', messageToSend, msg.agentId, msg.agentName, workspaceId);
+            }
+        } catch (err) {
+            console.error(`[teams-bridge] Failed to handle completion for ${processId}:`, err);
+        }
+    }
+
+    /**
+     * Send a message to Teams for a given process.
+     */
+    private async sendToTeams(
+        processId: string,
+        role: string,
+        content: string,
+        agentId: string,
+        agentName: string,
+        workspaceId: string,
+    ): Promise<void> {
+        if (!this.bot || !this.store) return;
+
+        let target = this.bot.getChannelId() ?? this.opts.config.channelId;
+        if (!target) {
+            console.warn('[teams-bridge] No target (chatId/channelId) available — skipping');
+            return;
+        }
+
+        if (this.bot.getStatus() !== 'connected') return;
+
+        const agentAddr = this.getAgentAddress(agentId);
+        const repoName = await this.resolveWorkspaceName(undefined, undefined, workspaceId, agentAddr || '');
+
+        // Fetch process title
+        let title = '';
+        if (agentAddr) {
+            try {
+                const res = await fetch(`${agentAddr}/api/processes/${processId}?workspaceId=${encodeURIComponent(workspaceId)}`);
+                if (res.ok) {
+                    const body = await res.json() as Record<string, unknown>;
+                    const pd = (body.process ?? body) as Record<string, unknown>;
+                    title = (pd.title ?? '') as string;
+                }
+            } catch { /* ignore */ }
+        }
+
+        const sender = this.store.getProcessSender(processId);
+        const teamsText = this.formatOutboundMessage({
+            role,
+            agent: agentName,
+            repo: repoName,
+            title,
+            content,
+            botName: this.opts.config.botName,
+            mentionName: sender?.senderName,
+            processId,
+        });
+
+        try {
+            const mentions = sender
+                ? [{ aadId: sender.senderAadId, displayName: sender.senderName }]
+                : undefined;
+            const messageId = await this.bot.send(target, teamsText, { mentions });
+            console.log(`[teams-bridge] ✅ Sent message ${messageId} for process ${processId} (role=${role}, ${content.length} chars)`);
+            this.store.bindMessage(messageId, processId, agentId, `${agentName}:${repoName}`, workspaceId);
+        } catch (err: any) {
+            if (err?.message?.includes('NotFound') && this.opts.config.teamName) {
+                console.warn(`[teams-bridge] Channel NotFound — re-resolving...`);
+                this.opts.config.channelId = undefined;
+                this.opts.config.teamId = undefined;
+                await this.resolveTeamAndChannel();
+                const newTarget = this.bot.getChannelId();
+                if (newTarget && newTarget !== target) {
+                    target = newTarget;
+                    try {
+                        const mentions = sender
+                            ? [{ aadId: sender.senderAadId, displayName: sender.senderName }]
+                            : undefined;
+                        const messageId = await this.bot.send(target, teamsText, { mentions });
+                        console.log(`[teams-bridge] ✅ Sent message ${messageId} (after re-resolve) for process ${processId}`);
+                        this.store.bindMessage(messageId, processId, agentId, `${agentName}:${repoName}`, workspaceId);
+                    } catch (retryErr) {
+                        console.error('[teams-bridge] Retry after re-resolve also failed:', retryErr);
+                    }
+                }
+            } else {
+                console.error('[teams-bridge] Failed to send outbound message:', err);
+            }
         }
     }
 
@@ -689,4 +941,23 @@ export class TeamsBridge {
         if (localUrl) return localUrl;
         return this.opts.agentStore.get(agentId)?.address;
     }
+}
+
+/**
+ * Extract content chunks from a turn's timeline array.
+ * Each timeline item with type === 'content' represents a separate prose chunk
+ * emitted between tool calls during streaming. Returns the non-empty chunks
+ * in order, or an empty array if no usable timeline is available.
+ */
+export function extractTimelineContentChunks(
+    timeline: Array<{ type: string; content?: string }> | undefined | null,
+): string[] {
+    if (!timeline || !Array.isArray(timeline) || timeline.length === 0) return [];
+    const chunks: string[] = [];
+    for (const item of timeline) {
+        if (item.type === 'content' && item.content?.trim()) {
+            chunks.push(item.content.trim());
+        }
+    }
+    return chunks;
 }

--- a/packages/coccontainer/src/messaging/whatsapp-bridge.ts
+++ b/packages/coccontainer/src/messaging/whatsapp-bridge.ts
@@ -222,6 +222,7 @@ export class WhatsAppBridge {
 
         // Skip if WhatsApp is not connected (e.g. qr-pending, disconnected)
         if (!this.bot || this.bot.getStatus() !== 'connected') {
+            console.log(`[whatsapp-bridge] Not connected (status=${this.bot?.getStatus() ?? 'no-bot'}) — skipping outbound for ${processId}`);
             this._processingLocks.delete(processId);
             return;
         }

--- a/packages/coccontainer/src/proxy/sse-relay.ts
+++ b/packages/coccontainer/src/proxy/sse-relay.ts
@@ -57,6 +57,16 @@ export class SSERelay extends EventEmitter {
                     buffer = lastIdx >= 0 ? buffer.slice(lastIdx + 2) : buffer;
 
                     for (const event of events) {
+                        // Log relay dispatch with event type
+                        try {
+                            const parsed = JSON.parse(event.data);
+                            const type = parsed.type || event.event || 'unknown';
+                            const processId = parsed.process?.id || '';
+                            const status = parsed.process?.status || '';
+                            console.log(`[sse-relay] 📨 Received from ${agentName}: type=${type} process=${processId} status=${status} → dispatching to ${this.listenerCount('event')} subscriber(s)`);
+                        } catch {
+                            console.log(`[sse-relay] 📨 Received event from ${agentName} → dispatching to ${this.listenerCount('event')} subscriber(s)`);
+                        }
                         this.emit('event', event);
                     }
                 });

--- a/packages/coccontainer/src/proxy/ws-relay.ts
+++ b/packages/coccontainer/src/proxy/ws-relay.ts
@@ -43,6 +43,16 @@ export class WebSocketRelay extends EventEmitter {
                 agentName,
                 data: data.toString(),
             };
+            // Log relay dispatch with event type
+            try {
+                const parsed = JSON.parse(message.data);
+                const type = parsed.type || 'unknown';
+                const processId = parsed.process?.id || '';
+                const status = parsed.process?.status || '';
+                console.log(`[ws-relay] 📨 Received from ${agentName}: type=${type} process=${processId} status=${status} → dispatching to ${this.listenerCount('message')} subscriber(s)`);
+            } catch {
+                console.log(`[ws-relay] 📨 Received raw data from ${agentName} → dispatching to ${this.listenerCount('message')} subscriber(s)`);
+            }
             this.emit('message', message);
         });
 

--- a/packages/coccontainer/src/server/index.ts
+++ b/packages/coccontainer/src/server/index.ts
@@ -101,6 +101,7 @@ export async function createContainerServer(config: ResolvedContainerConfig): Pr
             config: teamsConfig,
             dataDir: config.serve.dataDir,
             wsRelay,
+            sseRelay,
             agentStore,
             tunnelBridge,
         });
@@ -471,6 +472,7 @@ export async function createContainerServer(config: ResolvedContainerConfig): Pr
                                 config: resolvedTeamsConfig,
                                 dataDir: config.serve.dataDir,
                                 wsRelay,
+                                sseRelay,
                                 agentStore,
                                 tunnelBridge,
                             });

--- a/packages/coccontainer/test/messaging/teams-bridge.test.ts
+++ b/packages/coccontainer/test/messaging/teams-bridge.test.ts
@@ -62,7 +62,7 @@ vi.mock('@plusplusoneplusplus/teams-bot', () => {
     };
 });
 
-import { TeamsBridge, type TeamsBridgeOptions } from '../../src/messaging/teams-bridge';
+import { TeamsBridge, extractTimelineContentChunks, type TeamsBridgeOptions } from '../../src/messaging/teams-bridge';
 
 function createMockAgentStore() {
     return {
@@ -109,6 +109,7 @@ function emitProcessUpdate(wsRelay: EventEmitter, agentId: string, agentName: st
 describe('TeamsBridge', () => {
     let tmpDir: string;
     let wsRelay: EventEmitter & { on: any; off: any; emit: any };
+    let sseRelay: EventEmitter & { on: any; off: any; emit: any };
     let agentStore: ReturnType<typeof createMockAgentStore>;
     let tunnelBridge: ReturnType<typeof createMockTunnelBridge>;
 
@@ -116,6 +117,7 @@ describe('TeamsBridge', () => {
         botInstances = [];
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teams-bridge-test-'));
         wsRelay = new EventEmitter() as any;
+        sseRelay = new EventEmitter() as any;
         agentStore = createMockAgentStore();
         tunnelBridge = createMockTunnelBridge();
     });
@@ -146,6 +148,7 @@ describe('TeamsBridge', () => {
             },
             dataDir: tmpDir,
             wsRelay: wsRelay as any,
+            sseRelay: sseRelay as any,
             agentStore: agentStore as any,
             tunnelBridge: tunnelBridge as any,
         });
@@ -162,6 +165,62 @@ describe('TeamsBridge', () => {
 
             await bridge.stop();
             expect(lastBot().stop).toHaveBeenCalled();
+        });
+
+        it('should subscribe to both WS relay and SSE relay', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            expect(wsRelay.listenerCount('message')).toBe(1);
+            expect(sseRelay.listenerCount('event')).toBe(1);
+
+            await bridge.stop();
+
+            expect(wsRelay.listenerCount('message')).toBe(0);
+            expect(sseRelay.listenerCount('event')).toBe(0);
+        });
+
+        it('should dispatch SSE events same as WS events', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            agentStore.list.mockReturnValue([{ id: 'agent-a', name: 'Agent-A', address: 'http://localhost:4001' }]);
+
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-sse',
+                        status: 'completed',
+                        conversationTurns: [
+                            { role: 'user', content: 'SSE test' },
+                            { role: 'assistant', content: 'SSE response', toolCalls: [
+                                { name: 'task_complete', args: { summary: 'SSE response' }, status: 'completed' },
+                            ] },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch);
+
+            // Emit via SSE relay instead of WS relay
+            sseRelay.emit('event', {
+                agentId: 'agent-a',
+                agentName: 'Agent-A',
+                data: JSON.stringify({
+                    type: 'process-updated',
+                    process: { id: 'proc-sse', status: 'completed', workspaceId: 'ws-1' },
+                }),
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // Should have processed the event and sent to Teams
+            expect(lastBot().send).toHaveBeenCalled();
+            const calls = lastBot().send.mock.calls;
+            expect(calls.some((c: any[]) => c[1]?.includes('SSE response'))).toBe(true);
+
+            await bridge.stop();
         });
 
         it('should pass config to TeamsBot', async () => {
@@ -245,7 +304,7 @@ describe('TeamsBridge', () => {
             const bridge = createBridge();
             await bridge.start();
 
-            // Mock fetch for process turns
+            // Mock fetch for process turns — includes task_complete tool call
             const mockFetch = vi.fn().mockResolvedValue({
                 ok: true,
                 json: async () => ({
@@ -254,7 +313,9 @@ describe('TeamsBridge', () => {
                         status: 'completed',
                         conversationTurns: [
                             { role: 'user', content: 'Hello' },
-                            { role: 'assistant', content: 'Hi there!' },
+                            { role: 'assistant', content: 'Hi there!', toolCalls: [
+                                { name: 'task_complete', args: { summary: 'Hi there!' }, status: 'completed' },
+                            ] },
                         ],
                     },
                 }),
@@ -271,12 +332,155 @@ describe('TeamsBridge', () => {
 
             expect(lastBot().send).toHaveBeenCalledTimes(2);
             const calls = lastBot().send.mock.calls;
-            // First call is user turn with botName as sender
-            expect(calls[0][1]).toContain('TestBot');
+            // First call is user turn (forwarded immediately)
             expect(calls[0][1]).toContain('Hello');
-            // Second call is assistant turn with 'CoC Agent' as sender
+            // Second call is the task_complete summary
             expect(calls[1][1]).toContain('CoC Agent');
             expect(calls[1][1]).toContain('Hi there!');
+
+            vi.unstubAllGlobals();
+            await bridge.stop();
+        });
+
+        it('should only send task_complete summary on completion (not process.result fallback)', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            // Process with task_complete tool call in turns
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-1',
+                        status: 'completed',
+                        result: 'Long verbose reasoning that should NOT be sent...',
+                        conversationTurns: [
+                            { role: 'user', content: 'Disable the test' },
+                            { role: 'assistant', content: 'Long intermediate reasoning...', toolCalls: [
+                                { name: 'task_complete', args: { summary: 'Disabled the test successfully.' }, status: 'completed' },
+                            ] },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch);
+
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-1', status: 'completed', workspaceId: 'ws-1' },
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            expect(lastBot().send).toHaveBeenCalledTimes(2);
+            const calls = lastBot().send.mock.calls;
+            // First: user turn forwarded
+            expect(calls[0][1]).toContain('Disable the test');
+            // Second: task_complete summary (not verbose reasoning)
+            expect(calls[1][1]).toContain('Disabled the test successfully.');
+            expect(calls[1][1]).not.toContain('Long intermediate reasoning');
+            expect(calls[1][1]).not.toContain('Long verbose reasoning');
+
+            vi.unstubAllGlobals();
+            await bridge.stop();
+        });
+
+        it('should send task_complete summary even when watermark is already at end (no new turns)', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            // First event: running with user turn — user turn forwarded immediately
+            const mockFetch1 = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-wm',
+                        status: 'running',
+                        conversationTurns: [
+                            { role: 'user', content: 'Plan auth feature' },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch1);
+
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-wm', status: 'running', workspaceId: 'ws-1' },
+            });
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(lastBot().send).toHaveBeenCalledTimes(1); // user turn sent
+
+            // Second event: completed with task_complete tool call
+            const mockFetch2 = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-wm',
+                        status: 'completed',
+                        conversationTurns: [
+                            { role: 'user', content: 'Plan auth feature' },
+                            { role: 'assistant', content: 'Long verbose planning...', toolCalls: [
+                                { name: 'task_complete', args: { summary: 'Here is the auth plan with 10 tasks.' }, status: 'completed' },
+                            ] },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch2);
+
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-wm', status: 'completed', workspaceId: 'ws-1' },
+            });
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // Should send task_complete summary even though watermark covered the assistant turn
+            expect(lastBot().send).toHaveBeenCalledTimes(2);
+            expect(lastBot().send.mock.calls[1][1]).toContain('Here is the auth plan with 10 tasks.');
+
+            vi.unstubAllGlobals();
+            await bridge.stop();
+        });
+
+        it('should not re-send task_complete on duplicate completion events', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-dup',
+                        status: 'completed',
+                        conversationTurns: [
+                            { role: 'user', content: 'Do something' },
+                            { role: 'assistant', content: 'Done', toolCalls: [
+                                { name: 'task_complete', args: { summary: 'Task done.' }, status: 'completed' },
+                            ] },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch);
+
+            // First completion event
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-dup', status: 'completed', workspaceId: 'ws-1' },
+            });
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(lastBot().send).toHaveBeenCalledTimes(2); // user + task_complete
+
+            // Duplicate completion event (same turns, same status)
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-dup', status: 'completed', workspaceId: 'ws-1' },
+            });
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // Should NOT re-send — watermark already past task_complete
+            expect(lastBot().send).toHaveBeenCalledTimes(2);
 
             vi.unstubAllGlobals();
             await bridge.stop();
@@ -295,6 +499,140 @@ describe('TeamsBridge', () => {
             expect(lastBot().send).not.toHaveBeenCalled();
 
             await bridge.stop();
+        });
+
+        it('should send only the last content chunk when timeline has multiple content items', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-chunked',
+                        status: 'completed',
+                        conversationTurns: [
+                            { role: 'user', content: 'Show Batch 4 details' },
+                            {
+                                role: 'assistant',
+                                content: 'Chunk one text. Chunk two text. Chunk three text.',
+                                timeline: [
+                                    { type: 'content', content: 'Chunk one text.' },
+                                    { type: 'tool-start', toolCall: { id: 'tc1', toolName: 'grep' } },
+                                    { type: 'tool-complete', toolCall: { id: 'tc1', toolName: 'grep' } },
+                                    { type: 'content', content: 'Chunk two text.' },
+                                    { type: 'tool-start', toolCall: { id: 'tc2', toolName: 'view' } },
+                                    { type: 'tool-complete', toolCall: { id: 'tc2', toolName: 'view' } },
+                                    { type: 'content', content: 'Chunk three text.' },
+                                ],
+                                toolCalls: [
+                                    { name: 'grep', args: {} },
+                                    { name: 'view', args: {} },
+                                ],
+                            },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch);
+
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-chunked', status: 'completed', workspaceId: 'ws-1' },
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // Expect: 1 user turn + 1 last-chunk assistant message = 2 sends
+            expect(lastBot().send).toHaveBeenCalledTimes(2);
+            const calls = lastBot().send.mock.calls;
+            // First call: user turn forwarded
+            expect(calls[0][1]).toContain('Show Batch 4 details');
+            // Second: only the last chunk
+            expect(calls[1][1]).toContain('Chunk three text.');
+            expect(calls[1][1]).not.toContain('Chunk one text.');
+            expect(calls[1][1]).not.toContain('Chunk two text.');
+
+            vi.unstubAllGlobals();
+            await bridge.stop();
+        });
+
+        it('should send single message when timeline has only one content item', async () => {
+            const bridge = createBridge();
+            await bridge.start();
+
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    process: {
+                        id: 'proc-single',
+                        status: 'completed',
+                        conversationTurns: [
+                            { role: 'user', content: 'Quick question' },
+                            {
+                                role: 'assistant',
+                                content: 'Here is the answer.',
+                                timeline: [
+                                    { type: 'content', content: 'Here is the answer.' },
+                                ],
+                            },
+                        ],
+                    },
+                }),
+            });
+            vi.stubGlobal('fetch', mockFetch);
+
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-single', status: 'completed', workspaceId: 'ws-1' },
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // 1 user turn + 1 single final message = 2 sends
+            expect(lastBot().send).toHaveBeenCalledTimes(2);
+            const calls = lastBot().send.mock.calls;
+            expect(calls[1][1]).toContain('Here is the answer.');
+
+            vi.unstubAllGlobals();
+            await bridge.stop();
+        });
+    });
+
+    describe('extractTimelineContentChunks', () => {
+        it('should extract content chunks from timeline', () => {
+            const timeline = [
+                { type: 'content', content: 'First chunk' },
+                { type: 'tool-start', toolCall: { id: 'tc1' } },
+                { type: 'tool-complete', toolCall: { id: 'tc1' } },
+                { type: 'content', content: 'Second chunk' },
+                { type: 'content', content: 'Third chunk' },
+            ];
+            expect(extractTimelineContentChunks(timeline)).toEqual(['First chunk', 'Second chunk', 'Third chunk']);
+        });
+
+        it('should return empty array for undefined/null timeline', () => {
+            expect(extractTimelineContentChunks(undefined)).toEqual([]);
+            expect(extractTimelineContentChunks(null)).toEqual([]);
+            expect(extractTimelineContentChunks([])).toEqual([]);
+        });
+
+        it('should skip empty content items', () => {
+            const timeline = [
+                { type: 'content', content: 'Valid' },
+                { type: 'content', content: '   ' },
+                { type: 'content', content: '' },
+                { type: 'content', content: 'Also valid' },
+            ];
+            expect(extractTimelineContentChunks(timeline)).toEqual(['Valid', 'Also valid']);
+        });
+
+        it('should return empty array when no content items exist', () => {
+            const timeline = [
+                { type: 'tool-start', toolCall: { id: 'tc1' } },
+                { type: 'tool-complete', toolCall: { id: 'tc1' } },
+            ];
+            expect(extractTimelineContentChunks(timeline)).toEqual([]);
         });
     });
 
@@ -403,7 +741,9 @@ describe('TeamsBridge', () => {
                                 id: 'proc-alice-001',
                                 status: 'completed',
                                 conversationTurns: [
-                                    { role: 'assistant', content: 'Hello Alice!' },
+                                    { role: 'assistant', content: 'Hello Alice!', toolCalls: [
+                                        { name: 'task_complete', args: { summary: 'Hello Alice!' }, status: 'completed' },
+                                    ] },
                                 ],
                             },
                         }),
@@ -459,7 +799,9 @@ describe('TeamsBridge', () => {
                         id: 'proc-unknown',
                         status: 'completed',
                         conversationTurns: [
-                            { role: 'assistant', content: 'Done' },
+                            { role: 'assistant', content: 'Done', toolCalls: [
+                                { name: 'task_complete', args: { summary: 'Done' }, status: 'completed' },
+                            ] },
                         ],
                     },
                 }),
@@ -489,7 +831,7 @@ describe('TeamsBridge', () => {
     });
 
     describe('outbound locking — messages sent in all scenarios', () => {
-        function mockProcessFetch(turns: Array<{ role: string; content: string; streaming?: boolean }>) {
+        function mockProcessFetch(turns: Array<{ role: string; content: string; streaming?: boolean; toolCalls?: Array<{ name: string; args?: any; status?: string }> }>) {
             return vi.fn().mockResolvedValue({
                 ok: true,
                 json: async () => ({
@@ -508,7 +850,9 @@ describe('TeamsBridge', () => {
 
             // First completion
             const mockFetch = mockProcessFetch([
-                { role: 'assistant', content: 'First response' },
+                { role: 'assistant', content: 'First response', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'First response' }, status: 'completed' },
+                ] },
             ]);
             vi.stubGlobal('fetch', mockFetch);
 
@@ -521,9 +865,13 @@ describe('TeamsBridge', () => {
 
             // Second completion (simulating follow-up response — same processId)
             const mockFetch2 = mockProcessFetch([
-                { role: 'assistant', content: 'First response' },
+                { role: 'assistant', content: 'First response', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'First response' }, status: 'completed' },
+                ] },
                 { role: 'user', content: 'Follow-up question' },
-                { role: 'assistant', content: 'Second response' },
+                { role: 'assistant', content: 'Second response', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'Second response' }, status: 'completed' },
+                ] },
             ]);
             vi.stubGlobal('fetch', mockFetch2);
 
@@ -533,7 +881,7 @@ describe('TeamsBridge', () => {
             });
             await new Promise(resolve => setTimeout(resolve, 50));
 
-            // Should have sent the 2 new turns (watermark was at 1, now 3 turns)
+            // Should have sent user turn + final assistant turn for the follow-up round
             expect(lastBot().send).toHaveBeenCalledTimes(3);
 
             vi.unstubAllGlobals();
@@ -562,7 +910,9 @@ describe('TeamsBridge', () => {
 
             // Second event: now has turns — should NOT be blocked
             const goodFetch = mockProcessFetch([
-                { role: 'assistant', content: 'Now I have something' },
+                { role: 'assistant', content: 'Now I have something', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'Now I have something' }, status: 'completed' },
+                ] },
             ]);
             vi.stubGlobal('fetch', goodFetch);
 
@@ -596,7 +946,9 @@ describe('TeamsBridge', () => {
 
             // Second event: fetch succeeds — should NOT be blocked
             const goodFetch = mockProcessFetch([
-                { role: 'assistant', content: 'Recovered!' },
+                { role: 'assistant', content: 'Recovered!', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'Recovered!' }, status: 'completed' },
+                ] },
             ]);
             vi.stubGlobal('fetch', goodFetch);
 
@@ -630,7 +982,9 @@ describe('TeamsBridge', () => {
 
             // Second event: succeeds — should NOT be blocked
             const goodFetch = mockProcessFetch([
-                { role: 'assistant', content: 'After error' },
+                { role: 'assistant', content: 'After error', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'After error' }, status: 'completed' },
+                ] },
             ]);
             vi.stubGlobal('fetch', goodFetch);
 
@@ -647,7 +1001,7 @@ describe('TeamsBridge', () => {
             await bridge.stop();
         });
 
-        it('should send messages for running status after first event completes', async () => {
+        it('should skip intermediate assistant turns during running status', async () => {
             const bridge = createBridge();
             await bridge.start();
 
@@ -656,15 +1010,15 @@ describe('TeamsBridge', () => {
             ]);
             vi.stubGlobal('fetch', mockFetch);
 
-            // First running event
+            // First running event — only assistant turn, should be skipped
             emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
                 type: 'process-updated',
                 process: { id: 'proc-lock', status: 'running', workspaceId: 'ws-1' },
             });
             await new Promise(resolve => setTimeout(resolve, 50));
-            expect(lastBot().send).toHaveBeenCalledTimes(1);
+            expect(lastBot().send).toHaveBeenCalledTimes(0);
 
-            // Second running event for same process — lock released, should work again
+            // Second running event with more assistant turns — still skipped
             const mockFetch2 = mockProcessFetch([
                 { role: 'assistant', content: 'Streaming done' },
                 { role: 'assistant', content: 'More content' },
@@ -677,8 +1031,27 @@ describe('TeamsBridge', () => {
             });
             await new Promise(resolve => setTimeout(resolve, 50));
 
-            // Watermark was at 1, now 2 turns → sends the new one
-            expect(lastBot().send).toHaveBeenCalledTimes(2);
+            // Intermediate assistant turns are not sent during running
+            expect(lastBot().send).toHaveBeenCalledTimes(0);
+
+            // Completion event — only task_complete summary is sent
+            const mockFetch3 = mockProcessFetch([
+                { role: 'assistant', content: 'Streaming done' },
+                { role: 'assistant', content: 'More content' },
+                { role: 'assistant', content: 'Final answer', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'Final answer' }, status: 'completed' },
+                ] },
+            ]);
+            vi.stubGlobal('fetch', mockFetch3);
+
+            emitProcessUpdate(wsRelay, 'agent-a', 'Agent-A', {
+                type: 'process-updated',
+                process: { id: 'proc-lock', status: 'completed', workspaceId: 'ws-1' },
+            });
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            expect(lastBot().send).toHaveBeenCalledTimes(1);
+            expect(lastBot().send.mock.calls[0][1]).toContain('Final answer');
 
             vi.unstubAllGlobals();
             await bridge.stop();
@@ -692,7 +1065,9 @@ describe('TeamsBridge', () => {
             lastBot().getStatus.mockReturnValue('disconnected');
 
             const mockFetch = mockProcessFetch([
-                { role: 'assistant', content: 'Should not arrive' },
+                { role: 'assistant', content: 'Should not arrive', toolCalls: [
+                    { name: 'task_complete', args: { summary: 'Should not arrive' }, status: 'completed' },
+                ] },
             ]);
             vi.stubGlobal('fetch', mockFetch);
 
@@ -731,7 +1106,9 @@ describe('TeamsBridge', () => {
                             id,
                             status: 'completed',
                             conversationTurns: [
-                                { role: 'assistant', content: `Response from ${id}` },
+                                { role: 'assistant', content: `Response from ${id}`, toolCalls: [
+                                    { name: 'task_complete', args: { summary: `Response from ${id}` }, status: 'completed' },
+                                ] },
                             ],
                         },
                     }),
@@ -774,7 +1151,9 @@ describe('TeamsBridge', () => {
                                 id: 'proc-target',
                                 status: 'completed',
                                 conversationTurns: [
-                                    { role: 'assistant', content: 'First response' },
+                                    { role: 'assistant', content: 'First response', toolCalls: [
+                                        { name: 'task_complete', args: { summary: 'First response' }, status: 'completed' },
+                                    ] },
                                 ],
                             },
                         }),
@@ -830,7 +1209,9 @@ describe('TeamsBridge', () => {
                                 id: 'proc-strip',
                                 status: 'completed',
                                 conversationTurns: [
-                                    { role: 'assistant', content: 'Done' },
+                                    { role: 'assistant', content: 'Done', toolCalls: [
+                                        { name: 'task_complete', args: { summary: 'Done' }, status: 'completed' },
+                                    ] },
                                 ],
                             },
                         }),

--- a/packages/teams-bot/src/bot.ts
+++ b/packages/teams-bot/src/bot.ts
@@ -113,6 +113,7 @@ export class TeamsBot {
         if (this._status !== 'connected') {
             throw new Error('TeamsBot is not connected');
         }
+        this.resetPollInterval();
 
         console.log(`[teams-bot] send() target=${channelId.substring(0, 20)}..., text length=${text.length}, mode=${this.mode}`);
         try {
@@ -180,6 +181,10 @@ export class TeamsBot {
         this.opts.onStatusChange?.(status);
     }
 
+    private _lastActivityTime: number = Date.now();
+    private static readonly IDLE_TIMEOUT_MS = 60_000; // 1 minute
+    private static readonly IDLE_POLL_MS = 30_000; // 30s when idle
+
     private startPolling(): void {
         // Graph mode is send-only — do not poll for messages
         if (this.mode === 'graph') {
@@ -187,18 +192,44 @@ export class TeamsBot {
             return;
         }
         if (this._pollTimer) return;
-        this._pollTimer = setInterval(() => void this.pollMessages(), this.opts.pollIntervalMs);
+        this._lastActivityTime = Date.now();
+        this.schedulePoll();
+    }
+
+    private schedulePoll(): void {
+        if (this._pollTimer) return;
+        const elapsed = Date.now() - this._lastActivityTime;
+        const interval = elapsed >= TeamsBot.IDLE_TIMEOUT_MS
+            ? TeamsBot.IDLE_POLL_MS
+            : this.opts.pollIntervalMs;
+        this._pollTimer = setTimeout(() => {
+            this._pollTimer = null;
+            void this.pollMessages();
+        }, interval);
     }
 
     private stopPolling(): void {
         if (this._pollTimer) {
-            clearInterval(this._pollTimer);
+            clearTimeout(this._pollTimer);
             this._pollTimer = null;
         }
     }
 
+    /** Cancel any pending slow poll and reschedule at fast interval. */
+    private resetPollInterval(): void {
+        this._lastActivityTime = Date.now();
+        if (this._pollTimer) {
+            clearTimeout(this._pollTimer);
+            this._pollTimer = null;
+            this.schedulePoll();
+        }
+    }
+
     private async pollMessages(): Promise<void> {
-        if (this._status !== 'connected' || !this._channelId) return;
+        if (this._status !== 'connected' || !this._channelId) {
+            this.schedulePoll();
+            return;
+        }
 
         try {
             const since = this.mode === 'graph' ? this._lastSeenTimestamp ?? undefined : this._lastPolledId ?? undefined;
@@ -209,6 +240,11 @@ export class TeamsBot {
             } else {
                 await this.handleGraphPoll(messages, nextSince);
             }
+
+            // Reset activity timer when new messages arrive
+            if (messages.length > 0) {
+                this._lastActivityTime = Date.now();
+            }
         } catch (err: any) {
             // On 401, attempt token refresh
             if (err.message?.includes('401') && !this._refreshingToken) {
@@ -217,6 +253,9 @@ export class TeamsBot {
                 console.error(`[teams-bot] ${this.mode} poll error:`, err.message);
             }
         }
+
+        // Schedule next poll (adaptive interval based on activity)
+        this.schedulePoll();
     }
 
     /**

--- a/packages/teams-bot/src/transport-mcp.ts
+++ b/packages/teams-bot/src/transport-mcp.ts
@@ -156,13 +156,16 @@ export class McpTransport implements TeamsTransport {
     private async sendChat(_chatId: string, text: string): Promise<string> {
         if (!this.client) throw new Error('McpTransport not initialized');
 
+        // Escape backslashes — the MCP server rejects unrecognized escape sequences in content
+        const sanitizedText = text.replace(/\\/g, '\\\\');
+
         // SendMessageToSelf sends to the logged-in user — no chatId needed
         const toolName = this._availableTools.includes('SendMessageToSelf')
             ? 'SendMessageToSelf'
             : (this._availableTools.includes('SendMessageToChat') ? 'SendMessageToChat' : 'SendMessageToSelf');
 
         const args: Record<string, unknown> = {
-            content: text,
+            content: sanitizedText,
             contentType: 'html',
         };
 


### PR DESCRIPTION
…pletion

Overhaul teams-bridge messaging to send only the final content chunk from the assistant's timeline to Teams. Previously the bridge sent the entire concatenated response (often 40KB+), causing MCP SSE failures.

Key changes:
- Extract timeline content chunks from completed process turns
- Send only the last chunk (final prose after all tool calls)
- Fall back to full content when timeline is unavailable or has <=1 item
- Add extractTimelineContentChunks() helper (exported, tested)
- Refactor WS relay integration and diagnostic logging
- Add comprehensive test coverage for chunked message extraction