### PR TITLE
redesign workitem system - Part 1

### DIFF
--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -70,6 +70,7 @@ export interface AdminResolvedConfig {
   claude?: { enabled?: boolean };
   activeProvider?: 'copilot' | 'codex' | 'claude';
   mcpOauth?: { enabled?: boolean };
+  workItems?: { hierarchy?: { enabled?: boolean } };
   [key: string]: unknown;
 }
 
@@ -124,6 +125,7 @@ export interface AdminConfigUpdate {
   'codex.enabled'?: boolean;
   'claude.enabled'?: boolean;
   activeProvider?: 'copilot' | 'codex' | 'claude';
+  'workItems.hierarchy.enabled'?: boolean;
   [key: string]: unknown;
 }
 
@@ -155,6 +157,7 @@ export interface RuntimeDashboardConfig {
     codexEnabled: boolean;
     claudeEnabled: boolean;
     activeProvider: 'copilot' | 'codex' | 'claude';
+    workItemsHierarchyEnabled: boolean;
   };
   hostname?: string;
   bindAddress?: string;

--- a/packages/coc-client/src/contracts/work-items.ts
+++ b/packages/coc-client/src/contracts/work-items.ts
@@ -199,3 +199,52 @@ export interface WorkItemChange {
   prUrl?: string;
   prStatus?: 'open' | 'merged' | 'closed' | string;
 }
+
+// ============================================================================
+// Hierarchy tree types
+// ============================================================================
+
+/** Descendant count roll-up for a hierarchy tree node. */
+export interface WorkItemRollup {
+  descendantCount: number;
+  byType: {
+    epic: number;
+    feature: number;
+    pbi: number;
+    'work-item': number;
+    bug: number;
+  };
+  byStatus: {
+    created: number;
+    planning: number;
+    readyToExecute: number;
+    executing: number;
+    aiDone: number;
+    aiFailed: number;
+    done: number;
+    failed: number;
+  };
+}
+
+/** A node in the work item hierarchy tree. */
+export interface WorkItemTreeNode {
+  item: WorkItem;
+  children: WorkItemTreeNode[];
+  rollup: WorkItemRollup;
+}
+
+/** Response from the work item tree endpoint. */
+export interface WorkItemTreeResponse {
+  roots: WorkItemTreeNode[];
+  total: number;
+  /** True when the hierarchy feature flag is disabled. */
+  disabled?: boolean;
+}
+
+/** Filter options for the tree endpoint. */
+export interface WorkItemTreeFilter {
+  q?: string;
+  type?: WorkItemType;
+  status?: WorkItemStatus;
+  includeArchived?: boolean;
+}

--- a/packages/coc-client/src/contracts/work-items.ts
+++ b/packages/coc-client/src/contracts/work-items.ts
@@ -12,7 +12,7 @@ export type WorkItemStatus =
   | string;
 export type WorkItemPriority = 'high' | 'normal' | 'low';
 export type WorkItemSource = 'manual' | 'chat' | 'schedule';
-export type WorkItemType = 'work-item' | 'bug';
+export type WorkItemType = 'work-item' | 'bug' | 'epic' | 'feature' | 'pbi';
 
 export interface WorkItemPlan {
   version: number;
@@ -52,6 +52,8 @@ export interface WorkItem {
   description: string;
   status: WorkItemStatus;
   type?: WorkItemType;
+  /** Parent work item ID (hierarchy). Only set when hierarchy is enabled. */
+  parentId?: string;
   createdAt: string;
   updatedAt: string;
   completedAt?: string;
@@ -100,6 +102,8 @@ export interface CreateWorkItemRequest {
   title: string;
   description?: string;
   type?: WorkItemType;
+  /** Parent work item ID (hierarchy). Only accepted when hierarchy flag is enabled. */
+  parentId?: string;
   source?: WorkItemSource;
   sourceId?: string;
   priority?: WorkItemPriority;
@@ -121,6 +125,8 @@ export interface CreateWorkItemFromChatRequest extends JsonObject {
 export interface UpdateWorkItemRequest extends Partial<Pick<WorkItem, 'title' | 'description' | 'status' | 'priority' | 'tags' | 'autoExecute'>> {
   completedAt?: string;
   reviewComments?: unknown[];
+  /** Update parent link (hierarchy). Only accepted when hierarchy flag is enabled. */
+  parentId?: string | null;
 }
 
 export interface ExecuteWorkItemRequest extends JsonObject {

--- a/packages/coc-client/src/contracts/work-items.ts
+++ b/packages/coc-client/src/contracts/work-items.ts
@@ -14,6 +14,31 @@ export type WorkItemPriority = 'high' | 'normal' | 'low';
 export type WorkItemSource = 'manual' | 'chat' | 'schedule';
 export type WorkItemType = 'work-item' | 'bug' | 'epic' | 'feature' | 'pbi';
 
+/**
+ * Allowed parent types for each work item type.
+ * An empty array means the type cannot have a parent (top-level only).
+ * Any item may be temporarily unparented (parentId absent) regardless of type.
+ */
+export const ALLOWED_PARENT_TYPES: Record<WorkItemType, readonly WorkItemType[]> = {
+  epic:        [],
+  feature:     ['epic'],
+  pbi:         ['feature'],
+  'work-item': ['pbi'],
+  bug:         ['pbi'],
+};
+
+/**
+ * Allowed child types for each work item type.
+ * An empty array means the type cannot have children.
+ */
+export const ALLOWED_CHILD_TYPES: Record<WorkItemType, readonly WorkItemType[]> = {
+  epic:        ['feature'],
+  feature:     ['pbi'],
+  pbi:         ['work-item', 'bug'],
+  'work-item': [],
+  bug:         [],
+};
+
 export interface WorkItemPlan {
   version: number;
   content: string;

--- a/packages/coc-client/src/domains/work-items.ts
+++ b/packages/coc-client/src/domains/work-items.ts
@@ -16,6 +16,8 @@ import type {
   WorkItemPlanResponse,
   WorkItemPlanUpdateResponse,
   WorkItemPlanVersion,
+  WorkItemTreeFilter,
+  WorkItemTreeResponse,
 } from '../contracts';
 import type { RequestAdapter } from '../types';
 import { encodePathSegment } from '../url';
@@ -130,5 +132,14 @@ export class WorkItemsClient {
       method: 'POST',
       body: { ...request },
     });
+  }
+
+  tree(workspaceId: string, filter?: WorkItemTreeFilter): Promise<WorkItemTreeResponse> {
+    const query: Record<string, string | number | boolean | undefined> = {};
+    if (filter?.q) query.q = filter.q;
+    if (filter?.type) query.type = filter.type;
+    if (filter?.status) query.status = filter.status;
+    if (filter?.includeArchived !== undefined) query.includeArchived = filter.includeArchived;
+    return this.transport.request<WorkItemTreeResponse>(path(workspaceId, '/tree'), { query });
   }
 }

--- a/packages/coc-client/test/contracts/work-item-constants.test.ts
+++ b/packages/coc-client/test/contracts/work-item-constants.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { ALLOWED_PARENT_TYPES, ALLOWED_CHILD_TYPES } from '../../src/contracts/work-items';
+
+const ALL_TYPES = ['epic', 'feature', 'pbi', 'work-item', 'bug'] as const;
+
+describe('work item hierarchy constants', () => {
+    describe('ALLOWED_PARENT_TYPES', () => {
+        it('covers all work item types', () => {
+            for (const type of ALL_TYPES) {
+                expect(ALLOWED_PARENT_TYPES).toHaveProperty(type);
+            }
+        });
+
+        it('epics have no parent', () => {
+            expect(ALLOWED_PARENT_TYPES['epic']).toEqual([]);
+        });
+
+        it('features can only be parented under epics', () => {
+            expect(ALLOWED_PARENT_TYPES['feature']).toEqual(['epic']);
+        });
+
+        it('pbis can only be parented under features', () => {
+            expect(ALLOWED_PARENT_TYPES['pbi']).toEqual(['feature']);
+        });
+
+        it('work-items can only be parented under pbis', () => {
+            expect(ALLOWED_PARENT_TYPES['work-item']).toEqual(['pbi']);
+        });
+
+        it('bugs can only be parented under pbis', () => {
+            expect(ALLOWED_PARENT_TYPES['bug']).toEqual(['pbi']);
+        });
+
+        it('all values are readonly arrays', () => {
+            for (const type of ALL_TYPES) {
+                expect(Array.isArray(ALLOWED_PARENT_TYPES[type])).toBe(true);
+            }
+        });
+    });
+
+    describe('ALLOWED_CHILD_TYPES', () => {
+        it('covers all work item types', () => {
+            for (const type of ALL_TYPES) {
+                expect(ALLOWED_CHILD_TYPES).toHaveProperty(type);
+            }
+        });
+
+        it('epics contain features as children', () => {
+            expect(ALLOWED_CHILD_TYPES['epic']).toEqual(['feature']);
+        });
+
+        it('features contain pbis as children', () => {
+            expect(ALLOWED_CHILD_TYPES['feature']).toEqual(['pbi']);
+        });
+
+        it('pbis contain work-items and bugs as children', () => {
+            expect(ALLOWED_CHILD_TYPES['pbi']).toEqual(['work-item', 'bug']);
+        });
+
+        it('work-items have no children', () => {
+            expect(ALLOWED_CHILD_TYPES['work-item']).toEqual([]);
+        });
+
+        it('bugs have no children', () => {
+            expect(ALLOWED_CHILD_TYPES['bug']).toEqual([]);
+        });
+
+        it('all values are readonly arrays', () => {
+            for (const type of ALL_TYPES) {
+                expect(Array.isArray(ALLOWED_CHILD_TYPES[type])).toBe(true);
+            }
+        });
+    });
+
+    describe('parent/child consistency', () => {
+        it('parent and child relationships are inverses of each other', () => {
+            for (const parentType of ALL_TYPES) {
+                const children = ALLOWED_CHILD_TYPES[parentType];
+                for (const childType of children) {
+                    expect(ALLOWED_PARENT_TYPES[childType]).toContain(parentType);
+                }
+            }
+        });
+    });
+});

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -191,6 +191,13 @@ export interface CLIConfig {
         /** Bundled skills to auto-install on first serve startup if not already present */
         defaultSkills?: string[];
     };
+    /** Work Items configuration */
+    workItems?: {
+        /** Work item hierarchy board feature (Azure DevOps-like Epic/Feature/PBI hierarchy). Disabled by default. */
+        hierarchy?: {
+            enabled?: boolean;
+        };
+    };
 }
 
 // ============================================================================
@@ -381,6 +388,13 @@ export interface ResolvedCLIConfig {
         /** Bundled skills to auto-install on first serve startup if not already present */
         defaultSkills: string[];
     };
+    /** Work Items configuration */
+    workItems: {
+        /** Work item hierarchy board feature. */
+        hierarchy: {
+            enabled: boolean;
+        };
+    };
 }
 
 // ============================================================================
@@ -513,6 +527,11 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
     skills: {
         autoUpdate: true,
         defaultSkills: [...DEFAULT_BUNDLED_SKILLS],
+    },
+    workItems: {
+        hierarchy: {
+            enabled: false,
+        },
     },
 };
 

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -42,6 +42,7 @@ export type ResolvedConfigNamespaceValues = Pick<
     | 'store'
     | 'monitoring'
     | 'skills'
+    | 'workItems'
 >;
 
 const CHAT_FOLLOW_UP_SOURCE_KEYS = [
@@ -78,6 +79,7 @@ const CONTAINER_DEFAULT_AGENT_SOURCE_KEYS = ['containerDefaultAgent.enabled'] as
 const CODEX_SOURCE_KEYS = ['codex.enabled'] as const;
 const CLAUDE_SOURCE_KEYS = ['claude.enabled'] as const;
 const FEATURES_SOURCE_KEYS = ['features.autoMemoryPromotion', 'features.focusedDiff'] as const;
+const WORK_ITEMS_HIERARCHY_SOURCE_KEYS = ['workItems.hierarchy.enabled'] as const;
 
 const MEMORY_PROMOTION_SOURCE_KEYS = [
     'memoryPromotion.batchSize',
@@ -114,6 +116,7 @@ export const CONFIG_NAMESPACE_SOURCE_KEYS = [
     ...FEATURES_SOURCE_KEYS,
     ...MEMORY_PROMOTION_SOURCE_KEYS,
     ...MEMORY_PROMOTION_AI_NORMALIZATION_SOURCE_KEYS,
+    ...WORK_ITEMS_HIERARCHY_SOURCE_KEYS,
 ] as const;
 
 const source = (
@@ -346,6 +349,17 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
                 skills: {
                     autoUpdate: override?.skills?.autoUpdate ?? base.skills?.autoUpdate ?? true,
                     defaultSkills: override?.skills?.defaultSkills ?? base.skills?.defaultSkills ?? [...defaultBundledSkills],
+                },
+            }),
+        },
+        {
+            name: 'workItems',
+            sourceDescriptors: [source('workItems.hierarchy.', ['workItems', 'hierarchy'], WORK_ITEMS_HIERARCHY_SOURCE_KEYS)],
+            merge: (base, override) => ({
+                workItems: {
+                    hierarchy: {
+                        enabled: override?.workItems?.hierarchy?.enabled ?? base.workItems?.hierarchy?.enabled ?? false,
+                    },
                 },
             }),
         },

--- a/packages/coc/src/config/schema.ts
+++ b/packages/coc/src/config/schema.ts
@@ -143,6 +143,11 @@ export const CLIConfigSchema = z.object({
         autoUpdate: z.boolean().optional(),
         defaultSkills: z.array(z.string()).optional(),
     }).passthrough().optional(),
+    workItems: z.object({
+        hierarchy: z.object({
+            enabled: z.boolean().optional(),
+        }).passthrough().optional(),
+    }).passthrough().optional(),
 }).passthrough();
 
 /**

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -236,6 +236,12 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
         if (!cfg.features) { cfg.features = {}; }
         cfg.features.focusedDiff = v;
     }),
+
+    bool('workItems.hierarchy.enabled', (cfg, v) => {
+        if (!cfg.workItems) { cfg.workItems = {}; }
+        if (!cfg.workItems.hierarchy) { cfg.workItems.hierarchy = {}; }
+        cfg.workItems.hierarchy.enabled = v;
+    }),
 ];
 
 /** Flat keys accepted by PUT /api/admin/config — derived from the registry. */

--- a/packages/coc/src/server/config/runtime-config-handler.ts
+++ b/packages/coc/src/server/config/runtime-config-handler.ts
@@ -50,6 +50,7 @@ export function buildRuntimeDashboardConfig(
             codexEnabled: config.codex?.enabled ?? false,
             claudeEnabled: config.claude?.enabled ?? false,
             activeProvider: (config.activeProvider ?? 'copilot') as 'copilot' | 'codex' | 'claude',
+            workItemsHierarchyEnabled: config.workItems?.hierarchy?.enabled ?? false,
         },
         hostname: config.serve?.serverName || shortenHostname(hostname),
         bindAddress,

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -60,6 +60,7 @@ import { registerTerminalRoutes } from '../terminal/terminal-routes';
 import { registerMyWorkRoutes } from '../workspaces/my-work-handler';
 import { registerMyLifeRoutes } from '../workspaces/my-life-handler';
 import { registerWorkItemRoutes } from './work-item-routes';
+import { registerWorkItemHierarchyRoutes } from './work-item-hierarchy-routes';
 import { registerWorkItemPlanRoutes } from './work-item-plan-routes';
 import { registerWorkItemExecutionRoutes } from './work-item-execution-routes';
 import { registerWorkItemChangesRoutes } from './work-item-changes-routes';
@@ -433,7 +434,12 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     // Work item routes
     const workItemStore = new FileWorkItemStore({ dataDir });
     const enqueueForWorkItems = bridge.enqueue.bind(bridge) as EnqueueFunction;
-    registerWorkItemRoutes({ routes, workItemStore, processStore: store, enqueue: enqueueForWorkItems, getWsServer });
+    const getWorkItemsHierarchyEnabled = opts.runtimeConfigService
+        ? () => opts.runtimeConfigService!.config.workItems?.hierarchy?.enabled ?? false
+        : () => opts.resolvedConfig?.workItems?.hierarchy?.enabled ?? false;
+    // Hierarchy tree route must be registered before generic /:workItemId to win the match
+    registerWorkItemHierarchyRoutes({ routes, workItemStore, getHierarchyEnabled: getWorkItemsHierarchyEnabled });
+    registerWorkItemRoutes({ routes, workItemStore, processStore: store, enqueue: enqueueForWorkItems, getWsServer, getHierarchyEnabled: getWorkItemsHierarchyEnabled });
     registerWorkItemPlanRoutes({ routes, workItemStore, getWsServer });
     registerWorkItemExecutionRoutes({ routes, workItemStore, processStore: store, enqueue: enqueueForWorkItems, getWsServer, dataDir });
     registerWorkItemChangesRoutes({ routes, workItemStore, getWsServer });

--- a/packages/coc/src/server/routes/work-item-execution-routes.ts
+++ b/packages/coc/src/server/routes/work-item-execution-routes.ts
@@ -16,6 +16,7 @@ import { execGit } from '@plusplusoneplusplus/forge';
 import { sendJSON, parseBody } from '../core/api-handler';
 import { handleAPIError, notFound, badRequest } from '../errors';
 import type { WorkItemStore, WorkItem } from '../work-items/types';
+import { HIERARCHY_CONTAINER_TYPES } from '../work-items/types';
 import { executeWorkItem, resolveWorkItemComments, type EnqueueFunction } from '../work-items/work-item-executor';
 import { upsertWorkItemTaskFile } from '../work-items/work-item-task-file';
 import { buildPlanFromContext } from '../work-items/plan-template';
