### PR TITLE
fix(coc-memory): capture nowMs once per blend for deterministic recency scores

### DIFF
--- a/packages/coc-memory/src/hybrid-search.ts
+++ b/packages/coc-memory/src/hybrid-search.ts
@@ -152,6 +152,7 @@ export class HybridSearchEngine {
         vectorHits: VectorHit[],
         limit: number,
     ): MemorySearchResult[] {
+        const nowMs = Date.now(); // capture once so all recency scores within a search are deterministic
         const hasBm25 = bm25Results.length > 0;
         const hasVec = vectorHits.length > 0;
         const weights =
@@ -180,7 +181,7 @@ export class HybridSearchEngine {
 
         const results: MemorySearchResult[] = [];
         for (const { fact, bm25Score, vectorScore } of map.values()) {
-            const rec = recencyScore(fact.createdAt);
+            const rec = recencyScore(fact.createdAt, undefined, nowMs);
             const score =
                 weights.lex * bm25Score +
                 weights.vec * (vectorScore ?? 0) +

--- a/packages/coc-memory/src/vector-ranker.ts
+++ b/packages/coc-memory/src/vector-ranker.ts
@@ -73,7 +73,7 @@ export function normalise(values: number[]): number[] {
  * Recency decay score: `exp(-ageDays / halfLifeDays)`.
  * A fact created today scores 1.0; one created 90 days ago scores ~0.37.
  */
-export function recencyScore(createdAt: string, halfLifeDays = 90): number {
-    const ageDays = (Date.now() - new Date(createdAt).getTime()) / (1000 * 60 * 60 * 24);
+export function recencyScore(createdAt: string, halfLifeDays = 90, nowMs = Date.now()): number {
+    const ageDays = (nowMs - new Date(createdAt).getTime()) / (1000 * 60 * 60 * 24);
     return Math.exp(-ageDays / halfLifeDays);
 }


### PR DESCRIPTION
recencyScore() was calling Date.now() on each invocation, so two
consecutive engine.search() calls could return slightly different scores
as wall-clock time advanced between them.

Fix: add an optional nowMs parameter to recencyScore() and capture
Date.now() once at the start of _blend(), passing it to every
recencyScore() call within that operation. This ensures all facts in a
single search are evaluated at the same instant.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
