### PR TITLE
fix(notes): scope undo/redo history to the currently loaded note

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
@@ -22,6 +22,7 @@ import { extractHeadings } from './noteTocUtils';
 import './noteEditor.css';
 
 import { NoteConflictBanner } from './NoteConflictBanner';
+import { resetEditorHistory } from './editorHistory';
 import { FilePreviewTooltip } from './FilePreviewTooltip';
 import { NoteVersionHistoryPanel } from './NoteVersionHistoryPanel';
 import { NoteMetadataPanel } from './NoteMetadataPanel';
@@ -591,6 +592,7 @@ export function NoteEditor({
             html = rewriteHtmlImageSrc(html, ioRef.current, workspaceIdRef.current, rootRef.current);
             ed.commands.setContent(html, { emitUpdate: false });
             ed.commands.setTextSelection?.(1);
+            resetEditorHistory(ed);
 
             // Cancel any save triggered by setContent
             pendingContentRef.current = null;
@@ -642,6 +644,7 @@ export function NoteEditor({
             let html = markdownToHtml(richMarkdown);
             html = rewriteHtmlImageSrc(html, ioRef.current, workspaceIdRef.current, rootRef.current);
             ed.commands.setContent(html, { emitUpdate: false });
+            resetEditorHistory(ed);
         }
         setRawMarkdown(conflictContent);
         pendingContentRef.current = null;
@@ -734,6 +737,7 @@ export function NoteEditor({
                 if (ed && !ed.isDestroyed) {
                     ed.commands.setContent(html, { emitUpdate: false });
                     ed.commands.setTextSelection?.(1);
+                    resetEditorHistory(ed);
                     pendingContentRef.current = null;
                     if (saveTimerRef.current) {
                         clearTimeout(saveTimerRef.current);
@@ -997,6 +1001,7 @@ export function NoteEditor({
                 let html = markdownToHtml(richMarkdown);
                 html = rewriteHtmlImageSrc(html, ioRef.current, workspaceIdRef.current, rootRef.current);
                 ed.commands.setContent(html, { emitUpdate: false });
+                resetEditorHistory(ed);
                 setDirty(false);
                 setRawMarkdown(content);
 

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/editorHistory.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/editorHistory.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for managing TipTap / prosemirror-history state on the note editor.
+ *
+ * The note editor keeps a single TipTap instance mounted across note switches
+ * for performance. The default UndoRedo extension records every transaction —
+ * including `setContent` — on a shared undo stack. Without resetting that
+ * stack when a new note is loaded, Ctrl+Z would walk back across notes and
+ * replace the visible note's content with a previously loaded note.
+ *
+ * This module provides a single helper, `resetEditorHistory`, which rebuilds
+ * the editor's `EditorState` from scratch. Plugin state fields are
+ * reinitialized via `state.init()`, which gives the history plugin a fresh,
+ * empty undo/redo stack while preserving the current document, selection,
+ * and stored marks.
+ */
+
+import type { Editor } from '@tiptap/core';
+import { EditorState } from '@tiptap/pm/state';
+
+/**
+ * Clear the editor's undo/redo history without changing the visible document.
+ *
+ * Safe to call after `setContent` to scope the history to the most recently
+ * loaded content.
+ */
+export function resetEditorHistory(editor: Editor | null | undefined): void {
+    if (!editor || editor.isDestroyed) return;
+    const view = editor.view;
+    if (!view) return;
+    const oldState = view.state;
+    const newState = EditorState.create({
+        doc: oldState.doc,
+        plugins: oldState.plugins,
+        selection: oldState.selection,
+        storedMarks: oldState.storedMarks,
+    });
+    view.updateState(newState);
+}

--- a/packages/coc/test/spa/react/notes/editorHistory.test.ts
+++ b/packages/coc/test/spa/react/notes/editorHistory.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for resetEditorHistory — the helper that gives every loaded note
+ * its own per-note undo/redo stack on the shared TipTap instance.
+ *
+ * Uses a real Tiptap editor (not mocked) so the prosemirror-history plugin
+ * actually runs and we can observe undo behavior end to end.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { StarterKit } from '@tiptap/starter-kit';
+import { undoDepth, redoDepth } from '@tiptap/pm/history';
+
+import { resetEditorHistory } from '../../../../src/server/spa/client/react/features/notes/editor/editorHistory';
+
+function makeEditor(initial = '<p></p>') {
+    return new Editor({
+        extensions: [StarterKit],
+        content: initial,
+    });
+}
+
+describe('resetEditorHistory', () => {
+    it('clears the undo stack while preserving the current document', () => {
+        const editor = makeEditor('<p>start</p>');
+
+        // Make some edits so the undo stack is populated.
+        editor.commands.setContent('<p>note A loaded</p>');
+        editor.commands.insertContent(' edit-1');
+
+        expect(undoDepth(editor.state)).toBeGreaterThan(0);
+        const beforeReset = editor.getHTML();
+
+        resetEditorHistory(editor);
+
+        expect(undoDepth(editor.state)).toBe(0);
+        expect(redoDepth(editor.state)).toBe(0);
+        expect(editor.getHTML()).toBe(beforeReset);
+
+        editor.destroy();
+    });
+
+    it('Ctrl+Z after switching notes does NOT bring back the previous note (regression)', () => {
+        const editor = makeEditor('<p></p>');
+
+        // Simulate loading note A and the user editing it.
+        editor.commands.setContent('<p>content of note A</p>');
+        editor.commands.insertContent(' edited in A');
+        // Sanity: undo would currently take us back through note A's history.
+        expect(undoDepth(editor.state)).toBeGreaterThan(0);
+
+        // Simulate switching to note B (mirrors NoteEditor.tsx load flow).
+        editor.commands.setContent('<p>content of note B</p>');
+        resetEditorHistory(editor);
+        const afterSwitch = editor.getHTML();
+
+        // The user types something in note B.
+        editor.commands.focus();
+        editor.commands.insertContent(' typed in B');
+        const beforeUndo = editor.getHTML();
+        expect(beforeUndo).toContain('typed in B');
+
+        // Press undo: should only undo the last edit in note B, never reach note A.
+        editor.commands.undo();
+        const afterOneUndo = editor.getHTML();
+        expect(afterOneUndo).toBe(afterSwitch);
+        expect(afterOneUndo).not.toContain('note A');
+        expect(afterOneUndo).not.toContain('typed in B');
+
+        // Pressing undo again should be a no-op — note A's history is gone.
+        editor.commands.undo();
+        expect(editor.getHTML()).toBe(afterSwitch);
+        expect(editor.getHTML()).not.toContain('note A');
+
+        editor.destroy();
+    });
+
+    it('preserves undo for edits made AFTER a reset', () => {
+        const editor = makeEditor('<p></p>');
+
+        editor.commands.setContent('<p>note B</p>');
+        resetEditorHistory(editor);
+        const baseline = editor.getHTML();
+
+        editor.commands.focus();
+        editor.commands.insertContent(' first edit');
+        editor.commands.insertContent(' second edit');
+
+        expect(editor.getHTML()).toContain('first edit');
+        expect(editor.getHTML()).toContain('second edit');
+        expect(undoDepth(editor.state)).toBeGreaterThan(0);
+
+        // Walk the undo stack all the way back to the post-reset baseline.
+        while (undoDepth(editor.state) > 0) {
+            editor.commands.undo();
+        }
+        expect(editor.getHTML()).toBe(baseline);
+
+        editor.destroy();
+    });
+
+    it('handles a null or destroyed editor without throwing', () => {
+        expect(() => resetEditorHistory(null)).not.toThrow();
+        expect(() => resetEditorHistory(undefined)).not.toThrow();
+
+        const editor = makeEditor('<p>x</p>');
+        editor.destroy();
+        expect(() => resetEditorHistory(editor)).not.toThrow();
+    });
+});


### PR DESCRIPTION
The note editor keeps a single TipTap instance mounted across note switches for performance. Previously, loading a new note via `setContent` left the previous note's transactions on the shared prosemirror-history stack, so pressing Ctrl+Z on note B could replace its visible content with a previously loaded note.

Add a `resetEditorHistory` helper that rebuilds the EditorState (which re-runs each plugin's `state.init()`, yielding an empty history while preserving the current doc, selection, and stored marks), and call it after every external `setContent` — initial load, source/rich switch, conflict-resolution load-from-disk, and notes-changed reload.

Includes regression tests using a real Tiptap editor that prove undo no longer crosses note boundaries and that new edits remain undoable after a reset.