### PR TITLE
feat(coc): mirror bundled skills to Codex home

### DIFF
--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -30,6 +30,10 @@ all have their own `references/*.md`.
 
 - **627+ Vitest test files** live under `packages/coc/test/server/`. Any
   server change should add or update tests there.
+- **Codex skill mirroring** runs once at server startup (when
+  `resolvedConfig.codex?.enabled === true`), not per-install. The
+  `syncInstalledSkillsToCodex` function copies all globally installed bundled
+  skills from `~/.coc/skills` to `~/.codex/skills` (`$CODEX_HOME/skills`).
 - **Adding an editable config field** is a single registry entry — do not
   modify `admin-handler.ts` (see [admin-config.md](../../.github/skills/coc-knowledge/references/admin-config.md)).
 - **Adding a namespaced config field** must update

--- a/packages/coc/src/commands/skills.ts
+++ b/packages/coc/src/commands/skills.ts
@@ -47,6 +47,10 @@ function getGlobalSkillsDir(): string {
     return path.join(dataDir, 'skills');
 }
 
+function getDataDir(): string {
+    return process.env.COC_DATA_DIR || path.join(os.homedir(), '.coc');
+}
+
 function getInstallPath(workspaceRoot: string, installPathOverride?: string): string {
     return path.join(workspaceRoot, installPathOverride || DEFAULT_SKILLS_SETTINGS.installPath);
 }

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -416,6 +416,23 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         }).catch(() => { /* best-effort — never block startup */ });
     }
 
+    // Mirror installed bundled skills to Codex when Codex is enabled (non-blocking on errors).
+    // This happens once on server startup to ensure Codex has access to all globally installed
+    // bundled skills without needing to read from ~/.coc/skills directly.
+    if (resolvedConfig.codex?.enabled) {
+        const globalSkillsDir = path.join(dataDir, 'skills');
+        import('./skills/codex-skill-mirror').then(({ syncInstalledSkillsToCodex }) => {
+            return syncInstalledSkillsToCodex(globalSkillsDir);
+        }).then(result => {
+            if (result.synced.length > 0) {
+                process.stderr.write(`[skills] Synced ${result.synced.length} skill(s) to Codex\n`);
+            }
+            for (const e of result.errors) {
+                process.stderr.write(`[skills] Failed to sync "${e.name}" to Codex: ${e.error}\n`);
+            }
+        }).catch(() => { /* best-effort — never block startup */ });
+    }
+
     const globalWorkspace = await ensureGlobalWorkspace(dataDir, store);
     bridge.registerRepoId(globalWorkspace.id, globalWorkspace.rootPath);
 

