### PR TITLE
fix(container-link): use name:port as stable agent ID for call-home

### DIFF
--- a/packages/coc/src/server/container-link/container-client.ts
+++ b/packages/coc/src/server/container-link/container-client.ts
@@ -174,9 +174,15 @@ export class ContainerLinkClient extends EventEmitter {
     }
 
     private async sendRegister(): Promise<void> {
+        const name = this.options.agentName ?? os.hostname();
+        // Derive a stable agentId from name + port so that agents on the same
+        // machine with different ports are uniquely identified.
+        const stableId = this.options.localPort
+            ? `${name}:${this.options.localPort}`
+            : name;
         const payload: RegisterPayload = {
-            name: this.options.agentName ?? os.hostname(),
-            agentId: this._assignedAgentId ?? this.options.agentId,
+            name,
+            agentId: this._assignedAgentId ?? this.options.agentId ?? stableId,
         };
         // Fetch workspaces before sending register so they're included in the first message
         if (this.options.getWorkspaces) {

--- a/packages/coccontainer/src/server/index.ts
+++ b/packages/coccontainer/src/server/index.ts
@@ -82,18 +82,13 @@ export async function createContainerServer(config: ResolvedContainerConfig): Pr
 
     // Inbound agent lifecycle — auto-register/deregister agents that call home
     inboundManager.on('agent-connected', (agent: { id: string; name: string }) => {
-        // Remove stale entries with same name and inbound address (from prior connections with different IDs)
-        const stale = agentStore.list().filter(a =>
-            a.address.startsWith('inbound://') && a.name === agent.name && a.address !== `inbound://${agent.id}`
-        );
-        for (const s of stale) {
-            agentStore.remove(s.id);
-        }
-
         // Add or update in agent store with a placeholder address (inbound agents don't expose a port)
         const existing = agentStore.list().find(a => a.address === `inbound://${agent.id}`);
         if (!existing) {
             agentStore.add(`inbound://${agent.id}`, agent.name);
+        } else if (existing.name !== agent.name) {
+            // Agent reconnected with updated name — sync it
+            agentStore.update(existing.id, { name: agent.name });
         }
         const entry = agentStore.list().find(a => a.address === `inbound://${agent.id}`);
         if (entry) {


### PR DESCRIPTION
Agents connecting to a container now derive a deterministic agentId from their name + local port (e.g. 'Agent-Dev3:4000'). This ensures:
- Two agents on the same machine with different ports get unique IDs
- Reconnecting after container restart matches the existing entry
- No random UUID generated on each first connection

Also removed the overly-aggressive stale cleanup that removed agents by name alone — with stable IDs, each agent keeps its own entry and reconnections match by address.