@@ -55,6 +56,12 @@ export function registerWorkItemExecutionRoutes(ctx: WorkItemExecutionRouteConte
             const item = await workItemStore.getWorkItem(workItemId, repoId);
             if (!item) {
                 return handleAPIError(res, notFound('Work item'));
+            }
+
+            // Only leaf types (work-item, bug) can be executed.
+            const effectiveType = item.type ?? 'work-item';
+            if (HIERARCHY_CONTAINER_TYPES.has(effectiveType)) {
+                return handleAPIError(res, badRequest(`Only WorkItem and Bug items can be executed. "${effectiveType}" is a planning container.`));
             }
 
             let body: any;
@@ -132,6 +139,12 @@ export function registerWorkItemExecutionRoutes(ctx: WorkItemExecutionRouteConte
             const item = await workItemStore.getWorkItem(workItemId, repoId);
             if (!item) {
                 return handleAPIError(res, notFound('Work item'));
+            }
+
+            // Only leaf types (work-item, bug) can run resolve-comments.
+            const effectiveResolveType = item.type ?? 'work-item';
+            if (HIERARCHY_CONTAINER_TYPES.has(effectiveResolveType)) {
+                return handleAPIError(res, badRequest(`Only WorkItem and Bug items can have comments resolved. "${effectiveResolveType}" is a planning container.`));
             }
 
             let body: any;

--- a/packages/coc/src/server/routes/work-item-hierarchy-routes.ts
+++ b/packages/coc/src/server/routes/work-item-hierarchy-routes.ts
@@ -1,0 +1,244 @@
+/**
+ * Work Item Hierarchy Routes
+ *
+ * Provides the hierarchy tree read API for the work item board.
+ *
+ * Routes:
+ *   GET /api/workspaces/:id/work-items/tree — Full hierarchy tree with rollup counts
+ *
+ * All routes are gated by the workItems.hierarchy.enabled feature flag.
+ * When the flag is false the endpoints return a `{ disabled: true }` response
+ * so the SPA can gracefully degrade.
+ */
+
+import * as http from 'http';
+import * as url from 'url';
+import type { Route } from '../types';
+import { sendJSON } from '../core/api-handler';
+import type { WorkItemStore, WorkItemIndexEntry, WorkItemStatus, WorkItemType } from '../work-items/types';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Descendant roll-up for a single tree node. */
+interface WorkItemRollup {
+    descendantCount: number;
+    byType: Record<WorkItemType, number>;
+    byStatus: Record<WorkItemStatus, number>;
+}
+
+/** One node in the hierarchy tree returned by the tree endpoint. */
+interface WorkItemTreeNode {
+    item: WorkItemIndexEntry;
+    children: WorkItemTreeNode[];
+    rollup: WorkItemRollup;
+}
+
+/** Response shape from GET /work-items/tree. */
+interface WorkItemTreeResponse {
+    roots: WorkItemTreeNode[];
+    total: number;
+    disabled?: boolean;
+}
+
+export interface WorkItemHierarchyRouteContext {
+    routes: Route[];
+    workItemStore: WorkItemStore;
+    /** Returns true when the hierarchy feature flag is enabled. */
+    getHierarchyEnabled: () => boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function emptyRollup(): WorkItemRollup {
+    return {
+        descendantCount: 0,
+        byType: { epic: 0, feature: 0, pbi: 0, 'work-item': 0, bug: 0 },
+        byStatus: {
+            created: 0,
+            planning: 0,
+            readyToExecute: 0,
+            executing: 0,
+            aiDone: 0,
+            aiFailed: 0,
+            done: 0,
+            failed: 0,
+        },
+    };
+}
+
+function mergeRollup(target: WorkItemRollup, source: WorkItemRollup): void {
+    target.descendantCount += source.descendantCount;
+    for (const t of Object.keys(source.byType) as WorkItemType[]) {
+        target.byType[t] = (target.byType[t] ?? 0) + source.byType[t];
+    }
+    for (const s of Object.keys(source.byStatus) as WorkItemStatus[]) {
+        target.byStatus[s] = (target.byStatus[s] ?? 0) + source.byStatus[s];
+    }
+}
+
+/** Accumulate a descendant's own type/status into its ancestor's rollup. */
+function accumulateEntry(rollup: WorkItemRollup, entry: WorkItemIndexEntry): void {
+    const type = (entry.type ?? 'work-item') as WorkItemType;
+    rollup.byType[type] = (rollup.byType[type] ?? 0) + 1;
+    rollup.byStatus[entry.status as WorkItemStatus] = (rollup.byStatus[entry.status as WorkItemStatus] ?? 0) + 1;
+    rollup.descendantCount++;
+}
+
+/**
+ * Sort index entries: pinned-first, then by lastRunAt/updatedAt descending.
+ * Mutates the array in-place and returns it.
+ */
+function sortEntries(entries: WorkItemIndexEntry[]): WorkItemIndexEntry[] {
+    return entries.sort((a, b) => {
+        if (a.pinnedAt && !b.pinnedAt) return -1;
+        if (!a.pinnedAt && b.pinnedAt) return 1;
+        const aTime = a.lastRunAt ?? a.updatedAt;
+        const bTime = b.lastRunAt ?? b.updatedAt;
+        return bTime.localeCompare(aTime);
+    });
+}
+
+/**
+ * Build a hierarchy tree from a flat list of index entries.
+ *
+ * - Entries whose parentId is absent or references an id not in the working set
+ *   are placed at the root.
+ * - Cycles are prevented via a visited set (each entry is visited at most once).
+ * - Rollup counts are computed bottom-up.
+ */
+function buildTree(entries: WorkItemIndexEntry[]): WorkItemTreeNode[] {
+    const idMap = new Map<string, WorkItemIndexEntry>(entries.map(e => [e.id, e]));
+
+    // Group direct children by effective parentId (null = root)
+    const childrenMap = new Map<string | null, WorkItemIndexEntry[]>();
+    for (const e of entries) {
+        const parentId = e.parentId && idMap.has(e.parentId) ? e.parentId : null;
+        const list = childrenMap.get(parentId) ?? [];
+        list.push(e);
+        childrenMap.set(parentId, list);
+    }
+
+    const visited = new Set<string>();
+
+    function buildNode(entry: WorkItemIndexEntry): WorkItemTreeNode {
+        visited.add(entry.id);
+        const childEntries = sortEntries(
+            (childrenMap.get(entry.id) ?? []).filter(c => !visited.has(c.id)),
+        );
+        const children = childEntries.map(c => buildNode(c));
+
+        // Build rollup from children bottom-up
+        const rollup = emptyRollup();
+        for (const child of children) {
+            // Count the child itself
+            accumulateEntry(rollup, child.item);
+            // Add child's own rollup
+            mergeRollup(rollup, child.rollup);
+        }
+
+        return { item: entry, children, rollup };
+    }
+
+    const roots = sortEntries(
+        (childrenMap.get(null) ?? []).filter(e => !visited.has(e.id)),
+    );
+    return roots.map(e => buildNode(e));
+}
+
+/**
+ * Filter entries and preserve ancestors of matching entries so the SPA
+ * can show full tree context for search results.
+ */
+function filterWithAncestors(
+    entries: WorkItemIndexEntry[],
+    opts: {
+        q?: string;
+        type?: string;
+        status?: string;
+        includeArchived: boolean;
+    },
+): WorkItemIndexEntry[] {
+    // Step 1: apply archived filter
+    let working = opts.includeArchived
+        ? entries
+        : entries.filter(e => !e.archivedAt);
+
+    // Step 2: if no content filters, return as-is
+    const hasContentFilter = opts.q || opts.type || opts.status;
+    if (!hasContentFilter) return working;
+
+    const q = opts.q?.toLowerCase();
+    const idMap = new Map<string, WorkItemIndexEntry>(working.map(e => [e.id, e]));
+
+    const matchedIds = new Set<string>();
+    for (const e of working) {
+        const typeMatch = !opts.type || (e.type ?? 'work-item') === opts.type;
+        const statusMatch = !opts.status || e.status === opts.status;
+        let textMatch = true;
+        if (q) {
+            textMatch =
+                e.title.toLowerCase().includes(q) ||
+                (e.description?.toLowerCase().includes(q) ?? false) ||
+                (e.tags?.some(t => t.toLowerCase().includes(q)) ?? false);
+        }
+        if (typeMatch && statusMatch && textMatch) {
+            matchedIds.add(e.id);
+        }
+    }
+
+    // Step 3: collect all ancestors of matching entries
+    const toInclude = new Set<string>(matchedIds);
+    for (const id of matchedIds) {
+        let entry: WorkItemIndexEntry | undefined = idMap.get(id);
+        const path = new Set<string>(); // cycle guard
+        while (entry?.parentId && !path.has(entry.id)) {
+            path.add(entry.id);
+            toInclude.add(entry.parentId);
+            entry = idMap.get(entry.parentId);
+        }
+    }
+
+    return working.filter(e => toInclude.has(e.id));
+}
+
+// ── Route registration ─────────────────────────────────────────────────────────
+
+export function registerWorkItemHierarchyRoutes(ctx: WorkItemHierarchyRouteContext): void {
+    const { routes, workItemStore, getHierarchyEnabled } = ctx;
+
+    // GET /api/workspaces/:id/work-items/tree
+    // Must be registered BEFORE the generic /:workItemId route to win the match.
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/workspaces\/([^/]+)\/work-items\/tree$/,
+        handler: async (req: http.IncomingMessage, res: http.ServerResponse, match?: RegExpMatchArray) => {
+            if (!getHierarchyEnabled()) {
+                return sendJSON(res, 200, { disabled: true, roots: [], total: 0 } satisfies WorkItemTreeResponse);
+            }
+
+            const repoId = decodeURIComponent(match![1]);
+            const parsed = url.parse(req.url || '/', true);
+            const query = parsed.query;
+
+            const q = typeof query.q === 'string' ? query.q.trim() || undefined : undefined;
+            const typeFilter = typeof query.type === 'string' ? query.type : undefined;
+            const statusFilter = typeof query.status === 'string' ? query.status : undefined;
+            const includeArchived = query.includeArchived === 'true';
+
+            // Load the full index for this workspace
+            const result = await workItemStore.listWorkItems({ repoId });
+            const entries = result.items as WorkItemIndexEntry[];
+
+            // Filter and preserve ancestors
+            const filtered = filterWithAncestors(entries, {
+                q,
+                type: typeFilter,
+                status: statusFilter,
+                includeArchived,
+            });
+
+            const roots = buildTree(filtered);
+            sendJSON(res, 200, { roots, total: filtered.length } satisfies WorkItemTreeResponse);
+        },
+    });
+}

--- a/packages/coc/src/server/routes/work-item-hierarchy-routes.ts
+++ b/packages/coc/src/server/routes/work-item-hierarchy-routes.ts
@@ -16,6 +16,7 @@ import * as url from 'url';
 import type { Route } from '../types';
 import { sendJSON } from '../core/api-handler';
 import type { WorkItemStore, WorkItemIndexEntry, WorkItemStatus, WorkItemType } from '../work-items/types';
+import { WORK_ITEM_TYPES, WORK_ITEM_STATUSES } from '../work-items/types';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -52,35 +53,26 @@ export interface WorkItemHierarchyRouteContext {
 function emptyRollup(): WorkItemRollup {
     return {
         descendantCount: 0,
-        byType: { epic: 0, feature: 0, pbi: 0, 'work-item': 0, bug: 0 },
-        byStatus: {
-            created: 0,
-            planning: 0,
-            readyToExecute: 0,
-            executing: 0,
-            aiDone: 0,
-            aiFailed: 0,
-            done: 0,
-            failed: 0,
-        },
+        byType: Object.fromEntries(WORK_ITEM_TYPES.map(t => [t, 0])) as Record<WorkItemType, number>,
+        byStatus: Object.fromEntries(WORK_ITEM_STATUSES.map(s => [s, 0])) as Record<WorkItemStatus, number>,
     };
 }
 
 function mergeRollup(target: WorkItemRollup, source: WorkItemRollup): void {
     target.descendantCount += source.descendantCount;
     for (const t of Object.keys(source.byType) as WorkItemType[]) {
-        target.byType[t] = (target.byType[t] ?? 0) + source.byType[t];
+        target.byType[t] = target.byType[t] + source.byType[t];
     }
     for (const s of Object.keys(source.byStatus) as WorkItemStatus[]) {
-        target.byStatus[s] = (target.byStatus[s] ?? 0) + source.byStatus[s];
+        target.byStatus[s] = target.byStatus[s] + source.byStatus[s];
     }
 }
 
 /** Accumulate a descendant's own type/status into its ancestor's rollup. */
 function accumulateEntry(rollup: WorkItemRollup, entry: WorkItemIndexEntry): void {
     const type = (entry.type ?? 'work-item') as WorkItemType;
-    rollup.byType[type] = (rollup.byType[type] ?? 0) + 1;
-    rollup.byStatus[entry.status as WorkItemStatus] = (rollup.byStatus[entry.status as WorkItemStatus] ?? 0) + 1;
+    rollup.byType[type] = rollup.byType[type] + 1;
+    rollup.byStatus[entry.status as WorkItemStatus] = rollup.byStatus[entry.status as WorkItemStatus] + 1;
     rollup.descendantCount++;
 }
 

--- a/packages/coc/src/server/routes/work-item-routes.ts
+++ b/packages/coc/src/server/routes/work-item-routes.ts
@@ -20,13 +20,14 @@ import { execGit } from '@plusplusoneplusplus/forge';
 import { sendJSON, parseBody } from '../core/api-handler';
 import { handleAPIError, missingFields, notFound, badRequest, conflict } from '../errors';
 import type { WorkItemStore, WorkItemFilter, WorkItemStatus, WorkItemSource, WorkItemPriority, WorkItemType, WorkItem } from '../work-items/types';
-import { WORK_ITEM_STATUSES, WORK_ITEM_TYPES, isValidTransition } from '../work-items/types';
+import { WORK_ITEM_STATUSES, WORK_ITEM_TYPES, isValidTransition, HIERARCHY_CONTAINER_TYPES, isValidParentChildTypes, getEffectiveType } from '../work-items/types';
 import { executeWorkItem, type EnqueueFunction } from '../work-items/work-item-executor';
 import type { ProcessWebSocketServer } from '../streaming/websocket';
 
 const VALID_SOURCES: Set<string> = new Set(['manual', 'chat', 'schedule']);
 const VALID_PRIORITIES: Set<string> = new Set(['high', 'normal', 'low']);
-const VALID_TYPES: Set<string> = new Set(['work-item', 'bug']);
+/** Types allowed when hierarchy is disabled (legacy behavior). */
+const LEAF_VALID_TYPES: Set<string> = new Set(['work-item', 'bug']);
 
 export interface WorkItemRouteContext {
     routes: Route[];
@@ -34,10 +35,15 @@ export interface WorkItemRouteContext {
     processStore: ProcessStore;
     enqueue?: EnqueueFunction;
     getWsServer?: () => ProcessWebSocketServer;
+    /** Returns true when the workItems.hierarchy feature flag is enabled. */
+    getHierarchyEnabled?: () => boolean;
 }
 
 export function registerWorkItemRoutes(ctx: WorkItemRouteContext): void {
     const { routes, workItemStore, processStore, enqueue, getWsServer } = ctx;
+    const isHierarchyEnabled = () => ctx.getHierarchyEnabled?.() ?? false;
+    // All valid types when hierarchy is enabled
+    const ALL_VALID_TYPES = new Set<string>(WORK_ITEM_TYPES);
 
     // GET /api/workspaces/:id/work-items — List with optional filters
     routes.push({
@@ -66,7 +72,7 @@ export function registerWorkItemRoutes(ctx: WorkItemRouteContext): void {
             if (typeof query.tags === 'string' && query.tags) {
                 filter.tags = query.tags.split(',');
             }
-            if (typeof query.type === 'string' && VALID_TYPES.has(query.type)) {
+            if (typeof query.type === 'string' && ALL_VALID_TYPES.has(query.type)) {
                 filter.type = query.type as WorkItemType;
             }
             if (typeof query.q === 'string' && query.q.trim()) {
@@ -106,7 +112,7 @@ export function registerWorkItemRoutes(ctx: WorkItemRouteContext): void {
             if (typeof query.tags === 'string' && query.tags) {
                 filter.tags = query.tags.split(',');
             }
-            if (typeof query.type === 'string' && VALID_TYPES.has(query.type)) {
+            if (typeof query.type === 'string' && ALL_VALID_TYPES.has(query.type)) {
                 filter.type = query.type as WorkItemType;
             }
             if (typeof query.q === 'string' && query.q.trim()) {
@@ -151,13 +157,55 @@ export function registerWorkItemRoutes(ctx: WorkItemRouteContext): void {
             }
 
             const now = new Date().toISOString();
+            const hierarchyEnabled = isHierarchyEnabled();
+
+            // Validate type: hierarchy-only types require the flag to be enabled
+            let resolvedType: WorkItemType | undefined;
+            if (body.type) {
+                if (ALL_VALID_TYPES.has(body.type)) {
+                    if (HIERARCHY_CONTAINER_TYPES.has(body.type as WorkItemType) && !hierarchyEnabled) {
+                        return handleAPIError(res, badRequest(
+                            `Type '${body.type}' requires the workItems.hierarchy feature flag to be enabled`,
+                        ));
+                    }
+                    resolvedType = body.type as WorkItemType;
+                }
+                // Unknown types are silently ignored (treated as work-item)
+            }
+
+            // Validate parentId: only allowed when hierarchy is enabled
+            if (body.parentId && !hierarchyEnabled) {
+                return handleAPIError(res, badRequest(
+                    'parentId requires the workItems.hierarchy feature flag to be enabled',
+                ));
+            }
+
+            // Validate parent-child type relationship when parentId is provided
+            if (body.parentId && hierarchyEnabled) {
+                const parentItem = await workItemStore.getWorkItem(body.parentId, repoId);
+                if (!parentItem) {
+                    return handleAPIError(res, badRequest(`Parent work item not found: ${body.parentId}`));
+                }
+                if (parentItem.repoId !== repoId) {
+                    return handleAPIError(res, badRequest('Parent work item must be in the same workspace'));
+                }
+                const childType = resolvedType ?? 'work-item';
+                const parentType = getEffectiveType(parentItem.type);
+                if (!isValidParentChildTypes(childType, parentType)) {
+                    return handleAPIError(res, badRequest(
+                        `Invalid parent-child type combination: '${parentType}' cannot be a parent of '${childType}'`,
+                    ));
+                }
+            }
+
             const item: WorkItem = {
                 id: body.id || crypto.randomUUID(),
                 repoId,
                 title: body.title,
                 description: body.description || '',
                 status: 'created',
-                type: VALID_TYPES.has(body.type) ? body.type : undefined,
+                type: resolvedType,
+                parentId: hierarchyEnabled && body.parentId ? String(body.parentId) : undefined,
                 createdAt: now,
                 updatedAt: now,
                 source: VALID_SOURCES.has(body.source) ? body.source : 'manual',
@@ -246,6 +294,43 @@ export function registerWorkItemRoutes(ctx: WorkItemRouteContext): void {
             if (body.autoExecute !== undefined) updates.autoExecute = body.autoExecute;
             if (body.completedAt !== undefined) updates.completedAt = body.completedAt;
             if (body.reviewComments !== undefined) updates.reviewComments = body.reviewComments;
+
+            // Handle parentId reparenting when hierarchy is enabled
+            if ('parentId' in body) {
+                if (!isHierarchyEnabled()) {
+                    return handleAPIError(res, badRequest(
+                        'parentId requires the workItems.hierarchy feature flag to be enabled',
+                    ));
+                }
+                if (body.parentId === null || body.parentId === '') {
+                    // Unlink parent
+                    updates.parentId = undefined;
+                } else if (typeof body.parentId === 'string') {
+                    // Validate new parent
+                    if (body.parentId === workItemId) {
+                        return handleAPIError(res, badRequest('A work item cannot be its own parent'));
+                    }
+                    const newParent = await workItemStore.getWorkItem(body.parentId, repoId);
+                    if (!newParent) {
+                        return handleAPIError(res, badRequest(`Parent work item not found: ${body.parentId}`));
+                    }
+                    if (newParent.repoId !== repoId) {
+                        return handleAPIError(res, badRequest('Parent work item must be in the same workspace'));
+                    }
+                    // Fetch the current item to know its type for parent-child validation
+                    const currentForType = await workItemStore.getWorkItem(workItemId, repoId);
+                    if (currentForType) {
+                        const childType = getEffectiveType(currentForType.type);
+                        const parentType = getEffectiveType(newParent.type);
+                        if (!isValidParentChildTypes(childType, parentType)) {
+                            return handleAPIError(res, badRequest(
+                                `Invalid parent-child type combination: '${parentType}' cannot be a parent of '${childType}'`,
+                            ));
+                        }
+                    }
+                    updates.parentId = body.parentId;
+                }
+            }
 
             const updated = await workItemStore.updateWorkItem(workItemId, updates);
             if (!updated) {

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -332,6 +332,7 @@ export function AdminPanel() {
     const [excalidrawEnabled, setExcalidrawEnabled] = useState(false);
     const [mcpOauthEnabled, setMcpOauthEnabled] = useState(false);
     const [focusedDiffEnabled, setFocusedDiffEnabled] = useState(false);
+    const [workItemsHierarchyEnabled, setWorkItemsHierarchyEnabled] = useState(false);
     const [codexEnabled, setCodexEnabled] = useState(false);
     const [claudeEnabled, setClaudeEnabled] = useState(false);
     const [activeProvider, setActiveProvider] = useState<'copilot' | 'codex' | 'claude'>('copilot');
@@ -377,7 +378,7 @@ export function AdminPanel() {
         taskCardDensity: 'compact' as 'compact' | 'dense',
         historyGrouping: true,
     });
-    const [featuresSnapshot, setFeaturesSnapshot] = useState({ terminal: true, notes: true, myWork: false, myLife: false, scratchpad: false, scratchpadLayout: 'horizontal' as 'horizontal' | 'vertical', workflows: false, pullRequests: false, pullRequestsSuggestions: false, servers: false, ralph: false, vimNavigation: false, loops: false, excalidraw: false, mcpOauth: false, focusedDiff: false });
+    const [featuresSnapshot, setFeaturesSnapshot] = useState({ terminal: true, notes: true, myWork: false, myLife: false, scratchpad: false, scratchpadLayout: 'horizontal' as 'horizontal' | 'vertical', workflows: false, pullRequests: false, pullRequestsSuggestions: false, servers: false, ralph: false, vimNavigation: false, loops: false, excalidraw: false, mcpOauth: false, focusedDiff: false, workItemsHierarchy: false });
 
     // Export
     const [exportStatus, setExportStatus] = useState<string>('');
@@ -488,13 +489,15 @@ export function AdminPanel() {
             setMcpOauthEnabled(moae);
             const fde = resolved.features?.focusedDiff ?? false;
             setFocusedDiffEnabled(fde);
+            const wihe = resolved.workItems?.hierarchy?.enabled ?? false;
+            setWorkItemsHierarchyEnabled(wihe);
             const cxe = resolved.codex?.enabled ?? false;
             setCodexEnabled(cxe);
             const cle = resolved.claude?.enabled ?? false;
             setClaudeEnabled(cle);
             const ap = (resolved.activeProvider === 'codex' ? 'codex' : resolved.activeProvider === 'claude' ? 'claude' : 'copilot') as 'copilot' | 'codex' | 'claude';
             setActiveProvider(ap);
-            setFeaturesSnapshot({ terminal: te, notes: ne, myWork: mwe, myLife: mle, scratchpad: se, scratchpadLayout: sl, workflows: we, pullRequests: pre, pullRequestsSuggestions: prse, servers: svre, ralph: re, vimNavigation: vne, loops: loe, excalidraw: exe, mcpOauth: moae, focusedDiff: fde });
+            setFeaturesSnapshot({ terminal: te, notes: ne, myWork: mwe, myLife: mle, scratchpad: se, scratchpadLayout: sl, workflows: we, pullRequests: pre, pullRequestsSuggestions: prse, servers: svre, ralph: re, vimNavigation: vne, loops: loe, excalidraw: exe, mcpOauth: moae, focusedDiff: fde, workItemsHierarchy: wihe });
             setAiExecSnapshot({ model: form.model, parallel: form.parallel, timeout: form.timeout, output: form.output });
             setActiveProviderSnapshot({ provider: ap, codexEnabled: cxe, claudeEnabled: cle });
             const sgr = resolved.sync?.gitRemote ?? '';
@@ -605,7 +608,8 @@ export function AdminPanel() {
         loopsEnabled !== featuresSnapshot.loops ||
         excalidrawEnabled !== featuresSnapshot.excalidraw ||
         mcpOauthEnabled !== featuresSnapshot.mcpOauth ||
-        focusedDiffEnabled !== featuresSnapshot.focusedDiff;
+        focusedDiffEnabled !== featuresSnapshot.focusedDiff ||
+        workItemsHierarchyEnabled !== featuresSnapshot.workItemsHierarchy;
 
     // ── AI & Execution card ──
     const handleSaveAiExec = useCallback(async () => {
@@ -829,16 +833,17 @@ export function AdminPanel() {
                 'excalidraw.enabled': excalidrawEnabled,
                 'mcpOauth.enabled': mcpOauthEnabled,
                 'features.focusedDiff': focusedDiffEnabled,
+                'workItems.hierarchy.enabled': workItemsHierarchyEnabled,
             });
             addToast('Settings saved', 'success');
             invalidateDisplaySettings();
-            setFeaturesSnapshot({ terminal: terminalEnabled, notes: notesEnabled, myWork: myWorkEnabled, myLife: myLifeEnabled, scratchpad: scratchpadEnabled, scratchpadLayout: scratchpadLayout, workflows: workflowsEnabled, pullRequests: pullRequestsEnabled, pullRequestsSuggestions: pullRequestsSuggestionsEnabled, servers: serversEnabled, ralph: ralphEnabled, vimNavigation: vimNavigationEnabled, loops: loopsEnabled, excalidraw: excalidrawEnabled, mcpOauth: mcpOauthEnabled, focusedDiff: focusedDiffEnabled });
+            setFeaturesSnapshot({ terminal: terminalEnabled, notes: notesEnabled, myWork: myWorkEnabled, myLife: myLifeEnabled, scratchpad: scratchpadEnabled, scratchpadLayout: scratchpadLayout, workflows: workflowsEnabled, pullRequests: pullRequestsEnabled, pullRequestsSuggestions: pullRequestsSuggestionsEnabled, servers: serversEnabled, ralph: ralphEnabled, vimNavigation: vimNavigationEnabled, loops: loopsEnabled, excalidraw: excalidrawEnabled, mcpOauth: mcpOauthEnabled, focusedDiff: focusedDiffEnabled, workItemsHierarchy: workItemsHierarchyEnabled });
         } catch (err: unknown) {
             addToast(getSpaCocClientErrorMessage(err, 'Save failed'), 'error');
         } finally {
             setFeaturesSaving(false);
         }
-    }, [terminalEnabled, notesEnabled, myWorkEnabled, myLifeEnabled, scratchpadEnabled, scratchpadLayout, workflowsEnabled, pullRequestsEnabled, pullRequestsSuggestionsEnabled, serversEnabled, ralphEnabled, vimNavigationEnabled, loopsEnabled, excalidrawEnabled, mcpOauthEnabled, focusedDiffEnabled, addToast]);
+    }, [terminalEnabled, notesEnabled, myWorkEnabled, myLifeEnabled, scratchpadEnabled, scratchpadLayout, workflowsEnabled, pullRequestsEnabled, pullRequestsSuggestionsEnabled, serversEnabled, ralphEnabled, vimNavigationEnabled, loopsEnabled, excalidrawEnabled, mcpOauthEnabled, focusedDiffEnabled, workItemsHierarchyEnabled, addToast]);
 
     const handleCancelFeatures = useCallback(() => {
         setTerminalEnabled(featuresSnapshot.terminal);
@@ -857,6 +862,7 @@ export function AdminPanel() {
         setExcalidrawEnabled(featuresSnapshot.excalidraw);
         setMcpOauthEnabled(featuresSnapshot.mcpOauth);
         setFocusedDiffEnabled(featuresSnapshot.focusedDiff);
+        setWorkItemsHierarchyEnabled(featuresSnapshot.workItemsHierarchy);
     }, [featuresSnapshot]);
 
     const handleSaveServerName = useCallback(async () => {
@@ -1667,6 +1673,13 @@ export function AdminPanel() {
                                     >
                                         <SourceBadge source={sources['features.focusedDiff']} />
                                         <AdminToggle checked={focusedDiffEnabled} onChange={setFocusedDiffEnabled} data-testid="toggle-focused-diff-enabled" />
+                                    </AdminRow>
+                                    <AdminRow
+                                        name="Work Items Hierarchy Board"
+                                        hint="Extends the Work Items tab into an Epic → Feature → PBI → Work Item / Bug hierarchy board. Disabled by default."
+                                    >
+                                        <SourceBadge source={sources['workItems.hierarchy.enabled']} />
+                                        <AdminToggle checked={workItemsHierarchyEnabled} onChange={setWorkItemsHierarchyEnabled} data-testid="toggle-work-items-hierarchy-enabled" />
                                     </AdminRow>
                                 </SettingsCard>
                                 )}

--- a/packages/coc/src/server/spa/client/react/contexts/WorkItemContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/WorkItemContext.tsx
@@ -9,6 +9,7 @@ export interface WorkItemSummary {
     description?: string;
     status: string;
     type?: string;
+    parentId?: string;
     priority?: string;
     source?: string;
     createdAt: string;

--- a/packages/coc/src/server/spa/client/react/features/work-items/CreateWorkItemDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/CreateWorkItemDialog.tsx
@@ -2,6 +2,17 @@ import { useState, useEffect, useCallback } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button } from '../../ui';
 import { getSpaCocClient } from '../../api/cocClient';
+import { isWorkItemsHierarchyEnabled } from '../../utils/config';
+
+type WorkItemTypeAll = 'work-item' | 'bug' | 'epic' | 'feature' | 'pbi';
+
+const TYPE_LABELS: Record<WorkItemTypeAll, string> = {
+    epic:        'Epic',
+    feature:     'Feature',
+    pbi:         'PBI / Story',
+    'work-item': 'Work Item',
+    bug:         'Bug',
+};
 
 export interface CreateWorkItemDialogProps {
     open: boolean;
@@ -10,17 +21,21 @@ export interface CreateWorkItemDialogProps {
     onCreated?: (item: any) => void;
     /** Pre-fill from a chat session */
     fromChatId?: string;
-    /** Work item type — 'work-item' (default) or 'bug'. */
-    itemType?: 'work-item' | 'bug';
+    /** Work item type — 'work-item' (default), 'bug', or hierarchy types when enabled. */
+    itemType?: WorkItemTypeAll;
+    /** Parent work item ID (hierarchy). Only used when hierarchy is enabled. */
+    parentId?: string;
 }
 
-export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fromChatId, itemType = 'work-item' }: CreateWorkItemDialogProps) {
+export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fromChatId, itemType = 'work-item', parentId }: CreateWorkItemDialogProps) {
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
     const [priority, setPriority] = useState<'normal' | 'high' | 'low'>('normal');
     const [tags, setTags] = useState('');
+    const [selectedType, setSelectedType] = useState<WorkItemTypeAll>(itemType);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const hierarchyEnabled = isWorkItemsHierarchyEnabled();
 
     useEffect(() => {
         if (open) {
@@ -28,10 +43,11 @@ export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fr
             setDescription('');
             setPriority('normal');
             setTags('');
+            setSelectedType(itemType);
             setLoading(false);
             setError(null);
         }
-    }, [open]);
+    }, [open, itemType]);
 
     const handleSubmit = useCallback(async () => {
         if (!fromChatId && !title.trim()) {
@@ -52,7 +68,8 @@ export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fr
                     priority,
                     tags: parsedTags.length > 0 ? parsedTags : undefined,
                     source: 'manual',
-                    type: itemType,
+                    type: selectedType,
+                    parentId: (hierarchyEnabled && parentId) ? parentId : undefined,
                 });
             }
             onCreated?.(data);
@@ -62,11 +79,15 @@ export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fr
         } finally {
             setLoading(false);
         }
-    }, [workspaceId, fromChatId, title, description, priority, tags, itemType, onCreated, onClose]);
+    }, [workspaceId, fromChatId, title, description, priority, tags, selectedType, hierarchyEnabled, parentId, onCreated, onClose]);
 
-    const isBug = itemType === 'bug';
-    const dialogTitle = isBug ? 'Create Bug' : 'Create Work Item';
-    const titlePlaceholder = isBug ? 'Bug title' : 'Work item title';
+    const effectiveType = selectedType;
+    const isBug = effectiveType === 'bug';
+    const isContainer = ['epic', 'feature', 'pbi'].includes(effectiveType);
+    const dialogTitle = hierarchyEnabled
+        ? `Create ${TYPE_LABELS[effectiveType]}`
+        : (isBug ? 'Create Bug' : 'Create Work Item');
+    const titlePlaceholder = isBug ? 'Bug title' : isContainer ? `${TYPE_LABELS[effectiveType]} title` : 'Work item title';
 
     return (
         <Dialog
@@ -91,6 +112,25 @@ export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fr
             )}
             {!fromChatId && (
                 <div className="space-y-3">
+                    {/* Type selector — only shown when hierarchy is enabled */}
+                    {hierarchyEnabled && (
+                        <div>
+                            <label className="block text-xs font-medium text-[#848484] dark:text-[#999] mb-1">Type</label>
+                            <select
+                                className="w-full rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-sm text-[#1e1e1e] dark:text-[#cccccc] p-2 focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                                value={selectedType}
+                                onChange={e => setSelectedType(e.target.value as WorkItemTypeAll)}
+                                disabled={loading}
+                                data-testid="create-work-item-type"
+                            >
+                                <option value="epic">Epic</option>
+                                <option value="feature">Feature</option>
+                                <option value="pbi">PBI / Story</option>
+                                <option value="work-item">Work Item</option>
+                                <option value="bug">Bug</option>
+                            </select>
+                        </div>
+                    )}
                     <div>
                         <label className="block text-xs font-medium text-[#848484] dark:text-[#999] mb-1">Title *</label>
                         <input

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
@@ -15,6 +15,8 @@ import { useWorkItems } from '../../contexts/WorkItemContext';
 import { useCommitCommentTotals } from '../git/hooks/useCommitCommentTotals';
 import type { DiffComment } from '../../../comments/diff-comment-types';
 import { computeStorageKey, patchDiffComment } from '../../utils/diffCommentApi';
+import { isWorkItemsHierarchyEnabled } from '../../utils/config';
+import { WorkItemParentPicker } from './WorkItemParentPicker';
 
 const STATUS_LABELS: Record<string, { label: string; badgeStatus: string }> = {
     created:          { label: 'Created',          badgeStatus: 'queued' },
@@ -88,6 +90,16 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
     const [resolvingDiffComments, setResolvingDiffComments] = useState(false);
     const [resolvingCommitSha, setResolvingCommitSha] = useState<string | null>(null);
     const [resolvingChangeIdx, setResolvingChangeIdx] = useState<number | null>(null);
+    // ── Inline edit state (container items only) ──
+    const [isEditing, setIsEditing] = useState(false);
+    const [editTitle, setEditTitle] = useState('');
+    const [editDescription, setEditDescription] = useState('');
+    const [editPriority, setEditPriority] = useState<'high' | 'normal' | 'low'>('normal');
+    const [editTags, setEditTags] = useState('');
+    const [editParentId, setEditParentId] = useState<string | undefined>(undefined);
+    const [editError, setEditError] = useState<string | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [showParentPicker, setShowParentPicker] = useState(false);
 
     const fetchItem = useCallback(async () => {
         setLoading(true);
@@ -117,7 +129,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
     const commentTotals = useCommitCommentTotals(workspaceId, allCommitShas);
 
     /* ── Auto-refresh via WorkItemContext (WebSocket events) ── */
-    const { state: workItemState } = useWorkItems();
+    const { state: workItemState, dispatch } = useWorkItems();
     const contextItems = workItemState.workItemsByRepo[workspaceId] || [];
     const contextItem = contextItems.find(i => i.id === workItemId);
 
@@ -144,6 +156,12 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
             onBack?.();
         }
     }, [contextItem, onBack]);
+
+    // Reset edit mode when navigating to a different work item
+    useEffect(() => {
+        setIsEditing(false);
+        setEditError(null);
+    }, [workItemId]);
 
     const handleExecuteDialogDone = useCallback(async () => {
         setShowExecuteDialog(false);
@@ -287,6 +305,53 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         }
     };
 
+    const handleEditStart = useCallback(() => {
+        if (!item) return;
+        setEditTitle(item.title);
+        setEditDescription(item.description || '');
+        setEditPriority((item.priority ?? 'normal') as 'high' | 'normal' | 'low');
+        setEditTags((item.tags ?? []).join(', '));
+        setEditParentId(item.parentId);
+        setEditError(null);
+        setIsEditing(true);
+    }, [item]);
+
+    const handleEditCancel = useCallback(() => {
+        setIsEditing(false);
+        setEditError(null);
+    }, []);
+
+    const handleEditSave = useCallback(async () => {
+        const trimmedTitle = editTitle.trim();
+        if (!trimmedTitle) {
+            setEditError('Title is required');
+            return;
+        }
+        setSaving(true);
+        setEditError(null);
+        try {
+            const parsedTags = editTags.split(',').map((t: string) => t.trim()).filter(Boolean);
+            const uniqueTags = [...new Set(parsedTags)];
+            const updates: Record<string, unknown> = {
+                title: trimmedTitle,
+                description: editDescription,
+                priority: editPriority,
+                tags: uniqueTags,
+            };
+            if (editParentId !== undefined) {
+                updates.parentId = editParentId;
+            }
+            const updated = await getSpaCocClient().workItems.update(workspaceId, workItemId, updates as any);
+            dispatch({ type: 'WORK_ITEM_UPDATED', repoId: workspaceId, item: updated as any });
+            await fetchItem();
+            setIsEditing(false);
+        } catch (err: any) {
+            setEditError(err.message || 'Failed to save changes');
+        } finally {
+            setSaving(false);
+        }
+    }, [editTitle, editDescription, editPriority, editTags, editParentId, workspaceId, workItemId, dispatch, fetchItem]);
+
     if (loading) {
         return <div className="flex items-center justify-center h-full text-sm text-[#848484]">Loading…</div>;
     }
@@ -311,6 +376,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
     const canEditPlan = !isContainer && ['created', 'planning', 'readyToExecute'].includes(item.status);
     const isAiDone = !isContainer && item.status === 'aiDone';
     const validNextStatuses = VALID_TRANSITIONS[item.status] ?? [];
+    const hierarchyEnabled = isWorkItemsHierarchyEnabled();
 
     return (
         <div className="flex flex-col h-full" data-testid="work-item-detail">
@@ -337,7 +403,18 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                                 {effectiveType === 'epic' ? 'Epic' : effectiveType === 'feature' ? 'Feature' : 'PBI / Story'}
                             </span>
                         )}
-                        <h2 className="text-sm font-semibold truncate" title={item.title}>{item.title}</h2>
+                        {isEditing ? (
+                            <input
+                                type="text"
+                                className="text-sm font-semibold flex-1 min-w-0 rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                                value={editTitle}
+                                onChange={e => setEditTitle(e.target.value)}
+                                disabled={saving}
+                                data-testid="wi-edit-title-input"
+                            />
+                        ) : (
+                            <h2 className="text-sm font-semibold truncate" title={item.title}>{item.title}</h2>
+                        )}
                     </div>
                     <div className="flex items-center flex-wrap gap-1.5 text-[10px] text-[#848484] dark:text-[#999] mt-1">
                         {/* Status dropdown */}
@@ -364,7 +441,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                                 <option key={s} value={s}>{STATUS_LABELS[s]?.label ?? s}</option>
                             ))}
                         </select>
-                        {item.priority && item.priority !== 'normal' && (
+                        {!isEditing && item.priority && item.priority !== 'normal' && (
                             <span className={cn('px-1.5 py-0.5 rounded text-[10px]',
                                 item.priority === 'high' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
                             )}>{item.priority}</span>
@@ -376,6 +453,23 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                 </div>
                 {/* Execute + Actions in header — leaf items only */}
                 <div className="flex items-center gap-2 shrink-0">
+                    {/* Edit / Save+Cancel for container items with hierarchy enabled */}
+                    {isContainer && hierarchyEnabled && (
+                        isEditing ? (
+                            <>
+                                <Button variant="primary" size="sm" onClick={handleEditSave} disabled={saving} loading={saving} data-testid="wi-edit-save-btn">
+                                    Save
+                                </Button>
+                                <Button variant="ghost" size="sm" onClick={handleEditCancel} disabled={saving} data-testid="wi-edit-cancel-btn">
+                                    Cancel
+                                </Button>
+                            </>
+                        ) : (
+                            <Button variant="ghost" size="sm" onClick={handleEditStart} data-testid="wi-edit-btn">
+                                Edit
+                            </Button>
+                        )
+                    )}
                     {!isContainer && (
                         <>
                             <label className="flex items-center gap-1 text-[10px] cursor-pointer" title="Auto-execute when status reaches Ready to Execute" data-testid="work-item-auto-execute-toggle">
@@ -448,24 +542,86 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                         <button className="text-[10px] shrink-0" onClick={() => setError(null)}>✕</button>
                     </div>
                 )}
+                {editError && (
+                    <div className="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 rounded p-2" data-testid="wi-edit-error">
+                        {editError}
+                    </div>
+                )}
 
-                {/* Parent info row (shown when parentId is set) */}
-                {item.parentId && (
+                {/* Parent info row */}
+                {isEditing && isContainer && effectiveType !== 'epic' ? (
+                    <section data-testid="work-item-parent-edit">
+                        <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Parent</h3>
+                        <div className="flex items-center gap-2">
+                            <span className="text-xs text-[#3c3c3c] dark:text-[#cccccc] flex-1">
+                                {editParentId
+                                    ? <span className="font-mono text-[#848484]">{editParentId}</span>
+                                    : <span className="italic text-[#848484]">No parent</span>
+                                }
+                            </span>
+                            <Button variant="ghost" size="sm" onClick={() => setShowParentPicker(true)} disabled={saving} data-testid="wi-edit-parent-btn">
+                                {editParentId ? 'Change Parent' : 'Set Parent'}
+                            </Button>
+                        </div>
+                    </section>
+                ) : item.parentId ? (
                     <section data-testid="work-item-parent-info">
                         <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Part Of</h3>
                         <div className="text-xs text-[#3c3c3c] dark:text-[#cccccc]">
                             <span className="font-mono text-[#848484]">{item.parentId}</span>
                         </div>
                     </section>
-                )}
+                ) : null}
 
                 {/* Description */}
                 <section>
                     <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Description</h3>
-                    <div className="text-sm whitespace-pre-wrap text-[#3c3c3c] dark:text-[#cccccc]">
-                        {item.description || <span className="italic text-[#848484]">No description</span>}
-                    </div>
+                    {isEditing && isContainer ? (
+                        <textarea
+                            className="w-full min-h-[80px] text-sm p-2 rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] resize-y focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                            value={editDescription}
+                            onChange={e => setEditDescription(e.target.value)}
+                            disabled={saving}
+                            data-testid="wi-edit-description-input"
+                        />
+                    ) : (
+                        <div className="text-sm whitespace-pre-wrap text-[#3c3c3c] dark:text-[#cccccc]">
+                            {item.description || <span className="italic text-[#848484]">No description</span>}
+                        </div>
+                    )}
                 </section>
+
+                {/* Priority + Tags in edit mode */}
+                {isEditing && isContainer && (
+                    <section className="space-y-3" data-testid="wi-edit-fields">
+                        <div>
+                            <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Priority</h3>
+                            <select
+                                className="text-sm px-2 py-1 rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                                value={editPriority}
+                                onChange={e => setEditPriority(e.target.value as 'high' | 'normal' | 'low')}
+                                disabled={saving}
+                                data-testid="wi-edit-priority-select"
+                            >
+                                <option value="high">High</option>
+                                <option value="normal">Normal</option>
+                                <option value="low">Low</option>
+                            </select>
+                        </div>
+                        <div>
+                            <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Tags (comma-separated)</h3>
+                            <input
+                                type="text"
+                                className="w-full text-sm px-2 py-1 rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                                value={editTags}
+                                onChange={e => setEditTags(e.target.value)}
+                                disabled={saving}
+                                placeholder="e.g. frontend, critical"
+                                data-testid="wi-edit-tags-input"
+                            />
+                        </div>
+                    </section>
+                )}
 
                 {/* Plan — leaf items only */}
                 {!isContainer && (
@@ -795,6 +951,17 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                     workItemTitle={item.title}
                     onClose={() => setShowExecuteDialog(false)}
                     onExecuted={handleExecuteDialogDone}
+                />
+            )}
+            {showParentPicker && (
+                <WorkItemParentPicker
+                    workspaceId={workspaceId}
+                    workItemId={workItemId}
+                    workItemType={effectiveType as any}
+                    currentParentId={editParentId}
+                    onlyPick={true}
+                    onParentChanged={(newParentId) => setEditParentId(newParentId)}
+                    onClose={() => setShowParentPicker(false)}
                 />
             )}
         </div>

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
@@ -53,6 +53,8 @@ interface WorkItemDetailProps {
 
 interface WorkItemFull {
     id: string; workItemNumber?: number; title: string; description: string; status: string;
+    type?: string;
+    parentId?: string;
     priority?: string; source?: string; sourceId?: string;
     createdAt: string; updatedAt: string; completedAt?: string;
     pinnedAt?: string; archivedAt?: string;
@@ -302,10 +304,12 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
 
     if (!item) return null;
 
+    const effectiveType = item.type ?? 'work-item';
+    const isContainer = ['epic', 'feature', 'pbi'].includes(effectiveType);
     const statusCfg = STATUS_LABELS[item.status] || STATUS_LABELS.created;
-    const canExecute = item.status === 'readyToExecute';
-    const canEditPlan = ['created', 'planning', 'readyToExecute'].includes(item.status);
-    const isAiDone = item.status === 'aiDone';
+    const canExecute = !isContainer && item.status === 'readyToExecute';
+    const canEditPlan = !isContainer && ['created', 'planning', 'readyToExecute'].includes(item.status);
+    const isAiDone = !isContainer && item.status === 'aiDone';
     const validNextStatuses = VALID_TRANSITIONS[item.status] ?? [];
 
     return (
@@ -320,7 +324,18 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5">
                         {item.workItemNumber != null && (
-                            <span className="text-xs text-[#848484] dark:text-[#999] font-mono shrink-0" data-testid="work-item-detail-number">WI-{item.workItemNumber}</span>
+                            <span className="text-xs text-[#848484] dark:text-[#999] font-mono shrink-0" data-testid="work-item-detail-number">
+                                {effectiveType === 'epic' ? 'E'
+                                    : effectiveType === 'feature' ? 'F'
+                                    : effectiveType === 'pbi' ? 'PBI'
+                                    : effectiveType === 'bug' ? 'BUG'
+                                    : 'WI'}-{item.workItemNumber}
+                            </span>
+                        )}
+                        {isContainer && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 font-medium">
+                                {effectiveType === 'epic' ? 'Epic' : effectiveType === 'feature' ? 'Feature' : 'PBI / Story'}
+                            </span>
                         )}
                         <h2 className="text-sm font-semibold truncate" title={item.title}>{item.title}</h2>
                     </div>
@@ -359,32 +374,36 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                         <span>{formatRelativeTime(item.updatedAt)}</span>
                     </div>
                 </div>
-                {/* Execute + Actions in header */}
+                {/* Execute + Actions in header — leaf items only */}
                 <div className="flex items-center gap-2 shrink-0">
-                    <label className="flex items-center gap-1 text-[10px] cursor-pointer" title="Auto-execute when status reaches Ready to Execute" data-testid="work-item-auto-execute-toggle">
-                        <input
-                            type="checkbox"
-                            checked={item.autoExecute ?? false}
-                            onChange={async (e) => {
-                                try {
-                                    await getSpaCocClient().workItems.update(workspaceId, workItemId, { autoExecute: e.target.checked });
-                                    await fetchItem();
-                                } catch (err: any) {
-                                    setError(err.message || 'Failed to update');
-                                }
-                            }}
-                            className="rounded"
-                        />
-                        Auto
-                    </label>
-                    <Button
-                        variant="primary" size="sm"
-                        onClick={() => setShowExecuteDialog(true)}
-                        disabled={!canExecute}
-                        data-testid="work-item-execute-btn"
-                    >
-                        ⚡ Start Implementing
-                    </Button>
+                    {!isContainer && (
+                        <>
+                            <label className="flex items-center gap-1 text-[10px] cursor-pointer" title="Auto-execute when status reaches Ready to Execute" data-testid="work-item-auto-execute-toggle">
+                                <input
+                                    type="checkbox"
+                                    checked={item.autoExecute ?? false}
+                                    onChange={async (e) => {
+                                        try {
+                                            await getSpaCocClient().workItems.update(workspaceId, workItemId, { autoExecute: e.target.checked });
+                                            await fetchItem();
+                                        } catch (err: any) {
+                                            setError(err.message || 'Failed to update');
+                                        }
+                                    }}
+                                    className="rounded"
+                                />
+                                Auto
+                            </label>
+                            <Button
+                                variant="primary" size="sm"
+                                onClick={() => setShowExecuteDialog(true)}
+                                disabled={!canExecute}
+                                data-testid="work-item-execute-btn"
+                            >
+                                ⚡ Start Implementing
+                            </Button>
+                        </>
+                    )}
                     <Button variant="ghost" size="sm" data-testid="work-item-pin-btn"
                         title={item.pinnedAt ? 'Unpin' : 'Pin'}
                         onClick={async () => {
@@ -430,6 +449,16 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                     </div>
                 )}
 
+                {/* Parent info row (shown when parentId is set) */}
+                {item.parentId && (
+                    <section data-testid="work-item-parent-info">
+                        <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Part Of</h3>
+                        <div className="text-xs text-[#3c3c3c] dark:text-[#cccccc]">
+                            <span className="font-mono text-[#848484]">{item.parentId}</span>
+                        </div>
+                    </section>
+                )}
+
                 {/* Description */}
                 <section>
                     <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Description</h3>
@@ -438,7 +467,8 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                     </div>
                 </section>
 
-                {/* Plan */}
+                {/* Plan — leaf items only */}
+                {!isContainer && (
                 <section>
                     <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-2">
                         Detail Plan {item.plan ? <span className="text-[#848484] normal-case">(v{item.plan.version})</span> : ''}
@@ -453,6 +483,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                         onNavigateToTasksTab={onNavigateToTasksTab}
                     />
                 </section>
+                )}
 
                 {/* AI Review section (aiDone only) */}
                 {isAiDone && (
@@ -492,8 +523,8 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                     </section>
                 )}
 
-                {/* Execution session entry — shown when a task has been queued/run */}
-                {item.taskId && (onViewTask || onNavigateToTasksTab) && ['executing', 'aiDone', 'aiFailed'].includes(item.status) && (
+                {/* Execution session entry — shown when a task has been queued/run (leaf items only) */}
+                {!isContainer && item.taskId && (onViewTask || onNavigateToTasksTab) && ['executing', 'aiDone', 'aiFailed'].includes(item.status) && (
                     <section>
                         <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Execution Session</h3>
                         {item.status === 'aiDone' && onNavigateToTasksTab ? (
@@ -547,10 +578,9 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                 )}
 
                 {/* Execution history */}
-                {((item.executionHistory && item.executionHistory.length > 0) || (item.changes && item.changes.some(c => !c.taskId || !item.executionHistory?.some(e => e.taskId === c.taskId)))) && (
+                {!isContainer && ((item.executionHistory && item.executionHistory.length > 0) || (item.changes && item.changes.some(c => !c.taskId || !item.executionHistory?.some(e => e.taskId === c.taskId)))) && (
                     <section>
-                        <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Execution History</h3>
-                        <div className="space-y-2">
+                        <h3 className="text-xs font-medium text-[#848484] dark:text-[#999] uppercase mb-1">Execution History</h3><div className="space-y-2">
                             {item.executionHistory?.map((exec, i) => {
                                 const matchingChange = item.changes?.find(c => c.taskId === exec.taskId);
                                 const commits = matchingChange?.commits ?? [];

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyNode.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyNode.tsx
@@ -1,0 +1,174 @@
+/**
+ * WorkItemHierarchyNode — a single row in the hierarchy tree.
+ * Renders type pill, number, title, status chip, rollup summary, and collapse toggle.
+ */
+
+import { type ReactNode } from 'react';
+import { cn } from '../../ui';
+import type { WorkItemTreeNode } from '@plusplusoneplusplus/coc-client';
+import { formatRelativeTime } from '../../utils/format';
+
+// ── Type display config ──────────────────────────────────────────────────────
+
+export type WorkItemTypeLabel = 'epic' | 'feature' | 'pbi' | 'work-item' | 'bug';
+
+export const TYPE_LABELS: Record<WorkItemTypeLabel, string> = {
+    epic: 'Epic',
+    feature: 'Feature',
+    pbi: 'PBI',
+    'work-item': 'Work Item',
+    bug: 'Bug',
+};
+
+const TYPE_PREFIX: Record<WorkItemTypeLabel, string> = {
+    epic: 'E',
+    feature: 'F',
+    pbi: 'PBI',
+    'work-item': 'WI',
+    bug: 'BUG',
+};
+
+const TYPE_PILL_CLASS: Record<WorkItemTypeLabel, string> = {
+    epic:        'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+    feature:     'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+    pbi:         'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300',
+    'work-item': 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    bug:         'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+};
+
+const STATUS_CHIP_CLASS: Record<string, string> = {
+    created:          'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+    planning:         'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+    readyToExecute:   'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    executing:        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    aiDone:           'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+    aiFailed:         'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+    done:             'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    failed:           'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+    created: 'Created',
+    planning: 'Planning',
+    readyToExecute: 'Ready',
+    executing: 'Executing',
+    aiDone: 'AI Done',
+    aiFailed: 'AI Failed',
+    done: 'Done',
+    failed: 'Failed',
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export interface WorkItemHierarchyNodeProps {
+    node: WorkItemTreeNode;
+    depth: number;
+    collapsed: boolean;
+    selected: boolean;
+    hasChildren: boolean;
+    onSelect: (id: string) => void;
+    onToggleCollapse: (id: string) => void;
+    onContextMenu: (e: React.MouseEvent, node: WorkItemTreeNode) => void;
+    children?: ReactNode;
+}
+
+export function WorkItemHierarchyNode({
+    node,
+    depth,
+    collapsed,
+    selected,
+    hasChildren,
+    onSelect,
+    onToggleCollapse,
+    onContextMenu,
+    children,
+}: WorkItemHierarchyNodeProps) {
+    const { item, rollup } = node;
+    const effectiveType = (item.type ?? 'work-item') as WorkItemTypeLabel;
+    const typeLabel = TYPE_LABELS[effectiveType] ?? effectiveType;
+    const typePrefix = TYPE_PREFIX[effectiveType] ?? 'WI';
+    const pillClass = TYPE_PILL_CLASS[effectiveType] ?? TYPE_PILL_CLASS['work-item'];
+    const statusChipClass = STATUS_CHIP_CLASS[item.status] ?? STATUS_CHIP_CLASS.created;
+    const statusLabel = STATUS_LABEL[item.status] ?? item.status;
+    const isContainer = ['epic', 'feature', 'pbi'].includes(effectiveType);
+
+    const indentWidth = depth * 16;
+
+    return (
+        <div data-testid={`hierarchy-node-${item.id}`}>
+            <div
+                className={cn(
+                    'group flex items-center gap-1 px-2 py-1.5 cursor-pointer text-[12px] rounded-sm transition-colors',
+                    selected
+                        ? 'bg-[#007acc]/15 dark:bg-[#007acc]/20'
+                        : 'hover:bg-[#f5f5f5] dark:hover:bg-[#2a2d2e]',
+                )}
+                style={{ paddingLeft: `${8 + indentWidth}px` }}
+                onClick={() => onSelect(item.id)}
+                onContextMenu={e => { e.preventDefault(); onContextMenu(e, node); }}
+                data-testid={`hierarchy-node-row-${item.id}`}
+            >
+                {/* Collapse toggle */}
+                <button
+                    className={cn(
+                        'flex-shrink-0 w-4 h-4 flex items-center justify-center rounded text-[10px] text-[#848484]',
+                        hasChildren ? 'hover:text-[#333] dark:hover:text-[#ccc]' : 'invisible',
+                    )}
+                    onClick={e => { e.stopPropagation(); if (hasChildren) onToggleCollapse(item.id); }}
+                    data-testid={`hierarchy-node-collapse-${item.id}`}
+                    aria-label={collapsed ? 'Expand' : 'Collapse'}
+                >
+                    {hasChildren ? (collapsed ? '▶' : '▼') : null}
+                </button>
+
+                {/* Type pill */}
+                <span
+                    className={cn('flex-shrink-0 px-1 py-0.5 rounded text-[9px] font-medium leading-none', pillClass)}
+                    title={typeLabel}
+                    data-testid={`hierarchy-node-type-${item.id}`}
+                >
+                    {typeLabel}
+                </span>
+
+                {/* Number */}
+                {item.workItemNumber != null && (
+                    <span className="flex-shrink-0 text-[10px] text-[#848484] dark:text-[#999] font-mono">
+                        {typePrefix}-{item.workItemNumber}
+                    </span>
+                )}
+
+                {/* Title */}
+                <span
+                    className="flex-1 min-w-0 truncate text-[#3c3c3c] dark:text-[#cccccc]"
+                    title={item.title}
+                    data-testid={`hierarchy-node-title-${item.id}`}
+                >
+                    {item.title}
+                </span>
+
+                {/* Rollup summary for containers */}
+                {isContainer && rollup.descendantCount > 0 && (
+                    <span className="flex-shrink-0 text-[10px] text-[#848484] dark:text-[#999]" title="Done / Total descendants">
+                        {rollup.byStatus.done}/{rollup.descendantCount}
+                    </span>
+                )}
+
+                {/* Status chip */}
+                <span
+                    className={cn('flex-shrink-0 px-1 py-0.5 rounded text-[9px] font-medium leading-none', statusChipClass)}
+                    data-testid={`hierarchy-node-status-${item.id}`}
+                >
+                    {statusLabel}
+                </span>
+
+                {/* Updated time */}
+                <span className="flex-shrink-0 text-[10px] text-[#848484] dark:text-[#999] opacity-0 group-hover:opacity-100 transition-opacity">
+                    {formatRelativeTime(item.updatedAt)}
+                </span>
+            </div>
+
+            {/* Children */}
+            {!collapsed && children}
+        </div>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
@@ -12,17 +12,9 @@ import { WorkItemHierarchyNode } from './WorkItemHierarchyNode';
 import { WorkItemParentPicker } from './WorkItemParentPicker';
 import { ContextMenu } from '../../tasks/comments/ContextMenu';
 import type { ContextMenuItem } from '../../tasks/comments/ContextMenu';
+import { ALLOWED_CHILD_TYPES } from '@plusplusoneplusplus/coc-client';
 import type { WorkItemTreeNode, WorkItemTreeResponse } from '@plusplusoneplusplus/coc-client';
 import type { WorkItemTypeLabel } from './WorkItemHierarchyNode';
-
-/** Valid child types for each container type. */
-const ALLOWED_CHILD_TYPES: Record<WorkItemTypeLabel, WorkItemTypeLabel[]> = {
-    epic:        ['feature'],
-    feature:     ['pbi'],
-    pbi:         ['work-item', 'bug'],
-    'work-item': [],
-    bug:         [],
-};
 
 const TYPE_CHILD_LABELS: Record<WorkItemTypeLabel, string> = {
     epic:        'Feature',
@@ -198,7 +190,7 @@ export function WorkItemHierarchyTree({
                     icon: '🔓',
                     onClick: async () => {
                         try {
-                            await getSpaCocClient().workItems.update(workspaceId, node.item.id, { parentId: null as any });
+                            await getSpaCocClient().workItems.update(workspaceId, node.item.id, { parentId: null });
                             fetchTree();
                         } catch (err: any) {
                             alert(err.message ?? 'Failed to unlink');

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
@@ -1,0 +1,418 @@
+/**
+ * WorkItemHierarchyTree — the hierarchy board left pane.
+ * Renders a collapsible hierarchy tree with Epic → Feature → PBI → WI/Bug.
+ * Includes create actions, search, and context menu per node.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Button, cn } from '../../ui';
+import { getSpaCocClient } from '../../api/cocClient';
+import { useWorkItems } from '../../contexts/WorkItemContext';
+import { WorkItemHierarchyNode } from './WorkItemHierarchyNode';
+import { WorkItemParentPicker } from './WorkItemParentPicker';
+import { ContextMenu } from '../../tasks/comments/ContextMenu';
+import type { ContextMenuItem } from '../../tasks/comments/ContextMenu';
+import type { WorkItemTreeNode, WorkItemTreeResponse } from '@plusplusoneplusplus/coc-client';
+import type { WorkItemTypeLabel } from './WorkItemHierarchyNode';
+
+/** Valid child types for each container type. */
+const ALLOWED_CHILD_TYPES: Record<WorkItemTypeLabel, WorkItemTypeLabel[]> = {
+    epic:        ['feature'],
+    feature:     ['pbi'],
+    pbi:         ['work-item', 'bug'],
+    'work-item': [],
+    bug:         [],
+};
+
+const TYPE_CHILD_LABELS: Record<WorkItemTypeLabel, string> = {
+    epic:        'Feature',
+    feature:     'PBI / Story',
+    pbi:         'Work Item / Bug',
+    'work-item': '',
+    bug:         '',
+};
+
+const COLLAPSE_STORAGE_KEY = (workspaceId: string) => `coc-hierarchy-collapsed-${workspaceId}`;
+
+function loadCollapsed(workspaceId: string): Set<string> {
+    try {
+        const raw = localStorage.getItem(COLLAPSE_STORAGE_KEY(workspaceId));
+        return raw ? new Set(JSON.parse(raw)) : new Set();
+    } catch { return new Set(); }
+}
+
+function saveCollapsed(workspaceId: string, ids: Set<string>): void {
+    try {
+        localStorage.setItem(COLLAPSE_STORAGE_KEY(workspaceId), JSON.stringify([...ids]));
+    } catch { /* quota exceeded */ }
+}
+
+export interface WorkItemHierarchyTreeProps {
+    workspaceId: string;
+    selectedWorkItemId: string | null;
+    onSelectWorkItem: (id: string) => void;
+    /** Called when a new work item is created from within the tree. */
+    onCreated: (item: any) => void;
+    /** Open the create dialog for a given type with an optional parent. */
+    onCreateItem: (type: WorkItemTypeLabel, parentId?: string) => void;
+}
+
+export function WorkItemHierarchyTree({
+    workspaceId,
+    selectedWorkItemId,
+    onSelectWorkItem,
+    onCreated,
+    onCreateItem,
+}: WorkItemHierarchyTreeProps) {
+    const [treeData, setTreeData] = useState<WorkItemTreeNode[]>([]);
+    const [total, setTotal] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => loadCollapsed(workspaceId));
+    const [showArchived, setShowArchived] = useState(false);
+
+    const [contextMenu, setContextMenu] = useState<{
+        node: WorkItemTreeNode;
+        position: { x: number; y: number };
+    } | null>(null);
+
+    const [parentPicker, setParentPicker] = useState<{
+        itemId: string;
+        itemType: WorkItemTypeLabel;
+        currentParentId?: string;
+    } | null>(null);
+
+    const { state: workItemState } = useWorkItems();
+    const lastFetchedAt = useRef<string>('');
+
+    const fetchTree = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const resp: WorkItemTreeResponse = await getSpaCocClient().workItems.tree(workspaceId, {
+                q: searchQuery || undefined,
+                includeArchived: showArchived,
+            });
+            if (resp.disabled) {
+                setError('Hierarchy feature is disabled.');
+                return;
+            }
+            setTreeData(resp.roots);
+            setTotal(resp.total);
+            lastFetchedAt.current = new Date().toISOString();
+        } catch (err: any) {
+            setError(err.message ?? 'Failed to load hierarchy');
+        } finally {
+            setLoading(false);
+        }
+    }, [workspaceId, searchQuery, showArchived]);
+
+    // Initial load
+    useEffect(() => { fetchTree(); }, [fetchTree]);
+
+    // Refresh when WebSocket events arrive (work item context changes)
+    const repoItems = workItemState.workItemsByRepo[workspaceId];
+    const prevRepoItemsRef = useRef(repoItems);
+    useEffect(() => {
+        if (prevRepoItemsRef.current === repoItems) return;
+        prevRepoItemsRef.current = repoItems;
+        // Debounce to avoid multiple rapid refreshes
+        const timer = setTimeout(() => fetchTree(), 300);
+        return () => clearTimeout(timer);
+    }, [repoItems, fetchTree]);
+
+    // Persist collapse state
+    useEffect(() => {
+        saveCollapsed(workspaceId, collapsedIds);
+    }, [workspaceId, collapsedIds]);
+
+    const handleToggleCollapse = useCallback((id: string) => {
+        setCollapsedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    }, []);
+
+    const handleContextMenu = useCallback((e: React.MouseEvent, node: WorkItemTreeNode) => {
+        e.preventDefault();
+        setContextMenu({ node, position: { x: e.clientX, y: e.clientY } });
+    }, []);
+
+    const handleDelete = useCallback(async (id: string) => {
+        if (!confirm('Delete this work item? Children must be moved or deleted first.')) return;
+        try {
+            await getSpaCocClient().workItems.delete(workspaceId, id);
+            fetchTree();
+        } catch (err: any) {
+            alert(err.message ?? 'Failed to delete');
+        }
+    }, [workspaceId, fetchTree]);
+
+    const buildContextMenuItems = useCallback((node: WorkItemTreeNode): ContextMenuItem[] => {
+        const effectiveType = (node.item.type ?? 'work-item') as WorkItemTypeLabel;
+        const childTypes = ALLOWED_CHILD_TYPES[effectiveType] ?? [];
+        const items: ContextMenuItem[] = [];
+
+        // Create child actions
+        if (childTypes.length > 0) {
+            const childLabel = TYPE_CHILD_LABELS[effectiveType];
+            items.push({
+                label: `Add ${childLabel}`,
+                icon: '➕',
+                onClick: () => {
+                    if (childTypes.length === 1) {
+                        onCreateItem(childTypes[0], node.item.id);
+                    } else {
+                        // pbi → work-item or bug; open dialog for work-item first
+                        onCreateItem('work-item', node.item.id);
+                    }
+                },
+            });
+            if (childTypes.length > 1) {
+                items.push({
+                    label: 'Add Bug',
+                    icon: '🐛',
+                    onClick: () => onCreateItem('bug', node.item.id),
+                });
+            }
+        }
+
+        // Change parent
+        if (effectiveType !== 'epic') {
+            items.push({
+                label: 'Change Parent…',
+                icon: '🔗',
+                onClick: () => setParentPicker({
+                    itemId: node.item.id,
+                    itemType: effectiveType,
+                    currentParentId: node.item.parentId ?? undefined,
+                }),
+                separator: childTypes.length > 0,
+            });
+            if (node.item.parentId) {
+                items.push({
+                    label: 'Unlink Parent',
+                    icon: '🔓',
+                    onClick: async () => {
+                        try {
+                            await getSpaCocClient().workItems.update(workspaceId, node.item.id, { parentId: null as any });
+                            fetchTree();
+                        } catch (err: any) {
+                            alert(err.message ?? 'Failed to unlink');
+                        }
+                    },
+                });
+            }
+        }
+
+        // Pin/archive/delete
+        items.push({
+            label: node.item.pinnedAt ? 'Unpin' : 'Pin',
+            icon: '📌',
+            separator: true,
+            onClick: async () => {
+                try {
+                    await getSpaCocClient().workItems.pin(workspaceId, node.item.id, !node.item.pinnedAt);
+                    fetchTree();
+                } catch (err: any) {
+                    alert(err.message ?? 'Failed to pin');
+                }
+            },
+        });
+        items.push({
+            label: node.item.archivedAt ? 'Unarchive' : 'Archive',
+            icon: '🗄️',
+            onClick: async () => {
+                try {
+                    await getSpaCocClient().workItems.archive(workspaceId, node.item.id, !node.item.archivedAt);
+                    fetchTree();
+                } catch (err: any) {
+                    alert(err.message ?? 'Failed to archive');
+                }
+            },
+        });
+        items.push({
+            label: 'Delete',
+            icon: '🗑',
+            onClick: () => handleDelete(node.item.id),
+        });
+
+        return items;
+    }, [workspaceId, onCreateItem, fetchTree, handleDelete]);
+
+    /** Recursively render a tree node and its children. */
+    const renderNode = useCallback((node: WorkItemTreeNode, depth: number): React.ReactNode => {
+        const id = node.item.id;
+        const hasChildren = node.children.length > 0;
+        const collapsed = collapsedIds.has(id);
+
+        return (
+            <WorkItemHierarchyNode
+                key={id}
+                node={node}
+                depth={depth}
+                collapsed={collapsed}
+                selected={selectedWorkItemId === id}
+                hasChildren={hasChildren}
+                onSelect={onSelectWorkItem}
+                onToggleCollapse={handleToggleCollapse}
+                onContextMenu={handleContextMenu}
+            >
+                {!collapsed && node.children.map(child => renderNode(child, depth + 1))}
+            </WorkItemHierarchyNode>
+        );
+    }, [collapsedIds, selectedWorkItemId, onSelectWorkItem, handleToggleCollapse, handleContextMenu]);
+
+    // ── Render ────────────────────────────────────────────────────────────────
+
+    return (
+        <div className="flex flex-col h-full" data-testid="work-item-hierarchy-tree">
+            {/* ── Header ── */}
+            <div className="px-3 pt-3 pb-2 flex items-center justify-between gap-2 shrink-0">
+                <h2 className="text-sm font-medium truncate">Work Items Board</h2>
+                <div className="flex gap-1 shrink-0">
+                    <Button
+                        variant="primary"
+                        size="sm"
+                        onClick={() => onCreateItem('epic')}
+                        data-testid="create-epic-btn"
+                        title="Create top-level Epic"
+                    >
+                        + Epic
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onCreateItem('work-item')}
+                        data-testid="create-wi-btn"
+                        title="Create unparented Work Item"
+                    >
+                        + WI
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onCreateItem('bug')}
+                        data-testid="create-bug-btn"
+                        title="Create unparented Bug"
+                    >
+                        🐛
+                    </Button>
+                </div>
+            </div>
+
+            {/* ── Search ── */}
+            <div className="px-3 pb-2 shrink-0 flex items-center gap-2">
+                <input
+                    type="text"
+                    className="flex-1 rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-[12px] text-[#1e1e1e] dark:text-[#cccccc] px-2 py-1 focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                    placeholder="Search hierarchy…"
+                    value={searchQuery}
+                    onChange={e => setSearchQuery(e.target.value)}
+                    data-testid="hierarchy-search-input"
+                />
+                <button
+                    className={cn(
+                        'text-[11px] px-1.5 py-0.5 rounded border transition-colors',
+                        showArchived
+                            ? 'border-[#007acc] text-[#007acc] bg-[#007acc]/10'
+                            : 'border-[#d0d0d0] dark:border-[#555] text-[#848484] hover:border-[#999]',
+                    )}
+                    onClick={() => setShowArchived(p => !p)}
+                    title="Toggle archived items"
+                    data-testid="hierarchy-archived-toggle"
+                >
+                    📂
+                </button>
+            </div>
+
+            {/* ── Tree body ── */}
+            <div className="flex-1 overflow-y-auto min-h-0">
+                {loading ? (
+                    <div className="flex items-center justify-center h-16 text-sm text-[#848484]" data-testid="hierarchy-loading">
+                        Loading…
+                    </div>
+                ) : error ? (
+                    <div className="flex flex-col items-center justify-center h-16 gap-2 px-3" data-testid="hierarchy-error">
+                        <p className="text-xs text-red-500 text-center">{error}</p>
+                        <Button variant="ghost" size="sm" onClick={fetchTree}>Retry</Button>
+                    </div>
+                ) : treeData.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center h-24 gap-3 px-4 text-center" data-testid="hierarchy-empty">
+                        <div className="text-3xl">🗂️</div>
+                        <p className="text-xs text-[#848484]">
+                            {searchQuery ? 'No results found.' : 'No work items yet. Create an Epic to start, or add an unparented Work Item.'}
+                        </p>
+                        {!searchQuery && (
+                            <div className="flex gap-2">
+                                <Button variant="primary" size="sm" onClick={() => onCreateItem('epic')} data-testid="empty-create-epic-btn">
+                                    + Create Epic
+                                </Button>
+                                <Button variant="ghost" size="sm" onClick={() => onCreateItem('work-item')}>
+                                    + Work Item
+                                </Button>
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <div data-testid="hierarchy-tree-list">
+                        {/* Rooted nodes (epics and parented items at each level) */}
+                        {treeData
+                            .filter(n => n.item.type === 'epic' || (n.item.type && ['feature', 'pbi'].includes(n.item.type) && n.item.parentId == null))
+                            .map(n => renderNode(n, 0))}
+
+                        {/* Unparented group — roots that are not epics */}
+                        {(() => {
+                            const unparented = treeData.filter(n => {
+                                const t = n.item.type ?? 'work-item';
+                                return t !== 'epic' && !n.item.parentId;
+                            });
+                            if (unparented.length === 0) return null;
+                            return (
+                                <div data-testid="hierarchy-unparented-group">
+                                    <div className="px-3 py-1 mt-2 text-[10px] font-medium text-[#848484] dark:text-[#999] uppercase tracking-wide border-t border-[#e8e8e8] dark:border-[#333]">
+                                        Unparented
+                                    </div>
+                                    {unparented.map(n => renderNode(n, 0))}
+                                </div>
+                            );
+                        })()}
+
+                        {/* Count */}
+                        <div className="px-3 py-2 text-[10px] text-[#848484] dark:text-[#999]">
+                            {total} item{total !== 1 ? 's' : ''}
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            {/* ── Context menu ── */}
+            {contextMenu && (
+                <ContextMenu
+                    position={contextMenu.position}
+                    items={buildContextMenuItems(contextMenu.node)}
+                    onClose={() => setContextMenu(null)}
+                />
+            )}
+
+            {/* ── Parent picker ── */}
+            {parentPicker && (
+                <WorkItemParentPicker
+                    open={true}
+                    onClose={() => setParentPicker(null)}
+                    workspaceId={workspaceId}
+                    itemId={parentPicker.itemId}
+                    itemType={parentPicker.itemType}
+                    currentParentId={parentPicker.currentParentId}
+                    onParentChanged={() => {
+                        setParentPicker(null);
+                        fetchTree();
+                    }}
+                />
+            )}
+        </div>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
@@ -1,0 +1,246 @@
+/**
+ * WorkItemParentPicker — dialog for selecting/changing a work item's parent.
+ * Lists valid parent candidates filtered by the child item's type constraints.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Dialog } from '../../ui/Dialog';
+import { Button } from '../../ui';
+import { getSpaCocClient } from '../../api/cocClient';
+import { TYPE_LABELS } from './WorkItemHierarchyNode';
+import type { WorkItemTypeLabel } from './WorkItemHierarchyNode';
+
+/** Maps each child type to its valid parent types. */
+const VALID_PARENT_TYPES: Record<WorkItemTypeLabel, WorkItemTypeLabel[]> = {
+    epic:        [],
+    feature:     ['epic'],
+    pbi:         ['feature'],
+    'work-item': ['pbi'],
+    bug:         ['pbi'],
+};
+
+const TYPE_PREFIX: Record<WorkItemTypeLabel, string> = {
+    epic: 'E',
+    feature: 'F',
+    pbi: 'PBI',
+    'work-item': 'WI',
+    bug: 'BUG',
+};
+
+interface ParentCandidate {
+    id: string;
+    title: string;
+    type: WorkItemTypeLabel;
+    workItemNumber?: number;
+    status: string;
+}
+
+export interface WorkItemParentPickerProps {
+    open: boolean;
+    onClose: () => void;
+    workspaceId: string;
+    itemId: string;
+    itemType: WorkItemTypeLabel;
+    currentParentId?: string;
+    /** Called with null to unlink, or with newParentId to re-parent. */
+    onParentChanged: (newParentId: string | null) => void;
+}
+
+export function WorkItemParentPicker({
+    open,
+    onClose,
+    workspaceId,
+    itemId,
+    itemType,
+    currentParentId,
+    onParentChanged,
+}: WorkItemParentPickerProps) {
+    const [searchQuery, setSearchQuery] = useState('');
+    const [candidates, setCandidates] = useState<ParentCandidate[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedId, setSelectedId] = useState<string | null>(currentParentId ?? null);
+
+    const validParentTypes = VALID_PARENT_TYPES[itemType] ?? [];
+
+    const fetchCandidates = useCallback(async () => {
+        if (validParentTypes.length === 0) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const results: ParentCandidate[] = [];
+            for (const parentType of validParentTypes) {
+                const resp = await getSpaCocClient().workItems.list(workspaceId, {
+                    type: parentType,
+                    q: searchQuery || undefined,
+                    limit: 50,
+                });
+                for (const wi of resp.items) {
+                    if (wi.id === itemId) continue; // exclude self
+                    results.push({
+                        id: wi.id,
+                        title: wi.title,
+                        type: (wi.type ?? 'work-item') as WorkItemTypeLabel,
+                        workItemNumber: wi.workItemNumber,
+                        status: wi.status,
+                    });
+                }
+            }
+            setCandidates(results);
+        } catch (err: any) {
+            setError(err.message ?? 'Failed to load candidates');
+        } finally {
+            setLoading(false);
+        }
+    }, [workspaceId, itemId, validParentTypes, searchQuery]);
+
+    useEffect(() => {
+        if (open) {
+            setSelectedId(currentParentId ?? null);
+            setSearchQuery('');
+            setError(null);
+            fetchCandidates();
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        const timer = setTimeout(() => fetchCandidates(), 300);
+        return () => clearTimeout(timer);
+    }, [searchQuery, fetchCandidates, open]);
+
+    const handleConfirm = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            await getSpaCocClient().workItems.update(workspaceId, itemId, { parentId: selectedId ?? undefined });
+            onParentChanged(selectedId);
+            onClose();
+        } catch (err: any) {
+            setError(err.message ?? 'Failed to update parent');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleUnlink = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            await getSpaCocClient().workItems.update(workspaceId, itemId, { parentId: null as any });
+            onParentChanged(null);
+            onClose();
+        } catch (err: any) {
+            setError(err.message ?? 'Failed to unlink parent');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (validParentTypes.length === 0) {
+        return (
+            <Dialog open={open} onClose={onClose} title="Parent">
+                <p className="text-sm text-[#848484]">
+                    {TYPE_LABELS[itemType] ?? itemType} items cannot have a parent.
+                </p>
+                <div className="mt-3 flex justify-end">
+                    <Button variant="secondary" size="sm" onClick={onClose}>Close</Button>
+                </div>
+            </Dialog>
+        );
+    }
+
+    const filtered = searchQuery
+        ? candidates.filter(c => c.title.toLowerCase().includes(searchQuery.toLowerCase()))
+        : candidates;
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            title="Change Parent"
+            footer={
+                <>
+                    {currentParentId && (
+                        <Button variant="ghost" size="sm" onClick={handleUnlink} disabled={saving} className="mr-auto text-red-500">
+                            Unlink Parent
+                        </Button>
+                    )}
+                    <Button variant="secondary" size="sm" onClick={onClose} disabled={saving}>Cancel</Button>
+                    <Button
+                        variant="primary"
+                        size="sm"
+                        onClick={handleConfirm}
+                        disabled={saving || selectedId === currentParentId}
+                        loading={saving}
+                    >
+                        Confirm
+                    </Button>
+                </>
+            }
+        >
+            <div className="space-y-3">
+                <p className="text-xs text-[#848484]">
+                    Valid parent types: {validParentTypes.map(t => TYPE_LABELS[t]).join(', ')}
+                </p>
+                <input
+                    type="text"
+                    className="w-full rounded border border-[#c8c8c8] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-sm text-[#1e1e1e] dark:text-[#cccccc] p-2 focus:outline-none focus:ring-1 focus:ring-[#0078d4]"
+                    placeholder="Search…"
+                    value={searchQuery}
+                    onChange={e => setSearchQuery(e.target.value)}
+                    data-testid="parent-picker-search"
+                />
+                {error && (
+                    <p className="text-xs text-red-500" data-testid="parent-picker-error">{error}</p>
+                )}
+                {loading ? (
+                    <p className="text-xs text-[#848484] py-2">Loading…</p>
+                ) : filtered.length === 0 ? (
+                    <p className="text-xs text-[#848484] py-2">No candidates found.</p>
+                ) : (
+                    <div className="max-h-60 overflow-y-auto border border-[#e0e0e0] dark:border-[#555] rounded" data-testid="parent-picker-list">
+                        {filtered.map(c => {
+                            const prefix = TYPE_PREFIX[c.type] ?? 'WI';
+                            const label = TYPE_LABELS[c.type] ?? c.type;
+                            const isSelected = c.id === selectedId;
+                            return (
+                                <button
+                                    key={c.id}
+                                    className={cn(
+                                        'w-full text-left px-3 py-2 text-sm flex items-center gap-2 border-b border-[#f0f0f0] dark:border-[#333] last:border-0 transition-colors',
+                                        isSelected
+                                            ? 'bg-[#007acc]/10 dark:bg-[#007acc]/15'
+                                            : 'hover:bg-[#f5f5f5] dark:hover:bg-[#2a2d2e]',
+                                    )}
+                                    onClick={() => setSelectedId(c.id)}
+                                    data-testid={`parent-candidate-${c.id}`}
+                                >
+                                    <span className="text-[9px] px-1 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 font-medium">
+                                        {label}
+                                    </span>
+                                    {c.workItemNumber != null && (
+                                        <span className="text-[10px] text-[#848484] font-mono shrink-0">
+                                            {prefix}-{c.workItemNumber}
+                                        </span>
+                                    )}
+                                    <span className="flex-1 truncate text-[#3c3c3c] dark:text-[#cccccc]" title={c.title}>
+                                        {c.title}
+                                    </span>
+                                    {isSelected && <span className="text-[#007acc] text-xs shrink-0">✓</span>}
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </Dialog>
+    );
+}
+
+// ── Local helper ─────────────────────────────────────────────────────────────
+function cn(...classes: (string | boolean | undefined | null)[]): string {
+    return classes.filter(Boolean).join(' ');
+}

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
@@ -7,17 +7,9 @@ import { useState, useEffect, useCallback } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button } from '../../ui';
 import { getSpaCocClient } from '../../api/cocClient';
+import { ALLOWED_PARENT_TYPES } from '@plusplusoneplusplus/coc-client';
 import { TYPE_LABELS } from './WorkItemHierarchyNode';
 import type { WorkItemTypeLabel } from './WorkItemHierarchyNode';
-
-/** Maps each child type to its valid parent types. */
-const VALID_PARENT_TYPES: Record<WorkItemTypeLabel, WorkItemTypeLabel[]> = {
-    epic:        [],
-    feature:     ['epic'],
-    pbi:         ['feature'],
-    'work-item': ['pbi'],
-    bug:         ['pbi'],
-};
 
 const TYPE_PREFIX: Record<WorkItemTypeLabel, string> = {
     epic: 'E',
@@ -62,7 +54,7 @@ export function WorkItemParentPicker({
     const [error, setError] = useState<string | null>(null);
     const [selectedId, setSelectedId] = useState<string | null>(currentParentId ?? null);
 
-    const validParentTypes = VALID_PARENT_TYPES[itemType] ?? [];
+    const validParentTypes = ALLOWED_PARENT_TYPES[itemType] ?? [];
 
     const fetchCandidates = useCallback(async () => {
         if (validParentTypes.length === 0) return;
@@ -129,7 +121,7 @@ export function WorkItemParentPicker({
         setSaving(true);
         setError(null);
         try {
-            await getSpaCocClient().workItems.update(workspaceId, itemId, { parentId: null as any });
+            await getSpaCocClient().workItems.update(workspaceId, itemId, { parentId: null });
             onParentChanged(null);
             onClose();
         } catch (err: any) {

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
@@ -36,6 +36,12 @@ export interface WorkItemParentPickerProps {
     currentParentId?: string;
     /** Called with null to unlink, or with newParentId to re-parent. */
     onParentChanged: (newParentId: string | null) => void;
+    /**
+     * When true, the dialog only selects a new parent without making API calls,
+     * and does not offer an unlink action. The caller is responsible for persisting
+     * the chosen parent.
+     */
+    onlyPick?: boolean;
 }
 
 export function WorkItemParentPicker({
@@ -46,6 +52,7 @@ export function WorkItemParentPicker({
     itemType,
     currentParentId,
     onParentChanged,
+    onlyPick = false,
 }: WorkItemParentPickerProps) {
     const [searchQuery, setSearchQuery] = useState('');
     const [candidates, setCandidates] = useState<ParentCandidate[]>([]);
@@ -104,6 +111,11 @@ export function WorkItemParentPicker({
     }, [searchQuery, fetchCandidates, open]);
 
     const handleConfirm = async () => {
+        if (onlyPick) {
+            onParentChanged(selectedId);
+            onClose();
+            return;
+        }
         setSaving(true);
         setError(null);
         try {
@@ -155,7 +167,7 @@ export function WorkItemParentPicker({
             title="Change Parent"
             footer={
                 <>
-                    {currentParentId && (
+                    {currentParentId && !onlyPick && (
                         <Button variant="ghost" size="sm" onClick={handleUnlink} disabled={saving} className="mr-auto text-red-500">
                             Unlink Parent
                         </Button>

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemsTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemsTab.tsx
@@ -11,6 +11,7 @@ import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { WorkItemSection } from './WorkItemSection';
 import { WorkItemDetail } from './WorkItemDetail';
 import { WorkItemExecutionSession } from './WorkItemExecutionSession';
+import { WorkItemHierarchyTree } from './WorkItemHierarchyTree';
 import { CommitDetail } from '../git/commits/CommitDetail';
 import { FileDiffPanel } from '../git/diff/FileDiffPanel';
 import { createCommitDiffSource } from '../git/diff/diffSource';
@@ -22,6 +23,8 @@ import { buildFileTree, compactFolders, FileTreeView } from '../git/diff/FileTre
 import { useFileCommentCounts } from '../git/hooks/useFileCommentCounts';
 import { computeDiffCommentKey } from '../../../comments/diff-comment-utils';
 import { buildWorkItemHash, buildWorkItemSessionHash, buildWorkItemCommitHash } from '../../layout/Router';
+import { isWorkItemsHierarchyEnabled } from '../../utils/config';
+import type { WorkItemTypeLabel } from './WorkItemHierarchyNode';
 
 export interface WorkItemsTabProps {
     workspaceId: string;
@@ -38,12 +41,14 @@ export function WorkItemsTab({ workspaceId, onNavigateToTasksTab }: WorkItemsTab
     const [commitFilesLoading, setCommitFilesLoading] = useState(false);
     const [hunkTarget, setHunkTarget] = useState<'first' | 'last' | undefined>(undefined);
     const [showCreateDialog, setShowCreateDialog] = useState(false);
-    const [createDialogType, setCreateDialogType] = useState<'work-item' | 'bug'>('work-item');
+    const [createDialogType, setCreateDialogType] = useState<WorkItemTypeLabel>('work-item');
+    const [createDialogParentId, setCreateDialogParentId] = useState<string | undefined>(undefined);
     const [mobileShowDetail, setMobileShowDetail] = useState(false);
     const { isMobile, isTablet } = useBreakpoint();
     const { dispatch } = useWorkItems();
     const { state: appState } = useApp();
     const deepLinkConsumedRef = useRef(false);
+    const hierarchyEnabled = isWorkItemsHierarchyEnabled();
     const { width: leftPanelWidth, isDragging, handleMouseDown, handleTouchStart } = useResizablePanel({
         initialWidth: isTablet ? 280 : 340,
         minWidth: 200,
@@ -208,12 +213,21 @@ export function WorkItemsTab({ workspaceId, onNavigateToTasksTab }: WorkItemsTab
         dispatch({ type: 'SET_LOADING', repoId: workspaceId, loading: true });
     }, [dispatch, workspaceId]);
 
-    const openCreateDialog = useCallback((type: 'work-item' | 'bug') => {
+    const openCreateDialog = useCallback((type: WorkItemTypeLabel, parentId?: string) => {
         setCreateDialogType(type);
+        setCreateDialogParentId(parentId);
         setShowCreateDialog(true);
     }, []);
 
-    const listPane = (
+    const listPane = hierarchyEnabled ? (
+        <WorkItemHierarchyTree
+            workspaceId={workspaceId}
+            selectedWorkItemId={selectedWorkItemId}
+            onSelectWorkItem={handleSelectWorkItem}
+            onCreated={handleCreated}
+            onCreateItem={openCreateDialog}
+        />
+    ) : (
         <div className="p-4 flex flex-col gap-3 overflow-y-auto flex-1">
             <div className="flex items-center justify-between">
                 <h2 className="text-sm font-medium">Work Items</h2>
@@ -358,6 +372,7 @@ export function WorkItemsTab({ workspaceId, onNavigateToTasksTab }: WorkItemsTab
                     workspaceId={workspaceId}
                     onCreated={handleCreated}
                     itemType={createDialogType}
+                    parentId={createDialogParentId}
                 />
             </>
         );
@@ -389,6 +404,7 @@ export function WorkItemsTab({ workspaceId, onNavigateToTasksTab }: WorkItemsTab
                 workspaceId={workspaceId}
                 onCreated={handleCreated}
                 itemType={createDialogType}
+                parentId={createDialogParentId}
             />
         </>
     );

--- a/packages/coc/src/server/spa/client/react/utils/config.ts
+++ b/packages/coc/src/server/spa/client/react/utils/config.ts
@@ -34,6 +34,8 @@ interface DashboardConfig {
     codexEnabled?: boolean;
     /** Active AI provider ('copilot' | 'codex'). */
     activeProvider?: 'copilot' | 'codex';
+    /** Whether the Work Items hierarchy board is enabled (feature flag). */
+    workItemsHierarchyEnabled?: boolean;
 }
 
 /** Cached runtime config loaded from the API. */
@@ -94,6 +96,7 @@ async function _doLoadRuntimeConfig(): Promise<void> {
             containerDefaultAgentEnabled: data.features.containerDefaultAgentEnabled,
             codexEnabled: data.features.codexEnabled,
             activeProvider: data.features.activeProvider,
+            workItemsHierarchyEnabled: data.features.workItemsHierarchyEnabled,
             hostname: data.hostname ?? bootstrap.hostname,
             bindAddress: data.bindAddress ?? bootstrap.bindAddress,
         };
@@ -224,6 +227,11 @@ export function isContainerDefaultAgentEnabled(): boolean {
 /** Returns true when the Codex SDK provider feature flag is enabled. */
 export function isCodexEnabled(): boolean {
     return getConfig().codexEnabled === true;
+}
+
+/** Returns true when the Work Items hierarchy board feature flag is enabled. */
+export function isWorkItemsHierarchyEnabled(): boolean {
+    return getConfig().workItemsHierarchyEnabled === true;
 }
 
 /** Returns the currently configured active AI provider ('copilot' by default). */

--- a/packages/coc/src/server/work-items/types.ts
+++ b/packages/coc/src/server/work-items/types.ts
@@ -34,11 +34,52 @@ export type WorkItemSource = 'manual' | 'chat' | 'schedule';
 /** Priority levels for work items. */
 export type WorkItemPriority = 'high' | 'normal' | 'low';
 
-/** Work item type — distinguishes bugs from regular work items. */
-export type WorkItemType = 'work-item' | 'bug';
+/**
+ * Work item type.
+ * - `work-item`, `bug`: leaf types that can be planned and executed.
+ * - `epic`, `feature`, `pbi`: hierarchy container types (planning only).
+ */
+export type WorkItemType = 'work-item' | 'bug' | 'epic' | 'feature' | 'pbi';
 
 /** All valid work item types (useful for validation). */
-export const WORK_ITEM_TYPES: readonly WorkItemType[] = Object.freeze(['work-item', 'bug']);
+export const WORK_ITEM_TYPES: readonly WorkItemType[] = Object.freeze([
+    'work-item', 'bug', 'epic', 'feature', 'pbi',
+]);
+
+/** Container types — hierarchy planning containers, not directly executable. */
+export const HIERARCHY_CONTAINER_TYPES: ReadonlySet<WorkItemType> = new Set<WorkItemType>([
+    'epic', 'feature', 'pbi',
+]);
+
+/** Leaf types — executable items that support plan/execution flows. */
+export const LEAF_WORK_ITEM_TYPES: ReadonlySet<WorkItemType> = new Set<WorkItemType>([
+    'work-item', 'bug',
+]);
+
+/**
+ * Allowed parent types for each work item type.
+ * An empty array means the type cannot have a parent (top-level only).
+ * Any item may be temporarily unparented (parentId absent) regardless of type.
+ */
+export const ALLOWED_PARENT_TYPES: Record<WorkItemType, readonly WorkItemType[]> = {
+    epic:        [],
+    feature:     ['epic'],
+    pbi:         ['feature'],
+    'work-item': ['pbi'],
+    bug:         ['pbi'],
+};
+
+/**
+ * Allowed child types for each work item type.
+ * An empty array means the type cannot have children.
+ */
+export const ALLOWED_CHILD_TYPES: Record<WorkItemType, readonly WorkItemType[]> = {
+    epic:        ['feature'],
+    feature:     ['pbi'],
+    pbi:         ['work-item', 'bug'],
+    'work-item': [],
+    bug:         [],
+};
 
 // ============================================================================
 // Plan Types
@@ -167,8 +208,10 @@ export interface WorkItem {
     description: string;
     /** Current lifecycle status. */
     status: WorkItemStatus;
-    /** Work item type — 'work-item' (default) or 'bug'. */
+    /** Work item type — 'work-item' (default), 'bug', 'epic', 'feature', or 'pbi'. */
     type?: WorkItemType;
+    /** Parent work item ID (hierarchy). Only set when hierarchy is enabled. */
+    parentId?: string;
     /** ISO timestamp when the work item was created. */
     createdAt: string;
     /** ISO timestamp of last modification. */
@@ -248,6 +291,8 @@ export interface WorkItemIndexEntry {
     description?: string;
     status: WorkItemStatus;
     type?: WorkItemType;
+    /** Parent work item ID (hierarchy). Only set when hierarchy is enabled. */
+    parentId?: string;
     source: WorkItemSource;
     priority?: WorkItemPriority;
     planVersion?: number;
@@ -312,6 +357,8 @@ export interface WorkItemStore {
     listWorkItems(filter?: WorkItemFilter): Promise<WorkItemListResult>;
     /** List work items grouped by status with per-group pagination. */
     listWorkItemsGrouped(filter?: WorkItemFilter): Promise<WorkItemGroupedResult>;
+    /** List direct children of a work item within a repo. */
+    listChildren(parentId: string, repoId: string): Promise<WorkItemIndexEntry[]>;
 
     // Plan versioning
     getPlanVersions(workItemId: string): Promise<WorkItemPlanVersion[]>;
@@ -385,6 +432,7 @@ export function toIndexEntry(item: WorkItem): WorkItemIndexEntry {
         description: item.description || undefined,
         status: item.status,
         type: item.type,
+        parentId: item.parentId,
         source: item.source,
         priority: item.priority,
         planVersion: item.plan?.version,
@@ -396,4 +444,36 @@ export function toIndexEntry(item: WorkItem): WorkItemIndexEntry {
         lastRunAt: getLastRunTime(item.executionHistory),
         tags: item.tags,
     };
+}
+
+// ============================================================================
+// Hierarchy Helpers
+// ============================================================================
+
+/**
+ * Returns the effective type for an item, defaulting to 'work-item' for
+ * existing data that pre-dates the type field.
+ */
+export function getEffectiveType(type?: WorkItemType): WorkItemType {
+    return type ?? 'work-item';
+}
+
+/** Returns true if the type is a hierarchy container (epic, feature, pbi). */
+export function isContainerType(type: WorkItemType): boolean {
+    return HIERARCHY_CONTAINER_TYPES.has(type);
+}
+
+/** Returns true if the type is an executable leaf (work-item, bug). */
+export function isLeafType(type: WorkItemType): boolean {
+    return LEAF_WORK_ITEM_TYPES.has(type);
+}
+
+/**
+ * Returns true if `parentType` is a valid parent for `childType`.
+ * Note: being unparented (no parentId) is always valid; this function
+ * only validates when a parentId is present.
+ */
+export function isValidParentChildTypes(childType: WorkItemType, parentType: WorkItemType): boolean {
+    const allowed = ALLOWED_PARENT_TYPES[childType] as readonly WorkItemType[];
+    return allowed.includes(parentType);
 }

--- a/packages/coc/src/server/work-items/work-item-store.ts
+++ b/packages/coc/src/server/work-items/work-item-store.ts
@@ -308,6 +308,17 @@ export class FileWorkItemStore implements WorkItemStore {
             const repoId = await this.findRepoForItem(id);
             if (!repoId) return;
 
+            const index = await this.readIndex(repoId);
+
+            // Block deletion if children exist
+            const childCount = index.filter(e => e.parentId === id).length;
+            if (childCount > 0) {
+                throw new Error(
+                    `Cannot delete work item: it has ${childCount} child item(s). ` +
+                    `Move, unlink, or delete children first.`,
+                );
+            }
+
             // Remove item file
             try {
                 await fs.unlink(this.itemPath(repoId, id));
@@ -319,7 +330,6 @@ export class FileWorkItemStore implements WorkItemStore {
             } catch { /* ignore */ }
 
             // Remove from index
-            const index = await this.readIndex(repoId);
             const filtered = index.filter(e => e.id !== id);
             await this.writeIndex(repoId, filtered);
 
@@ -539,6 +549,15 @@ export class FileWorkItemStore implements WorkItemStore {
         if (!repoId) return [];
         const item = await this.readItem(repoId, workItemId);
         return item?.changes ?? [];
+    }
+
+    /**
+     * List all index entries whose parentId matches the given id.
+     * Used by hierarchy routes to enumerate direct children.
+     */
+    async listChildren(parentId: string, repoId: string): Promise<WorkItemIndexEntry[]> {
+        const index = await this.readIndex(repoId);
+        return index.filter(e => e.parentId === parentId);
     }
 
     // ── Internal helpers ────────────────────────────────────────

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -825,6 +825,9 @@ timeout: 300
                 '    enabled: true',
                 '    timeoutMs: 30000',
                 '    model: gpt-normalize',
+                'workItems:',
+                '  hierarchy:',
+                '    enabled: true',
             ].join('\n'));
             const result = getResolvedConfigWithSource(configPath);
 
@@ -1062,6 +1065,11 @@ timeout: 300
                   "vimNavigation": {
                     "enabled": true,
                   },
+                  "workItems": {
+                    "hierarchy": {
+                      "enabled": false,
+                    },
+                  },
                   "workflows": {
                     "enabled": true,
                   },
@@ -1112,6 +1120,7 @@ timeout: 300
                   "timeout": "file",
                   "toolCompactness": "file",
                   "vimNavigation.enabled": "file",
+                  "workItems.hierarchy.enabled": "default",
                   "workflows.enabled": "file",
                 },
               }

--- a/packages/coc/test/server/config/runtime-config-handler.test.ts
+++ b/packages/coc/test/server/config/runtime-config-handler.test.ts
@@ -85,6 +85,18 @@ describe('buildRuntimeDashboardConfig', () => {
         expect(result.features.ralphEnabled).toBe(true);
     });
 
+    it('defaults workItemsHierarchyEnabled to false', () => {
+        const svc = createMockRuntimeConfigService();
+        const result = buildRuntimeDashboardConfig(svc, 'my-host', '127.0.0.1');
+        expect(result.features.workItemsHierarchyEnabled).toBe(false);
+    });
+
+    it('reflects workItems.hierarchy.enabled = true from config', () => {
+        const svc = createMockRuntimeConfigService({ workItems: { hierarchy: { enabled: true } } } as any);
+        const result = buildRuntimeDashboardConfig(svc, 'my-host', '127.0.0.1');
+        expect(result.features.workItemsHierarchyEnabled).toBe(true);
+    });
+
     it('uses serve.serverName for hostname when set', () => {
         const svc = createMockRuntimeConfigService({ serve: { serverName: 'custom-name' } } as any);
         const result = buildRuntimeDashboardConfig(svc, 'raw-hostname.local', '127.0.0.1');
@@ -106,6 +118,41 @@ describe('buildRuntimeDashboardConfig', () => {
         expect(json).not.toContain('test-model');
     });
 });
+
+describe('AC-01: workItems.hierarchy.enabled live enablement end-to-end', () => {
+    it('workItems.hierarchy.enabled update through service is reflected in runtime dashboard config', async () => {
+        const fs = await import('fs');
+        const path = await import('path');
+        const os = await import('os');
+        const { RuntimeConfigService } = await import('../../../src/config/runtime-config-service');
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-ac01-'));
+        try {
+            const configPath = path.join(tmpDir, 'config.yaml');
+            const svc = new RuntimeConfigService({ configPath });
+
+            // Initial state: hierarchy disabled by default
+            const before = buildRuntimeDashboardConfig(svc, 'test-host', '127.0.0.1');
+            expect(before.features.workItemsHierarchyEnabled).toBe(false);
+
+            // Admin update enables hierarchy
+            const updateResult = await svc.updateConfig({ 'workItems.hierarchy.enabled': true });
+            expect(updateResult.config.workItems.hierarchy.enabled).toBe(true);
+
+            // Runtime dashboard config now reflects hierarchy enabled
+            const after = buildRuntimeDashboardConfig(svc, 'test-host', '127.0.0.1');
+            expect(after.features.workItemsHierarchyEnabled).toBe(true);
+
+            // Verify the effect classifies the field as live
+            const effect = updateResult.effects.find((e: { field: string }) => e.field === 'workItems.hierarchy.enabled');
+            expect(effect).toBeDefined();
+            expect(effect!.runtime).toBe('live');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});
+
 
 describe('AC-05: ralph.enabled live enablement end-to-end', () => {
     it('ralph.enabled update through service is reflected in runtime dashboard config', async () => {

--- a/packages/coc/test/server/work-items/types.test.ts
+++ b/packages/coc/test/server/work-items/types.test.ts
@@ -3,14 +3,24 @@ import {
     WORK_ITEM_STATUSES,
     TERMINAL_WORK_ITEM_STATUSES,
     VALID_TRANSITIONS,
+    WORK_ITEM_TYPES,
+    HIERARCHY_CONTAINER_TYPES,
+    LEAF_WORK_ITEM_TYPES,
+    ALLOWED_PARENT_TYPES,
+    ALLOWED_CHILD_TYPES,
     isTerminalStatus,
     isValidTransition,
     toIndexEntry,
     getLastRunTime,
+    getEffectiveType,
+    isContainerType,
+    isLeafType,
+    isValidParentChildTypes,
 } from '../../../src/server/work-items/types';
 import type {
     WorkItem,
     WorkItemStatus,
+    WorkItemType,
     WorkItemIndexEntry,
     WorkItemExecution,
 } from '../../../src/server/work-items/types';
@@ -178,7 +188,7 @@ describe('Work Item Types', () => {
 
             const entry = toIndexEntry(item);
 
-            expect(entry).toEqual<WorkItemIndexEntry>({
+            expect(entry).toMatchObject<Partial<WorkItemIndexEntry>>({
                 id: 'wi-001',
                 repoId: 'repo-1',
                 title: 'Test work item',
@@ -189,10 +199,22 @@ describe('Work Item Types', () => {
                 planVersion: 3,
                 createdAt: '2026-01-01T00:00:00.000Z',
                 updatedAt: '2026-01-01T00:00:00.000Z',
-                completedAt: undefined,
-                lastRunAt: undefined,
                 tags: ['backend', 'auth'],
             });
+            expect(entry.completedAt).toBeUndefined();
+            expect(entry.lastRunAt).toBeUndefined();
+        });
+
+        it('includes parentId when set', () => {
+            const item = makeWorkItem({ parentId: 'epic-parent' });
+            const entry = toIndexEntry(item);
+            expect(entry.parentId).toBe('epic-parent');
+        });
+
+        it('omits parentId when not set', () => {
+            const item = makeWorkItem();
+            const entry = toIndexEntry(item);
+            expect(entry.parentId).toBeUndefined();
         });
 
         it('handles work item without optional fields', () => {
@@ -273,6 +295,130 @@ describe('Work Item Types', () => {
                 { taskId: 't-2', startedAt: '2026-03-01T00:00:00.000Z', status: 'running' },
             ];
             expect(getLastRunTime(history)).toBe('2026-06-01T00:00:00.000Z');
+        });
+    });
+
+    describe('Hierarchy type constants', () => {
+        it('WORK_ITEM_TYPES includes all five types', () => {
+            expect(WORK_ITEM_TYPES).toContain('work-item');
+            expect(WORK_ITEM_TYPES).toContain('bug');
+            expect(WORK_ITEM_TYPES).toContain('epic');
+            expect(WORK_ITEM_TYPES).toContain('feature');
+            expect(WORK_ITEM_TYPES).toContain('pbi');
+        });
+
+        it('HIERARCHY_CONTAINER_TYPES contains epic, feature, pbi', () => {
+            expect(HIERARCHY_CONTAINER_TYPES.has('epic')).toBe(true);
+            expect(HIERARCHY_CONTAINER_TYPES.has('feature')).toBe(true);
+            expect(HIERARCHY_CONTAINER_TYPES.has('pbi')).toBe(true);
+            expect(HIERARCHY_CONTAINER_TYPES.has('work-item')).toBe(false);
+            expect(HIERARCHY_CONTAINER_TYPES.has('bug')).toBe(false);
+        });
+
+        it('LEAF_WORK_ITEM_TYPES contains work-item and bug', () => {
+            expect(LEAF_WORK_ITEM_TYPES.has('work-item')).toBe(true);
+            expect(LEAF_WORK_ITEM_TYPES.has('bug')).toBe(true);
+            expect(LEAF_WORK_ITEM_TYPES.has('epic')).toBe(false);
+            expect(LEAF_WORK_ITEM_TYPES.has('feature')).toBe(false);
+            expect(LEAF_WORK_ITEM_TYPES.has('pbi')).toBe(false);
+        });
+
+        it('ALLOWED_PARENT_TYPES defines correct hierarchy', () => {
+            expect(ALLOWED_PARENT_TYPES.epic).toEqual([]);
+            expect(ALLOWED_PARENT_TYPES.feature).toEqual(['epic']);
+            expect(ALLOWED_PARENT_TYPES.pbi).toEqual(['feature']);
+            expect(ALLOWED_PARENT_TYPES['work-item']).toEqual(['pbi']);
+            expect(ALLOWED_PARENT_TYPES.bug).toEqual(['pbi']);
+        });
+
+        it('ALLOWED_CHILD_TYPES defines correct hierarchy', () => {
+            expect(ALLOWED_CHILD_TYPES.epic).toEqual(['feature']);
+            expect(ALLOWED_CHILD_TYPES.feature).toEqual(['pbi']);
+            expect(ALLOWED_CHILD_TYPES.pbi).toContain('work-item');
+            expect(ALLOWED_CHILD_TYPES.pbi).toContain('bug');
+            expect(ALLOWED_CHILD_TYPES['work-item']).toEqual([]);
+            expect(ALLOWED_CHILD_TYPES.bug).toEqual([]);
+        });
+    });
+
+    describe('getEffectiveType', () => {
+        it('returns work-item for undefined (existing data compat)', () => {
+            expect(getEffectiveType(undefined)).toBe('work-item');
+        });
+
+        it('returns the type when provided', () => {
+            const types: WorkItemType[] = ['work-item', 'bug', 'epic', 'feature', 'pbi'];
+            for (const t of types) {
+                expect(getEffectiveType(t)).toBe(t);
+            }
+        });
+    });
+
+    describe('isContainerType', () => {
+        it('returns true for container types', () => {
+            expect(isContainerType('epic')).toBe(true);
+            expect(isContainerType('feature')).toBe(true);
+            expect(isContainerType('pbi')).toBe(true);
+        });
+
+        it('returns false for leaf types', () => {
+            expect(isContainerType('work-item')).toBe(false);
+            expect(isContainerType('bug')).toBe(false);
+        });
+    });
+
+    describe('isLeafType', () => {
+        it('returns true for leaf types', () => {
+            expect(isLeafType('work-item')).toBe(true);
+            expect(isLeafType('bug')).toBe(true);
+        });
+
+        it('returns false for container types', () => {
+            expect(isLeafType('epic')).toBe(false);
+            expect(isLeafType('feature')).toBe(false);
+            expect(isLeafType('pbi')).toBe(false);
+        });
+    });
+
+    describe('isValidParentChildTypes', () => {
+        it('allows feature under epic', () => {
+            expect(isValidParentChildTypes('feature', 'epic')).toBe(true);
+        });
+
+        it('allows pbi under feature', () => {
+            expect(isValidParentChildTypes('pbi', 'feature')).toBe(true);
+        });
+
+        it('allows work-item under pbi', () => {
+            expect(isValidParentChildTypes('work-item', 'pbi')).toBe(true);
+        });
+
+        it('allows bug under pbi', () => {
+            expect(isValidParentChildTypes('bug', 'pbi')).toBe(true);
+        });
+
+        it('rejects skipped levels (work-item under epic)', () => {
+            expect(isValidParentChildTypes('work-item', 'epic')).toBe(false);
+        });
+
+        it('rejects skipped levels (bug under feature)', () => {
+            expect(isValidParentChildTypes('bug', 'feature')).toBe(false);
+        });
+
+        it('rejects pbi under epic (skip feature)', () => {
+            expect(isValidParentChildTypes('pbi', 'epic')).toBe(false);
+        });
+
+        it('rejects epic having any parent', () => {
+            const types: WorkItemType[] = ['work-item', 'bug', 'epic', 'feature', 'pbi'];
+            for (const t of types) {
+                expect(isValidParentChildTypes('epic', t)).toBe(false);
+            }
+        });
+
+        it('rejects leaf items as parents', () => {
+            expect(isValidParentChildTypes('work-item', 'bug')).toBe(false);
+            expect(isValidParentChildTypes('bug', 'work-item')).toBe(false);
         });
     });
 });

--- a/packages/coc/test/server/work-items/work-item-execution-routes.test.ts
+++ b/packages/coc/test/server/work-items/work-item-execution-routes.test.ts
@@ -127,6 +127,45 @@ describe('Work Item Execution Routes', () => {
             const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items/nonexistent/execute`, {});
             expect(res.status).toBe(404);
         });
+
+        it('rejects execution of epic (container type)', async () => {
+            const epicId = `epic-test-${Date.now()}`;
+            await store.addWorkItem({
+                id: epicId, repoId: REPO_ID, title: 'My epic', type: 'epic',
+                description: '', status: 'readyToExecute', source: 'manual',
+                createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+            });
+
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items/${epicId}/execute`, {});
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('planning container');
+        });
+
+        it('rejects execution of feature (container type)', async () => {
+            const featureId = `feature-test-${Date.now()}`;
+            await store.addWorkItem({
+                id: featureId, repoId: REPO_ID, title: 'My feature', type: 'feature',
+                description: '', status: 'readyToExecute', source: 'manual',
+                createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+            });
+
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items/${featureId}/execute`, {});
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('planning container');
+        });
+
+        it('rejects execution of pbi (container type)', async () => {
+            const pbiId = `pbi-test-${Date.now()}`;
+            await store.addWorkItem({
+                id: pbiId, repoId: REPO_ID, title: 'My pbi', type: 'pbi',
+                description: '', status: 'readyToExecute', source: 'manual',
+                createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+            });
+
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items/${pbiId}/execute`, {});
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('planning container');
+        });
     });
 
     describe('POST /execute with skillNames', () => {
@@ -417,6 +456,23 @@ describe('Work Item Execution Routes', () => {
                 type: 'plan',
             });
             expect(res.status).toBe(404);
+        });
+
+        it('rejects resolve-comments on container types (epic, feature, pbi)', async () => {
+            for (const containerType of ['epic', 'feature', 'pbi'] as const) {
+                const itemId = `${containerType}-resolve-test-${Date.now()}`;
+                await store.addWorkItem({
+                    id: itemId, repoId: REPO_ID, title: `Container ${containerType}`, type: containerType,
+                    description: '', status: 'created', source: 'manual',
+                    createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+                });
+
+                const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items/${itemId}/resolve-comments`, {
+                    type: 'plan',
+                });
+                expect(res.status).toBe(400);
+                expect(res.body.error).toContain('planning container');
+            }
         });
 
         it('rejects missing type field', async () => {

--- a/packages/coc/test/server/work-items/work-item-hierarchy-routes.test.ts
+++ b/packages/coc/test/server/work-items/work-item-hierarchy-routes.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Work Item Hierarchy Routes Tests
+ *
+ * Tests for:
+ * - GET /api/workspaces/:id/work-items/tree (disabled response when flag is off)
+ * - GET /api/workspaces/:id/work-items/tree (tree structure + rollup when enabled)
+ * - POST /api/workspaces/:id/work-items with hierarchy types when enabled
+ * - POST /api/workspaces/:id/work-items rejecting hierarchy types when disabled
+ * - PATCH /api/workspaces/:id/work-items/:id with parentId when enabled
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as http from 'http';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { Route } from '../../../src/server/types';
+import { createRouter } from '../../../src/server/shared/router';
+import { registerWorkItemHierarchyRoutes } from '../../../src/server/routes/work-item-hierarchy-routes';
+import { registerWorkItemRoutes } from '../../../src/server/routes/work-item-routes';
+import { FileWorkItemStore } from '../../../src/server/work-items/work-item-store';
+
+const REPO_ID = 'hierarchy-test-repo';
+
+let tmpDir: string;
+let store: FileWorkItemStore;
+let hierarchyEnabled = false;
+
+function makeServer(): http.Server {
+    const routes: Route[] = [];
+    const getHierarchyEnabled = () => hierarchyEnabled;
+    // Hierarchy tree route must be registered first
+    registerWorkItemHierarchyRoutes({ routes, workItemStore: store, getHierarchyEnabled });
+    registerWorkItemRoutes({
+        routes,
+        workItemStore: store,
+        processStore: { getWorkspaces: async () => [] } as any,
+        getHierarchyEnabled,
+    });
+    const handler = createRouter({ routes, spaHtml: '' });
+    return http.createServer(handler);
+}
+
+let server: http.Server;
+let baseUrl: string;
+
+async function startServer(): Promise<void> {
+    return new Promise((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const addr = server.address() as any;
+            baseUrl = `http://127.0.0.1:${addr.port}`;
+            resolve();
+        });
+    });
+}
+
+async function stopServer(): Promise<void> {
+    return new Promise(resolve => server.close(() => resolve()));
+}
+
+async function request(
+    method: string,
+    urlPath: string,
+    body?: unknown,
+): Promise<{ status: number; body: any }> {
+    return new Promise((resolve, reject) => {
+        const urlObj = new URL(urlPath, baseUrl);
+        const opts: http.RequestOptions = {
+            hostname: urlObj.hostname,
+            port: urlObj.port,
+            path: urlObj.pathname + urlObj.search,
+            method,
+            headers: body ? { 'Content-Type': 'application/json' } : {},
+        };
+        const req = http.request(opts, (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (c: Buffer) => chunks.push(c));
+            res.on('end', () => {
+                const raw = Buffer.concat(chunks).toString('utf-8');
+                let parsed: any = null;
+                try { parsed = JSON.parse(raw); } catch { parsed = raw; }
+                resolve({ status: res.statusCode!, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        if (body) req.write(JSON.stringify(body));
+        req.end();
+    });
+}
+
+beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'coc-wi-hier-'));
+    store = new FileWorkItemStore({ dataDir: tmpDir });
+    hierarchyEnabled = false;
+    server = makeServer();
+    await startServer();
+});
+
+afterEach(async () => {
+    await stopServer();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('Work Item Hierarchy Routes', () => {
+    describe('GET /tree — when hierarchy flag is disabled', () => {
+        it('returns disabled:true with empty roots', async () => {
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.status).toBe(200);
+            expect(res.body.disabled).toBe(true);
+            expect(res.body.roots).toEqual([]);
+            expect(res.body.total).toBe(0);
+        });
+    });
+
+    describe('GET /tree — when hierarchy flag is enabled', () => {
+        beforeEach(() => { hierarchyEnabled = true; });
+
+        it('returns empty tree for a workspace with no items', async () => {
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.status).toBe(200);
+            expect(res.body.disabled).toBeUndefined();
+            expect(res.body.roots).toEqual([]);
+            expect(res.body.total).toBe(0);
+        });
+
+        it('returns unparented items as roots', async () => {
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Standalone task',
+                type: 'work-item',
+            });
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.status).toBe(200);
+            expect(res.body.roots).toHaveLength(1);
+            expect(res.body.roots[0].item.title).toBe('Standalone task');
+            expect(res.body.roots[0].children).toEqual([]);
+        });
+
+        it('builds a nested tree: epic → feature → pbi → work-item', async () => {
+            const epicRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My Epic',
+                type: 'epic',
+            });
+            const epicId = epicRes.body.id;
+
+            const featRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My Feature',
+                type: 'feature',
+                parentId: epicId,
+            });
+            const featId = featRes.body.id;
+
+            const pbiRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My PBI',
+                type: 'pbi',
+                parentId: featId,
+            });
+            const pbiId = pbiRes.body.id;
+
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My Task',
+                type: 'work-item',
+                parentId: pbiId,
+            });
+
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.status).toBe(200);
+            expect(res.body.roots).toHaveLength(1);
+
+            const epic = res.body.roots[0];
+            expect(epic.item.type).toBe('epic');
+            expect(epic.item.title).toBe('My Epic');
+            expect(epic.children).toHaveLength(1);
+
+            const feat = epic.children[0];
+            expect(feat.item.type).toBe('feature');
+            expect(feat.children).toHaveLength(1);
+
+            const pbi = feat.children[0];
+            expect(pbi.item.type).toBe('pbi');
+            expect(pbi.children).toHaveLength(1);
+
+            const task = pbi.children[0];
+            expect(task.item.type).toBe('work-item');
+            expect(task.children).toEqual([]);
+        });
+
+        it('computes correct rollup counts', async () => {
+            const epicRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Epic',
+                type: 'epic',
+            });
+            const epicId = epicRes.body.id;
+
+            const featRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Feature',
+                type: 'feature',
+                parentId: epicId,
+            });
+            const featId = featRes.body.id;
+
+            const pbiRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'PBI',
+                type: 'pbi',
+                parentId: featId,
+            });
+            const pbiId = pbiRes.body.id;
+
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Task',
+                type: 'work-item',
+                parentId: pbiId,
+            });
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Bug',
+                type: 'bug',
+                parentId: pbiId,
+            });
+
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            const epic = res.body.roots[0];
+
+            // Epic rollup should count all 4 descendants (feature, pbi, work-item, bug)
+            expect(epic.rollup.descendantCount).toBe(4);
+            expect(epic.rollup.byType.feature).toBe(1);
+            expect(epic.rollup.byType.pbi).toBe(1);
+            expect(epic.rollup.byType['work-item']).toBe(1);
+            expect(epic.rollup.byType.bug).toBe(1);
+            // All in created status
+            expect(epic.rollup.byStatus.created).toBe(4);
+        });
+
+        it('excludes archived items when includeArchived is false (default)', async () => {
+            const itemRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Archived item',
+                type: 'work-item',
+            });
+            await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/${itemRes.body.id}/archive`, {
+                archived: true,
+            });
+
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.status).toBe(200);
+            expect(res.body.roots).toHaveLength(0);
+            expect(res.body.total).toBe(0);
+        });
+
+        it('includes archived items when includeArchived=true', async () => {
+            const itemRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Archived item',
+                type: 'work-item',
+            });
+            await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/${itemRes.body.id}/archive`, {
+                archived: true,
+            });
+
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree?includeArchived=true`);
+            expect(res.status).toBe(200);
+            expect(res.body.roots).toHaveLength(1);
+        });
+
+        it('preserves ancestors when search matches a descendant', async () => {
+            const epicRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My Epic',
+                type: 'epic',
+            });
+            const epicId = epicRes.body.id;
+
+            const featRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My Feature',
+                type: 'feature',
+                parentId: epicId,
+            });
+            const featId = featRes.body.id;
+
+            const pbiRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'My PBI',
+                type: 'pbi',
+                parentId: featId,
+            });
+            const pbiId = pbiRes.body.id;
+
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Special task',
+                type: 'work-item',
+                parentId: pbiId,
+            });
+
+            // Search for "Special" — should include epic, feature, pbi as ancestors
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree?q=Special`);
+            expect(res.status).toBe(200);
+            expect(res.body.roots).toHaveLength(1);
+            expect(res.body.roots[0].item.title).toBe('My Epic');
+            expect(res.body.roots[0].children).toHaveLength(1);
+            expect(res.body.roots[0].children[0].children).toHaveLength(1);
+            expect(res.body.roots[0].children[0].children[0].children).toHaveLength(1);
+        });
+
+        it('returns total count as number of filtered entries', async () => {
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, { title: 'A', type: 'epic' });
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, { title: 'B', type: 'work-item' });
+
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.body.total).toBe(2);
+        });
+    });
+
+    describe('POST /work-items — hierarchy type validation', () => {
+        it('rejects epic/feature/pbi types when hierarchy is disabled', async () => {
+            for (const type of ['epic', 'feature', 'pbi']) {
+                const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                    title: `Create ${type}`,
+                    type,
+                });
+                expect(res.status).toBe(400);
+                expect(res.body.error).toContain('hierarchy');
+            }
+        });
+
+        it('rejects parentId when hierarchy is disabled', async () => {
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Child item',
+                type: 'work-item',
+                parentId: 'some-parent-id',
+            });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('hierarchy');
+        });
+
+        it('allows epic/feature/pbi types when hierarchy is enabled', async () => {
+            hierarchyEnabled = true;
+            for (const type of ['epic', 'feature', 'pbi']) {
+                const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                    title: `Create ${type}`,
+                    type,
+                });
+                expect(res.status).toBe(201);
+                expect(res.body.type).toBe(type);
+            }
+        });
+
+        it('allows parentId when hierarchy is enabled and parent-child types are valid', async () => {
+            hierarchyEnabled = true;
+            const epicRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Epic',
+                type: 'epic',
+            });
+            expect(epicRes.status).toBe(201);
+
+            const featRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Feature',
+                type: 'feature',
+                parentId: epicRes.body.id,
+            });
+            expect(featRes.status).toBe(201);
+            expect(featRes.body.parentId).toBe(epicRes.body.id);
+        });
+
+        it('rejects invalid parent-child type combinations', async () => {
+            hierarchyEnabled = true;
+            const epicRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Epic',
+                type: 'epic',
+            });
+
+            // work-item cannot be a child of epic (must go through pbi first)
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Invalid child',
+                type: 'work-item',
+                parentId: epicRes.body.id,
+            });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('parent-child type');
+        });
+
+        it('rejects non-existent parent', async () => {
+            hierarchyEnabled = true;
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Orphan',
+                type: 'work-item',
+                parentId: 'non-existent-id',
+            });
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('PATCH /work-items/:id — parentId reparenting', () => {
+        it('rejects parentId patch when hierarchy is disabled', async () => {
+            const created = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Item',
+            });
+            const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/${created.body.id}`, {
+                parentId: 'some-id',
+            });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('hierarchy');
+        });
+
+        it('allows reparenting when hierarchy is enabled', async () => {
+            hierarchyEnabled = true;
+
+            const pbi1Res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'PBI 1',
+                type: 'pbi',
+            });
+            const pbi2Res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'PBI 2',
+                type: 'pbi',
+            });
+            const taskRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Task',
+                type: 'work-item',
+                parentId: pbi1Res.body.id,
+            });
+
+            // Reparent task to pbi2
+            const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/${taskRes.body.id}`, {
+                parentId: pbi2Res.body.id,
+            });
+            expect(res.status).toBe(200);
+            expect(res.body.parentId).toBe(pbi2Res.body.id);
+        });
+
+        it('allows unlinking parent by setting parentId to null', async () => {
+            hierarchyEnabled = true;
+
+            const pbiRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'PBI',
+                type: 'pbi',
+            });
+            const taskRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Task',
+                type: 'work-item',
+                parentId: pbiRes.body.id,
+            });
+
+            // Unlink parent
+            const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/${taskRes.body.id}`, {
+                parentId: null,
+            });
+            expect(res.status).toBe(200);
+            expect(res.body.parentId).toBeUndefined();
+
+            // Verify item appears as root in tree
+            const tree = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            // Both pbi and task are now unparented roots
+            expect(tree.body.roots).toHaveLength(2);
+        });
+
+        it('rejects self-parenting', async () => {
+            hierarchyEnabled = true;
+
+            const itemRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Item',
+                type: 'pbi',
+            });
+            const id = itemRes.body.id;
+
+            const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/${id}`, {
+                parentId: id,
+            });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toContain('own parent');
+        });
+    });
+});

--- a/packages/coc/test/server/work-items/work-item-hierarchy-routes.test.ts
+++ b/packages/coc/test/server/work-items/work-item-hierarchy-routes.test.ts
@@ -19,6 +19,7 @@ import { createRouter } from '../../../src/server/shared/router';
 import { registerWorkItemHierarchyRoutes } from '../../../src/server/routes/work-item-hierarchy-routes';
 import { registerWorkItemRoutes } from '../../../src/server/routes/work-item-routes';
 import { FileWorkItemStore } from '../../../src/server/work-items/work-item-store';
+import { WORK_ITEM_TYPES, WORK_ITEM_STATUSES } from '../../../src/server/work-items/types';
 
 const REPO_ID = 'hierarchy-test-repo';
 
@@ -302,6 +303,74 @@ describe('Work Item Hierarchy Routes', () => {
 
             const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
             expect(res.body.total).toBe(2);
+        });
+
+        it('rollup byType and byStatus contain every canonical key with correct counts', async () => {
+            // Create one item of each type under a common root epic so the epic's rollup
+            // captures all of them.  The epic itself is the root and is not included in its
+            // own rollup, so we only need the remaining four types.
+            const epicRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Root Epic',
+                type: 'epic',
+            });
+            const epicId = epicRes.body.id;
+
+            const featRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Feature',
+                type: 'feature',
+                parentId: epicId,
+            });
+            const featId = featRes.body.id;
+
+            const pbiRes = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'PBI',
+                type: 'pbi',
+                parentId: featId,
+            });
+            const pbiId = pbiRes.body.id;
+
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Task',
+                type: 'work-item',
+                parentId: pbiId,
+            });
+            await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Bug',
+                type: 'bug',
+                parentId: pbiId,
+            });
+
+            const res = await request('GET', `/api/workspaces/${REPO_ID}/work-items/tree`);
+            expect(res.status).toBe(200);
+            const epicRollup = res.body.roots[0].rollup;
+
+            // Every type key from the canonical array must be present (including 'epic' which counts 0)
+            for (const t of WORK_ITEM_TYPES) {
+                expect(epicRollup.byType).toHaveProperty(t);
+                expect(typeof epicRollup.byType[t]).toBe('number');
+            }
+
+            // Every status key from the canonical array must be present
+            for (const s of WORK_ITEM_STATUSES) {
+                expect(epicRollup.byStatus).toHaveProperty(s);
+                expect(typeof epicRollup.byStatus[s]).toBe('number');
+            }
+
+            // Spot-check expected counts
+            expect(epicRollup.byType.feature).toBe(1);
+            expect(epicRollup.byType.pbi).toBe(1);
+            expect(epicRollup.byType['work-item']).toBe(1);
+            expect(epicRollup.byType.bug).toBe(1);
+            // epic itself is the root — not counted in its own rollup
+            expect(epicRollup.byType.epic).toBe(0);
+            // all items start with status 'created'
+            expect(epicRollup.byStatus.created).toBe(4);
+            // all other statuses should be 0
+            for (const s of WORK_ITEM_STATUSES) {
+                if (s !== 'created') {
+                    expect(epicRollup.byStatus[s]).toBe(0);
+                }
+            }
         });
     });
 

--- a/packages/coc/test/server/work-items/work-item-routes.test.ts
+++ b/packages/coc/test/server/work-items/work-item-routes.test.ts
@@ -156,10 +156,19 @@ describe('Work Item Routes', () => {
             expect(res.body.priority).toBe('high');
         });
 
-        it('ignores invalid type values', async () => {
+        it('rejects hierarchy container types when hierarchy flag is disabled', async () => {
             const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
                 title: 'Invalid type',
                 type: 'epic',
+            });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('ignores genuinely unknown type values', async () => {
+            const res = await request('POST', `/api/workspaces/${REPO_ID}/work-items`, {
+                title: 'Unknown type',
+                type: 'unknown-type-xyz',
             });
 
             expect(res.status).toBe(201);

--- a/packages/coc/test/server/work-items/work-item-store.test.ts
+++ b/packages/coc/test/server/work-items/work-item-store.test.ts
@@ -130,6 +130,61 @@ describe('FileWorkItemStore', () => {
             const entries = await store.listWorkItems({ repoId: 'test-repo' });
             expect(entries.items.find(e => e.id === 'wi-rm2')).toBeUndefined();
         });
+
+        it('blocks deletion when children exist', async () => {
+            const parent = makeWorkItem({ id: 'wi-parent', type: 'pbi' });
+            const child = makeWorkItem({ id: 'wi-child', type: 'work-item', parentId: 'wi-parent' });
+            await store.addWorkItem(parent);
+            await store.addWorkItem(child);
+
+            await expect(store.removeWorkItem('wi-parent')).rejects.toThrow(
+                'Cannot delete work item: it has 1 child item(s)',
+            );
+            // Parent still exists
+            const retrieved = await store.getWorkItem('wi-parent', 'test-repo');
+            expect(retrieved).toBeDefined();
+        });
+
+        it('allows deletion of parent after children are removed', async () => {
+            const parent = makeWorkItem({ id: 'wi-par2', type: 'feature' });
+            const child = makeWorkItem({ id: 'wi-chi2', type: 'pbi', parentId: 'wi-par2' });
+            await store.addWorkItem(parent);
+            await store.addWorkItem(child);
+
+            // Remove child first
+            await store.removeWorkItem('wi-chi2');
+
+            // Now parent can be removed
+            const removed = await store.removeWorkItem('wi-par2');
+            expect(removed).toBe(true);
+        });
+    });
+
+    describe('listChildren', () => {
+        it('lists direct children of a parent item', async () => {
+            const epic = makeWorkItem({ id: 'epic-1', type: 'epic' });
+            const feat1 = makeWorkItem({ id: 'feat-1', type: 'feature', parentId: 'epic-1' });
+            const feat2 = makeWorkItem({ id: 'feat-2', type: 'feature', parentId: 'epic-1' });
+            const unrelated = makeWorkItem({ id: 'wi-unrelated' });
+
+            await store.addWorkItem(epic);
+            await store.addWorkItem(feat1);
+            await store.addWorkItem(feat2);
+            await store.addWorkItem(unrelated);
+
+            const children = await store.listChildren('epic-1', 'test-repo');
+            expect(children).toHaveLength(2);
+            expect(children.map(c => c.id)).toContain('feat-1');
+            expect(children.map(c => c.id)).toContain('feat-2');
+        });
+
+        it('returns empty array when parent has no children', async () => {
+            const item = makeWorkItem({ id: 'lone-item' });
+            await store.addWorkItem(item);
+
+            const children = await store.listChildren('lone-item', 'test-repo');
+            expect(children).toHaveLength(0);
+        });
     });
 
     describe('listWorkItems', () => {

--- a/packages/coc/test/server/work-items/work-item-type-constants-parity.test.ts
+++ b/packages/coc/test/server/work-items/work-item-type-constants-parity.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Parity test: verifies that the ALLOWED_PARENT_TYPES and ALLOWED_CHILD_TYPES
+ * exported by coc-client exactly match the authoritative definitions in the
+ * server-side types module. This guards against the two copies drifting apart
+ * when new work item types are added.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    ALLOWED_PARENT_TYPES as SERVER_ALLOWED_PARENT_TYPES,
+    ALLOWED_CHILD_TYPES as SERVER_ALLOWED_CHILD_TYPES,
+} from '../../../src/server/work-items/types';
+import {
+    ALLOWED_PARENT_TYPES,
+    ALLOWED_CHILD_TYPES,
+} from '@plusplusoneplusplus/coc-client';
+
+describe('work item type constants parity (coc-client vs server)', () => {
+    it('ALLOWED_PARENT_TYPES in coc-client matches the server definition', () => {
+        // Convert readonly arrays to plain arrays for deep equality comparison
+        const clientParent = Object.fromEntries(
+            Object.entries(ALLOWED_PARENT_TYPES).map(([k, v]) => [k, [...v]])
+        );
+        const serverParent = Object.fromEntries(
+            Object.entries(SERVER_ALLOWED_PARENT_TYPES).map(([k, v]) => [k, [...v]])
+        );
+        expect(clientParent).toEqual(serverParent);
+    });
+
+    it('ALLOWED_CHILD_TYPES in coc-client matches the server definition', () => {
+        const clientChild = Object.fromEntries(
+            Object.entries(ALLOWED_CHILD_TYPES).map(([k, v]) => [k, [...v]])
+        );
+        const serverChild = Object.fromEntries(
+            Object.entries(SERVER_ALLOWED_CHILD_TYPES).map(([k, v]) => [k, [...v]])
+        );
+        expect(clientChild).toEqual(serverChild);
+    });
+});

--- a/packages/coc/test/spa/react/repos/WorkItemDetail.inline-edit.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemDetail.inline-edit.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Layout/source-string tests for WorkItemDetail inline edit mode.
+ * These tests verify that the source file contains the expected patterns
+ * for the container work item inline edit feature (AC-01, AC-02, AC-03).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('WorkItemDetail inline edit', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = readFileSync(
+            resolve(__dirname, '../../../../src/server/spa/client/react/features/work-items/WorkItemDetail.tsx'),
+            'utf8'
+        );
+    });
+
+    describe('AC-01: Edit mode for container items', () => {
+        it('imports isWorkItemsHierarchyEnabled', () => {
+            expect(src).toContain('isWorkItemsHierarchyEnabled');
+        });
+
+        it('imports WorkItemParentPicker', () => {
+            expect(src).toContain('WorkItemParentPicker');
+        });
+
+        it('defines hierarchyEnabled constant', () => {
+            expect(src).toContain('hierarchyEnabled = isWorkItemsHierarchyEnabled()');
+        });
+
+        it('defines isEditing state', () => {
+            expect(src).toContain('isEditing');
+        });
+
+        it('renders Edit button only when isContainer and hierarchyEnabled', () => {
+            expect(src).toContain('isContainer && hierarchyEnabled');
+            expect(src).toContain("wi-edit-btn");
+        });
+
+        it('shows Save and Cancel buttons in edit mode', () => {
+            expect(src).toContain("wi-edit-save-btn");
+            expect(src).toContain("wi-edit-cancel-btn");
+        });
+
+        it('handleEditStart populates edit state from item', () => {
+            expect(src).toContain('handleEditStart');
+            expect(src).toContain('setEditTitle(item.title)');
+        });
+
+        it('handleEditCancel clears editing state', () => {
+            expect(src).toContain('handleEditCancel');
+            expect(src).toContain('setIsEditing(false)');
+        });
+
+        it('resets edit mode when workItemId changes', () => {
+            expect(src).toContain('setIsEditing(false)');
+            expect(src).toContain('[workItemId]');
+        });
+    });
+
+    describe('AC-02: Editable fields', () => {
+        it('has title input in edit mode', () => {
+            expect(src).toContain('wi-edit-title-input');
+        });
+
+        it('has description textarea in edit mode', () => {
+            expect(src).toContain('wi-edit-description-input');
+        });
+
+        it('has priority select with High, Normal, Low options', () => {
+            expect(src).toContain('wi-edit-priority-select');
+            expect(src).toContain('"high"');
+            expect(src).toContain('"normal"');
+            expect(src).toContain('"low"');
+        });
+
+        it('has tags input', () => {
+            expect(src).toContain('wi-edit-tags-input');
+        });
+
+        it('has parent edit section for non-epic containers', () => {
+            expect(src).toContain('work-item-parent-edit');
+            expect(src).toContain('wi-edit-parent-btn');
+        });
+
+        it('does not offer parent unlink in edit UI — no null parentId send', () => {
+            // The new edit UI should not set parentId to null
+            expect(src).not.toContain("parentId: null");
+        });
+
+        it('keeps type immutable — no type field in edit form', () => {
+            expect(src).not.toContain("updates.type");
+        });
+    });
+
+    describe('AC-03: Validation, save, and error handling', () => {
+        it('handleEditSave trims title and validates', () => {
+            expect(src).toContain('trimmedTitle = editTitle.trim()');
+            expect(src).toContain("Title is required");
+        });
+
+        it('normalizes tags to unique trimmed non-empty values', () => {
+            expect(src).toContain("split(',')");
+            expect(src).toContain('new Set(parsedTags)');
+        });
+
+        it('shows edit error display', () => {
+            expect(src).toContain('wi-edit-error');
+            expect(src).toContain('editError');
+        });
+
+        it('does not send status from editor', () => {
+            const handleSaveBlock = src.slice(
+                src.indexOf('handleEditSave = useCallback'),
+                src.indexOf('}, [editTitle')
+            );
+            expect(handleSaveBlock).not.toContain('status');
+        });
+
+        it('dispatches WORK_ITEM_UPDATED on success', () => {
+            expect(src).toContain("WORK_ITEM_UPDATED");
+        });
+
+        it('disables controls during save via saving state', () => {
+            expect(src).toContain('disabled={saving}');
+        });
+
+        it('uses existing PATCH endpoint via workItems.update', () => {
+            expect(src).toContain('workItems.update(workspaceId, workItemId');
+        });
+
+        it('shows WorkItemParentPicker with onlyPick for parent editing', () => {
+            expect(src).toContain('onlyPick={true}');
+            expect(src).toContain('showParentPicker');
+        });
+    });
+});

--- a/packages/coc/test/spa/react/repos/WorkItemHierarchy.layout.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemHierarchy.layout.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Layout tests for Work Item Hierarchy Board (AC-06).
+ *
+ * Verifies source-level structure guarantees for:
+ * - WorkItemHierarchyNode: type pills, labels, collapse toggle
+ * - WorkItemHierarchyTree: disabled mode, create actions, tree structure, parent picker integration
+ * - WorkItemDetail: container detection, leaf-only plan/execution sections
+ * - WorkItemsTab: conditional hierarchy tree vs classic list
+ * - WorkItemDetail: type-aware number prefix (E-/F-/PBI-/WI-/BUG-)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REACT_SRC = path.join(__dirname, '..', '..', '..', '..', 'src', 'server', 'spa', 'client', 'react');
+const WORK_ITEMS_DIR = path.join(REACT_SRC, 'features', 'work-items');
+
+const NODE_SRC_PATH = path.join(WORK_ITEMS_DIR, 'WorkItemHierarchyNode.tsx');
+const TREE_SRC_PATH = path.join(WORK_ITEMS_DIR, 'WorkItemHierarchyTree.tsx');
+const PICKER_SRC_PATH = path.join(WORK_ITEMS_DIR, 'WorkItemParentPicker.tsx');
+const DETAIL_SRC_PATH = path.join(WORK_ITEMS_DIR, 'WorkItemDetail.tsx');
+const TAB_SRC_PATH = path.join(WORK_ITEMS_DIR, 'WorkItemsTab.tsx');
+const CONFIG_SRC_PATH = path.join(REACT_SRC, 'utils', 'config.ts');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkItemHierarchyNode — type labels, pills, and collapse toggle
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkItemHierarchyNode — type system', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = fs.readFileSync(NODE_SRC_PATH, 'utf-8');
+    });
+
+    it('exports WorkItemTypeLabel type with all 5 hierarchy types', () => {
+        expect(src).toContain("'epic' | 'feature' | 'pbi' | 'work-item' | 'bug'");
+    });
+
+    it('exports TYPE_LABELS map with all 5 human-readable labels', () => {
+        expect(src).toContain("epic: 'Epic'");
+        expect(src).toContain("feature: 'Feature'");
+        expect(src).toContain("pbi: 'PBI'");
+        expect(src).toContain("'work-item': 'Work Item'");
+        expect(src).toContain("bug: 'Bug'");
+    });
+
+    it('uses distinct prefix characters for each type', () => {
+        expect(src).toContain("epic: 'E'");
+        expect(src).toContain("feature: 'F'");
+        expect(src).toContain("pbi: 'PBI'");
+        expect(src).toContain("'work-item': 'WI'");
+        expect(src).toContain("bug: 'BUG'");
+    });
+
+    it('has distinct CSS classes for each type pill', () => {
+        expect(src).toContain('bg-purple-100');   // epic
+        expect(src).toContain('bg-blue-100');      // feature
+        expect(src).toContain('bg-cyan-100');      // pbi
+        expect(src).toContain('bg-gray-100');      // work-item
+        expect(src).toContain('bg-red-100');       // bug
+    });
+
+    it('renders a collapse toggle button', () => {
+        expect(src).toContain('collapse');
+        expect(src).toContain('onClick');
+    });
+
+    it('renders rollup count summary', () => {
+        expect(src).toContain('rollup');
+        expect(src).toContain('descendantCount');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkItemHierarchyTree — tree structure and create actions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkItemHierarchyTree — structure', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = fs.readFileSync(TREE_SRC_PATH, 'utf-8');
+    });
+
+    it('imports WorkItemHierarchyNode', () => {
+        expect(src).toContain("from './WorkItemHierarchyNode'");
+    });
+
+    it('imports WorkItemParentPicker', () => {
+        expect(src).toContain("from './WorkItemParentPicker'");
+    });
+
+    it('fetches tree using coc-client workItems.tree()', () => {
+        expect(src).toContain('workItems.tree(');
+        expect(src).toContain('getSpaCocClient()');
+    });
+
+    it('has top-level Epic create action', () => {
+        expect(src).toContain("'epic'");
+        expect(src).toContain('onCreateItem');
+    });
+
+    it('has secondary unparented WorkItem and Bug actions', () => {
+        expect(src).toContain("'work-item'");
+        expect(src).toContain("'bug'");
+    });
+
+    it('persists collapse state in localStorage', () => {
+        expect(src).toContain('localStorage');
+        expect(src).toContain('coc-hierarchy-collapsed-');
+    });
+
+    it('uses ALLOWED_CHILD_TYPES for constrained child creation', () => {
+        expect(src).toContain('ALLOWED_CHILD_TYPES');
+    });
+
+    it('handles Unparented group for root-level non-epic items', () => {
+        expect(src).toContain('Unparented');
+    });
+
+    it('renders a search input for the hierarchy', () => {
+        expect(src).toContain('search');
+    });
+
+    it('renders loading and error states', () => {
+        expect(src).toContain('loading');
+        expect(src).toContain('error');
+    });
+
+    it('handles disabled response from tree endpoint', () => {
+        expect(src).toContain('disabled');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkItemParentPicker — dialog structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkItemParentPicker — structure', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = fs.readFileSync(PICKER_SRC_PATH, 'utf-8');
+    });
+
+    it('accepts itemType prop to determine valid parent types', () => {
+        expect(src).toContain('itemType');
+    });
+
+    it('filters candidates by valid parent types', () => {
+        expect(src).toContain('VALID_PARENT_TYPES');
+    });
+
+    it('has a cancel button to dismiss without selecting', () => {
+        expect(src).toContain('Cancel');
+        expect(src).toContain('onClose');
+    });
+
+    it('calls onSelect with the chosen parent id', () => {
+        expect(src).toContain('onParentChanged');
+    });
+
+    it('renders search input for filtering candidates', () => {
+        expect(src).toContain('search');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkItemDetail — container detection and leaf-only sections
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkItemDetail — container vs leaf', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = fs.readFileSync(DETAIL_SRC_PATH, 'utf-8');
+    });
+
+    it('detects container types (epic, feature, pbi) to set isContainer flag', () => {
+        expect(src).toContain('isContainer');
+        expect(src).toContain("'epic'");
+        expect(src).toContain("'feature'");
+        expect(src).toContain("'pbi'");
+    });
+
+    it('hides plan section for container items', () => {
+        const planSectionPos = src.indexOf('{/* Plan — leaf items only */}');
+        const containerGuardPos = src.indexOf('!isContainer', planSectionPos > 0 ? planSectionPos : 0);
+        // The plan section should be guarded by !isContainer nearby
+        expect(planSectionPos).toBeGreaterThan(-1);
+        expect(containerGuardPos).toBeGreaterThan(-1);
+    });
+
+    it('hides execution history for container items', () => {
+        const execHistPos = src.indexOf('{/* Execution history */}');
+        expect(execHistPos).toBeGreaterThan(-1);
+        // The !isContainer guard should appear within 50 chars after the comment
+        const nearbyGuard = src.indexOf('!isContainer', execHistPos);
+        expect(nearbyGuard).toBeGreaterThan(execHistPos);
+        expect(nearbyGuard - execHistPos).toBeLessThan(50);
+    });
+
+    it('hides Start Implementing / Execute button for container items', () => {
+        const execBtnPos = src.indexOf('data-testid="work-item-execute-btn"');
+        expect(execBtnPos).toBeGreaterThan(-1);
+        // Should be preceded by !isContainer guard
+        const guardPos = src.lastIndexOf('!isContainer', execBtnPos);
+        expect(guardPos).toBeGreaterThan(-1);
+    });
+
+    it('shows type-aware number prefix based on item type', () => {
+        // Type-specific prefix ternary chain in the header
+        expect(src).toContain("effectiveType === 'epic' ? 'E'");
+        expect(src).toContain("effectiveType === 'feature' ? 'F'");
+        expect(src).toContain("effectiveType === 'bug' ? 'BUG'");
+        expect(src).toContain("'WI'");
+    });
+
+    it('shows parent info row for items with a parentId', () => {
+        expect(src).toContain('parentId');
+        expect(src).toContain('Parent');
+    });
+
+    it('does not auto-execute containers (autoExecute hidden)', () => {
+        // The auto-execute toggle should be guarded by !isContainer
+        const autoExecutePos = src.indexOf('autoExecute');
+        const guardPos = src.lastIndexOf('!isContainer', autoExecutePos);
+        if (autoExecutePos > -1 && guardPos > -1) {
+            // Guard must come before the auto-execute reference
+            expect(guardPos).toBeLessThan(autoExecutePos);
+        }
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkItemsTab — conditional hierarchy tree vs classic list
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkItemsTab — hierarchy flag conditional', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = fs.readFileSync(TAB_SRC_PATH, 'utf-8');
+    });
+
+    it('imports WorkItemHierarchyTree', () => {
+        expect(src).toContain("from './WorkItemHierarchyTree'");
+    });
+
+    it('uses isWorkItemsHierarchyEnabled() to detect flag', () => {
+        expect(src).toContain('isWorkItemsHierarchyEnabled');
+    });
+
+    it('renders WorkItemHierarchyTree when hierarchy is enabled', () => {
+        expect(src).toContain('<WorkItemHierarchyTree');
+    });
+
+    it('still renders WorkItemSection when hierarchy is disabled', () => {
+        expect(src).toContain('<WorkItemSection');
+    });
+
+    it('WorkItemHierarchyTree appears before WorkItemSection in the conditional', () => {
+        const treePos = src.indexOf('<WorkItemHierarchyTree');
+        const sectionPos = src.indexOf('<WorkItemSection');
+        expect(treePos).toBeGreaterThan(-1);
+        expect(sectionPos).toBeGreaterThan(-1);
+        expect(treePos).toBeLessThan(sectionPos);
+    });
+
+    it('has createDialogParentId state for hierarchy child creation', () => {
+        expect(src).toContain('createDialogParentId');
+        expect(src).toContain('setCreateDialogParentId');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SPA config — feature flag plumbing
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SPA config — workItemsHierarchyEnabled', () => {
+    let src: string;
+
+    beforeAll(() => {
+        src = fs.readFileSync(CONFIG_SRC_PATH, 'utf-8');
+    });
+
+    it('includes workItemsHierarchyEnabled in DashboardConfig interface', () => {
+        expect(src).toContain('workItemsHierarchyEnabled');
+    });
+
+    it('exports isWorkItemsHierarchyEnabled() function', () => {
+        expect(src).toContain('isWorkItemsHierarchyEnabled');
+        expect(src).toContain('function isWorkItemsHierarchyEnabled');
+    });
+
+    it('default value is false (returns false when config is not set to true)', () => {
+        // The function returns `getConfig().workItemsHierarchyEnabled === true`
+        // so it returns false unless explicitly set to true
+        expect(src).toContain('=== true');
+        // The function name must be present
+        expect(src).toContain('isWorkItemsHierarchyEnabled');
+    });
+});

--- a/packages/coc/test/spa/react/repos/WorkItemHierarchy.layout.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemHierarchy.layout.test.ts
@@ -150,7 +150,7 @@ describe('WorkItemParentPicker — structure', () => {
     });
 
     it('filters candidates by valid parent types', () => {
-        expect(src).toContain('VALID_PARENT_TYPES');
+        expect(src).toContain('validParentTypes');
     });
 
     it('has a cancel button to dismiss without selecting', () => {

--- a/work-item-hierarchy-board.goal.md
+++ b/work-item-hierarchy-board.goal.md
@@ -1,0 +1,543 @@
+---
+feature: work-item-hierarchy-board
+status: ready-for-ralph
+---
+
+# Work Item Hierarchy Board MVP
+
+## Goal
+
+Extend the existing CoC Work Items tab into a feature-gated, Azure DevOps-like hierarchy board for one workspace at a time: Epic -> Feature -> PBI / Story -> WorkItem or Bug.
+
+The MVP must reuse the existing repo-scoped work item store, REST routes, coc-client domain, WebSocket refresh flow, and Work Items tab where practical. Existing WorkItem/Bug creation, listing, planning, execution, review, pinning, archive, delete, search, and deep-link behavior must remain unchanged when `workItems.hierarchy.enabled` is false.
+
+## Functional Acceptance Criteria
+
+1. [decision] AC-01: Add a disabled-by-default `workItems.hierarchy.enabled` config flag that controls hierarchy-only UI/API behavior without hiding the current Work Items tab.
+2. [decision] AC-02: Extend the existing work item data model to support `epic`, `feature`, `pbi`, `work-item`, and `bug` types plus parent linkage in the same repo-scoped file store.
+3. [decision] AC-03: Add hierarchy-aware server and coc-client APIs, including a tree endpoint with descendant roll-up counts, while keeping existing list/grouped endpoints compatible.
+4. [decision] AC-04: Replace the enabled Work Items left pane with a collapsible hierarchy tree that supports top-level Epic creation, constrained child creation, parent picking, unlinking, and clear validation errors.
+5. [decision] AC-05: Keep AI planning/execution/review flows leaf-only for `work-item` and `bug`; container nodes show metadata, children, and roll-up state only.
+6. [decision] AC-06: Preserve existing Work Items behavior and tests when the hierarchy flag is disabled, and add targeted unit/client/SPA coverage for hierarchy mode.
+
+## Out of Scope
+
+- [decision] Drag-and-drop reparenting.
+- [decision] Full Kanban board columns/swimlanes.
+- [decision] Automatic parent status changes from child progress.
+- [decision] Custom hierarchy levels or custom work item types.
+- [decision] Azure DevOps service integration, import, sync, or remote IDs.
+- [decision] Sprint/iteration planning, backlog ranking, area paths, assignments, permissions, or estimates.
+- [decision] Cross-repo parent/child relationships.
+- [decision] Changes under `packages\vscode-extension\`.
+
+## Constraints
+
+- [decision] Multi-repo support is required. Hierarchies are scoped to exactly one workspace/repo, and parent/child links must never cross workspace IDs.
+- [decision] All per-repo hierarchy data must remain under `getRepoDataPath(dataDir, workspaceId, 'work-items')`; do not add top-level per-repo directories under `~/.coc`.
+- [decision] Existing records with missing `type` are treated as `work-item`; existing records without `parentId` remain unparented leaf items.
+- [decision] Feature flag default is false.
+- [decision] When the flag is false, existing WorkItem/Bug behavior stays unchanged; hierarchy-only types, hierarchy parent fields, and tree UI/API are hidden or rejected.
+- [decision] Use the existing `@plusplusoneplusplus/coc-client` work-items domain for typed SPA transport.
+- [decision] Do not add SDK session caching or any `sendFollowUp`-style API.
+- [decision] Prefer existing route/store/component conventions; keep changes surgical.
+
+## References to Load
+
+- `.github\skills\coc-knowledge\references\server-architecture.md`
+- `.github\skills\coc-knowledge\references\rest-api.md`
+- `.github\skills\coc-knowledge\references\dashboard-spa.md`
+- `.github\skills\coc-knowledge\references\admin-config.md`
+- `packages\coc\AGENTS.md`
+- `packages\coc\src\server\work-items\types.ts`
+- `packages\coc\src\server\work-items\work-item-store.ts`
+- `packages\coc\src\server\routes\work-item-routes.ts`
+- `packages\coc\src\server\routes\work-item-plan-routes.ts`
+- `packages\coc\src\server\routes\work-item-execution-routes.ts`
+- `packages\coc\src\server\routes\work-item-changes-routes.ts`
+- `packages\coc-client\src\contracts\work-items.ts`
+- `packages\coc-client\src\domains\work-items.ts`
+- `packages\coc\src\server\spa\client\react\features\work-items\WorkItemsTab.tsx`
+- `packages\coc\src\server\spa\client\react\features\work-items\WorkItemSection.tsx`
+- `packages\coc\src\server\spa\client\react\features\work-items\WorkItemDetail.tsx`
+- `packages\coc\src\server\spa\client\react\features\work-items\CreateWorkItemDialog.tsx`
+- `packages\coc\src\server\spa\client\react\contexts\WorkItemContext.tsx`
+- `packages\coc\src\config.ts`
+- `packages\coc\src\config\schema.ts`
+- `packages\coc\src\config\namespace-registry.ts`
+- `packages\coc\src\server\admin\admin-config-fields.ts`
+- `packages\coc-client\src\contracts\admin.ts`
+
+## Dependency Graph
+
+- AC-02 depends on AC-01.
+- AC-03 depends on AC-01 and AC-02.
+- AC-04 depends on AC-01, AC-02, and AC-03.
+- AC-05 depends on AC-02 and AC-04.
+- AC-06 depends on AC-01 through AC-05.
+
+## Slice Specs
+
+### AC-01: Feature flag and runtime config
+
+#### Behavior
+
+1. [decision] Add `workItems.hierarchy.enabled` to CLI config, resolved config, default config, schema validation, namespace source tracking, admin config field registry, coc-client admin contracts, and runtime dashboard config.
+2. [decision] Default value is false.
+3. [decision] The current Work Items tab remains visible and works exactly as it does today when the flag is false.
+4. [decision] When false, the SPA must not show hierarchy tree controls or hierarchy creation choices.
+5. [decision] When false, the server must reject hierarchy-only writes: creating `epic`, `feature`, or `pbi`, or setting `parentId`.
+6. [assumption] The tree endpoint may be registered always, but should return a clear disabled response when the flag is false.
+7. [assumption] Mark the admin field runtime as live if the implementation can read `runtimeConfigService.config`; otherwise mark it reloadable and document reload behavior in tests.
+
+#### Surfaces
+
+- [decision] `packages\coc\src\config.ts`
+- [decision] `packages\coc\src\config\schema.ts`
+- [decision] `packages\coc\src\config\namespace-registry.ts`
+- [decision] `packages\coc\src\server\admin\admin-config-fields.ts`
+- [decision] `packages\coc\src\server\config\runtime-config-handler.ts`
+- [decision] `packages\coc-client\src\contracts\admin.ts`
+- [assumption] `packages\coc\src\server\spa\client\react\admin\AdminPanel.tsx`
+
+#### API Contract
+
+Admin config accepts:
+
+```json
+{
+  "workItems.hierarchy.enabled": true
+}
+```
+
+Runtime dashboard config adds:
+
+```json
+{
+  "features": {
+    "workItemsHierarchyEnabled": true
+  }
+}
+```
+
+#### Data Model
+
+No new persistent work item hierarchy data is added by this slice beyond config in the existing CoC config file.
+
+#### UX States
+
+- Disabled: current Work Items UI only.
+- Enabled: hierarchy board UI becomes available inside the existing Work Items tab.
+- Admin dirty/saving/error states follow existing AdminPanel feature-toggle patterns.
+
+#### Edge Cases and Failure Modes
+
+- Invalid non-boolean config values are rejected by schema/admin validation.
+- Runtime config refresh should not require stale HTML-only dashboard config.
+- Existing routes for normal WorkItem/Bug must not be blocked by this flag.
+
+#### Definition of Done
+
+1. Manual demo: open Admin settings, enable the hierarchy flag, reload or refresh runtime config as required, navigate to a repo's Work Items tab, and see the hierarchy board entry point; disable it and confirm the current list/detail Work Items UI returns.
+2. Test commands must include `npm --workspace @plusplusoneplusplus/coc run test:run -- test/server` for relevant config/admin tests and `npm --workspace @plusplusoneplusplus/coc-client run test:run -- test/domains test/client-integration.test.ts`.
+3. Code-search assertions: `workItems.hierarchy.enabled` appears in config defaults, schema, namespace registry, admin field registry, coc-client admin contracts, and runtime dashboard config; feature flag default remains false.
+
+### AC-02: Hierarchy data model and validation
+
+#### Behavior
+
+1. [decision] Extend `WorkItemType` to `epic | feature | pbi | work-item | bug`.
+2. [decision] Add `parentId?: string` to full work items and index entries.
+3. [decision] Treat missing `type` as `work-item` for all existing data.
+4. [decision] Allowed parent-child pairs are strict:
+   - Epic: no parent.
+   - Feature: Epic parent or no parent.
+   - PBI: Feature parent or no parent.
+   - WorkItem: PBI parent or no parent.
+   - Bug: PBI parent or no parent.
+5. [decision] Skipped levels are invalid, except that any item may be temporarily unparented.
+6. [decision] Parent and child must have the same `repoId`.
+7. [decision] Self-parenting and cycles are invalid.
+8. [decision] Deleting a parent with children is blocked with a clear conflict error; users must move/unlink/delete children first.
+9. [assumption] Keep the existing repo-wide `workItemNumber` counter and use type-specific display labels in the SPA rather than adding separate counters per type.
+10. [assumption] Do not add a persisted sort/order field in MVP; tree siblings sort by pinned first, then latest run/update time, matching current list behavior as closely as possible.
+
+#### Surfaces
+
+- [decision] `packages\coc\src\server\work-items\types.ts`
+- [decision] `packages\coc\src\server\work-items\work-item-store.ts`
+- [decision] `packages\coc-client\src\contracts\work-items.ts`
+- [assumption] Add small reusable validation helpers near existing work item type helpers instead of duplicating validation across routes.
+
+#### API Contract
+
+Create/update payloads may include:
+
+```json
+{
+  "type": "pbi",
+  "parentId": "feature-123"
+}
+```
+
+Validation failures return non-2xx JSON errors with clear messages for disabled hierarchy, invalid type, invalid parent type, cross-repo parent, self-parent, cycle, or parent deletion with children.
+
+#### Data Model
+
+Persistent files stay in:
+
+```text
+<dataDir>/repos/<workspaceId>/work-items/
+  index.json
+  <workItemId>.json
+  plans/<workItemId>/vN.md
+```
+
+Full item/index entry additions:
+
+```json
+{
+  "type": "epic",
+  "parentId": "optional-parent-id"
+}
+```
+
+#### UX States
+
+No direct UX in this slice, but invalid hierarchy writes must surface as readable form errors in AC-04.
+
+#### Edge Cases and Failure Modes
+
+- Existing work items with no type must list as `work-item`.
+- Existing bugs remain bugs if they have `type: "bug"`.
+- Reparenting must be atomic with index updates.
+- Parent deletion must check index entries without relying on client state.
+- Corrupt or missing parent references should not crash listing; [assumption] show such items as unparented with a validation warning only where practical.
+
+#### Definition of Done
+
+1. Manual demo: create an Epic, Feature, PBI, WorkItem, and Bug via API with valid parent links; verify files are stored under the same workspace work-items directory and list as one repo-scoped collection.
+2. Test commands must include `npm --workspace @plusplusoneplusplus/coc run test:run -- test/server/work-items`.
+3. Code-search assertions: no new top-level per-repo data directory is introduced; `getRepoDataPath(..., workspaceId, 'work-items')` remains the storage base; no `packages\vscode-extension\` files are touched.
+
+### AC-03: Hierarchy REST and coc-client API
+
+#### Behavior
+
+1. [decision] Keep existing list/grouped/get/create/patch/delete routes compatible for current WorkItem/Bug behavior.
+2. [decision] Add a hierarchy tree read API instead of forcing the SPA to reconstruct the full tree from paginated grouped status responses.
+3. [decision] Extend create and patch handling to accept `type` and `parentId` when the hierarchy flag is enabled.
+4. [decision] Existing `type=work-item` filtering includes items with missing type.
+5. [decision] Tree results include unparented items at their natural level and descendant roll-up counts by type and status.
+6. [decision] Tree roll-ups count all descendants, not only immediate children.
+7. [decision] Parent picker can use existing list search/type filtering or a small helper API if needed; do not load all process data or unrelated repositories.
+8. [assumption] Add `WorkItemsClient.tree(workspaceId, filter?)` and extend existing request/response contract types.
+
+#### Surfaces
+
+- [decision] `packages\coc\src\server\routes\work-item-routes.ts`
+- [assumption] Add `packages\coc\src\server\routes\work-item-hierarchy-routes.ts` only if it keeps route code cleaner.
+- [decision] `packages\coc\src\server\routes\index.ts`
+- [decision] `packages\coc-client\src\contracts\work-items.ts`
+- [decision] `packages\coc-client\src\domains\work-items.ts`
+- [decision] `packages\coc-client\test\domains\work-items.test.ts`
+- [decision] `packages\coc-client\test\domains\work-items.mock.test.ts`
+
+#### API Contract
+
+Recommended tree endpoint:
+
+```text
+GET /api/workspaces/:id/work-items/tree?q=&type=&status=&includeArchived=false
+```
+
+Recommended response:
+
+```json
+{
+  "roots": [
+    {
+      "item": {
+        "id": "epic-1",
+        "repoId": "repo-a",
+        "type": "epic",
+        "title": "Example epic",
+        "status": "created",
+        "parentId": null
+      },
+      "children": [],
+      "rollup": {
+        "descendantCount": 0,
+        "byType": {
+          "epic": 0,
+          "feature": 0,
+          "pbi": 0,
+          "work-item": 0,
+          "bug": 0
+        },
+        "byStatus": {
+          "created": 0,
+          "planning": 0,
+          "readyToExecute": 0,
+          "executing": 0,
+          "aiDone": 0,
+          "aiFailed": 0,
+          "done": 0,
+          "failed": 0
+        }
+      }
+    }
+  ],
+  "total": 1
+}
+```
+
+Existing create route accepts hierarchy fields when enabled:
+
+```text
+POST /api/workspaces/:id/work-items
+```
+
+Existing patch route accepts parent changes when enabled:
+
+```text
+PATCH /api/workspaces/:id/work-items/:itemId
+```
+
+#### Data Model
+
+No separate tree file is required. The tree is derived from the existing per-workspace `index.json` plus full item reads only when required for detail.
+
+#### UX States
+
+- Loading: tree fetch in progress.
+- Empty: no work items in hierarchy mode, with a primary Create Epic action and secondary Create unparented WorkItem/Bug actions.
+- Error: readable API error with retry.
+- Disabled: endpoint returns disabled response and SPA hides hierarchy UI.
+
+#### Edge Cases and Failure Modes
+
+- Tree endpoint handles archived items consistently with current archive toggle behavior.
+- Tree endpoint must not include another workspace's items.
+- Invalid parent links from older/corrupt data must not create infinite recursion.
+- Search should match current search fields: title, description, tags.
+- Parent picker should not offer descendants as valid parents.
+
+#### Definition of Done
+
+1. Manual demo: enable the flag, create a valid hierarchy via REST/client, fetch `/work-items/tree`, and confirm nested children plus descendant roll-up counts are correct.
+2. Test commands must include `npm --workspace @plusplusoneplusplus/coc run test:run -- test/server/work-items test/server/work-items/work-item-routes.test.ts` and `npm --workspace @plusplusoneplusplus/coc-client run test:run -- test/domains/work-items.test.ts test/domains/work-items.mock.test.ts`.
+3. Code-search assertions: existing `WorkItemsClient.list`, `grouped`, `get`, `create`, `update`, `delete`, `pin`, `archive`, `execute`, and plan methods remain present; existing route paths remain unchanged.
+
+### AC-04: Hierarchy board UI inside Work Items tab
+
+#### Behavior
+
+1. [decision] When `workItemsHierarchyEnabled` is false, `WorkItemsTab` renders the existing `WorkItemSection` list/detail UI.
+2. [decision] When enabled, the left pane renders a collapsible hierarchy tree.
+3. [decision] The enabled left pane has a header action to create a top-level Epic and secondary actions for unparented WorkItem/Bug so existing workflows remain accessible.
+4. [decision] Selecting a tree node opens the right detail pane for that node.
+5. [decision] Tree context/menu actions include valid child creation, parent change, unlink parent, pin/archive/delete, constrained by item type and deletion rules.
+6. [decision] Child creation is constrained:
+   - Epic -> Feature
+   - Feature -> PBI / Story
+   - PBI -> WorkItem or Bug
+   - WorkItem/Bug -> no children
+7. [decision] Reparenting uses a parent picker, not drag-and-drop.
+8. [decision] Tree node labels use API type values but user-facing labels show `Epic`, `Feature`, `PBI / Story`, `Work Item`, and `Bug`.
+9. [decision] Parent nodes show descendant roll-up counts by status/type and child counts.
+10. [assumption] Tree rows show type label/pill, existing number if present, title, status chip, descendant progress summary, and updated time.
+11. [assumption] Collapse state is persisted per workspace in localStorage.
+
+#### Visual Design
+
+Use the existing split-pane Work Items layout. The left pane becomes a board outline:
+
+```text
+Work Items Board                         + Epic
+Search hierarchy...
+
+Epic E-12  Checkout modernization     3/8 done
+  Feature F-13  Cart flow             1/5 done
+    PBI PBI-14  Guest checkout        0/2 done
+      WI-15  Add address form         readyToExecute
+      BUG-16 Tax total mismatch       aiDone
+
+Unparented
+  WI-7 Existing task                   planning
+```
+
+The right pane keeps the current detail shell. Container details show title, description, status, parent picker, children list, and roll-up cards. Leaf details reuse existing plan/execution/review sections with an added parent metadata row.
+
+#### Surfaces
+
+- [decision] `packages\coc\src\server\spa\client\react\features\work-items\WorkItemsTab.tsx`
+- [assumption] New `WorkItemHierarchyTree.tsx`
+- [assumption] New `WorkItemHierarchyNode.tsx`
+- [assumption] New `WorkItemParentPicker.tsx`
+- [decision] `packages\coc\src\server\spa\client\react\features\work-items\CreateWorkItemDialog.tsx`
+- [decision] `packages\coc\src\server\spa\client\react\features\work-items\WorkItemDetail.tsx`
+- [decision] `packages\coc\src\server\spa\client\react\contexts\WorkItemContext.tsx`
+- [decision] `packages\coc\src\server\spa\client\react\App.tsx`
+
+#### API Contract
+
+The SPA uses `getSpaCocClient().workItems.tree(...)`, `create(...)`, and `update(...)` rather than raw `fetchApi` for hierarchy work item operations where client methods exist.
+
+#### Data Model
+
+UI stores only transient selection/collapse/search state. Persistent hierarchy state stays in server work item files.
+
+#### UX States
+
+- Flag disabled: existing UI.
+- Empty hierarchy: Create Epic primary action plus Create WorkItem/Bug secondary actions.
+- Loading: tree skeleton or current small loading indicator.
+- Error: retry action and readable message.
+- Unparented: dedicated tree group for existing items and intentionally unlinked items.
+- Archived: follow current hidden-by-default/toggle semantics.
+- Mobile: preserve current list/detail mobile navigation pattern; tree is the mobile list.
+
+#### Edge Cases and Failure Modes
+
+- Parent picker must not list invalid parent types, current item, descendants, archived parents unless explicitly allowed by existing archive toggle state, or items from other workspaces.
+- If a selected item is deleted by WebSocket update, navigate back to tree/list as current detail does.
+- If a parent delete is blocked, keep the item selected and show the conflict error.
+- Search results should preserve enough ancestors to show context, or clearly show matched nodes in an Unparented/Search Results group. [assumption] Preserve ancestors where practical.
+
+#### Definition of Done
+
+1. Manual demo: enable the flag, open a repo Work Items tab, create Epic -> Feature -> PBI / Story -> WorkItem and Bug, collapse/expand nodes, move a WorkItem to another PBI through parent picker, unlink it, and verify it appears under Unparented.
+2. Test commands must include `npm --workspace @plusplusoneplusplus/coc run test:run -- test/spa/react` for targeted Work Items hierarchy tests.
+3. Code-search assertions: no `drag`/`drop` reparenting implementation is added; `WorkItemSection` remains available for disabled mode; Work Items tab still has existing create WorkItem/Bug affordances when hierarchy mode is disabled.
+
+### AC-05: Leaf-only planning and execution behavior
+
+#### Behavior
+
+1. [decision] Only `work-item` and `bug` show plan editing, Start Implementing, execution session, AI review, request changes, commit review, and resolve-comment flows.
+2. [decision] Epics, Features, and PBIs are planning containers only in this MVP.
+3. [decision] Container nodes may use the existing status values, but they do not auto-execute and do not auto-transition based on descendants.
+4. [decision] Existing WorkItem/Bug plan/execution behavior remains unchanged except for optional parent metadata display.
+5. [decision] Existing deep links to work item detail/session/commit continue to work for leaf items.
+6. [assumption] If a user deep-links to a container item, show container detail without plan/execution sections.
+
+#### Surfaces
+
+- [decision] `packages\coc\src\server\spa\client\react\features\work-items\WorkItemDetail.tsx`
+- [decision] `packages\coc\src\server\spa\client\react\features\work-items\WorkItemPlanSection.tsx`
+- [decision] `packages\coc\src\server\spa\client\react\features\work-items\WorkItemExecuteDialog.tsx`
+- [decision] `packages\coc\src\server\routes\work-item-execution-routes.ts`
+- [decision] `packages\coc\src\server\work-items\work-item-executor.ts`
+
+#### API Contract
+
+Execution routes reject container types:
+
+```text
+POST /api/workspaces/:id/work-items/:itemId/execute
+POST /api/workspaces/:id/work-items/:itemId/resolve-comments
+```
+
+If `item.type` is `epic`, `feature`, or `pbi`, return a clear non-2xx error such as `Only WorkItem and Bug items can be executed`.
+
+#### Data Model
+
+No execution history, changes, or plan versions are created for containers by MVP UI flows.
+
+#### UX States
+
+- Container selected: metadata and children only.
+- Leaf selected: existing detail behavior plus parent metadata.
+- Invalid execute attempt by API: readable server error.
+
+#### Edge Cases and Failure Modes
+
+- Container status manually set to `readyToExecute` must not trigger auto-execute.
+- `autoExecute` is ignored or hidden for containers.
+- Existing leaves with missing `type` still behave as executable `work-item`.
+
+#### Definition of Done
+
+1. Manual demo: select an Epic/Feature/PBI and verify no plan/execution controls appear; select a WorkItem/Bug and verify current plan/execution/review controls still appear and work.
+2. Test commands must include `npm --workspace @plusplusoneplusplus/coc run test:run -- test/server/work-items test/spa/react/repos`.
+3. Code-search assertions: execution route logic has an explicit leaf-type guard; container UI does not render `WorkItemPlanSection` or `WorkItemExecuteDialog`.
+
+### AC-06: Tests, compatibility, and final validation
+
+#### Behavior
+
+1. [decision] Add or update tests across server store, server routes, coc-client contracts/domain, SPA components/context, and disabled-mode compatibility.
+2. [decision] Do not remove or weaken existing Work Items tests.
+3. [decision] Existing WorkItem/Bug behavior remains the compatibility baseline.
+4. [assumption] Documentation updates are limited to directly related REST/API or admin config references if the repo keeps those generated/manually maintained docs in sync.
+
+#### Surfaces
+
+- [decision] `packages\coc\test\server\work-items\*.test.ts`
+- [decision] `packages\coc\test\server\work-items\work-item-routes.test.ts`
+- [decision] `packages\coc\test\spa\react\repos\*.test.tsx`
+- [decision] `packages\coc\test\spa\react\context\WorkItemContext.test.tsx`
+- [decision] `packages\coc-client\test\domains\work-items.test.ts`
+- [decision] `packages\coc-client\test\domains\work-items.mock.test.ts`
+- [decision] `packages\coc-client\test\client-integration.test.ts`
+
+#### API Contract
+
+Tests must cover:
+
+- Creating each hierarchy type when enabled.
+- Rejecting hierarchy types/parent fields when disabled.
+- Valid and invalid parent-child pairs.
+- Self-parent, cycle, cross-repo parent rejection.
+- Parent deletion blocked when children exist.
+- Tree response shape and descendant roll-ups.
+- Existing list/grouped responses still work for WorkItem/Bug.
+- Leaf-only execution guard.
+
+#### Data Model
+
+Test fixtures must use temporary per-test data directories and must not rely on shared local `~/.coc` state.
+
+#### UX States
+
+SPA tests must cover disabled mode, enabled empty state, tree rendering, constrained child creation affordances, parent picker/unlink behavior, and container-vs-leaf detail rendering.
+
+#### Edge Cases and Failure Modes
+
+- Tests must not depend on localStorage from other tests.
+- Tests must not rely on real git, network, or external Azure DevOps services.
+- Preserve Windows path compatibility.
+
+#### Definition of Done
+
+1. Manual demo script:
+   1. Start CoC with the hierarchy flag disabled and confirm current Work Items tab behavior is unchanged.
+   2. Enable `workItems.hierarchy.enabled`.
+   3. Create Epic -> Feature -> PBI / Story -> WorkItem and Bug.
+   4. Move and unlink a leaf through the parent picker.
+   5. Try to delete a parent with children and confirm deletion is blocked.
+   6. Execute a leaf WorkItem/Bug and confirm current execution flow still works.
+   7. Select a container item and confirm no plan/execution controls appear.
+2. Exact test/build commands:
+   1. `npm --workspace @plusplusoneplusplus/coc-client run test:run -- test/domains/work-items.test.ts test/domains/work-items.mock.test.ts test/client-integration.test.ts`
+   2. `npm --workspace @plusplusoneplusplus/coc run test:run -- test/server/work-items test/server/work-items/work-item-routes.test.ts test/spa/react`
+   3. `npm run build`
+   4. `npm run test`
+3. Code-search assertions:
+   1. `workItems.hierarchy.enabled` default is false.
+   2. No files under `packages\vscode-extension\` are modified.
+   3. No new top-level per-repo data directory under `~/.coc` is introduced.
+   4. No drag-and-drop hierarchy reparenting code is added.
+   5. No SDK session cache or `sendFollowUp` API is added.
+
+## Open Questions
+
+None.
+
+## Ready-for-Ralph Checklist
+
+- [x] Every functional AC has a Definition of Done.
+- [x] No `[open]` items remain.
+- [x] Dependency graph has no cycles.
+- [x] `## References to Load` lists the cross-cutting docs and code the implementer needs.


### PR DESCRIPTION
- **feat(work-items): AC-01 add workItems.hierarchy.enabled feature flag**
- **feat(work-items): AC-02 hierarchy data model and validation**
- **feat(work-items): AC-03 hierarchy tree REST endpoint and coc-client API**
- **feat(ac-04+05): hierarchy board UI and leaf-only execution guard**
- **test(ac-06): hierarchy layout tests and leaf-execution guard tests**
- **refactor: derive emptyRollup() keys from canonical WORK_ITEM_TYPES/STATUSES arrays**
- **refactor: eliminate duplicate hierarchy type constants in SPA components**
- **feat(coc): add inline edit mode for container work items in dashboard**
