### PR TITLE
fix(coc-serve-loop): build coc-agent-sdk first and fix build-failure detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21785,6 +21785,7 @@
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",
         "@octokit/rest": "^22.0.1",
+        "@plusplusoneplusplus/coc-agent-sdk": "*",
         "@plusplusoneplusplus/forge": "^1.2.0",
         "azure-devops-node-api": "^14.1.0",
         "better-sqlite3": "^11.9.1",

--- a/package.json
+++ b/package.json
@@ -3798,7 +3798,7 @@
     "coverage": "npm run coverage -w packages/coc-agent-sdk && npm run coverage -w packages/forge && npm run coverage -w packages/coc-client && npm run coverage -w packages/coc && npm run coverage -w packages/deep-wiki",
     "coverage:diff": "npm run coverage:diff -w packages/coc-agent-sdk && npm run coverage:diff -w packages/forge && npm run coverage:diff -w packages/coc-client && npm run coverage:diff -w packages/coc && npm run coverage:diff -w packages/deep-wiki",
     "build:packages": "npm run build -w packages/coc-agent-sdk && npm run build -w packages/forge && npm run build -w packages/coc-client && npm run build -w packages/teams-bot && npm run build -w packages/coc && npm run build -w packages/deep-wiki",
-    "coc:link": "cd packages/forge && npm run build && npm link && cd ../coc-client && npm run build && cd ../teams-bot && npm run build && cd ../coc && npm run build && npm link && node -e \"require('fs').rmSync('node_modules/@plusplusoneplusplus/forge', {recursive:true,force:true})\"",
+    "coc:link": "cd packages/coc-agent-sdk && npm run build && cd ../forge && npm run build && npm link && cd ../coc-client && npm run build && cd ../teams-bot && npm run build && cd ../coc && npm run build && npm link && node -e \"require('fs').rmSync('node_modules/@plusplusoneplusplus/forge', {recursive:true,force:true})\"",
     "deep-wiki:link": "cd packages/deep-wiki && npm run build && npm link",
     "vsce:package": "vsce package --no-dependencies",
     "vsce:publish": "vsce publish",

--- a/scripts/coc-serve-loop.ps1
+++ b/scripts/coc-serve-loop.ps1
@@ -244,13 +244,13 @@ function Build-Coc {
     Write-Log '=== Installing dependencies ===' -Color Cyan
     Push-Location $repoRoot
     try {
-        npm install
+        npm install 2>&1 | ForEach-Object { Write-Host $_ }
         if ($LASTEXITCODE -ne 0) {
             Write-Log "npm install failed with exit code $LASTEXITCODE" -Color Red
             return $false
         }
         Write-Log '=== Building coc packages ===' -Color Cyan
-        npm run coc:link
+        npm run coc:link 2>&1 | ForEach-Object { Write-Host $_ }
         if ($LASTEXITCODE -ne 0) {
             Write-Log "Build failed with exit code $LASTEXITCODE" -Color Red
             return $false


### PR DESCRIPTION
- Add coc-agent-sdk build step before forge in coc:link so forge's tsc
  can resolve the SDK's dist/index.js
- Pipe npm output through Write-Host in Build-Coc to prevent stdout from
  polluting the function's pipeline return value, which caused $ok to be
  a truthy array even on failure and silently skipped the retry loop

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
