### PR TITLE
feat(chat): style provider badge like Thinking pill and color avatar by provider

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -60,10 +60,21 @@ spa/client/react/
 ## Chat UI Architecture
 
 `ConversationTurnBubble` renders:
-- **Assistant turns:** Left-aligned with `C` avatar (green), borderless flowing content
+- **Assistant turns:** Left-aligned with `C` avatar whose color tracks the
+  chat's provider via `getProviderAvatarClasses` (`ProviderBadge.tsx`) —
+  Copilot=green, Claude=coral/orange, Codex=indigo. Body is borderless,
+  flowing content. The `provider` prop flows from `ChatDetail` →
+  `ConversationArea` → `ConversationTurnBubble`; missing/unknown provider
+  metadata falls back to the Copilot (green) palette.
 - **User turns:** Right-aligned with `Y` avatar (blue), soft-gray rounded bubbles
-- **Error turns:** Red error-strip aside with retry button
-- **Script output:** Dark terminal window with PASS/FAIL highlighting
+- **Error turns:** Red error-strip aside with retry button; the avatar
+  keeps its dedicated red palette and ignores `provider`.
+- **Script output:** Dark terminal window with PASS/FAIL highlighting; the
+  avatar keeps its dedicated dark-terminal palette and ignores `provider`.
+
+`ProviderBadge` (the chat-header agent pill) shares the same provider
+palette and mirrors `ChatStatusPill`'s "Thinking" style: rounded-full
+bordered pill with a leading colored dot followed by the provider label.
 
 `QueuedFollowUps` renders pending messages as compact dashed-border cards with cancel buttons.
 

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1261,6 +1261,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         onMcpOAuthCompleted={(requestId) => setMcpOAuthPrompts(prev => prev.filter(p => p.requestId !== requestId))}
                         onMcpOAuthFailed={(requestId) => setMcpOAuthPrompts(prev => prev.filter(p => p.requestId !== requestId))}
                         processError={processDetails?.error ?? null}
