### PR TITLE
docs: update AGENTS.md and coc-knowledge for coc-agent-sdk extraction and Codex support

### DIFF
--- a/.github/skills/coc-knowledge/SKILL.md
+++ b/.github/skills/coc-knowledge/SKILL.md
@@ -31,7 +31,7 @@ It consists of three packages (`coc`, `forge`, `deep-wiki`) plus a shared client
 | Loops | [loops.md](references/loops.md) | Recurring follow-ups, executor, circuit breakers, REST API, dashboard integration |
 | Memory System | [memory-system.md](references/memory-system.md) | Bounded memory, capture mode, candidate ranking, promotion, recall index |
 | LLM Tools | [llm-tools.md](references/llm-tools.md) | Tool registry, per-invocation factories, permissions, web search |
-| SDK Wrapper | [sdk-wrapper.md](references/sdk-wrapper.md) | Session lifecycle, streaming state machine, MCP config, model registry |
+| SDK Wrapper | [sdk-wrapper.md](references/sdk-wrapper.md) | `coc-agent-sdk` package: Copilot + Codex providers, `ISDKService`, `SDKServiceRegistry`, session lifecycle, streaming state machine, MCP config, model registry |
 | Process Store | [process-store.md](references/process-store.md) | SQLite schema, FTS5 search, seen-state, pin/archive, prompt autocomplete |
 | Workflow Engine | [workflow-engine.md](references/workflow-engine.md) | DAG executor, compiler, node types, concurrency, skill resolution |
 | Deep Wiki | [deep-wiki.md](references/deep-wiki.md) | Six-phase pipeline, caching, themes, CLI commands, core concepts |
@@ -47,7 +47,7 @@ It consists of three packages (`coc`, `forge`, `deep-wiki`) plus a shared client
 ## Key Invariants
 
 - **Multi-repo required** — never design a feature that breaks multi-repo scenarios
-- **No session caching** — copilot-sdk-wrapper must NEVER add keep-alive or session-object caching
+- **No session caching** — `coc-agent-sdk` must NEVER add keep-alive or session-object caching
 - **File paths in prompts** — prefer file path references over expanding file content inline
 - **Session-per-request** — each `sendMessage()` spawns its own `CopilotClient` process
 - **Repo-scoped data** — all per-repo runtime data lives under `~/.coc/repos/<workspaceId>/`
@@ -55,7 +55,7 @@ It consists of three packages (`coc`, `forge`, `deep-wiki`) plus a shared client
 ## Build & Test
 
 ```bash
-npm run build:packages    # Build all packages (forge, coc, deep-wiki, coc-client)
+npm run build:packages    # Build all packages (forge, coc, deep-wiki, coc-client, coc-agent-sdk)
 npm run test:run          # Vitest (in any package dir)
 cd packages/coc && npm run build && npm link  # Debug CoC locally
 ```

--- a/.github/skills/coc-knowledge/references/monorepo.md
+++ b/.github/skills/coc-knowledge/references/monorepo.md
@@ -13,7 +13,8 @@ All four published packages plus a frozen VS Code extension live in one npm work
 
 | Shared Package | Location | Description |
 |----------------|----------|-------------|
-| **forge** | `packages/forge/` | Core AI/pipeline engine: AI SDK (CopilotSDKService, session-per-request), DAG workflow engine (`executeWorkflow`, `compileToWorkflow`), task queue, runtime policies, process store, git CLI, utilities |
+| **forge** | `packages/forge/` | Core AI/pipeline engine: imports AI SDK from `coc-agent-sdk`, DAG workflow engine (`executeWorkflow`, `compileToWorkflow`), task queue, runtime policies, process store, git CLI, utilities |
+| **coc-agent-sdk** | `packages/coc-agent-sdk/` | Provider-agnostic AI agent SDK: `CopilotSDKService`, `CodexSDKService`, `SDKServiceRegistry`, session lifecycle, streaming state machine, MCP config, model registry |
 | **whatsapp-bot** | `packages/whatsapp-bot/` | Standalone WhatsApp bot via Baileys — no CoC/forge deps. Used by `coccontainer` when `messaging.whatsapp.enabled` is true |
 
 **Architectural boundary:** Pure Node.js logic lives in packages (no VS Code deps). VS Code-specific wrappers live in `packages/vscode-extension/src/shortcuts/`. Example: `forge/src/ai/` = pure AI SDK; `packages/vscode-extension/src/shortcuts/ai-service/` = VS Code UI wrapper. **`packages/vscode-extension/` is frozen — do not read, edit, or reason about its code.**

