### PR TITLE
fix: normalize Claude Code SDK PascalCase 'Skill' tool name to lowercase 'skill'

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -82,7 +82,9 @@ bordered pill with a leading colored dot followed by the provider label.
 
 Inside `WhisperCollapsedGroup`, tool calls render as compact "whisper-row" variant:
 - Single flat row: kind pill + truncated summary + duration + chevron
-- Color-coded pills: Read/blue, Grep/Glob/green, Edit/Write/amber, Shell/PS/SQL/purple
+- Color-coded pills: Read/blue, Grep/Glob/green, Edit/Write/amber, Shell/PS/SQL/purple, Skill/grey
+
+`toolNormalization.ts` → `normalizeToolName()` canonicalises SDK-specific names before display and storage. Notable aliases: `read_file`/`open_file` → `view`, `edit_file`/`str_replace`/`str_replace_editor` → `edit`, `write_file`/`create_file` → `create`, `command_execution` → `shell`, `file_change` → `apply_patch`, `Skill` (Claude Code SDK PascalCase) → `skill`. All downstream logic (`getToolKindInfo`, `getToolSummary`, `filterWhisperChunks` skill counting) operates on the normalised lowercase name.
 
 ## Input Area
 

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/toolKindUtils.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/toolKindUtils.ts
@@ -64,6 +64,8 @@ export function getToolKindInfo(toolName: string): ToolKindInfo {
             return { label: 'Poll', cls: 'agent' };
         case 'task_complete':
             return { label: 'Done', cls: 'task' };
+        case 'skill':
+            return { label: 'Skill', cls: 'other' };
         default: {
             const trimmed = canonicalName.length > 8 ? canonicalName.slice(0, 8) : canonicalName;
             return { label: trimmed, cls: 'other' };

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/toolNormalization.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/toolNormalization.ts
@@ -34,6 +34,11 @@ export function normalizeToolName(rawName: string | undefined): string {
             return 'shell';
         case 'file_change':
             return 'apply_patch';
+        // The Claude Code SDK emits its built-in skill tool as 'Skill' (PascalCase).
+        // Normalize to lowercase 'skill' so all downstream display/detection logic
+        // (getToolSummary, filterWhisperChunks, getToolKindInfo) handles it correctly.
+        case 'Skill':
+            return 'skill';
         default:
             return name || 'unknown';
     }

--- a/packages/coc/test/spa/processes/toolGroupUtils.test.ts
+++ b/packages/coc/test/spa/processes/toolGroupUtils.test.ts
@@ -1249,6 +1249,28 @@ describe('filterWhisperChunks', () => {
         expect(wg.summary.skillNames).toEqual(['draft', 'test-gap-analysis']);
     });
 
+    it('skillCount counts Claude SDK "Skill" (PascalCase) tool name', () => {
+        // The Claude Code SDK emits its built-in skill tool as "Skill" (capital S).
+        // normalizeToolName maps it to lowercase "skill" before storage, so
+        // filterWhisperChunks must count these as skill invocations.
+        const chunks = [
+            { kind: 'tool', key: 'k-t1', toolId: 't1' },
+            { kind: 'tool', key: 'k-t2', toolId: 't2' },
+            { kind: 'tool', key: 'k-t3', toolId: 't3' },
+            { kind: 'content', key: 'c1', html: '<p>Done.</p>' },
+        ];
+        const toolById = makeMap([
+            ['t1', { toolName: 'skill', status: 'completed', args: { name: 'impl' } }],
+            ['t2', { toolName: 'skill', status: 'completed', args: { name: 'code-review' } }],
+            ['t3', { toolName: 'skill', status: 'completed', args: { name: 'impl' } }],
+        ]);
+
+        const result = filterWhisperChunks(chunks, toolById);
+        const wg = result[0] as WhisperGroupChunk;
+        expect(wg.summary.skillCount).toBe(2);
+        expect(wg.summary.skillNames).toEqual(['code-review', 'impl']);
+    });
+
     it('skillCount from skills inside tool-group chunks', () => {
         const chunks = [
             {

--- a/packages/coc/test/spa/react/ToolCallView-whisper-row.test.tsx
+++ b/packages/coc/test/spa/react/ToolCallView-whisper-row.test.tsx
@@ -105,6 +105,70 @@ describe('ToolCallView — whisper-row variant', () => {
             expect(kind.className).toContain('bg-[#f5f5f4]');
         });
 
+        it('renders a "Skill" pill for the skill tool (lowercase)', () => {
+            const { container } = renderInWhisper({
+                id: 'sk1',
+                toolName: 'skill',
+                args: { name: 'impl' },
+                status: 'completed',
+            });
+            const kind = container.querySelector('[data-testid="tool-call-kind"]');
+            expect(kind?.textContent).toBe('Skill');
+            expect(container.querySelector('[data-tool-kind]')?.getAttribute('data-tool-kind')).toBe('other');
+        });
+
+        it('renders a "Skill" pill for the Claude Code SDK PascalCase "Skill" tool name', () => {
+            const { container } = renderInWhisper({
+                id: 'sk2',
+                toolName: 'Skill',
+                args: { name: 'impl' },
+                status: 'completed',
+            });
+            const kind = container.querySelector('[data-testid="tool-call-kind"]');
+            expect(kind?.textContent).toBe('Skill');
+            expect(container.querySelector('[data-tool-kind]')?.getAttribute('data-tool-kind')).toBe('other');
+        });
+
+        it('shows skill name in the row summary for both skill tool name casings', () => {
+            // lowercase 'skill'
+            const { container: c1 } = renderInWhisper({
+                id: 'sk3',
+                toolName: 'skill',
+                args: { name: 'impl' },
+                status: 'completed',
+            });
+            const path1 = c1.querySelector('.tool-call-row-path');
+            expect(path1?.textContent).toBe('impl');
+
+            // PascalCase 'Skill' — Claude Code SDK path
+            const { container: c2 } = renderInWhisper({
+                id: 'sk4',
+                toolName: 'Skill',
+                args: { name: 'go-deep' },
+                status: 'completed',
+            });
+            const path2 = c2.querySelector('.tool-call-row-path');
+            expect(path2?.textContent).toBe('go-deep');
+        });
+
+        it('shows skill name from args.skill and args.skill_name variants', () => {
+            const { container: ca } = renderInWhisper({
+                id: 'sk5',
+                toolName: 'Skill',
+                args: { skill: 'code-review' },
+                status: 'completed',
+            });
+            expect(ca.querySelector('.tool-call-row-path')?.textContent).toBe('code-review');
+
+            const { container: cb } = renderInWhisper({
+                id: 'sk6',
+                toolName: 'Skill',
+                args: { skill_name: 'draft' },
+                status: 'completed',
+            });
+            expect(cb.querySelector('.tool-call-row-path')?.textContent).toBe('draft');
+        });
+
         it('uses muted grey pill while running regardless of tool kind', () => {
             const { getByTestId } = renderInWhisper({
                 id: 't7',

--- a/packages/coc/test/spa/react/toolKindUtils.test.ts
+++ b/packages/coc/test/spa/react/toolKindUtils.test.ts
@@ -8,6 +8,17 @@ import {
     KIND_PILL_CLASSES,
     getToolMetric,
 } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/toolKindUtils';
+import { normalizeToolName } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/toolNormalization';
+
+describe('normalizeToolName — Claude provider aliases', () => {
+    it('normalizes PascalCase "Skill" (Claude Code SDK) to lowercase "skill"', () => {
+        expect(normalizeToolName('Skill')).toBe('skill');
+    });
+
+    it('passes through already-lowercase "skill" unchanged', () => {
+        expect(normalizeToolName('skill')).toBe('skill');
+    });
+});
 
 describe('getToolKindInfo', () => {
     it.each([
@@ -29,6 +40,9 @@ describe('getToolKindInfo', () => {
         ['task',         { label: 'Agent',  cls: 'agent' }],
         ['read_agent',   { label: 'Poll',   cls: 'agent' }],
         ['task_complete',{ label: 'Done',   cls: 'task'  }],
+        // skill tool — both casing variants
+        ['skill',        { label: 'Skill',  cls: 'other' }],
+        ['Skill',        { label: 'Skill',  cls: 'other' }],
     ])('classifies %s as %j', (toolName, expected) => {
         expect(getToolKindInfo(toolName as string)).toEqual(expected);
     });


### PR DESCRIPTION
The Claude Code SDK emits its built-in skill invocation tool as 'Skill'
(PascalCase), while all display/detection logic in the codebase expects
lowercase 'skill'. This caused three visible problems for the Claude
agent provider:

1. No skill name shown in the tool call header summary (getToolSummary
   'skill' case never matched 'Skill')
2. Skill invocations not counted in the whisper summary 'N skills' chip
   (filterWhisperChunks tc.toolName === 'skill' check never fired)
3. getToolKindInfo fell through to the truncated default pill instead of
   a dedicated 'Skill' label

Fix: add case 'Skill' -> 'skill' in normalizeToolName() so all
downstream consumers that go through normalizeToolForDisplay() see the
canonical lowercase name.

Also add a dedicated 'skill' case to getToolKindInfo() so both 'skill'
and 'Skill' get the 'Skill' pill label (cls: 'other') rather than an
ad-hoc truncated default.

Tests added:
- normalizeToolName('Skill') === 'skill' unit test
- getToolKindInfo for both 'skill' and 'Skill' asserted in the table
- ToolCallView whisper-row: Skill pill label and skill name summary for
  both lowercase and PascalCase tool names, covering args.name /
  args.skill / args.skill_name variants
- toolGroupUtils filterWhisperChunks: skill count using args.name
  (the primary arg key for Claude SDK Skill tool calls)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