+                        provider={sessionProvider}
                     />
                     {variant !== 'floating' && !isMobile && (
                         <ConversationMiniMap

--- a/packages/coc/src/server/spa/client/react/features/chat/ConversationArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ConversationArea.tsx
@@ -13,6 +13,7 @@ import type { QueuedMessage } from '../../utils/chatUtils';
 import type { BackgroundTasksState, AskUserBatch, McpOAuthPromptData } from './hooks/useChatSSE';
 import { MODE_ICONS, MODE_TEXT_COLORS } from '../../repos/modeConfig';
 import type { ChatMode } from '../../repos/modeConfig';
+import type { ChatProvider } from './ProviderBadge';
 
 export interface ConversationAreaProps {
     loading: boolean;
@@ -97,6 +98,12 @@ export interface ConversationAreaProps {
     onMcpOAuthCompleted?: (requestId: string) => void;
     /** Called when an MCP OAuth flow fails. */
     onMcpOAuthFailed?: (requestId: string) => void;
+    /**
+     * AI provider that owns this conversation. Threaded into
+     * {@link ConversationTurnBubble} so each assistant avatar takes on the
+     * provider's brand color (Copilot=green, Claude=orange, Codex=indigo).
+     */
+    provider?: ChatProvider;
 }
 
 export function ConversationArea({
@@ -139,6 +146,7 @@ export function ConversationArea({
     onMcpOAuthCompleted,
     onMcpOAuthFailed,
     processError,
+    provider,
 }: ConversationAreaProps) {
     const [showArchived, setShowArchived] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -220,6 +228,7 @@ export function ConversationArea({
                                                 noteEdits={noteEdits}
                                                 processId={processId}
                                                 processType={processType}
+                                                provider={provider}
                                             />
                                         ))}
                                     </div>
@@ -351,6 +360,7 @@ export function ConversationArea({
                                                     noteEdits={noteEdits}
                                                     processId={processId}
                                                     processType={processType}
+                                                    provider={provider}
                                                 />
                                             </div>
                                         </div>

--- a/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
@@ -1,20 +1,70 @@
 /**
- * ProviderBadge — small neutral pill showing the AI provider for a chat.
+ * ProviderBadge — pill-style indicator showing the AI provider for a chat.
  *
- * Renders a compact badge with the provider label ("Copilot", "Codex", or "Claude").
- * Used in the chat detail header and chat list rows to record which agent
- * handled (or is handling) the chat.
+ * Visual contract mirrors `ChatStatusPill` (the "Thinking" pill in the chat
+ * header): a rounded-full bordered pill with a leading colored dot followed
+ * by the provider label ("Copilot", "Codex", or "Claude"). Provider-specific
+ * brand colors set the dot, text, and border tints:
  *
- * Design decisions:
- * - Codex: emerald-tinted badge to distinguish from the default Copilot.
- * - Claude: violet/purple-tinted badge to distinguish from Codex and Copilot.
- * - Copilot: subtle gray badge (only shown when provider is explicitly set).
- * - Badge is always read-only; clicking does nothing.
+ *   - Copilot — green (matches the existing assistant avatar accent)
+ *   - Claude  — warm coral/orange (Anthropic brand)
+ *   - Codex   — indigo/blue-purple (OpenAI Codex cloud icon palette)
+ *
+ * The same provider palette also drives the assistant turn avatar so the
+ * avatar's color tracks whichever provider produced the response. Consumers
+ * outside this file should use {@link getProviderAvatarClasses} to opt into
+ * the shared palette.
  */
 
 import { cn } from '../../ui/cn';
 
 export type ChatProvider = 'copilot' | 'codex' | 'claude';
+
+interface ProviderColorVariant {
+    /** Pill border + bg + text classes (matches ChatStatusPill `variant.pill`). */
+    pill: string;
+    /** Leading dot color classes. */
+    dot: string;
+    /** Round avatar (assistant turn) color classes — bg + text + border, light + dark. */
+    avatar: string;
+}
+
+const PROVIDER_VARIANTS: Record<ChatProvider, ProviderColorVariant> = {
+    copilot: {
+        pill: 'border-[#16825d]/40 bg-[#16825d]/10 text-[#16825d] dark:text-[#89d185]',
+        dot: 'bg-[#16825d] dark:bg-[#89d185]',
+        avatar:
+            'bg-[#dafbe1] text-[#15703a] border-[#b8e6c1]'
+            + ' dark:bg-[#0f3a1f] dark:text-[#4ade80] dark:border-[#225a32]',
+    },
+    claude: {
+        pill: 'border-[#d97757]/45 bg-[#d97757]/12 text-[#b5532c] dark:text-[#f4a17d]',
+        dot: 'bg-[#d97757] dark:bg-[#f4a17d]',
+        avatar:
+            'bg-[#fdece1] text-[#b5532c] border-[#f5c7a8]'
+            + ' dark:bg-[#3d1f10] dark:text-[#f4a17d] dark:border-[#6b3520]',
+    },
+    codex: {
+        pill: 'border-[#6366f1]/45 bg-[#6366f1]/12 text-[#4f46e5] dark:text-[#a5b4fc]',
+        dot: 'bg-[#6366f1] dark:bg-[#a5b4fc]',
+        avatar:
+            'bg-[#eef0ff] text-[#4f46e5] border-[#c7d2fe]'
+            + ' dark:bg-[#1a1c3d] dark:text-[#a5b4fc] dark:border-[#3c40a0]',
+    },
+};
+
+/**
+ * Returns the Tailwind class string for the round assistant-turn avatar that
+ * corresponds to the given provider. Falls back to Copilot's palette for
+ * unknown / undefined providers so the visual stays in the existing green
+ * family (no surprise color shift when provider metadata is missing).
+ */
+export function getProviderAvatarClasses(provider: ChatProvider | undefined): string {
+    if (provider && PROVIDER_VARIANTS[provider]) {
+        return PROVIDER_VARIANTS[provider].avatar;
+    }
+    return PROVIDER_VARIANTS.copilot.avatar;
+}
 
 export interface ProviderBadgeProps {
     provider: ChatProvider;
@@ -23,26 +73,25 @@ export interface ProviderBadgeProps {
 
 export function ProviderBadge({ provider, className }: ProviderBadgeProps) {
     const label = provider === 'codex' ? 'Codex' : provider === 'claude' ? 'Claude' : 'Copilot';
-
-    const variantClasses =
-        provider === 'codex'
-            ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-400/50 dark:border-emerald-500/50'
-            : provider === 'claude'
-            ? 'bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-400/50 dark:border-violet-500/50'
-            : 'bg-[#f3f3f3] dark:bg-[#2a2a2a] text-[#6b6b6b] dark:text-[#999] border-[#d0d0d0]/70 dark:border-[#4a4a4a]';
+    const variant = PROVIDER_VARIANTS[provider] ?? PROVIDER_VARIANTS.copilot;
 
     return (
         <span
             className={cn(
-                'provider-badge inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border flex-shrink-0',
-                variantClasses,
+                'provider-badge inline-flex items-center gap-1.5 border rounded-full whitespace-nowrap',
+                'text-[11px] leading-none font-medium h-[20px] px-2 flex-shrink-0',
+                variant.pill,
                 className,
             )}
             data-testid="provider-badge"
             data-provider={provider}
             title={`Agent: ${label}`}
         >
-            {label}
+            <span
+                className={cn('inline-block w-[6px] h-[6px] rounded-full flex-shrink-0', variant.dot)}
+                aria-hidden="true"
+            />
+            <span>{label}</span>
         </span>
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -35,6 +35,7 @@ import { CommitStrip } from './CommitStrip';
 import { NoteEditCard } from './NoteEditCard';
 import { ScriptTerminalBlock } from './ScriptTerminalBlock';
 import { parseScriptOutput, describeScriptExit } from './scriptOutputParser';
+import { getProviderAvatarClasses, type ChatProvider } from '../ProviderBadge';
 
 function escapeAttr(value: string): string {
     return value
@@ -243,6 +244,13 @@ interface ConversationTurnBubbleProps {
     }>;
     /** Process ID — needed for NoteEditCard undo API call. */
     processId?: string;
+    /**
+     * AI provider that produced the assistant turns (`copilot`, `codex`, or
+     * `claude`). Controls the round avatar's color so it matches the
+     * provider's brand palette (Copilot=green, Claude=orange, Codex=indigo).
+     * Defaults to `copilot` (green) when omitted to preserve the legacy look.
+     */
+    provider?: ChatProvider;
 }
 
 interface RenderToolCall {
@@ -760,7 +768,7 @@ function AssistantStatsBadge({ tokenUsage, costTimeMs }: { tokenUsage?: ClientTo
     );
 }
 
-export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsId, turnIndex, onAttachContext, onDeleteTurn, onPinTurn, onArchiveTurn, noteEdits, processId }: ConversationTurnBubbleProps) {
+export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsId, turnIndex, onAttachContext, onDeleteTurn, onPinTurn, onArchiveTurn, noteEdits, processId, provider }: ConversationTurnBubbleProps) {
     const isUser = turn.role === 'user';
     const isScript = !isUser && processType === TaskDefs.runScript.kind;
     const { showReportIntent, toolCompactness, groupSingleLineMessages } = useDisplaySettings();
@@ -1028,10 +1036,11 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, processType, wsI
                             ? 'bg-[#1e1e1e] text-[#d4d4d4] border-[#000] font-mono text-[10px]'
                             : turn.isError
                                 ? 'bg-[#ffebe9] text-[#cf222e] border-[#f5c2c2] dark:bg-[#3a1a1a] dark:text-[#f87171] dark:border-[#7a3030] text-[11.5px] font-semibold'
-                                : 'bg-[#dafbe1] text-[#15703a] border-[#b8e6c1] dark:bg-[#0f3a1f] dark:text-[#4ade80] dark:border-[#225a32] text-[11.5px] font-semibold'
+                                : cn(getProviderAvatarClasses(provider), 'text-[11.5px] font-semibold')
                     )}
                     title={isScript ? 'Script Output' : turn.isError ? 'Assistant — error' : 'Assistant'}
                     aria-hidden="true"
+                    data-provider={isScript || turn.isError ? undefined : (provider ?? 'copilot')}
                 >
                     {isScript ? '$_' : 'C'}
                 </span>

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecutionSession.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecutionSession.tsx
@@ -20,6 +20,7 @@ import { useChatSSE } from '../chat/hooks/useChatSSE';
 import { getConversationTurns } from '../chat/conversation/chatConversationUtils';
 import { MetaRow, FilePathValue } from '../../queue/PendingTaskPayload';
 import type { ClientConversationTurn } from '../../types/dashboard';
+import type { ChatProvider } from '../chat/ProviderBadge';
 
 export interface WorkItemExecutionSessionProps {
     taskId: string;
@@ -400,6 +401,12 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
                         onArchiveTurn={handleArchiveTurn}
                         undoDeleteTurnIndex={undoDelete?.turnIndex ?? null}
                         onUndoDelete={handleUndoDelete}
+                        provider={(() => {
+                            const raw = processDetails?.metadata?.provider ?? task?.metadata?.provider;
+                            return raw === 'codex' || raw === 'claude' || raw === 'copilot'
+                                ? (raw as ChatProvider)
+                                : undefined;
+                        })()}
                     />
                     <ConversationMiniMap
                         turns={turns}

--- a/packages/coc/src/server/spa/client/react/processes/dag/ItemConversationPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/processes/dag/ItemConversationPanel.tsx
@@ -345,15 +345,22 @@ export function ItemConversationPanel({ processId, onClose, isDark }: ItemConver
                         No conversation data available.
                     </div>
                 )}
-                {turns.map((turn, i) => (
-                    <ConversationTurnBubble
-                        key={i}
-                        turn={turn}
-                        onRetry={turn.isError ? handleRetry : undefined}
-                        wsId={wsId}
-                        processType={proc?.type}
-                    />
-                ))}
+                {turns.map((turn, i) => {
+                    const rawProvider = proc?.metadata?.provider;
+                    const provider = rawProvider === 'codex' || rawProvider === 'claude' || rawProvider === 'copilot'
+                        ? rawProvider
+                        : undefined;
+                    return (
+                        <ConversationTurnBubble
+                            key={i}
+                            turn={turn}
+                            onRetry={turn.isError ? handleRetry : undefined}
+                            wsId={wsId}
+                            processType={proc?.type}
+                            provider={provider}
+                        />
+                    );
+                })}
                 <div ref={scrollRef} />
             </div>
 

--- a/packages/coc/test/server/spa/client/repos/ProviderBadge.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ProviderBadge.test.tsx
@@ -1,10 +1,18 @@
 /**
  * @vitest-environment jsdom
- * Tests for ProviderBadge — rendering for copilot, codex, and missing-provider metadata.
+ * Tests for ProviderBadge — rendering for copilot, codex, and claude metadata.
+ *
+ * Visual contract:
+ *  - Renders as a rounded-full pill with a leading colored dot, mirroring the
+ *    "Thinking" `ChatStatusPill` style.
+ *  - Provider-specific brand palette: Copilot=green, Claude=orange/coral,
+ *    Codex=indigo/blue-purple.
+ *  - `data-provider` attribute + `Agent: <Label>` title are stable for tests
+ *    and tooling.
  */
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { ProviderBadge } from '../../../../../src/server/spa/client/react/features/chat/ProviderBadge';
+import { ProviderBadge, getProviderAvatarClasses } from '../../../../../src/server/spa/client/react/features/chat/ProviderBadge';
 
 describe('ProviderBadge', () => {
     describe('rendering', () => {
@@ -13,6 +21,13 @@ describe('ProviderBadge', () => {
             const badge = screen.getByTestId('provider-badge');
             expect(badge.textContent).toBe('Codex');
             expect(badge.getAttribute('data-provider')).toBe('codex');
+        });
+
+        it('renders "Claude" label for claude provider', () => {
+            render(<ProviderBadge provider="claude" />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge.textContent).toBe('Claude');
+            expect(badge.getAttribute('data-provider')).toBe('claude');
         });
 
         it('renders "Copilot" label for copilot provider', () => {
@@ -27,6 +42,11 @@ describe('ProviderBadge', () => {
             expect(screen.getByTestId('provider-badge').getAttribute('title')).toBe('Agent: Codex');
         });
 
+        it('has title attribute with provider name for claude', () => {
+            render(<ProviderBadge provider="claude" />);
+            expect(screen.getByTestId('provider-badge').getAttribute('title')).toBe('Agent: Claude');
+        });
+
         it('has title attribute with provider name for copilot', () => {
             render(<ProviderBadge provider="copilot" />);
             expect(screen.getByTestId('provider-badge').getAttribute('title')).toBe('Agent: Copilot');
@@ -38,19 +58,79 @@ describe('ProviderBadge', () => {
         });
     });
 
-    describe('styling', () => {
-        it('codex badge has emerald tint classes', () => {
-            render(<ProviderBadge provider="codex" />);
+    describe('pill style (mirrors ChatStatusPill / "Thinking" badge)', () => {
+        it('renders a rounded-full pill with a leading dot', () => {
+            const { container } = render(<ProviderBadge provider="copilot" />);
             const badge = screen.getByTestId('provider-badge');
-            // The badge should have emerald variant classes
-            expect(badge.className).toContain('emerald');
+            expect(badge.className).toContain('rounded-full');
+            expect(badge.className).toContain('border');
+            // Leading dot — the first child span has the 6px×6px rounded dot.
+            const dot = container.querySelector('span[aria-hidden="true"]');
+            expect(dot).toBeTruthy();
+            expect(dot!.className).toContain('w-[6px]');
+            expect(dot!.className).toContain('h-[6px]');
+            expect(dot!.className).toContain('rounded-full');
+        });
+    });
+
+    describe('provider color palette', () => {
+        it('copilot badge uses green (#16825d) accents', () => {
+            const { container } = render(<ProviderBadge provider="copilot" />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge.className).toContain('16825d');
+            const dot = container.querySelector('span[aria-hidden="true"]')!;
+            expect(dot.className).toContain('16825d');
         });
 
-        it('copilot badge has neutral classes', () => {
-            render(<ProviderBadge provider="copilot" />);
+        it('claude badge uses warm coral/orange (#d97757) accents', () => {
+            const { container } = render(<ProviderBadge provider="claude" />);
             const badge = screen.getByTestId('provider-badge');
-            // The badge should NOT have emerald variant classes
+            expect(badge.className).toContain('d97757');
+            const dot = container.querySelector('span[aria-hidden="true"]')!;
+            expect(dot.className).toContain('d97757');
+        });
+
+        it('codex badge uses indigo (#6366f1) accents', () => {
+            const { container } = render(<ProviderBadge provider="codex" />);
+            const badge = screen.getByTestId('provider-badge');
+            expect(badge.className).toContain('6366f1');
+            const dot = container.querySelector('span[aria-hidden="true"]')!;
+            expect(dot.className).toContain('6366f1');
+        });
+
+        it('copilot badge does NOT carry emerald-tailwind tint (legacy)', () => {
+            render(<ProviderBadge provider="copilot" />);
+            // Old palette mistakenly applied emerald to codex; ensure we
+            // didn't regress copilot to the same Tailwind keyword.
+            const badge = screen.getByTestId('provider-badge');
             expect(badge.className).not.toContain('emerald');
         });
+    });
+});
+
+describe('getProviderAvatarClasses', () => {
+    it('returns the green palette for copilot', () => {
+        const classes = getProviderAvatarClasses('copilot');
+        expect(classes).toContain('15703a');
+        expect(classes).toContain('dafbe1');
+    });
+
+    it('returns the coral/orange palette for claude', () => {
+        const classes = getProviderAvatarClasses('claude');
+        expect(classes).toContain('b5532c');
+        expect(classes).toContain('fdece1');
+    });
+
+    it('returns the indigo palette for codex', () => {
+        const classes = getProviderAvatarClasses('codex');
+        expect(classes).toContain('4f46e5');
+        expect(classes).toContain('eef0ff');
+    });
+
+    it('falls back to the copilot palette for undefined provider', () => {
+        const classes = getProviderAvatarClasses(undefined);
+        // Must equal the copilot palette so the legacy avatar look is
+        // preserved when a chat has no provider metadata.
+        expect(classes).toBe(getProviderAvatarClasses('copilot'));
     });
 });

--- a/packages/coc/test/spa/react/ConversationTurnBubble-provider-avatar.test.tsx
+++ b/packages/coc/test/spa/react/ConversationTurnBubble-provider-avatar.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for ConversationTurnBubble — provider-driven assistant avatar palette.
+ *
+ * The assistant turn's circular avatar (the small letter "C" tile) now picks
+ * its background/text/border colors based on the `provider` prop so the chat
+ * surface mirrors the agent that produced the response:
+ *
+ *   - Copilot → green   (#15703a on #dafbe1)
+ *   - Claude  → coral   (#b5532c on #fdece1)
+ *   - Codex   → indigo  (#4f46e5 on #eef0ff)
+ *
+ * Missing/unknown providers must fall back to the Copilot palette so chats
+ * that have no provider metadata keep their previous look.
+ *
+ * Error + run-script avatars must NOT inherit the provider palette — they
+ * keep their existing dedicated palettes (red error tile and dark terminal
+ * tile, respectively).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ConversationTurnBubble } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
+import type { ClientConversationTurn } from '../../../src/server/spa/client/react/types/dashboard';
+
+vi.mock('../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({
+    useDisplaySettings: () => ({ showReportIntent: false }),
+}));
+
+vi.mock('../../../src/server/spa/client/react/shared/MarkdownView', () => ({
+    MarkdownView: ({ html }: { html: string }) => (
+        <div data-testid="markdown-view" className="markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
+    ),
+}));
+
+vi.mock('../../../src/server/spa/client/diff/markdown-renderer', () => ({
+    renderMarkdownToHtml: (s: string) => `<p>${s}</p>`,
+}));
+
+function makeAssistantTurn(overrides: Partial<ClientConversationTurn> = {}): ClientConversationTurn {
+    return {
+        role: 'assistant',
+        content: 'Sure, here is your answer.',
+        timestamp: '2026-01-15T10:30:00Z',
+        streaming: false,
+        timeline: [],
+        ...overrides,
+    };
+}
+
+describe('ConversationTurnBubble — provider-driven avatar palette', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('defaults to the Copilot green palette when no provider is supplied', () => {
+        const { container } = render(<ConversationTurnBubble turn={makeAssistantTurn()} />);
+        const avatar = container.querySelector('.turn-avatar') as HTMLElement;
+        expect(avatar.className).toContain('bg-[#dafbe1]');
+        expect(avatar.className).toContain('text-[#15703a]');
+        expect(avatar.getAttribute('data-provider')).toBe('copilot');
+    });
+
+    it('uses the Copilot green palette when provider="copilot"', () => {
+        const { container } = render(<ConversationTurnBubble turn={makeAssistantTurn()} provider="copilot" />);
+        const avatar = container.querySelector('.turn-avatar') as HTMLElement;
+        expect(avatar.className).toContain('bg-[#dafbe1]');
+        expect(avatar.className).toContain('text-[#15703a]');
+        expect(avatar.getAttribute('data-provider')).toBe('copilot');
+    });
+
+    it('uses the Claude coral palette when provider="claude"', () => {
+        const { container } = render(<ConversationTurnBubble turn={makeAssistantTurn()} provider="claude" />);
+        const avatar = container.querySelector('.turn-avatar') as HTMLElement;
+        expect(avatar.className).toContain('bg-[#fdece1]');
+        expect(avatar.className).toContain('text-[#b5532c]');
+        expect(avatar.getAttribute('data-provider')).toBe('claude');
+    });
+
+    it('uses the Codex indigo palette when provider="codex"', () => {
+        const { container } = render(<ConversationTurnBubble turn={makeAssistantTurn()} provider="codex" />);
+        const avatar = container.querySelector('.turn-avatar') as HTMLElement;
+        expect(avatar.className).toContain('bg-[#eef0ff]');
+        expect(avatar.className).toContain('text-[#4f46e5]');
+        expect(avatar.getAttribute('data-provider')).toBe('codex');
+    });
+
+    it('error assistant avatar keeps the red error palette and ignores provider', () => {
+        const { container } = render(
+            <ConversationTurnBubble turn={makeAssistantTurn({ isError: true })} provider="claude" />,
+        );
+        const avatar = container.querySelector('.turn-avatar') as HTMLElement;
+        expect(avatar.className).toContain('bg-[#ffebe9]');
+        // The Claude coral background must NOT leak into error avatars.
+        expect(avatar.className).not.toContain('bg-[#fdece1]');
+        expect(avatar.getAttribute('data-provider')).toBeNull();
+    });
+
+    it('script-output avatar keeps the dark terminal palette and ignores provider', () => {
+        const { container } = render(
+            <ConversationTurnBubble turn={makeAssistantTurn()} processType="run-script" provider="codex" />,
+        );
+        const avatar = container.querySelector('.turn-avatar') as HTMLElement;
+        expect(avatar.className).toContain('bg-[#1e1e1e]');
+        // The Codex indigo background must NOT leak into script avatars.
+        expect(avatar.className).not.toContain('bg-[#eef0ff]');
+        expect(avatar.getAttribute('data-provider')).toBeNull();
+    });
+});


### PR DESCRIPTION
The chat-header agent badge now mirrors the `ChatStatusPill` "Thinking"
style — a rounded-full bordered pill with a leading colored dot —
instead of the older squared neutral chip. Provider brand colors drive
both the badge and the assistant turn's circular avatar so each chat
takes on its agent's identity at a glance:

- Copilot → green   (`#15703a` / `#16825d`)
- Claude  → coral   (`#b5532c` / `#d97757`)
- Codex   → indigo  (`#4f46e5` / `#6366f1`)

`ProviderBadge` now exports `getProviderAvatarClasses` so
`ConversationTurnBubble`, `ConversationArea`, `ChatDetail`,
`WorkItemExecutionSession`, and `ItemConversationPanel` all consume the
same palette. Missing provider metadata falls back to the Copilot
palette so legacy chats keep their original green look. Error and
script-output avatars keep their dedicated palettes and ignore the
provider so failures + terminal output stay visually distinct.

Co-authored-by: Cursor <cursoragent@cursor.com>