--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -1,23 +1,30 @@
-# Copilot SDK Wrapper
+# CoC Agent SDK (`coc-agent-sdk`)
 
-Pure Node.js integration layer for `@github/copilot-sdk`. Manages AI session lifecycle, MCP server configuration, model registry and metadata, reasoning-effort resolution, and folder trust.
+Provider-agnostic AI agent SDK for CoC. Manages AI session lifecycle, MCP server configuration, model registry and metadata, reasoning-effort resolution, and folder trust. Supports **Copilot** (via `@github/copilot-sdk`) and **Codex** (via the optional `@openai/codex-sdk`) backends through a common `ISDKService` interface.
 
-Location: `packages/forge/src/copilot-sdk-wrapper/`
+Package: `@plusplusoneplusplus/coc-agent-sdk`  
+Location: `packages/coc-agent-sdk/src/`
+
+> **Forge relationship:** `packages/forge/src/copilot-sdk-wrapper/` has been removed. All forge source files import directly from `@plusplusoneplusplus/coc-agent-sdk`.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `copilot-sdk-service.ts` | Facade singleton (≤200 lines): lifecycle + single-delegation stubs |
+| `copilot-sdk-service.ts` | `CopilotSDKService` facade singleton — Copilot backend |
+| `codex-sdk-service.ts` | `CodexSDKService` — optional Codex backend (`@openai/codex-sdk`) |
+| `sdk-service-interface.ts` | `ISDKService` provider-agnostic contract |
+| `sdk-service-registry.ts` | `SDKServiceRegistry` — named-provider registry |
 | `request-runner.ts` | `sendMessage`/`transform` execution: session creation, MCP wiring, permission handler, streaming routing |
 | `stream-error-guard.ts` | `StreamErrorGuard` + `isStreamDestroyedError()`/`isConnectionDisposedError()` helpers |
 | `session-manager.ts` | Active session tracking and cancellation |
 | `streaming-session.ts` | Streaming orchestrator (`StreamingSession.run()`) — state machine, timers, telemetry |
-| `streaming-state-machine.ts` | Pure state machine: `Idle → Streaming → Settled | Cancelled` |
+| `streaming-state-machine.ts` | Pure state machine: `Idle → Streaming → Settled \| Cancelled` |
 | `session-timer-manager.ts` | Timer management: overall timeout, idle timeout, turn-end grace |
 | `session-telemetry.ts` | Token usage accumulation, tool-call tracking |
 | `sdk-client-factory.ts` | Per-request `CopilotClient` spawning: cwd validation, folder trust |
 | `sdk-loader.ts` | SDK binary discovery + ESM import workaround |
+| `sdk-esm-loader.ts` | Dynamic ESM import helper (webpack-safe `new Function` indirection) |
 | `types.ts` | Shared types: `SendMessageOptions`, MCP configs, permissions, tools, token usage |
 | `model-registry.ts` | Single source of truth for supported AI models |
 | `model-metadata-store.ts` | Runtime model metadata cache with SDK polling |
@@ -25,7 +32,33 @@ Location: `packages/forge/src/copilot-sdk-wrapper/`
 | `mcp-config-loader.ts` | Loads/merges MCP config from `~/.copilot/mcp-config.json`, workspace `.vscode/mcp.json`, and explicit request options |
 | `trusted-folder.ts` | Pre-registers working directories in `~/.copilot/config.json` |
 | `image-converter.ts` | Image file → data-URL conversion |
+| `tool-call.ts` | `ToolCall`, `ToolCallStatus`, `ToolCallPermissionRequest`, serialization types |
+| `model-info.ts` | `ModelInfo` type (id, name, description, tier, …) |
+| `logger.ts` | `initSDKLogger` / `resetSDKLogger` / `getSDKLogger` — pino logger lifecycle |
+| `internal/exec-utils.ts` | Internal: async `execFileAsync` helper |
+| `internal/path-security.ts` | Internal: path traversal validation |
+| `internal/path-utils.ts` | Internal: path resolution utilities |
+| `internal/workspace-execution.ts` | Internal: workspace execution helpers |
 | `index.ts` | Public API surface |