--- a/packages/coc/src/server/skills/codex-skill-mirror.ts
+++ b/packages/coc/src/server/skills/codex-skill-mirror.ts
@@ -1,0 +1,376 @@
+/**
+ * Codex Skill Mirror
+ *
+ * Mirrors globally-installed bundled CoC skills from ~/.coc/skills to
+ * ~/.codex/skills (or $CODEX_HOME/skills) so Codex can load them.
+ *
+ * Only mirrors bundled skills installed globally. Does not mirror:
+ * - Workspace-local skills
+ * - Per-repo skills
+ * - User-provided skill directories
+ *
+ * Uses a marker file (.coc-skill.json) to track CoC-managed mirrored skills.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseSkillVersionFromFile, compareVersions, getLogger, LogCategory } from '@plusplusoneplusplus/forge';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type MirrorStatus =
+    | 'copied'
+    | 'updated'
+    | 'skipped-existing-user-managed'
+    | 'skipped-same-version'
+    | 'skipped-newer-target'
+    | 'failed';
+
+export interface MirrorResult {
+    skillName: string;
+    status: MirrorStatus;
+    error?: string;
+}
+
+interface CoCSkillMarker {
+    source: 'coc-bundled';
+    name: string;
+    version?: string;
+}
+
+// ============================================================================
+// Codex Home Resolution
+// ============================================================================
+
+/**
+ * Resolve the Codex home directory.
+ * Uses $CODEX_HOME if set, otherwise falls back to ~/.codex
+ */
+export function getCodexHome(): string {
+    return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+/**
+ * Get the Codex skills directory.
+ */
+export function getCodexSkillsDir(): string {
+    return path.join(getCodexHome(), 'skills');
+}
+
+// ============================================================================
+// Marker File Management
+// ============================================================================
+
+const MARKER_FILENAME = '.coc-skill.json';
+
+/**
+ * Write a CoC marker file into the mirrored skill directory.
+ */
+function writeMarker(skillPath: string, skillName: string, version?: string): void {
+    const marker: CoCSkillMarker = {
+        source: 'coc-bundled',
+        name: skillName,
+        version,
+    };
+    const markerPath = path.join(skillPath, MARKER_FILENAME);
+    fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2), 'utf-8');
+}
+
+/**
+ * Read a CoC marker file from a skill directory.
+ * Returns the marker object if valid, undefined otherwise.
+ */
+function readMarker(skillPath: string): CoCSkillMarker | undefined {
+    try {
+        const markerPath = path.join(skillPath, MARKER_FILENAME);
+        if (!fs.existsSync(markerPath)) return undefined;
+        const content = fs.readFileSync(markerPath, 'utf-8');
+        const marker = JSON.parse(content);
+        if (marker.source === 'coc-bundled' && marker.name) {
+            return marker;
+        }
+        return undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+// ============================================================================
+// Version Comparison
+// ============================================================================
+
+/**
+ * Determine if we should replace the target skill with the source.
+ * Returns true if source is newer, false otherwise.
+ */
+function shouldReplaceByVersion(
+    sourcePath: string,
+    targetPath: string,
+    marker: CoCSkillMarker
+): boolean {
+    const sourceVersion = parseSkillVersionFromFile(path.join(sourcePath, 'SKILL.md'));
+    if (!sourceVersion) {
+        // No source version - skip to be safe
+        return false;
+    }
+
+    const targetVersion = parseSkillVersionFromFile(path.join(targetPath, 'SKILL.md'));
+    if (!targetVersion) {
+        // Target has no version but has CoC marker - safer to skip unless we know it's older
+        return false;
+    }
+
+    const comparison = compareVersions(sourceVersion, targetVersion);
+    if (comparison === undefined) {
+        // Cannot compare - skip to be safe
+        return false;
+    }
+
+    // Replace only if source is newer
+    return comparison > 0;
+}
+
+// ============================================================================
+// Atomic Copy Operations
+// ============================================================================
+
+/**
+ * Copy a skill directory to the target path atomically.
+ * Uses a temporary directory + rename for atomicity.
+ */
+async function copySkillDirectoryAtomic(
+    sourcePath: string,
+    targetPath: string,
+    skillName: string,
+    version?: string
+): Promise<void> {
+    const targetParent = path.dirname(targetPath);
+    const tempPath = path.join(targetParent, `.${skillName}.tmp.${Date.now()}`);
+
+    try {
+        // Copy to temporary location
+        await copyDirectory(sourcePath, tempPath);
+
+        // Write marker
+        writeMarker(tempPath, skillName, version);
+
+        // Remove existing target if present
+        if (fs.existsSync(targetPath)) {
+            fs.rmSync(targetPath, { recursive: true, force: true });
+        }
+
+        // Atomic rename
+        fs.renameSync(tempPath, targetPath);
+    } catch (error) {
+        // Clean up temp directory on error
+        try {
+            if (fs.existsSync(tempPath)) {
+                fs.rmSync(tempPath, { recursive: true, force: true });
+            }
+        } catch {
+            // Ignore cleanup errors
+        }
+        throw error;
+    }
+}
+
+/**
+ * Recursively copy a directory, preserving nested structure.
+ */
+async function copyDirectory(source: string, dest: string): Promise<void> {
+    fs.mkdirSync(dest, { recursive: true });
+
+    const entries = fs.readdirSync(source, { withFileTypes: true });
+    for (const entry of entries) {
+        const srcPath = path.join(source, entry.name);
+        const destPath = path.join(dest, entry.name);
+
+        if (entry.isDirectory()) {
+            await copyDirectory(srcPath, destPath);
+        } else {
+            fs.copyFileSync(srcPath, destPath);
+        }
+    }
+}
+
+// ============================================================================
+// Main Mirror Function
+// ============================================================================
+
+/**
+ * Mirror a bundled skill from CoC global skills to Codex skills directory.
+ *
+ * @param cocSkillsDir  CoC global skills directory (e.g. ~/.coc/skills)
+ * @param skillName     Name of the skill to mirror
+ * @param replace       If true, replace existing user-managed skills
+ * @returns Mirror result with status
+ */
+export async function mirrorBundledSkillToCodex(
+    cocSkillsDir: string,
+    skillName: string,
+    replace: boolean = false
+): Promise<MirrorResult> {
+    const logger = getLogger();
+
+    try {
+        // Validate source skill exists
+        const sourcePath = path.join(cocSkillsDir, skillName);
+        const sourceSkillMd = path.join(sourcePath, 'SKILL.md');
+        if (!fs.existsSync(sourceSkillMd)) {
+            return {
+                skillName,
+                status: 'failed',
+                error: 'Source skill does not exist'
+            };
+        }
+
+        // Get target path
+        const codexSkillsDir = getCodexSkillsDir();
+        const targetPath = path.join(codexSkillsDir, skillName);
+
+        // Ensure Codex skills directory exists
+        fs.mkdirSync(codexSkillsDir, { recursive: true });
+
+        // Never touch .system directory
+        if (skillName === '.system') {
+            return {
+                skillName,
+                status: 'skipped-existing-user-managed',
+                error: 'Cannot mirror .system directory'
+            };
+        }
+
+        // Parse source version
+        const sourceVersion = parseSkillVersionFromFile(sourceSkillMd);
+
+        // Check if target exists
+        const targetExists = fs.existsSync(targetPath);
+        if (!targetExists) {
+            // New skill - just copy it
+            await copySkillDirectoryAtomic(sourcePath, targetPath, skillName, sourceVersion);
+            logger.info(LogCategory.GENERAL, `Mirrored bundled skill to Codex: ${skillName}`);
+            return { skillName, status: 'copied' };
+        }
+
+        // Target exists - check for CoC marker
+        const marker = readMarker(targetPath);
+        if (!marker) {
+            // Existing skill without CoC marker - user-managed
+            if (replace) {
+                await copySkillDirectoryAtomic(sourcePath, targetPath, skillName, sourceVersion);
+                logger.info(LogCategory.GENERAL, `Replaced user-managed Codex skill: ${skillName}`);
+                return { skillName, status: 'copied' };
+            }
+            return {
+                skillName,
+                status: 'skipped-existing-user-managed',
+                error: 'Target skill is user-managed (no CoC marker)'
+            };
+        }
+
+        // CoC-managed skill - check version
+        if (shouldReplaceByVersion(sourcePath, targetPath, marker)) {
+            await copySkillDirectoryAtomic(sourcePath, targetPath, skillName, sourceVersion);
+            logger.info(LogCategory.GENERAL, `Updated Codex skill to newer version: ${skillName}`);
+            return { skillName, status: 'updated' };
+        }
+
+        // Check if versions are equal
+        const targetVersion = parseSkillVersionFromFile(path.join(targetPath, 'SKILL.md'));
+        if (sourceVersion && targetVersion && sourceVersion === targetVersion) {
+            return {
+                skillName,
+                status: 'skipped-same-version',
+                error: `Version ${targetVersion} already installed`
+            };
+        }
+
+        // Target is newer or versions cannot be compared
+        return {
+            skillName,
+            status: 'skipped-newer-target',
+            error: 'Target has newer or incomparable version'
+        };
+
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.error(LogCategory.GENERAL, `Failed to mirror skill to Codex: ${skillName}`, err);
+        return {
+            skillName,
+            status: 'failed',
+            error: err.message
+        };
+    }
+}
+
+/**
+ * Mirror multiple bundled skills to Codex.
+ *
+ * @param cocSkillsDir  CoC global skills directory
+ * @param skillNames    Names of skills to mirror
+ * @param replace       If true, replace existing user-managed skills
+ * @returns Array of mirror results
+ */
+export async function mirrorBundledSkillsToCodex(
+    cocSkillsDir: string,
+    skillNames: string[],
+    replace: boolean = false
+): Promise<MirrorResult[]> {
+    const results: MirrorResult[] = [];
+    for (const skillName of skillNames) {
+        const result = await mirrorBundledSkillToCodex(cocSkillsDir, skillName, replace);
+        results.push(result);
+    }
+    return results;
+}
+
+/**
+ * Sync all installed bundled skills from CoC to Codex on server startup.
+ * Called during server initialization when Codex is enabled.
+ *
+ * @param cocSkillsDir  CoC global skills directory (e.g. ~/.coc/skills)
+ * @returns Sync results
+ */
+export async function syncInstalledSkillsToCodex(cocSkillsDir: string): Promise<{
+    synced: string[];
+    errors: Array<{ name: string; error: string }>;
+}> {
+    const logger = getLogger();
+    const result = { synced: [], errors: [] } as { synced: string[]; errors: Array<{ name: string; error: string }> };
+
+    try {
+        // Get all installed skills in CoC directory
+        if (!fs.existsSync(cocSkillsDir)) {
+            return result;
+        }
+
+        const entries = fs.readdirSync(cocSkillsDir, { withFileTypes: true });
+        const skillNames = entries
+            .filter(e => e.isDirectory() && e.name !== '.system')
+            .map(e => e.name);
+
+        if (skillNames.length === 0) {
+            return result;
+        }
+
+        // Mirror each skill
+        const mirrorResults = await mirrorBundledSkillsToCodex(cocSkillsDir, skillNames, false);
+
+        for (const mr of mirrorResults) {
+            if (mr.status === 'copied' || mr.status === 'updated') {
+                result.synced.push(mr.skillName);
+            } else if (mr.status === 'failed') {
+                result.errors.push({ name: mr.skillName, error: mr.error ?? 'unknown error' });
+            }
+            // silently skip other statuses (skipped-same-version, skipped-existing-user-managed, etc.)
+        }
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.error(LogCategory.GENERAL, 'Failed to sync skills to Codex', err);
+    }
+
+    return result;
+}

--- a/packages/coc/test/server/skills/codex-skill-mirror.test.ts
+++ b/packages/coc/test/server/skills/codex-skill-mirror.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for Codex Skill Mirror
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    getCodexHome,
+    getCodexSkillsDir,
+    mirrorBundledSkillToCodex,
+    mirrorBundledSkillsToCodex,
+    type MirrorResult,
+} from '../../../src/server/skills/codex-skill-mirror';
+
+describe('codex-skill-mirror', () => {
+    let tempDir: string;
+    let cocSkillsDir: string;
+    let codexHome: string;
+    let originalCodexHome: string | undefined;
+
+    beforeEach(() => {
+        // Create temp directories for testing
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-mirror-test-'));
+        cocSkillsDir = path.join(tempDir, 'coc-skills');
+        codexHome = path.join(tempDir, 'codex-home');
+
+        fs.mkdirSync(cocSkillsDir, { recursive: true });
+        fs.mkdirSync(codexHome, { recursive: true });
+
+        // Mock CODEX_HOME
+        originalCodexHome = process.env.CODEX_HOME;
+        process.env.CODEX_HOME = codexHome;
+    });
+
+    afterEach(() => {
+        // Restore original CODEX_HOME
+        if (originalCodexHome !== undefined) {
+            process.env.CODEX_HOME = originalCodexHome;
+        } else {
+            delete process.env.CODEX_HOME;
+        }
+
+        // Clean up temp directory
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    describe('getCodexHome', () => {
+        it('should use CODEX_HOME when set', () => {
+            process.env.CODEX_HOME = '/custom/codex/home';
+            expect(getCodexHome()).toBe('/custom/codex/home');
+        });
+
+        it('should fall back to ~/.codex when CODEX_HOME is not set', () => {
+            delete process.env.CODEX_HOME;
+            expect(getCodexHome()).toBe(path.join(os.homedir(), '.codex'));
+        });
+    });
+
+    describe('getCodexSkillsDir', () => {
+        it('should return skills subdirectory of Codex home', () => {
+            process.env.CODEX_HOME = '/custom/codex/home';
+            expect(getCodexSkillsDir()).toBe(path.join('/custom/codex/home', 'skills'));
+        });
+    });
+
+    describe('mirrorBundledSkillToCodex', () => {
+        function createSkill(skillName: string, version?: string): void {
+            const skillPath = path.join(cocSkillsDir, skillName);
+            fs.mkdirSync(skillPath, { recursive: true });
+            
+            let content = '---\n';
+            if (version) {
+                content += `metadata:\n  version: ${version}\n`;
+            }
+            content += '---\n\n# Skill\n\nContent';
+            
+            fs.writeFileSync(path.join(skillPath, 'SKILL.md'), content);
+            
+            // Create nested files
+            const refsDir = path.join(skillPath, 'references');
+            fs.mkdirSync(refsDir, { recursive: true });
+            fs.writeFileSync(path.join(refsDir, 'ref.md'), '# Reference');
+        }
+
+        it('should copy new skill to Codex', async () => {
+            createSkill('test-skill', '1.0.0');
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', false);
+
+            expect(result.status).toBe('copied');
+            expect(result.skillName).toBe('test-skill');
+
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            expect(fs.existsSync(path.join(codexSkillPath, 'SKILL.md'))).toBe(true);
+            expect(fs.existsSync(path.join(codexSkillPath, 'references', 'ref.md'))).toBe(true);
+            expect(fs.existsSync(path.join(codexSkillPath, '.coc-skill.json'))).toBe(true);
+
+            const marker = JSON.parse(fs.readFileSync(path.join(codexSkillPath, '.coc-skill.json'), 'utf-8'));
+            expect(marker.source).toBe('coc-bundled');
+            expect(marker.name).toBe('test-skill');
+            expect(marker.version).toBe('1.0.0');
+        });
+
+        it('should fail if source skill does not exist', async () => {
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'nonexistent', false);
+
+            expect(result.status).toBe('failed');
+            expect(result.error).toContain('does not exist');
+        });
+
+        it('should skip .system directory', async () => {
+            createSkill('.system');
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, '.system', false);
+
+            expect(result.status).toBe('skipped-existing-user-managed');
+            expect(result.error).toContain('.system');
+        });
+
+        it('should skip existing user-managed skill when replace is false', async () => {
+            createSkill('test-skill', '1.0.0');
+
+            // Create existing user skill without marker
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            fs.mkdirSync(codexSkillPath, { recursive: true });
+            fs.writeFileSync(path.join(codexSkillPath, 'SKILL.md'), '# User skill');
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', false);
+
+            expect(result.status).toBe('skipped-existing-user-managed');
+            expect(fs.readFileSync(path.join(codexSkillPath, 'SKILL.md'), 'utf-8')).toBe('# User skill');
+        });
+
+        it('should replace existing user-managed skill when replace is true', async () => {
+            createSkill('test-skill', '1.0.0');
+
+            // Create existing user skill without marker
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            fs.mkdirSync(codexSkillPath, { recursive: true });
+            fs.writeFileSync(path.join(codexSkillPath, 'SKILL.md'), '# User skill');
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', true);
+
+            expect(result.status).toBe('copied');
+            expect(fs.readFileSync(path.join(codexSkillPath, 'SKILL.md'), 'utf-8')).toContain('# Skill');
+        });
+
+        it('should update when source version is newer', async () => {
+            createSkill('test-skill', '2.0.0');
+
+            // Create existing CoC-managed skill with older version
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            fs.mkdirSync(codexSkillPath, { recursive: true });
+            fs.writeFileSync(
+                path.join(codexSkillPath, 'SKILL.md'),
+                '---\nmetadata:\n  version: 1.0.0\n---\n\n# Old skill'
+            );
+            fs.writeFileSync(
+                path.join(codexSkillPath, '.coc-skill.json'),
+                JSON.stringify({ source: 'coc-bundled', name: 'test-skill', version: '1.0.0' })
+            );
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', false);
+
+            expect(result.status).toBe('updated');
+            expect(fs.readFileSync(path.join(codexSkillPath, 'SKILL.md'), 'utf-8')).toContain('2.0.0');
+        });
+
+        it('should skip when versions are the same', async () => {
+            createSkill('test-skill', '1.0.0');
+
+            // Create existing CoC-managed skill with same version
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            fs.mkdirSync(codexSkillPath, { recursive: true });
+            fs.writeFileSync(
+                path.join(codexSkillPath, 'SKILL.md'),
+                '---\nmetadata:\n  version: 1.0.0\n---\n\n# Skill'
+            );
+            fs.writeFileSync(
+                path.join(codexSkillPath, '.coc-skill.json'),
+                JSON.stringify({ source: 'coc-bundled', name: 'test-skill', version: '1.0.0' })
+            );
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', false);
+
+            expect(result.status).toBe('skipped-same-version');
+            expect(result.error).toContain('1.0.0');
+        });
+
+        it('should skip when target version is newer', async () => {
+            createSkill('test-skill', '1.0.0');
+
+            // Create existing CoC-managed skill with newer version
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            fs.mkdirSync(codexSkillPath, { recursive: true });
+            fs.writeFileSync(
+                path.join(codexSkillPath, 'SKILL.md'),
+                '---\nmetadata:\n  version: 2.0.0\n---\n\n# Newer skill'
+            );
+            fs.writeFileSync(
+                path.join(codexSkillPath, '.coc-skill.json'),
+                JSON.stringify({ source: 'coc-bundled', name: 'test-skill', version: '2.0.0' })
+            );
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', false);
+
+            expect(result.status).toBe('skipped-newer-target');
+        });
+
+        it('should preserve nested directory structure', async () => {
+            const skillPath = path.join(cocSkillsDir, 'test-skill');
+            fs.mkdirSync(skillPath, { recursive: true });
+            fs.writeFileSync(path.join(skillPath, 'SKILL.md'), '# Skill');
+
+            // Create nested structure
+            fs.mkdirSync(path.join(skillPath, 'references'), { recursive: true });
+            fs.mkdirSync(path.join(skillPath, 'scripts'), { recursive: true });
+            fs.mkdirSync(path.join(skillPath, 'assets', 'images'), { recursive: true });
+
+            fs.writeFileSync(path.join(skillPath, 'references', 'api.md'), '# API');
+            fs.writeFileSync(path.join(skillPath, 'scripts', 'test.sh'), '#!/bin/bash');
+            fs.writeFileSync(path.join(skillPath, 'assets', 'images', 'logo.png'), 'PNG');
+
+            const result = await mirrorBundledSkillToCodex(cocSkillsDir, 'test-skill', false);
+
+            expect(result.status).toBe('copied');
+
+            const codexSkillPath = path.join(codexHome, 'skills', 'test-skill');
+            expect(fs.existsSync(path.join(codexSkillPath, 'references', 'api.md'))).toBe(true);
+            expect(fs.existsSync(path.join(codexSkillPath, 'scripts', 'test.sh'))).toBe(true);
+            expect(fs.existsSync(path.join(codexSkillPath, 'assets', 'images', 'logo.png'))).toBe(true);
+        });
+    });
+
+    describe('mirrorBundledSkillsToCodex', () => {
+        it('should mirror multiple skills', async () => {
+            // Create multiple skills
+            const skillNames = ['skill-a', 'skill-b', 'skill-c'];
+            for (const name of skillNames) {
+                const skillPath = path.join(cocSkillsDir, name);
+                fs.mkdirSync(skillPath, { recursive: true });
+                fs.writeFileSync(path.join(skillPath, 'SKILL.md'), `# ${name}`);
+            }
+
+            const results = await mirrorBundledSkillsToCodex(cocSkillsDir, skillNames, false);
+
+            expect(results).toHaveLength(3);
+            expect(results.every(r => r.status === 'copied')).toBe(true);
+
+            for (const name of skillNames) {
+                const codexSkillPath = path.join(codexHome, 'skills', name);
+                expect(fs.existsSync(path.join(codexSkillPath, 'SKILL.md'))).toBe(true);
+            }
+        });
+
+        it('should handle mixed success and failure', async () => {
+            // Create one valid skill
+            const skillPath = path.join(cocSkillsDir, 'valid-skill');
+            fs.mkdirSync(skillPath, { recursive: true });
+            fs.writeFileSync(path.join(skillPath, 'SKILL.md'), '# Valid');
+
+            const results = await mirrorBundledSkillsToCodex(
+                cocSkillsDir,
+                ['valid-skill', 'invalid-skill'],
+                false
+            );
+
+            expect(results).toHaveLength(2);
+            expect(results[0].status).toBe('copied');
+            expect(results[0].skillName).toBe('valid-skill');
+            expect(results[1].status).toBe('failed');
+            expect(results[1].skillName).toBe('invalid-skill');
+        });
+    });
+});


### PR DESCRIPTION
- Mirror all bundled skills to the Codex home directory on server
  initialization (only when Codex is enabled), so Codex can discover
  and use them without manual setup.
- Mirroring is skipped when Codex is not enabled, avoiding unnecessary
  file-system writes.
- Document the Codex skill-mirroring behavior in the skills REST API
  response reference and in AGENTS.md.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