+
+## SDKServiceRegistry
+
+Replaces the `CopilotSDKService.getInstance()` singleton pattern. Providers register under a string key; callers look up by key.
+
+```ts
+// Well-known keys:
+COPILOT_PROVIDER / SDK_PROVIDER_COPILOT = 'copilot'
+CODEX_PROVIDER   / SDK_PROVIDER_CODEX   = 'codex'
+
+// Registration (done once during provider init):
+sdkServiceRegistry.register(SDK_PROVIDER_COPILOT, new CopilotSDKService());
+sdkServiceRegistry.register(SDK_PROVIDER_CODEX,   new CodexSDKService());
+
+// Lookup:
+const svc = sdkServiceRegistry.getOrThrow(SDK_PROVIDER_COPILOT);
+```
+
+`sdkServiceRegistry` is the module-level singleton. `CopilotSDKService.getInstance()` still exists for compatibility and re-registers itself if absent from the registry.
 
 ## CopilotSDKService Architecture
 
@@ -46,9 +79,26 @@ Location: `packages/forge/src/copilot-sdk-wrapper/`
 ### Singleton + Per-Session Client Isolation
 
 Each `sendMessage()` call creates its **own `CopilotClient`** child process — no shared client. Concurrent tasks with different working directories cannot interfere.
-The public Forge entrypoint registers the default `copilot` SDK provider when loaded, and `CopilotSDKService.getInstance()` idempotently re-registers the singleton if its registry entry was removed.
 
-## RequestRunner — sendMessage() Flow
+## CodexSDKService Architecture
+
+`CodexSDKService` implements `ISDKService` backed by the **optional** `@openai/codex-sdk` peer dependency. When the package is not installed, `isAvailable()` returns `{ available: false }` and `sendMessage()` returns an error result rather than throwing.
+
+**Thread ↔ session mapping:** Every CoC session ID maps to exactly one Codex thread. The mapping is created on the first `sendMessage()` call for a session and removed on abort or dispose.
+
+**Auth checker injection:** An optional `CodexAuthChecker` callback can be injected to gate requests. When not authenticated, `sendMessage()` returns an error with `authUrl` so callers can surface a sign-in link.
+
+```ts
+registerCodexSDKService();            // registers under SDK_PROVIDER_CODEX
+// or:
+const svc = new CodexSDKService();
+svc.setAuthChecker(() => ({ authenticated: true }));
+sdkServiceRegistry.register(SDK_PROVIDER_CODEX, svc);
+```
+
+**Lazy loading:** No SDK module is loaded until the first `isAvailable()` or `sendMessage()` call.
+
+## RequestRunner — sendMessage() Flow (Copilot)
 
 ```
 1. isAvailable() → check SDK exists
@@ -92,7 +142,7 @@ forceReload: true                        →  bypasses the path-keyed config cac
 Workspace MCP loading is resolved from the per-request `workingDirectory`, not
 the process current directory, so concurrent repos do not share MCP state. VS
 Code workspace config uses a top-level `servers` map, which is normalized into
-Forge's existing `mcpServers` shape before passing configuration to the SDK.
+the `mcpServers` shape before passing configuration to the SDK.
 Config load results include source-scoped `success`/`error` metadata so callers
 can continue with valid sources when another source is malformed.
 
@@ -106,6 +156,18 @@ Resolution order for per-request model:
 
 Variant models with `capabilities.family` base are sent to SDK as base model + resolved reasoning effort.
 
+## Logger Lifecycle
+
+`coc-agent-sdk` uses a pino logger injected by the host application:
+
+```ts
+import { initSDKLogger, resetSDKLogger } from '@plusplusoneplusplus/coc-agent-sdk';
+initSDKLogger(pinoInstance);   // call once at startup
+resetSDKLogger();              // call in tests to restore no-op logger
+```
+
+Without a call to `initSDKLogger`, all internal SDK log statements are silently discarded.
+
 ## Cleanup
 
 - `cleanup()` (async): aborts all sessions, removes stream error guard, nulls sdkModule
@@ -114,6 +176,7 @@ Variant models with `capabilities.family` base are sent to SDK as base model + r
 
 ## Testing Notes
 
-- Mock helpers in `test/helpers/mock-sdk.ts`
+- Mock helpers in `packages/coc-agent-sdk/test/helpers/mock-sdk.ts`
+- 306 tests in `packages/coc-agent-sdk/test/`
 - Set `serviceAny.sdkModule` and `serviceAny.availabilityCache` to bypass real SDK
-- Unit tests for: session-manager, streaming-session, sdk-loader, sdk-client-factory, stream-error-guard, request-runner
+- Unit tests cover: session-manager, streaming-session, sdk-loader, sdk-client-factory, stream-error-guard, request-runner, logger, codex-sdk-service

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Guidance for AI agents working in this repository. NEVER create document files u
 
 ## Repo Layout (one-liner)
 
-npm workspaces monorepo with one frozen VS Code extension and four published Node packages (`forge`, `coc`, `coc-client`, `deep-wiki`). `packages/vscode-extension/` is **FROZEN — do not read, edit, or reason about its code.**
+npm workspaces monorepo with one frozen VS Code extension and five published Node packages (`forge`, `coc`, `coc-client`, `coc-agent-sdk`, `deep-wiki`). `packages/vscode-extension/` is **FROZEN — do not read, edit, or reason about its code.**
 
 ## Load the CoC Knowledge Skill
 
@@ -30,6 +30,7 @@ Quick-start pointers (full detail lives in the skill):
 - **Deep Wiki six-phase pipeline** → [deep-wiki.md](.github/skills/coc-knowledge/references/deep-wiki.md)
 - **REST API catalog** → [rest-api.md](.github/skills/coc-knowledge/references/rest-api.md)
 - **Notes Git sync engine** → [sync.md](.github/skills/coc-knowledge/references/sync.md)
+- **SDK wrapper, Codex support, provider registry** → [sdk-wrapper.md](.github/skills/coc-knowledge/references/sdk-wrapper.md)
 
 ## Hard Invariants (apply even before reading the skill)
 
@@ -37,6 +38,6 @@ Quick-start pointers (full detail lives in the skill):
 - **Repo-scoped data:** all per-repo runtime data lives under `~/.coc/repos/<workspaceId>/`; resolve paths with `getRepoDataPath(dataDir, workspaceId, filename)`. Never add new top-level dirs under `~/.coc/` for per-repo data.
 - **Work items:** create/update via `POST http://localhost:4000/api/workspaces/<workspaceId>/work-items` — never write `work-items/*.json` files directly.
 - **VS Code extension is frozen:** do not read, edit, or reason about `packages/vscode-extension/`. It is not an npm workspace.
-- **No SDK session caching:** `copilot-sdk-wrapper` and above must never add `sendFollowUp` or keep-alive/session caches.
+- **No SDK session caching:** `coc-agent-sdk` and above must never add `sendFollowUp` or keep-alive/session caches.
 - **Model resolution order:** `task.config.model` > `PerRepoPreferences.defaultModels[mode]` > `defaultModel` > CLI default.
 - **Node.js ≥ 24** for every package (`engines.node`).

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -20,6 +20,7 @@ detailed architecture lives in its `references/*.md` files.
 | Dashboard SPA (`src/server/spa/`) | [dashboard-spa.md](../../.github/skills/coc-knowledge/references/dashboard-spa.md) |
 | REST endpoints | [rest-api.md](../../.github/skills/coc-knowledge/references/rest-api.md) |
 | Notes sync engine (`src/server/sync/`) | [sync.md](../../.github/skills/coc-knowledge/references/sync.md) |
+| SDK wrapper, Copilot/Codex providers, `ISDKService`, `SDKServiceRegistry` | [sdk-wrapper.md](../../.github/skills/coc-knowledge/references/sdk-wrapper.md) |
 
 Other domains (memory, workflow engine, prompt autocomplete, wiki serving,
 remote servers, task comments, llm-tools, sdk-wrapper, chat-prompt-history)


### PR DESCRIPTION
- AGENTS.md (root): add coc-agent-sdk to repo layout, add SDK wrapper pointer,
  update 'No SDK session caching' invariant to reference coc-agent-sdk
- packages/coc/AGENTS.md: add table row for ISDKService/SDKServiceRegistry
- references/sdk-wrapper.md: rewrite to reflect new package location
  (packages/coc-agent-sdk/src/), add CodexSDKService and SDKServiceRegistry
  sections, add all new files to the file table, add logger lifecycle section
- references/monorepo.md: add coc-agent-sdk to Shared Packages table,
  update forge description to reflect it imports AI SDK from coc-agent-sdk
- SKILL.md: update key invariant, build command, and Architecture Index
  description for SDK Wrapper

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
