### PR TITLE
add ralph self-validation step and pr review improvements

### DIFF
--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -94,6 +94,7 @@ CoC server exposes HTTP endpoints organized by domain. All routes are registered
 ## Notes
 
 All read/write/comment/search/image endpoints accept an optional `root` query or body param to scope operations to a specific notes root. Omit `root` for the default managed root.
+Page create and rename operations normalize page filenames by appending `.md` when the requested page path has no `.md` suffix; mutation responses return the effective path.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/packages/coc-client/src/contracts/workspaces.ts
+++ b/packages/coc-client/src/contracts/workspaces.ts
@@ -333,6 +333,35 @@ export interface RalphSessionRecord {
   iterations: RalphIterationRecord[];
   /** Multi-loop history. Absent on pre-existing single-loop sessions. */
   loops?: RalphLoopRecord[];
+  /** Final-check automation records. Absent on legacy sessions. */
+  finalChecks?: RalphFinalCheckRecord[];
+}
+
+// ============================================================================
+// Final-check types (AC-03, AC-06)
+// ============================================================================
+
+export type RalphFinalCheckStatus = 'running' | 'completed' | 'failed';
+
+/** Metadata record for one final-check run within a Ralph session. */
+export interface RalphFinalCheckRecord {
+  /** 1-based index of this check within the session. */
+  checkIndex: number;
+  /** The loop index that triggered this check. */
+  loopIndex: number;
+  /** The iteration number of the last iteration in the triggering loop. */
+  sourceIteration: number;
+  taskId?: string;
+  processId?: string;
+  startedAt: string;
+  completedAt?: string;
+  status: RalphFinalCheckStatus;
+  hasGaps?: boolean;
+  gapCount?: number;
+  gapLoopStarted?: boolean;
+  gapLoopIndex?: number;
+  capReached?: boolean;
+  goalSynthesized?: boolean;
 }
 
 export interface ParsedProgressSection {

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -125,6 +125,13 @@ export interface CLIConfig {
     /** Ralph mode configuration (autonomous iterative coding loop). Disabled by default. */
     ralph?: {
         enabled?: boolean;
+        finalCheck?: {
+            /**
+             * Maximum number of automated gap-fix loops to run after the initial
+             * implementation loop. Must be a positive integer. Default: 3.
+             */
+            maxGapFixLoops?: number;
+        };
     };
     /** Loops/recurring follow-up subsystem configuration. Disabled by default. */
     loops?: {
@@ -326,6 +333,10 @@ export interface ResolvedCLIConfig {
     /** Ralph orchestration mode configuration. */
     ralph: {
         enabled: boolean;
+        finalCheck: {
+            /** Maximum automated gap-fix loops after the initial loop. Default: 3. */
+            maxGapFixLoops: number;
+        };
     };
     /** Loops/recurring follow-up subsystem configuration. */
     loops: {
@@ -484,6 +495,9 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
     },
     ralph: {
         enabled: false,
+        finalCheck: {
+            maxGapFixLoops: 3,
+        },
     },
     loops: {
         enabled: true,

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -70,7 +70,8 @@ const SCRATCHPAD_SOURCE_KEYS = ['scratchpad.enabled', 'scratchpad.layout'] as co
 const WORKFLOWS_SOURCE_KEYS = ['workflows.enabled'] as const;
 const PULL_REQUESTS_SOURCE_KEYS = ['pullRequests.enabled', 'pullRequests.suggestions'] as const;
 const SERVERS_SOURCE_KEYS = ['servers.enabled'] as const;
-const RALPH_SOURCE_KEYS = ['ralph.enabled', 'ralph.finalCheck.maxGapFixLoops'] as const;
+const RALPH_SOURCE_KEYS = ['ralph.enabled'] as const;
+const RALPH_FINAL_CHECK_SOURCE_KEYS = ['ralph.finalCheck.maxGapFixLoops'] as const;
 const VIM_NAVIGATION_SOURCE_KEYS = ['vimNavigation.enabled'] as const;
 const LOOPS_SOURCE_KEYS = ['loops.enabled'] as const;
 const MCP_OAUTH_SOURCE_KEYS = ['mcpOauth.enabled'] as const;
@@ -106,6 +107,7 @@ export const CONFIG_NAMESPACE_SOURCE_KEYS = [
     ...PULL_REQUESTS_SOURCE_KEYS,
     ...SERVERS_SOURCE_KEYS,
     ...RALPH_SOURCE_KEYS,
+    ...RALPH_FINAL_CHECK_SOURCE_KEYS,
     ...VIM_NAVIGATION_SOURCE_KEYS,
     ...LOOPS_SOURCE_KEYS,
     ...MCP_OAUTH_SOURCE_KEYS,
@@ -243,7 +245,10 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
         },
         {
             name: 'ralph',
-            sourceDescriptors: [source('ralph.', ['ralph'], RALPH_SOURCE_KEYS)],
+            sourceDescriptors: [
+                source('ralph.finalCheck.', ['ralph', 'finalCheck'], RALPH_FINAL_CHECK_SOURCE_KEYS),
+                source('ralph.', ['ralph'], RALPH_SOURCE_KEYS),
+            ],
             merge: (base, override) => ({
                 ralph: {
                     enabled: override?.ralph?.enabled ?? base.ralph?.enabled ?? false,

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -70,7 +70,7 @@ const SCRATCHPAD_SOURCE_KEYS = ['scratchpad.enabled', 'scratchpad.layout'] as co
 const WORKFLOWS_SOURCE_KEYS = ['workflows.enabled'] as const;
 const PULL_REQUESTS_SOURCE_KEYS = ['pullRequests.enabled', 'pullRequests.suggestions'] as const;
 const SERVERS_SOURCE_KEYS = ['servers.enabled'] as const;
-const RALPH_SOURCE_KEYS = ['ralph.enabled'] as const;
+const RALPH_SOURCE_KEYS = ['ralph.enabled', 'ralph.finalCheck.maxGapFixLoops'] as const;
 const VIM_NAVIGATION_SOURCE_KEYS = ['vimNavigation.enabled'] as const;
 const LOOPS_SOURCE_KEYS = ['loops.enabled'] as const;
 const MCP_OAUTH_SOURCE_KEYS = ['mcpOauth.enabled'] as const;
@@ -244,7 +244,14 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
         {
             name: 'ralph',
             sourceDescriptors: [source('ralph.', ['ralph'], RALPH_SOURCE_KEYS)],
-            merge: (base, override) => ({ ralph: { enabled: override?.ralph?.enabled ?? base.ralph?.enabled ?? false } }),
+            merge: (base, override) => ({
+                ralph: {
+                    enabled: override?.ralph?.enabled ?? base.ralph?.enabled ?? false,
+                    finalCheck: {
+                        maxGapFixLoops: override?.ralph?.finalCheck?.maxGapFixLoops ?? base.ralph?.finalCheck?.maxGapFixLoops ?? 3,
+                    },
+                },
+            }),
         },
         {
             name: 'vimNavigation',

--- a/packages/coc/src/config/schema.ts
+++ b/packages/coc/src/config/schema.ts
@@ -108,6 +108,12 @@ export const CLIConfigSchema = z.object({
         enabled: z.boolean().optional(),
     }).passthrough().optional(),
     defaultProvider: z.enum(['copilot', 'codex', 'claude']).optional(),
+    ralph: z.object({
+        enabled: z.boolean().optional(),
+        finalCheck: z.object({
+            maxGapFixLoops: z.number().int().min(1).optional(),
+        }).passthrough().optional(),
+    }).passthrough().optional(),
     loops: z.object({
         enabled: z.boolean().optional(),
     }).passthrough().optional(),

--- a/packages/coc/src/server/admin/admin-config-fields.ts
+++ b/packages/coc/src/server/admin/admin-config-fields.ts
@@ -195,6 +195,18 @@ export const ADMIN_CONFIG_FIELDS: readonly AdminConfigFieldSpec[] = [
         if (!cfg.ralph) { cfg.ralph = {}; }
         cfg.ralph.enabled = v;
     }),
+    {
+        key: 'ralph.finalCheck.maxGapFixLoops',
+        runtime: 'live' as AdminConfigFieldRuntime,
+        validate: (v) => typeof v === 'number' && Number.isInteger(v) && v >= 1
+            ? undefined
+            : 'ralph.finalCheck.maxGapFixLoops must be a positive integer (≥ 1)',
+        apply: (cfg, v) => {
+            if (!cfg.ralph) { cfg.ralph = {}; }
+            if (!cfg.ralph.finalCheck) { cfg.ralph.finalCheck = {}; }
+            cfg.ralph.finalCheck.maxGapFixLoops = v as number;
+        },
+    },
     bool('vimNavigation.enabled', (cfg, v) => {
         if (!cfg.vimNavigation) { cfg.vimNavigation = {}; }
         cfg.vimNavigation.enabled = v;

--- a/packages/coc/src/server/notes/notes-write-handler.ts
+++ b/packages/coc/src/server/notes/notes-write-handler.ts
@@ -70,6 +70,10 @@ async function pathExists(filePath: string): Promise<boolean> {
     }
 }
 
+function ensureMarkdownExtension(notePath: string): string {
+    return notePath.endsWith('.md') ? notePath : `${notePath}.md`;
+}
+
 function normalizePathForComparison(filePath: string): string {
     return path.normalize(filePath);
 }
@@ -166,7 +170,7 @@ export function registerNotesWriteRoutes(
                     sendJSON(res, 201, { path: notePath, type });
                 } else {
                     // page — auto-append .md if missing, then create parent dir and empty file
-                    const effectivePath = notePath.endsWith('.md') ? notePath : `${notePath}.md`;
+                    const effectivePath = ensureMarkdownExtension(notePath);
                     const resolvedPage = path.resolve(notesRoot, effectivePath);
                     if (!isWithinDirectory(resolvedPage, notesRoot)) {
                         return sendError(res, 403, 'Access denied: path is outside notes directory');
@@ -288,12 +292,8 @@ export function registerNotesWriteRoutes(
 
             const notesRoot = rootResult.absolutePath;
             const resolvedOld = path.resolve(notesRoot, oldPath);
-            const resolvedNew = path.resolve(notesRoot, newPath);
 
             if (!isWithinDirectory(resolvedOld, notesRoot)) {
-                return sendError(res, 403, 'Access denied: path is outside notes directory');
-            }
-            if (!isWithinDirectory(resolvedNew, notesRoot)) {
                 return sendError(res, 403, 'Access denied: path is outside notes directory');
             }
 
@@ -303,10 +303,17 @@ export function registerNotesWriteRoutes(
             }
 
             // Check source exists
+            let oldStat: fs.Stats;
             try {
-                await fs.promises.access(resolvedOld);
+                oldStat = await fs.promises.stat(resolvedOld);
             } catch {
                 return sendError(res, 404, 'Source path not found');
+            }
+
+            const effectiveNewPath = oldStat.isFile() ? ensureMarkdownExtension(newPath) : newPath;
+            const resolvedNew = path.resolve(notesRoot, effectiveNewPath);
+            if (!isWithinDirectory(resolvedNew, notesRoot)) {
+                return sendError(res, 403, 'Access denied: path is outside notes directory');
             }
 
             if (resolvedOld === resolvedNew) {
@@ -369,7 +376,7 @@ export function registerNotesWriteRoutes(
                     }
                 }
 
-                sendJSON(res, 200, { oldPath, newPath, bindingsMoved });
+                sendJSON(res, 200, { oldPath, newPath: effectiveNewPath, bindingsMoved });
             } catch (err: any) {
                 return sendError(res, 500, 'Failed to rename: ' + (err.message || 'Unknown error'));
             }

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -11,6 +11,17 @@ import { TitleGenerationService } from '../executors/title-generator';
 import { ExecutorRegistry } from '../executors/executor-registry';
 import { parseRalphSignal } from '../executors/ralph-signal-parser';
 import { recordRalphIteration } from '../ralph/record-iteration';
+import { RalphSessionStore } from '../ralph/ralph-session-store';
+import {
+    buildFinalCheckTaskPayload,
+    buildFinalCheckStartRecord,
+    nextCheckIndex,
+    sessionHasFinalCheckFor,
+    wasFinalCheckEnqueued,
+    markFinalCheckEnqueued,
+} from '../ralph/enqueue-final-check';
+import { orchestrateFinalCheck } from '../ralph/orchestrate-final-check';
+import { loadConfigFile, DEFAULT_CONFIG } from '../../config';
 
 export const DEFAULT_FOLLOW_UP_SUGGESTIONS = { enabled: true, count: 3 } as const;
 
@@ -132,18 +143,30 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
      * progress section to the per-session journal (`progress.md` +
      * `session.json`), and either enqueues the next iteration or emits a
      * ralph-session-complete WS event.
+     *
+     * When the completed task is a final-check task (context.ralph.finalCheck
+     * is set), routes to handleFinalCheckCompletion instead.
      */
     private enqueueRalphNextIteration(processId: string, completedTask: QueuedTask, responseText: string): void {
         if (!this.queueManager) return;
         const logger = getLogger();
 
-        const { signal, progress } = parseRalphSignal(responseText);
         const payload = completedTask.payload as unknown as ChatPayload;
         const ralphCtx = payload.context?.ralph;
-        const currentIteration = ralphCtx?.currentIteration ?? 1;
-        const maxIterations = ralphCtx?.maxIterations ?? 20;
         const workspaceId = payload.workspaceId;
         const sessionId = ralphCtx?.sessionId;
+
+        // ── Route final-check completions separately (AC-01) ────────────────
+        if (ralphCtx?.finalCheck) {
+            this.handleFinalCheckCompletion(processId, completedTask, responseText, ralphCtx, workspaceId, sessionId).catch(err => {
+                logger.warn(LogCategory.AI, `[Ralph/FinalCheck] handleFinalCheckCompletion threw: ${err instanceof Error ? err.message : String(err)}`);
+            });
+            return;
+        }
+
+        const { signal, progress } = parseRalphSignal(responseText);
+        const currentIteration = ralphCtx?.currentIteration ?? 1;
+        const maxIterations = ralphCtx?.maxIterations ?? 20;
 
         const shouldContinue = signal === 'RALPH_NEXT' && currentIteration < maxIterations;
 
@@ -167,22 +190,20 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
         });
 
         if (!shouldContinue) {
-            // Session complete — emit WS event
-            const reason = signal === 'RALPH_COMPLETE' ? 'signal' : 'cap';
-            logger.debug(LogCategory.AI, `[Ralph] Session complete for ${processId} (reason: ${reason}, iterations: ${currentIteration})`);
-            if (workspaceId) {
-                try {
-                    this.getWsServer?.()?.broadcastProcessEvent({
-                        type: 'ralph-session-complete',
-                        workspaceId,
-                        sessionId,
-                        processId,
-                        totalIterations: currentIteration,
-                        reason,
-                    });
-                } catch (err) {
-                    logger.debug(LogCategory.AI, `[Ralph] Failed to broadcast ralph-session-complete: ${err instanceof Error ? err.message : String(err)}`);
-                }
+            if (signal === 'RALPH_COMPLETE') {
+                // Enqueue a final-check task before broadcasting session-complete (AC-01).
+                this.enqueueFinalCheckAfterComplete(
+                    workspaceId, sessionId, currentIteration, ralphCtx, completedTask, payload,
+                ).catch(err => {
+                    logger.warn(LogCategory.AI, `[Ralph] enqueueFinalCheckAfterComplete failed: ${err instanceof Error ? err.message : String(err)}`);
+                    // Broadcast session complete even if final-check enqueue fails
+                    this.broadcastRalphSessionComplete(workspaceId, sessionId, processId, currentIteration, 'signal');
+                });
+            } else {
+                // cap / no-signal / cancelled — broadcast immediately, no final check
+                const reason = 'cap';
+                logger.debug(LogCategory.AI, `[Ralph] Session complete for ${processId} (reason: ${reason}, iterations: ${currentIteration})`);
+                this.broadcastRalphSessionComplete(workspaceId, sessionId, processId, currentIteration, reason);
             }
             return;
         }
@@ -224,12 +245,170 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
         }
     }
 
+    /** Broadcast a ralph-session-complete WS event. */
+    private broadcastRalphSessionComplete(
+        workspaceId: string | undefined,
+        sessionId: string | undefined,
+        processId: string,
+        totalIterations: number,
+        reason: string,
+    ): void {
+        if (!workspaceId) return;
+        const logger = getLogger();
+        try {
+            this.getWsServer?.()?.broadcastProcessEvent({
+                type: 'ralph-session-complete',
+                workspaceId,
+                sessionId,
+                processId,
+                totalIterations,
+                reason,
+            });
+        } catch (err) {
+            logger.debug(LogCategory.AI, `[Ralph] Failed to broadcast ralph-session-complete: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
     /**
-     * Best-effort: append the parsed `RALPH_PROGRESS:` body to the
-     * session journal and update `session.json`. Implementation lives in
-     * `recordRalphIteration` so it can be unit-tested in isolation.
+     * After a normal Ralph loop ends with RALPH_COMPLETE, enqueue one
+     * final-check task (AC-01). Idempotency-guarded against duplicate events.
      */
-    // (delegated to recordRalphIteration above)
+    private async enqueueFinalCheckAfterComplete(
+        workspaceId: string | undefined,
+        sessionId: string | undefined,
+        sourceIteration: number,
+        ralphCtx: any,
+        completedTask: QueuedTask,
+        payload: ChatPayload,
+    ): Promise<void> {
+        if (!workspaceId || !sessionId || !this.queueManager || !this.dataDir) return;
+        const logger = getLogger();
+
+        // ── In-memory idempotency guard ──────────────────────────────────────
+        if (wasFinalCheckEnqueued(sessionId, sourceIteration)) {
+            logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Duplicate completion event ignored for ${sessionId}:${sourceIteration}`);
+            return;
+        }
+
+        // ── Persistent idempotency guard (survives server restart) ───────────
+        const store = new RalphSessionStore({ dataDir: this.dataDir! });
+        const session = await store.readSessionRecord(workspaceId, sessionId);
+        if (!session) {
+            logger.warn(LogCategory.AI, `[Ralph/FinalCheck] Session record missing for ${sessionId}; skipping final-check enqueue.`);
+            this.broadcastRalphSessionComplete(workspaceId, sessionId, completedTask.id, sourceIteration, 'signal');
+            return;
+        }
+
+        if (sessionHasFinalCheckFor(session, sourceIteration)) {
+            logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Persistent duplicate: check for ${sessionId}:${sourceIteration} already exists.`);
+            return;
+        }
+
+        markFinalCheckEnqueued(sessionId, sourceIteration);
+
+        const checkIndex = nextCheckIndex(session);
+        const loopIndex = (ralphCtx?.loopIndex as number | undefined)
+            ?? (session.loops?.[session.loops.length - 1]?.loopIndex ?? 1);
+
+        const progressPath = store.getProgressPath(workspaceId, sessionId);
+
+        const taskPayload = buildFinalCheckTaskPayload({
+            workspaceId,
+            sessionId,
+            originalGoal: session.originalGoal,
+            checkIndex,
+            sourceIteration,
+            loopIndex,
+            progressPath,
+            workingDirectory: payload.workingDirectory,
+            folderPath: (payload as any).folderPath,
+            repoId: completedTask.repoId,
+            provider: (payload as any).provider,
+        });
+
+        let taskId: string;
+        try {
+            taskId = this.queueManager.enqueue(taskPayload as any);
+        } catch (err) {
+            logger.warn(LogCategory.AI, `[Ralph/FinalCheck] Enqueue failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+            this.broadcastRalphSessionComplete(workspaceId, sessionId, completedTask.id, sourceIteration, 'signal');
+            return;
+        }
+
+        // Persist the running-status record immediately so the session response
+        // shows the check is in progress before the AI response arrives.
+        const startRecord = buildFinalCheckStartRecord(checkIndex, loopIndex, sourceIteration, taskId, undefined, new Date().toISOString());
+        await store.upsertFinalCheckRecord(workspaceId, sessionId, checkIndex, startRecord).catch(err => {
+            logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Failed to persist start record: ${err instanceof Error ? err.message : String(err)}`);
+        });
+
+        logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Enqueued final-check task ${taskId} (check ${checkIndex}) for session ${sessionId}`);
+    }
+
+    /**
+     * Handle completion of a final-check task.
+     * Routes to orchestrateFinalCheck which decides gap-loop or session-complete.
+     */
+    private async handleFinalCheckCompletion(
+        processId: string,
+        completedTask: QueuedTask,
+        responseText: string,
+        ralphCtx: any,
+        workspaceId: string | undefined,
+        sessionId: string | undefined,
+    ): Promise<void> {
+        if (!workspaceId || !sessionId || !this.queueManager || !this.dataDir) return;
+        const logger = getLogger();
+
+        const finalCheckCtx = ralphCtx.finalCheck;
+        const checkIndex: number = finalCheckCtx?.checkIndex ?? 1;
+        const loopIndex: number = finalCheckCtx?.loopIndex ?? 1;
+        const sourceIteration: number = finalCheckCtx?.sourceIteration ?? 0;
+
+        // Update the record to reflect the process ID (now known from processId)
+        const store = new RalphSessionStore({ dataDir: this.dataDir! });
+        await store.upsertFinalCheckRecord(workspaceId, sessionId, checkIndex, {
+            status: 'running',
+            loopIndex,
+            sourceIteration,
+            processId,
+        }).catch(err => {
+            logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Failed to update processId for check ${checkIndex}: ${err instanceof Error ? err.message : String(err)}`);
+        });
+
+        // Resolve config cap
+        const fileConfig = loadConfigFile();
+        const maxGapFixLoops = fileConfig?.ralph?.finalCheck?.maxGapFixLoops
+            ?? DEFAULT_CONFIG.ralph.finalCheck.maxGapFixLoops;
+
+        const qm = this.queueManager;
+        await orchestrateFinalCheck({
+            workspaceId,
+            sessionId,
+            checkIndex,
+            loopIndex,
+            sourceIteration,
+            taskId: completedTask.id,
+            processId,
+            responseText,
+            deps: {
+                store,
+                enqueueTask: (payload) => qm.enqueue(payload as any),
+                broadcastSessionComplete: (params) => this.broadcastRalphSessionComplete(
+                    params.workspaceId, params.sessionId, params.processId,
+                    params.totalIterations, params.reason,
+                ),
+                maxGapFixLoops,
+                dataDir: this.dataDir,
+                workingDirectory: (completedTask.payload as any).workingDirectory,
+                folderPath: (completedTask.payload as any).folderPath,
+                provider: (completedTask.payload as any).provider,
+                repoId: completedTask.repoId,
+            },
+        }).catch(err => {
+            logger.warn(LogCategory.AI, `[Ralph/FinalCheck] orchestrateFinalCheck threw: ${err instanceof Error ? err.message : String(err)}`);
+        });
+    }
 
     async requeueForFollowUp(taskId: string, prompt: string, attachments?: Attachment[], imageTempDir?: string, mode?: string, deliveryMode?: string, images?: string[], selectedSkillNames?: string[]): Promise<void> {
         if (!this.queueManager) throw new Error('Queue manager is not available');

--- a/packages/coc/src/server/ralph/enqueue-final-check.ts
+++ b/packages/coc/src/server/ralph/enqueue-final-check.ts
@@ -1,0 +1,165 @@
+/**
+ * AC-01 helpers — final-check task construction and idempotency guards.
+ *
+ * Responsibilities:
+ *  - Build the queue payload for a final-check task.
+ *  - Provide a per-process in-memory Set that guards against duplicate enqueues
+ *    (duplicate completion events for the same session + sourceIteration).
+ *  - Provide pure helpers for computing the next checkIndex and detecting whether
+ *    a check for a given sourceIteration already exists in the persisted record.
+ */
+
+import { buildFinalCheckPrompt } from './final-check-prompt';
+import type { RalphFinalCheckRecord, RalphSessionRecord } from './types';
+
+// ============================================================================
+// In-memory idempotency guard (AC-01 §assumption 5)
+// ============================================================================
+
+/**
+ * Key format: `<sessionId>:<sourceIteration>`
+ * Guards against duplicate completion events within the lifetime of the server
+ * process. Persistent duplicate detection uses `sessionHasFinalCheckFor`.
+ */
+const _enqueuedSet = new Set<string>();
+
+export function finalCheckIdempotencyKey(sessionId: string, sourceIteration: number): string {
+    return `${sessionId}:${sourceIteration}`;
+}
+
+export function wasFinalCheckEnqueued(sessionId: string, sourceIteration: number): boolean {
+    return _enqueuedSet.has(finalCheckIdempotencyKey(sessionId, sourceIteration));
+}
+
+export function markFinalCheckEnqueued(sessionId: string, sourceIteration: number): void {
+    _enqueuedSet.add(finalCheckIdempotencyKey(sessionId, sourceIteration));
+}
+
+/** Exposed for test isolation only. */
+export function _clearFinalCheckEnqueuedSet(): void {
+    _enqueuedSet.clear();
+}
+
+// ============================================================================
+// Persistent duplicate detection
+// ============================================================================
+
+/**
+ * Returns true when the session record already contains a final-check entry
+ * whose `sourceIteration` matches the given value.
+ *
+ * This catches duplicates that survive a server restart (in-memory Set empty).
+ */
+export function sessionHasFinalCheckFor(
+    session: RalphSessionRecord,
+    sourceIteration: number,
+): boolean {
+    return (session.finalChecks ?? []).some(c => c.sourceIteration === sourceIteration);
+}
+
+// ============================================================================
+// Check index helpers
+// ============================================================================
+
+/** Returns the 1-based index for the next final check. */
+export function nextCheckIndex(session: RalphSessionRecord): number {
+    return (session.finalChecks?.length ?? 0) + 1;
+}
+
+// ============================================================================
+// Task payload builder
+// ============================================================================
+
+export interface BuildFinalCheckTaskInput {
+    workspaceId: string;
+    sessionId: string;
+    originalGoal: string;
+    checkIndex: number;
+    sourceIteration: number;
+    loopIndex: number;
+    progressPath: string;
+    workingDirectory?: string;
+    folderPath?: string;
+    repoId?: string;
+    provider?: import('../tasks/task-types').ChatProvider;
+}
+
+/**
+ * Build a `chat` queue task payload for a final-check run.
+ *
+ * The task uses `mode='ralph'` so it is routed to the ralph executor, which
+ * calls `onRalphNext` on completion. The `context.ralph.finalCheck` field
+ * signals the bridge to route the completion to `handleFinalCheckCompletion`
+ * instead of enqueuing the next iteration.
+ */
+export function buildFinalCheckTaskPayload(input: BuildFinalCheckTaskInput) {
+    const {
+        workspaceId, sessionId, originalGoal, checkIndex, sourceIteration,
+        loopIndex, progressPath, workingDirectory, folderPath, repoId, provider,
+    } = input;
+
+    const prompt = buildFinalCheckPrompt({
+        originalGoal,
+        progressPath,
+        sessionId,
+        workspaceId,
+        loopIndex,
+        sourceIteration,
+    });
+
+    return {
+        type: 'chat' as const,
+        priority: 'normal' as const,
+        repoId,
+        folderPath,
+        displayName: `Ralph final check ${checkIndex} (${sessionId})`,
+        payload: {
+            kind: 'chat' as const,
+            mode: 'ralph' as const,
+            prompt,
+            workspaceId,
+            workingDirectory,
+            folderPath,
+            provider,
+            context: {
+                ralph: {
+                    phase: 'executing' as const,
+                    sessionId,
+                    originalGoal,
+                    currentIteration: sourceIteration,
+                    maxIterations: sourceIteration,
+                    finalCheck: {
+                        kind: 'goal-gap-check' as const,
+                        checkIndex,
+                        sourceIteration,
+                        loopIndex,
+                    },
+                },
+            },
+        },
+    };
+}
+
+// ============================================================================
+// Start-record builder
+// ============================================================================
+
+/** Build the initial (status=running) RalphFinalCheckRecord before the task runs. */
+export function buildFinalCheckStartRecord(
+    checkIndex: number,
+    loopIndex: number,
+    sourceIteration: number,
+    taskId: string,
+    processId?: string,
+    nowIso?: string,
+): RalphFinalCheckRecord {
+    return {
+        checkIndex,
+        loopIndex,
+        sourceIteration,
+        taskId,
+        processId,
+        startedAt: nowIso ?? new Date().toISOString(),
+        status: 'running',
+    };
+}

--- a/packages/coc/src/server/ralph/enqueue-iteration.ts
+++ b/packages/coc/src/server/ralph/enqueue-iteration.ts
@@ -9,6 +9,7 @@
 
 import { buildRalphIterationPrompt } from './iteration-prompt';
 import { getPromptOverride } from '../admin/ralph-prompt-overrides';
+import type { ChatProvider } from '../tasks/task-types';
 
 export interface BuildRalphIterationTaskInput {
     workspaceId?: string;
@@ -28,6 +29,8 @@ export interface BuildRalphIterationTaskInput {
     displayName?: string;
     /** Priority for the enqueued task. Defaults to 'normal'. */
     priority?: 'normal' | 'low' | 'high';
+    /** AI provider to use for this Ralph execution task. */
+    provider?: ChatProvider;
 }
 
 export function buildRalphIterationTask(input: BuildRalphIterationTaskInput) {
@@ -53,6 +56,7 @@ export function buildRalphIterationTask(input: BuildRalphIterationTaskInput) {
             workspaceId: input.workspaceId,
             workingDirectory: input.workingDirectory,
             folderPath: input.folderPath,
+            provider: input.provider,
             context: {
                 ...(input.extraContext ?? {}),
                 ralph: {

--- a/packages/coc/src/server/ralph/final-check-prompt.ts
+++ b/packages/coc/src/server/ralph/final-check-prompt.ts
@@ -1,0 +1,113 @@
+/**
+ * Builds the checker prompt for the Ralph Final Check task (AC-02).
+ *
+ * The checker AI is read-only. It must not edit files, commit, push,
+ * create Work Items, or invoke new-loop routes. Its only job is to compare
+ * the original goal/spec against the actual repo changes, validation
+ * evidence, and the Ralph progress journal, then output a structured
+ * RALPH_FINAL_CHECK_RESULT block.
+ *
+ * Prompt design principles:
+ * - File-path references only; large file contents are not inlined.
+ * - Repository-agnostic instructions.
+ * - Explicit prohibition on all write operations.
+ */
+
+export interface BuildFinalCheckPromptInput {
+    /** The original goal text (or path to goal.md). */
+    originalGoal: string;
+    /** Path to progress.md for this session. */
+    progressPath: string;
+    /** Session id for context. */
+    sessionId: string;
+    /** Workspace id for context. */
+    workspaceId: string;
+    /** 1-based loop index that just completed. */
+    loopIndex: number;
+    /** The last iteration number of the completed loop. */
+    sourceIteration: number;
+}
+
+const READ_ONLY_INSTRUCTIONS = `You are a read-only final-check agent for a Ralph autonomous coding session.
+
+IMPORTANT CONSTRAINTS — you must not:
+- Edit, create, delete, or rename any files.
+- Run git commit, git push, or any command that modifies repository state.
+- Call any API endpoint (new-loop, work-items, etc.).
+- Start a new Ralph session or loop yourself.
+
+Your only job is to evaluate whether the delivered changes satisfy the original goal/spec, then emit a structured RALPH_FINAL_CHECK_RESULT block.`;
+
+const EVALUATION_INSTRUCTIONS = `## Evaluation Steps
+
+1. Read the original goal and any referenced spec files (look for goal.md and ac-NN-*.spec.md in the working directory).
+2. Read the progress journal at the path provided below.
+3. Inspect recent git commits and diffs (run: git --no-pager log --oneline -20 and git --no-pager diff HEAD~<n>..HEAD for the relevant range).
+4. Run any validation commands referenced in the spec's "Definition of Done" sections or the progress journal (build, test, lint). These are read-only verification runs.
+5. Check for missing test evidence, failing validation, unmet acceptance criteria, "Remaining:" entries in progress journal that were not resolved, or contradictions between progress.md and the actual diff.
+
+## Gap Classification
+
+Treat the following as gaps:
+- An acceptance criterion has no recorded evidence it was tested/validated.
+- A "Remaining:" entry in the journal was not addressed.
+- Validation commands referenced in the spec fail or are missing.
+- The diff contradicts a claim in progress.md (e.g., a file listed as created does not exist).
+- A Definition of Done step is not satisfied with documented evidence.
+
+## Output Format
+
+After your evaluation, output EXACTLY ONE JSON block using this structure (no trailing text after the block):
+
+RALPH_FINAL_CHECK_RESULT
+\`\`\`json
+{
+  "marker": "RALPH_FINAL_CHECK_RESULT",
+  "hasGaps": <true|false>,
+  "summary": "<one-paragraph assessment>",
+  "gaps": [
+    {
+      "id": "GAP-01",
+      "title": "<short title>",
+      "evidence": "<what the gap is and why>",
+      "recommendedAction": "<what to do to close it>",
+      "validation": "<optional command to verify the fix>"
+    }
+  ],
+  "gapFixGoal": "<required when hasGaps is true — focused goal text for a gap-fix loop>"
+}
+\`\`\`
+
+Rules:
+- When hasGaps is false, gaps must be an empty array and gapFixGoal must be absent or empty.
+- When hasGaps is true, gaps must be non-empty and gapFixGoal must be a non-empty string.
+- Do not include both hasGaps:false and a non-empty gaps array.`;
+
+/**
+ * Build the user-message prompt for one final-check task.
+ */
+export function buildFinalCheckPrompt(input: BuildFinalCheckPromptInput): string {
+    const { originalGoal, progressPath, sessionId, workspaceId, loopIndex, sourceIteration } = input;
+    const goalSection = originalGoal.trim().startsWith('/')
+        ? `Read the original goal from: ${originalGoal.trim()}`
+        : `Original goal:\n${originalGoal.trim()}`;
+
+    return [
+        READ_ONLY_INSTRUCTIONS,
+        '',
+        '---',
+        '',
+        '## Session Context',
+        `Session ID: ${sessionId}`,
+        `Workspace ID: ${workspaceId}`,
+        `Loop just completed: ${loopIndex} (last iteration: ${sourceIteration})`,
+        '',
+        '## Goal Reference',
+        goalSection,
+        '',
+        '## Progress Journal',
+        `Read the Ralph progress journal from: ${progressPath}`,
+        '',
+        EVALUATION_INSTRUCTIONS,
+    ].join('\n');
+}

--- a/packages/coc/src/server/ralph/final-check-result-parser.ts
+++ b/packages/coc/src/server/ralph/final-check-result-parser.ts
@@ -1,0 +1,194 @@
+/**
+ * Parser for the structured RALPH_FINAL_CHECK_RESULT block emitted by the
+ * read-only final-check AI (AC-02).
+ *
+ * The checker AI is instructed to emit exactly one JSON block preceded by
+ * the `RALPH_FINAL_CHECK_RESULT` marker. This module extracts and validates
+ * that block, handling edge cases defensively.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FinalCheckGap {
+    id: string;
+    title: string;
+    evidence: string;
+    recommendedAction: string;
+    validation?: string;
+}
+
+export type FinalCheckParseStatus =
+    | 'clean'       // hasGaps: false, empty gaps array
+    | 'gaps'        // hasGaps: true, non-empty gaps array
+    | 'invalid'     // contradictory fields (hasGaps:false + non-empty gaps, or hasGaps:true + empty gaps)
+    | 'unparseable'; // no marker or malformed JSON
+
+export interface FinalCheckResult {
+    status: FinalCheckParseStatus;
+    hasGaps: boolean;
+    summary: string;
+    gaps: FinalCheckGap[];
+    /**
+     * Focused gap-fix goal. Present when hasGaps is true.
+     * When the AI omitted it but hasGaps is true, this field contains a
+     * synthesized goal (and `goalSynthesized` is true).
+     */
+    gapFixGoal?: string;
+    /** True when gapFixGoal was absent in the AI response and was synthesized. */
+    goalSynthesized?: boolean;
+    /** Raw error message when status is 'unparseable' or 'invalid'. */
+    error?: string;
+}
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+const MARKER = 'RALPH_FINAL_CHECK_RESULT';
+
+/**
+ * Extract and parse the RALPH_FINAL_CHECK_RESULT JSON block from a checker
+ * AI response string.
+ *
+ * Strategy:
+ * 1. Locate the `RALPH_FINAL_CHECK_RESULT` marker.
+ * 2. Extract the first ```json ... ``` fenced block after the marker, or a
+ *    bare `{...}` block.
+ * 3. Validate the parsed object.
+ * 4. Handle contradictory fields and synthesize missing gapFixGoal.
+ */
+export function parseFinalCheckResult(response: string): FinalCheckResult {
+    const normalised = response.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+    const markerIdx = normalised.indexOf(MARKER);
+    if (markerIdx === -1) {
+        return unparseable('Response does not contain RALPH_FINAL_CHECK_RESULT marker');
+    }
+
+    const afterMarker = normalised.slice(markerIdx + MARKER.length);
+
+    // Try to extract JSON from a fenced block first, then bare object
+    const raw = extractJson(afterMarker);
+    if (!raw) {
+        return unparseable('No JSON block found after RALPH_FINAL_CHECK_RESULT marker');
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (err) {
+        return unparseable(`Malformed JSON: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return validateParsed(parsed);
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function extractJson(text: string): string | null {
+    // Prefer fenced ```json ... ``` block
+    const fenced = /```json\s*\n([\s\S]*?)\n```/m.exec(text);
+    if (fenced) return fenced[1].trim();
+
+    // Fall back to first bare { ... } block (greedy from first `{`)
+    const start = text.indexOf('{');
+    if (start === -1) return null;
+
+    let depth = 0;
+    for (let i = start; i < text.length; i++) {
+        if (text[i] === '{') depth++;
+        else if (text[i] === '}') {
+            depth--;
+            if (depth === 0) return text.slice(start, i + 1);
+        }
+    }
+    return null;
+}
+
+function validateParsed(parsed: unknown): FinalCheckResult {
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return unparseable('JSON root must be an object');
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    if (obj['marker'] !== MARKER) {
+        return unparseable(`JSON "marker" field must equal "${MARKER}"`);
+    }
+
+    if (typeof obj['hasGaps'] !== 'boolean') {
+        return unparseable('"hasGaps" field must be a boolean');
+    }
+
+    const hasGaps = obj['hasGaps'] as boolean;
+    const summary = typeof obj['summary'] === 'string' ? obj['summary'] : '';
+    const rawGaps = Array.isArray(obj['gaps']) ? obj['gaps'] : [];
+    const gaps = rawGaps.map(normaliseGap).filter((g): g is FinalCheckGap => g !== null);
+    const rawGapFixGoal = typeof obj['gapFixGoal'] === 'string' ? obj['gapFixGoal'].trim() : '';
+
+    // Contradiction: hasGaps:false but non-empty gaps
+    if (!hasGaps && gaps.length > 0) {
+        return {
+            status: 'invalid',
+            hasGaps: false,
+            summary,
+            gaps,
+            error: 'Contradictory result: hasGaps is false but gaps array is non-empty',
+        };
+    }
+
+    // Contradiction: hasGaps:true but empty gaps
+    if (hasGaps && gaps.length === 0) {
+        return {
+            status: 'invalid',
+            hasGaps: true,
+            summary,
+            gaps: [],
+            error: 'Contradictory result: hasGaps is true but gaps array is empty',
+        };
+    }
+
+    if (!hasGaps) {
+        return { status: 'clean', hasGaps: false, summary, gaps: [] };
+    }
+
+    // hasGaps: true path
+    let gapFixGoal = rawGapFixGoal;
+    let goalSynthesized = false;
+
+    if (!gapFixGoal) {
+        // Synthesize a conservative goal from the gap list
+        const gapList = gaps.map(g => `- ${g.title}: ${g.evidence}`).join('\n');
+        gapFixGoal = `Fix only the following gaps found by the final checker. Preserve all completed behavior. Rerun required validation and emit RALPH_COMPLETE only when each gap is resolved.\n\nGaps:\n${gapList}`;
+        goalSynthesized = true;
+    }
+
+    return {
+        status: 'gaps',
+        hasGaps: true,
+        summary,
+        gaps,
+        gapFixGoal,
+        ...(goalSynthesized ? { goalSynthesized: true } : {}),
+    };
+}
+
+function normaliseGap(raw: unknown): FinalCheckGap | null {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const obj = raw as Record<string, unknown>;
+    return {
+        id: typeof obj['id'] === 'string' ? obj['id'] : 'GAP-?',
+        title: typeof obj['title'] === 'string' ? obj['title'] : '(untitled)',
+        evidence: typeof obj['evidence'] === 'string' ? obj['evidence'] : '',
+        recommendedAction: typeof obj['recommendedAction'] === 'string' ? obj['recommendedAction'] : '',
+        ...(typeof obj['validation'] === 'string' ? { validation: obj['validation'] } : {}),
+    };
+}
+
+function unparseable(error: string): FinalCheckResult {
+    return { status: 'unparseable', hasGaps: false, summary: '', gaps: [], error };
+}

--- a/packages/coc/src/server/ralph/orchestrate-final-check.ts
+++ b/packages/coc/src/server/ralph/orchestrate-final-check.ts
@@ -1,0 +1,323 @@
+/**
+ * AC-04/05 — Orchestrate the outcome of a completed final-check task.
+ *
+ * Responsibilities:
+ *  1. Parse the checker AI response for a RALPH_FINAL_CHECK_RESULT block.
+ *  2. Persist the result section in progress.md and update session.json.
+ *  3. When gaps exist and the safety cap is not reached, start a same-session
+ *     new loop with a focused gap-fix goal (AC-04).
+ *  4. Repeat check → gap-loop → check until clean or cap reached (AC-05).
+ *  5. Never create a Work Item or modify the session outside these boundaries.
+ *
+ * The caller (queue-executor-bridge) is responsible for supplying injected
+ * callbacks so this module remains testable without a live queue.
+ */
+
+import { parseFinalCheckResult, type FinalCheckResult } from './final-check-result-parser';
+import { RalphSessionStore } from './ralph-session-store';
+import { buildRalphIterationTask } from './enqueue-iteration';
+import type { RalphFinalCheckRecord } from './types';
+import { getLogger, LogCategory } from '@plusplusoneplusplus/forge';
+import { RALPH_DEFAULT_MAX_ITERATIONS, readRepoPreferences } from '../preferences-handler';
+
+// ============================================================================
+// Injected dependencies (allow testability without a live bridge/WS)
+// ============================================================================
+
+export interface OrchestrateFinalCheckDeps {
+    /** Persist final-check records and progress sections. */
+    store: RalphSessionStore;
+    /** Enqueue a task and return its assigned task ID. */
+    enqueueTask: (payload: ReturnType<typeof buildRalphIterationTask>) => string;
+    /**
+     * Broadcast a ralph-session-complete WS event when the session is
+     * genuinely finished (clean check or cap reached).
+     */
+    broadcastSessionComplete: (params: {
+        workspaceId: string;
+        sessionId: string;
+        processId: string;
+        totalIterations: number;
+        reason: string;
+    }) => void;
+    /** Resolved `ralph.finalCheck.maxGapFixLoops` from config (default: 3). */
+    maxGapFixLoops: number;
+    /** Repo-scoped data root (e.g. `~/.coc`). Used for prompt overrides & prefs. */
+    dataDir?: string;
+    /** Working directory for gap-fix iteration tasks. */
+    workingDirectory?: string;
+    /** folderPath for gap-fix iteration tasks. */
+    folderPath?: string;
+    /** AI provider override for gap-fix iterations. */
+    provider?: import('../tasks/task-types').ChatProvider;
+    /** repoId for gap-fix iteration tasks. */
+    repoId?: string;
+}
+
+export interface OrchestrateFinalCheckInput {
+    workspaceId: string;
+    sessionId: string;
+    checkIndex: number;
+    loopIndex: number;
+    sourceIteration: number;
+    taskId: string;
+    processId: string;
+    responseText: string;
+    deps: OrchestrateFinalCheckDeps;
+}
+
+// ============================================================================
+// Public entry point
+// ============================================================================
+
+/**
+ * Orchestrate the outcome of a completed final-check AI task.
+ *
+ * This function is intentionally async-void from the bridge's perspective:
+ * all errors are logged and do not propagate.
+ */
+export async function orchestrateFinalCheck(input: OrchestrateFinalCheckInput): Promise<void> {
+    const {
+        workspaceId, sessionId, checkIndex, loopIndex, sourceIteration,
+        taskId, processId, responseText, deps,
+    } = input;
+    const { store, enqueueTask, broadcastSessionComplete, maxGapFixLoops, dataDir } = deps;
+    const logger = getLogger();
+
+    // ── 1. Parse checker output ─────────────────────────────────────────────
+    const parsed = parseFinalCheckResult(responseText);
+
+    const nowIso = new Date().toISOString();
+
+    // ── 2. Persist progress section ─────────────────────────────────────────
+    const progressSection = buildProgressSection(checkIndex, loopIndex, parsed, nowIso);
+    try {
+        await store.appendFinalCheckSection(workspaceId, sessionId, progressSection);
+    } catch (err) {
+        logger.warn(LogCategory.AI, `[Ralph/FinalCheck] Failed to append progress section for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+        // A failure here must not silently report a clean result (AC-03 edge case).
+        // We still update metadata so the record shows failed status.
+    }
+
+    // ── 3. Determine result and decide next action ───────────────────────────
+    const session = await store.readSessionRecord(workspaceId, sessionId);
+
+    if (parsed.status === 'unparseable' || parsed.status === 'invalid') {
+        // Unparseable or contradictory response — record as failed, do not start gap loop
+        logger.warn(LogCategory.AI, `[Ralph/FinalCheck] Check ${checkIndex} ${parsed.status} for ${sessionId}: ${parsed.error ?? ''}`);
+        await safeUpsertRecord(store, workspaceId, sessionId, checkIndex, {
+            status: 'failed',
+            loopIndex,
+            sourceIteration,
+            taskId,
+            processId,
+            startedAt: session?.finalChecks?.find(c => c.checkIndex === checkIndex)?.startedAt ?? nowIso,
+            completedAt: nowIso,
+        }, logger);
+        broadcastSessionComplete({ workspaceId, sessionId, processId, totalIterations: sourceIteration, reason: 'final-check-failed' });
+        return;
+    }
+
+    if (!parsed.hasGaps || parsed.gaps.length === 0) {
+        // ── Clean result ─────────────────────────────────────────────────────
+        await safeUpsertRecord(store, workspaceId, sessionId, checkIndex, {
+            status: 'completed',
+            loopIndex,
+            sourceIteration,
+            taskId,
+            processId,
+            startedAt: session?.finalChecks?.find(c => c.checkIndex === checkIndex)?.startedAt ?? nowIso,
+            completedAt: nowIso,
+            hasGaps: false,
+            gapCount: 0,
+            gapLoopStarted: false,
+        }, logger);
+        broadcastSessionComplete({ workspaceId, sessionId, processId, totalIterations: sourceIteration, reason: 'signal' });
+        return;
+    }
+
+    // ── Gaps found — check safety cap ────────────────────────────────────────
+    // Count how many gap-fix loops have already been started (not initial loop).
+    const existingGapLoops = (session?.finalChecks ?? []).filter(c => c.gapLoopStarted === true).length;
+    if (existingGapLoops >= maxGapFixLoops) {
+        // Cap reached — persist and surface
+        logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Cap reached (${existingGapLoops}/${maxGapFixLoops}) for session ${sessionId}; stopping automation.`);
+        await safeUpsertRecord(store, workspaceId, sessionId, checkIndex, {
+            status: 'completed',
+            loopIndex,
+            sourceIteration,
+            taskId,
+            processId,
+            startedAt: session?.finalChecks?.find(c => c.checkIndex === checkIndex)?.startedAt ?? nowIso,
+            completedAt: nowIso,
+            hasGaps: true,
+            gapCount: parsed.gaps.length,
+            gapLoopStarted: false,
+            capReached: true,
+        }, logger);
+        broadcastSessionComplete({ workspaceId, sessionId, processId, totalIterations: sourceIteration, reason: 'cap' });
+        return;
+    }
+
+    // ── Start gap-fix loop (AC-04) ────────────────────────────────────────────
+    // The parser already synthesizes gapFixGoal when absent (AC-02); use it directly.
+    const gapFixGoal = (parsed.gapFixGoal ?? '').trim();
+    const goalSynthesized = parsed.goalSynthesized ?? false;
+    if (!gapFixGoal) {
+        // Should never happen (parser guarantees gapFixGoal when hasGaps: true), but defensive
+        logger.warn(LogCategory.AI, `[Ralph/FinalCheck] No gapFixGoal for ${sessionId} — falling back to gap titles.`);
+    }
+
+    // Resolve additional iterations from preferences or default.
+    let additionalIterations = RALPH_DEFAULT_MAX_ITERATIONS;
+    if (dataDir) {
+        try {
+            const prefs = readRepoPreferences(dataDir, workspaceId);
+            if (prefs.maxRalphIterations) additionalIterations = prefs.maxRalphIterations;
+        } catch {
+            // Preferences are optional
+        }
+    }
+
+    let newLoopRecord;
+    try {
+        newLoopRecord = await store.startNewLoop(workspaceId, sessionId, gapFixGoal, additionalIterations, nowIso);
+    } catch (err) {
+        logger.warn(LogCategory.AI, `[Ralph/FinalCheck] startNewLoop failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+        // Record that a gap loop was intended but failed to start.
+        await safeUpsertRecord(store, workspaceId, sessionId, checkIndex, {
+            status: 'completed',
+            loopIndex,
+            sourceIteration,
+            taskId,
+            processId,
+            startedAt: session?.finalChecks?.find(c => c.checkIndex === checkIndex)?.startedAt ?? nowIso,
+            completedAt: nowIso,
+            hasGaps: true,
+            gapCount: parsed.gaps.length,
+            gapLoopStarted: false,
+            goalSynthesized,
+        }, logger);
+        broadcastSessionComplete({ workspaceId, sessionId, processId, totalIterations: sourceIteration, reason: 'final-check-gap-loop-start-failed' });
+        return;
+    }
+
+    const newLoopIndex = newLoopRecord.loops?.[newLoopRecord.loops.length - 1]?.loopIndex ?? (loopIndex + 1);
+    const nextIteration = newLoopRecord.currentIteration + 1;
+
+    const taskInput = buildRalphIterationTask({
+        workspaceId,
+        workingDirectory: deps.workingDirectory,
+        folderPath: deps.folderPath,
+        sessionId,
+        originalGoal: gapFixGoal,
+        iteration: nextIteration,
+        maxIterations: newLoopRecord.maxIterations,
+        dataDir,
+        provider: deps.provider,
+        extraContext: { ralph: { loopIndex: newLoopIndex } },
+    });
+
+    let newTaskId: string;
+    try {
+        newTaskId = enqueueTask(taskInput);
+    } catch (err) {
+        logger.warn(LogCategory.AI, `[Ralph/FinalCheck] enqueue gap-fix failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+        await safeUpsertRecord(store, workspaceId, sessionId, checkIndex, {
+            status: 'completed',
+            loopIndex,
+            sourceIteration,
+            taskId,
+            processId,
+            startedAt: session?.finalChecks?.find(c => c.checkIndex === checkIndex)?.startedAt ?? nowIso,
+            completedAt: nowIso,
+            hasGaps: true,
+            gapCount: parsed.gaps.length,
+            gapLoopStarted: false,
+            goalSynthesized,
+        }, logger);
+        return;
+    }
+
+    logger.debug(LogCategory.AI, `[Ralph/FinalCheck] Gap-fix loop ${newLoopIndex} enqueued as task ${newTaskId} for session ${sessionId}.`);
+
+    await safeUpsertRecord(store, workspaceId, sessionId, checkIndex, {
+        status: 'completed',
+        loopIndex,
+        sourceIteration,
+        taskId,
+        processId,
+        startedAt: session?.finalChecks?.find(c => c.checkIndex === checkIndex)?.startedAt ?? nowIso,
+        completedAt: nowIso,
+        hasGaps: true,
+        gapCount: parsed.gaps.length,
+        gapLoopStarted: true,
+        gapLoopIndex: newLoopIndex,
+        goalSynthesized: goalSynthesized || undefined,
+    }, logger);
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+async function safeUpsertRecord(
+    store: RalphSessionStore,
+    workspaceId: string,
+    sessionId: string,
+    checkIndex: number,
+    partial: Partial<RalphFinalCheckRecord> & Pick<RalphFinalCheckRecord, 'status'>,
+    logger: ReturnType<typeof getLogger>,
+): Promise<void> {
+    try {
+        await store.upsertFinalCheckRecord(workspaceId, sessionId, checkIndex, partial);
+    } catch (err) {
+        logger.warn(LogCategory.AI, `[Ralph/FinalCheck] Failed to persist metadata for ${sessionId} check ${checkIndex}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+function buildProgressSection(
+    checkIndex: number,
+    loopIndex: number,
+    parsed: FinalCheckResult,
+    nowIso: string,
+): string {
+    if (parsed.status === 'unparseable' || parsed.status === 'invalid') {
+        return [
+            `---`,
+            `## Final Check ${checkIndex} - FAILED - ${nowIso}`,
+            `Loop: ${loopIndex}`,
+            ``,
+            `The final-check task completed but produced no parseable RALPH_FINAL_CHECK_RESULT block.`,
+            `Automation stopped. Manual review required.`,
+            ...(parsed.error ? [`Error: ${parsed.error}`] : []),
+        ].join('\n');
+    }
+    if (!parsed.hasGaps) {
+        return [
+            `---`,
+            `## Final Check ${checkIndex} - CLEAN - ${nowIso}`,
+            `Loop: ${loopIndex}`,
+            ``,
+            parsed.summary,
+        ].join('\n');
+    }
+    const gapLines = parsed.gaps.map((g: FinalCheckResult['gaps'][number]) =>
+        `- **${g.id}**: ${g.title}\n  Evidence: ${g.evidence}\n  Action: ${g.recommendedAction}${g.validation ? `\n  Validation: \`${g.validation}\`` : ''}`,
+    ).join('\n');
+    return [
+        `---`,
+        `## Final Check ${checkIndex} - GAPS - ${nowIso}`,
+        `Loop: ${loopIndex}`,
+        ``,
+        parsed.summary,
+        ``,
+        `### Gaps (${parsed.gaps.length})`,
+        gapLines,
+        ``,
+        `### Gap-fix goal`,
+        parsed.gapFixGoal ?? '*(synthesized)*',
+    ].join('\n');
+}
+
+

--- a/packages/coc/src/server/ralph/ralph-session-store.ts
+++ b/packages/coc/src/server/ralph/ralph-session-store.ts
@@ -13,6 +13,7 @@ import { getRepoDataPath } from '../paths';
 import type {
     ParsedProgressSection,
     RalphExitSignal,
+    RalphFinalCheckRecord,
     RalphLoopRecord,
     RalphSessionRecord,
 } from './types';
@@ -380,6 +381,71 @@ export class RalphSessionStore {
         }
 
         await fs.promises.appendFile(progressPath, marker, 'utf-8');
+    }
+
+    /**
+     * Append a final-check section to `progress.md`.
+     *
+     * The `content` is raw Markdown. The caller is responsible for formatting
+     * (heading, status, gap list, etc.). The content is appended with a leading
+     * newline separator so sections remain visually distinct.
+     */
+    async appendFinalCheckSection(
+        workspaceId: string,
+        sessionId: string,
+        content: string,
+    ): Promise<void> {
+        const dir = this.getSessionDir(workspaceId, sessionId);
+        await fs.promises.mkdir(dir, { recursive: true });
+        const progressPath = this.getProgressPath(workspaceId, sessionId);
+        const block = `\n${content.trim()}\n`;
+        await fs.promises.appendFile(progressPath, block, 'utf-8');
+        await this.enforceSizeCap(progressPath);
+    }
+
+    /**
+     * Add or update a `RalphFinalCheckRecord` in `session.json`.
+     *
+     * - If `finalChecks` is absent (legacy session), it is initialised as `[]`.
+     * - If a record with `checkIndex` already exists, it is replaced.
+     * - Otherwise the record is appended.
+     *
+     * Returns the updated session record.
+     */
+    async upsertFinalCheckRecord(
+        workspaceId: string,
+        sessionId: string,
+        checkIndex: number,
+        partial: Partial<RalphFinalCheckRecord> & Pick<RalphFinalCheckRecord, 'status'>,
+    ): Promise<RalphSessionRecord> {
+        return this.updateSessionRecord(workspaceId, sessionId, (rec) => {
+            const base = rec ?? {
+                sessionId,
+                workspaceId,
+                originalGoal: '',
+                maxIterations: 0,
+                currentIteration: 0,
+                phase: 'complete' as const,
+                startedAt: new Date().toISOString(),
+                iterations: [],
+            };
+            const existing = base.finalChecks ?? [];
+            const idx = existing.findIndex(c => c.checkIndex === checkIndex);
+            const updated: RalphFinalCheckRecord = {
+                checkIndex,
+                loopIndex: partial.loopIndex ?? 1,
+                sourceIteration: partial.sourceIteration ?? 0,
+                startedAt: partial.startedAt ?? new Date().toISOString(),
+                ...partial,
+            };
+            const next = [...existing];
+            if (idx >= 0) {
+                next[idx] = { ...next[idx], ...updated };
+            } else {
+                next.push(updated);
+            }
+            return { ...base, finalChecks: next };
+        });
     }
 
     private async atomicWriteJson(filePath: string, value: unknown): Promise<void> {

--- a/packages/coc/src/server/ralph/types.ts
+++ b/packages/coc/src/server/ralph/types.ts
@@ -49,6 +49,8 @@ export interface RalphSessionRecord {
     iterations: RalphIterationRecord[];
     /** Multi-loop history. Absent on pre-existing single-loop sessions. */
     loops?: RalphLoopRecord[];
+    /** Final-check automation records. Absent on legacy sessions. */
+    finalChecks?: RalphFinalCheckRecord[];
 }
 
 export interface ParsedProgressSection {
@@ -56,4 +58,36 @@ export interface ParsedProgressSection {
     signal: RalphExitSignal;
     timestamp: string;
     body: string;
+}
+
+// ============================================================================
+// Final-check types (AC-01, AC-03)
+// ============================================================================
+
+export type RalphFinalCheckStatus = 'running' | 'completed' | 'failed';
+
+/** Metadata record for one final-check run within a Ralph session. */
+export interface RalphFinalCheckRecord {
+    /** 1-based index of this check within the session. */
+    checkIndex: number;
+    /** The loop index that triggered this check (the loop that just completed). */
+    loopIndex: number;
+    /** The iteration number of the last iteration in the triggering loop. */
+    sourceIteration: number;
+    taskId?: string;
+    processId?: string;
+    startedAt: string;
+    completedAt?: string;
+    status: RalphFinalCheckStatus;
+    /** Undefined while running; set on completion or failure. */
+    hasGaps?: boolean;
+    gapCount?: number;
+    /** True if a gap-fix loop was started after this check. */
+    gapLoopStarted?: boolean;
+    /** The loopIndex of the gap-fix loop started, if any. */
+    gapLoopIndex?: number;
+    /** True when the gap-fix-loop cap was reached and no new loop was started. */
+    capReached?: boolean;
+    /** True when gapFixGoal was absent but synthesized server-side. */
+    goalSynthesized?: boolean;
 }

--- a/packages/coc/src/server/repos/pr-routes.ts
+++ b/packages/coc/src/server/repos/pr-routes.ts
@@ -19,6 +19,8 @@
  */
 
 import * as url from 'url';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import type { Route } from '../types';
 import { sendJson, send404, send400, send500, readJsonBody } from '../router';
 import { RepoTreeService } from './tree-service';
@@ -144,6 +146,32 @@ export function clearPrDiffCache(): void {
 /** Clear the cached diff for one specific PR (used by force-refresh). */
 function clearPrDiffCacheEntry(repoId: string, prId: string): void {
     prDiffCache.delete(makePrDiffCacheKey(repoId, prId));
+}
+
+/**
+ * Attempt to produce a full-file-context diff by running `git diff -U99999`
+ * with the PR's base and head SHAs against the local repo checkout.
+ *
+ * Returns the diff string on success, or null if git is unavailable,
+ * the SHAs are not present locally (e.g. fork commits), or any other error.
+ */
+async function getFullContextFileDiff(
+    localPath: string,
+    baseSha: string,
+    headSha: string,
+    filePath: string,
+): Promise<string | null> {
+    const execFileAsync = promisify(execFile);
+    try {
+        const { stdout } = await execFileAsync(
+            'git',
+            ['diff', '-U99999', baseSha, headSha, '--', filePath],
+            { cwd: localPath, encoding: 'utf-8', timeout: 10_000 },
+        );
+        return stdout || null;
+    } catch {
+        return null;
+    }
 }
 
 /**
@@ -604,11 +632,13 @@ export function registerPrRoutes(routes: Route[], dataDir: string, service?: Rep
     routes.push({
         method: 'GET',
         pattern: /^\/api\/repos\/([^/]+)\/pull-requests\/([^/]+)\/diff\/files\/(.+)$/,
-        handler: async (_req, res, match) => {
+        handler: async (req, res, match) => {
             try {
                 const repoId = decodeURIComponent(match![1]);
                 const prId = decodeURIComponent(match![2]);
                 const filePath = decodeURIComponent(match![3]);
+                const query = url.parse(req.url ?? '', true).query;
+                const fullContext = query.fullContext === 'true';
 
                 const repo = await svc.resolveRepo(repoId);
                 if (!repo) return send404(res, `Repo ${repoId} not found`);
@@ -633,6 +663,24 @@ export function registerPrRoutes(routes: Route[], dataDir: string, service?: Rep
                     prSvc.getDiff.bind(prSvc),
                 );
                 const fileDiff = extractFileDiffFromCombined(combinedDiff, filePath);
+
+                if (fullContext) {
+                    // Try to get a full-context diff via local git
+                    const cachedDetail = prDetailCache.get(makePrDetailCacheKey(repoId, prId));
+                    const prData = cachedDetail?.data as { headSha?: string; baseSha?: string } | undefined;
+                    const baseSha = prData?.baseSha;
+                    const headSha = prData?.headSha;
+
+                    if (baseSha && headSha && repo.localPath) {
+                        const fullCtxDiff = await getFullContextFileDiff(repo.localPath, baseSha, headSha, filePath);
+                        if (fullCtxDiff) {
+                            return sendJson(res, { diff: fullCtxDiff, fullContextUnavailable: false });
+                        }
+                    }
+                    // Could not produce full-context diff; return hunk diff with flag
+                    return sendJson(res, { diff: fileDiff ?? '', fullContextUnavailable: true });
+                }
+
                 sendJson(res, { diff: fileDiff ?? '' });
             } catch (err) {
                 if (err instanceof Error && (err.message.includes('not found') || err.message.includes('404'))) {

--- a/packages/coc/src/server/repos/pr-routes.ts
+++ b/packages/coc/src/server/repos/pr-routes.ts
@@ -124,6 +124,52 @@ export function clearPrDetailCache(): void {
 }
 
 // ============================================================================
+// PR diff cache (in-memory, no TTL — invalidated by PR force-refresh only)
+// ============================================================================
+
+// Keyed by repoId|prId. No TTL: the combined diff for a PR is stable until
+// the reviewer explicitly refreshes (force=true on the detail endpoint).
+
+const prDiffCache = new Map<string, string>();
+
+function makePrDiffCacheKey(repoId: string, prId: string): string {
+    return `${repoId}|${prId}`;
+}
+
+/** Clear all cached PR diff entries. Exported for testing. */
+export function clearPrDiffCache(): void {
+    prDiffCache.clear();
+}
+
+/** Clear the cached diff for one specific PR (used by force-refresh). */
+function clearPrDiffCacheEntry(repoId: string, prId: string): void {
+    prDiffCache.delete(makePrDiffCacheKey(repoId, prId));
+}
+
+/**
+ * Return the combined diff for a PR, fetching it once and caching the result.
+ * Both the full-diff and per-file-diff endpoints call this so only one
+ * provider round-trip occurs per PR per cache lifetime.
+ */
+async function getCachedCombinedDiff(
+    repoId: string,
+    prId: string,
+    getDiff: (repoId: string, prId: string) => Promise<string>,
+): Promise<string> {
+    const key = makePrDiffCacheKey(repoId, prId);
+    const hit = prDiffCache.get(key);
+    if (hit !== undefined) {
+        console.debug(`[pr-diff-cache] hit key=${key}`);
+        return hit;
+    }
+    console.debug(`[pr-diff-cache] miss key=${key}`);
+    const diff = await getDiff(repoId, prId);
+    prDiffCache.set(key, diff);
+    console.debug(`[pr-diff-cache] set key=${key}`);
+    return diff;
+}
+
+// ============================================================================
 // Registration
 // ============================================================================
 
@@ -353,6 +399,8 @@ export function registerPrRoutes(routes: Route[], dataDir: string, service?: Rep
                 // Serve from cache if valid and not forced
                 if (force) {
                     prDetailCache.delete(cacheKey);
+                    // Also evict the diff cache so the next diff request refetches.
+                    clearPrDiffCacheEntry(repoId, prId);
                     console.debug(`[pr-detail-cache] bypass key=${cacheKey}`);
                 }
 
@@ -579,7 +627,11 @@ export function registerPrRoutes(routes: Route[], dataDir: string, service?: Rep
                     return sendJson(res, { diff: '' });
                 }
 
-                const combinedDiff = await prSvc.getDiff(repoId, prId);
+                const combinedDiff = await getCachedCombinedDiff(
+                    repoId,
+                    prId,
+                    prSvc.getDiff.bind(prSvc),
+                );
                 const fileDiff = extractFileDiffFromCombined(combinedDiff, filePath);
                 sendJson(res, { diff: fileDiff ?? '' });
             } catch (err) {
@@ -623,7 +675,11 @@ export function registerPrRoutes(routes: Route[], dataDir: string, service?: Rep
                     return;
                 }
 
-                const diff = await prSvc.getDiff(repoId, prId);
+                const diff = await getCachedCombinedDiff(
+                    repoId,
+                    prId,
+                    prSvc.getDiff.bind(prSvc),
+                );
                 res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
                 res.end(diff);
             } catch (err) {

--- a/packages/coc/src/server/routes/ralph-launch-routes.ts
+++ b/packages/coc/src/server/routes/ralph-launch-routes.ts
@@ -14,6 +14,8 @@ import { toQueueProcessId, getLogger, LogCategory } from '@plusplusoneplusplus/f
 import { RalphSessionStore } from '../ralph/ralph-session-store';
 import { buildRalphIterationTask } from '../ralph/enqueue-iteration';
 import { RALPH_DEFAULT_MAX_ITERATIONS, readRepoPreferences } from '../preferences-handler';
+import { VALID_CHAT_PROVIDERS } from '../tasks/task-types';
+import type { ChatProvider } from '../tasks/task-types';
 
 export interface RalphLaunchRouteContext {
     bridge: MultiRepoQueueRouter;
@@ -53,6 +55,18 @@ export function registerRalphLaunchRoutes(routes: Route[], ctx: RalphLaunchRoute
             const workingDirectory = typeof body.workingDirectory === 'string' && body.workingDirectory
                 ? body.workingDirectory
                 : folderPath;
+            const provider = body.provider === undefined
+                ? undefined
+                : body.provider as ChatProvider;
+            if (provider !== undefined && !VALID_CHAT_PROVIDERS.has(provider)) {
+                return sendError(res, 400, `Invalid provider: '${String(body.provider)}'. Valid providers: ${[...VALID_CHAT_PROVIDERS].join(', ')}`);
+            }
+            const config = body.config && typeof body.config === 'object'
+                ? body.config as Record<string, unknown>
+                : {};
+            const model = typeof config.model === 'string' && config.model.trim()
+                ? config.model.trim()
+                : undefined;
 
             // Resolve max iterations: per-repo preference > hardcoded default.
             let prefMax: number | undefined;
@@ -93,11 +107,14 @@ export function registerRalphLaunchRoutes(routes: Route[], ctx: RalphLaunchRoute
                 iteration: 1,
                 maxIterations,
                 dataDir,
+                provider,
             });
 
             const taskId = await bridge.enqueue({
                 ...task,
-                config: {},
+                config: {
+                    ...(model ? { model } : {}),
+                },
             });
 
             sendJSON(res, 200, { processId: toQueueProcessId(taskId), sessionId });

--- a/packages/coc/src/server/spa/client/react/features/git/diff/FileDiffPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/FileDiffPanel.tsx
@@ -81,9 +81,18 @@ export function FileDiffPanel({
     const { dispatch: queueDispatch } = useQueue();
 
     // ── Diff fetching ──
-    const diffUrl = source.fileDiffUrl(filePath);
+    const [fullContextMode, setFullContextMode] = useState(false);
+
+    // Reset full-context mode when navigating to a different file
+    useEffect(() => {
+        setFullContextMode(false);
+    }, [filePath]);
+
+    const diffUrl = fullContextMode && source.fullContextFileDiffUrl
+        ? source.fullContextFileDiffUrl(filePath)
+        : source.fileDiffUrl(filePath);
     const fullDiffUrl = source.supportsTruncation ? source.fileDiffUrl(filePath, true) : null;
-    const { diff, loading, error, retry, truncated, totalLines, requestFullDiff } =
+    const { diff, loading, error, retry, truncated, totalLines, requestFullDiff, fullContextUnavailable } =
         useFileDiff(diffUrl, fullDiffUrl);
 
     // ── View mode ──
@@ -319,6 +328,21 @@ export function FileDiffPanel({
                 <div className="flex items-center gap-2">
                     <HunkNavButtons onPrev={handlePrev} onNext={handleNext} />
                     <DiffViewToggle mode={viewMode} onChange={setViewMode} />
+                    {source.fullContextFileDiffUrl && (
+                        <button
+                            onClick={() => setFullContextMode(m => !m)}
+                            title={fullContextMode ? 'Switch to hunk-only diff' : 'Show full-file context'}
+                            className={
+                                fullContextMode
+                                    ? 'inline-flex h-6 items-center gap-1 rounded border border-[#0078d4] bg-[#ddeeff] px-2 text-[11px] font-medium text-[#005a9e] hover:bg-[#cce0ff] dark:border-[#3794ff] dark:bg-[#1e3a5f] dark:text-[#79c0ff] dark:hover:bg-[#1e4a7a]'
+                                    : 'inline-flex h-6 items-center gap-1 rounded border border-gray-300 bg-white px-2 text-[11px] font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                            }
+                            data-testid="full-context-toggle-btn"
+                            aria-pressed={fullContextMode}
+                        >
+                            {fullContextMode ? '⊟ Full context' : '⊞ Full context'}
+                        </button>
+                    )}
                     {showSourceLabel && source.label && (
                         <span className="text-xs text-[#616161] dark:text-[#999] flex-shrink-0">
                             {source.label}
@@ -436,6 +460,16 @@ export function FileDiffPanel({
                                     >
                                         Load full diff
                                     </button>
+                                </div>
+                            )}
+                            {fullContextUnavailable && (
+                                <div
+                                    className="flex items-center gap-2 px-4 py-2 text-xs bg-[#fff3cd] dark:bg-[#3a3000] border-t border-[#e0e0e0] dark:border-[#3c3c3c]"
+                                    data-testid="full-context-unavailable-banner"
+                                >
+                                    <span>
+                                        Full-file context unavailable for this file (PR commit SHAs may not be locally present). Showing hunk diff instead.
+                                    </span>
                                 </div>
                             )}
                         </>

--- a/packages/coc/src/server/spa/client/react/features/git/diff/UnifiedDiffViewer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/UnifiedDiffViewer.tsx
@@ -554,6 +554,20 @@ export const UnifiedDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedDiff
         return map;
     }, [hunkRanges, activeFilters, expandedHunks, filePath, getHunkClassification]);
 
+    // AC-03: hunks that were filtered-out but manually expanded by the reviewer.
+    // These keep a compact classification badge + Collapse button on their @@ header.
+    const expandedByStart = useMemo(() => {
+        const map = new Map<number, HunkRange>();
+        if (!activeFilters || !filePath || !getHunkClassification) return map;
+        for (const h of hunkRanges) {
+            if (!h.classification) continue;
+            if (activeFilters.has(h.classification.category)) continue;
+            if (!expandedHunks.has(h.hunkIndex)) continue;
+            map.set(h.startIdx, h);
+        }
+        return map;
+    }, [hunkRanges, activeFilters, expandedHunks, filePath, getHunkClassification]);
+
     const skipIndices = useMemo(() => {
         const set = new Set<number>();
         for (const h of collapsedByStart.values()) {
@@ -578,6 +592,15 @@ export const UnifiedDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedDiff
             if (prev.has(hunkIndex)) return prev;
             const next = new Set(prev);
             next.add(hunkIndex);
+            return next;
+        });
+    }, []);
+
+    const collapseHunk = useCallback((hunkIndex: number) => {
+        setExpandedHunks(prev => {
+            if (!prev.has(hunkIndex)) return prev;
+            const next = new Set(prev);
+            next.delete(hunkIndex);
             return next;
         });
     }, []);
@@ -801,6 +824,8 @@ export const UnifiedDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedDiff
                         </div>
                     );
                 }
+                // AC-03: hunk that was filtered-out but manually expanded (shows badge + Collapse).
+                const expandedHunk = expandedByStart.get(i);
                 if ((type === 'added' || type === 'removed' || type === 'context') && line.length > 0) {
                     const content = line.slice(1);
                     const intraParts = (type === 'added' || type === 'removed') ? intraLinePartsMap.get(i) : undefined;
@@ -899,6 +924,25 @@ export const UnifiedDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedDiff
                             </span>
                         )}
                         <span className="px-1 flex-1 min-w-0">{line || '\u00a0'}</span>
+                        {expandedHunk?.classification && type === 'hunk-header' && (
+                            <>
+                                <span
+                                    className={`shrink-0 inline-flex items-center self-center px-1.5 py-0.5 mx-1 rounded text-[10px] font-semibold uppercase tracking-wide ${expandedHunk.classification.intensity === 'high' ? 'bg-[#ffd8b2] text-[#b94a00] dark:bg-[#5a2e00] dark:text-[#ffb380]' : 'bg-[#e0e7ff] text-[#3730a3] dark:bg-[#1e293b] dark:text-[#93c5fd]'}`}
+                                    title={expandedHunk.classification.reason}
+                                    data-testid="expanded-hunk-badge"
+                                >
+                                    {CATEGORY_LABELS[expandedHunk.classification.category]}
+                                </span>
+                                <button
+                                    type="button"
+                                    className="shrink-0 self-center text-[11px] px-2 py-0.5 mx-1 rounded bg-white dark:bg-[#1f2937] border border-[#d0d7de] dark:border-[#3c3c3c] text-[#24292f] dark:text-[#c9d1d9] hover:bg-[#f3f4f6] dark:hover:bg-[#2a3340]"
+                                    onClick={() => collapseHunk(expandedHunk.hunkIndex)}
+                                    data-testid="expanded-hunk-collapse"
+                                >
+                                    Collapse
+                                </button>
+                            </>
+                        )}
                     </div>
                 );
             })}

--- a/packages/coc/src/server/spa/client/react/features/git/diff/diffSource.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/diffSource.ts
@@ -10,6 +10,12 @@ export interface DiffFetchResult {
     diff: string;
     truncated: boolean;
     totalLines: number;
+    /**
+     * True when the caller requested a full-file-context diff but the server
+     * could not produce one (e.g. PR SHAs not locally available). The diff
+     * field will contain the normal hunk-only diff as a fallback.
+     */
+    fullContextUnavailable?: boolean;
 }
 
 /**
@@ -57,6 +63,13 @@ export interface DiffSource {
      * @param full — when true, appends ?full=true to bypass server truncation.
      */
     fileDiffUrl(filePath: string, full?: boolean): string;
+
+    /**
+     * Build the API URL for a full-file-context diff.
+     * When present, the UI may offer a toggle to switch from hunk-only to
+     * full-context. Returns null when the source does not support it.
+     */
+    fullContextFileDiffUrl?(filePath: string): string | null;
 
     /**
      * Build the API URL for the full (all-files) diff.
@@ -209,6 +222,7 @@ export async function fetchDiffFromSource(url: string): Promise<DiffFetchResult>
         diff: data.diff ?? '',
         truncated: !!data.truncated,
         totalLines: data.totalLines ?? 0,
+        fullContextUnavailable: data.fullContextUnavailable === true ? true : undefined,
     };
 }
 
@@ -233,6 +247,10 @@ export function createPrDiffSource(
 
         fileDiffUrl(filePath: string, _full?: boolean): string {
             return `/api/repos/${encodeURIComponent(repoId)}/pull-requests/${encodeURIComponent(prId)}/diff/files/${encodeURIComponent(filePath)}`;
+        },
+
+        fullContextFileDiffUrl(filePath: string): string {
+            return `/api/repos/${encodeURIComponent(repoId)}/pull-requests/${encodeURIComponent(prId)}/diff/files/${encodeURIComponent(filePath)}?fullContext=true`;
         },
 
         fullDiffUrl(): string {

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useFileDiff.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useFileDiff.ts
@@ -21,6 +21,12 @@ export interface FileDiffState {
     totalLines: number;
     /** Call to re-fetch with full=true. No-op if not truncated. */
     requestFullDiff: () => void;
+    /**
+     * True when a full-context diff was requested but the server could not
+     * produce one (e.g. PR SHAs not locally available). The diff field holds
+     * the normal hunk-only diff as a fallback.
+     */
+    fullContextUnavailable?: boolean;
 }
 
 /**
@@ -41,6 +47,7 @@ export function useFileDiff(
     const [truncated, setTruncated] = useState(false);
     const [totalLines, setTotalLines] = useState(0);
     const [fullRequested, setFullRequested] = useState(false);
+    const [fullContextUnavailable, setFullContextUnavailable] = useState<boolean | undefined>(undefined);
 
     // Track the latest url to avoid stale fetches
     const urlRef = useRef(url);
@@ -56,6 +63,7 @@ export function useFileDiff(
                 setDiff(result.diff);
                 setTruncated(result.truncated);
                 setTotalLines(result.totalLines);
+                setFullContextUnavailable(result.fullContextUnavailable);
             })
             .catch((err: Error) => {
                 if (urlRef.current !== url) return;
@@ -72,6 +80,7 @@ export function useFileDiff(
         setFullRequested(false);
         setTruncated(false);
         setTotalLines(0);
+        setFullContextUnavailable(undefined);
         if (!url) {
             setDiff(null);
             setLoading(false);
@@ -98,5 +107,5 @@ export function useFileDiff(
         setFullRequested(true);
     }, [truncated, fullUrl]);
 
-    return { diff, loading, error, retry, truncated, totalLines, requestFullDiff };
+    return { diff, loading, error, retry, truncated, totalLines, requestFullDiff, fullContextUnavailable };
 }

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
@@ -1494,7 +1494,7 @@ export function NoteEditor({
                     onClose={() => setRalphDialogOpen(false)}
                     onLaunched={(processId) => {
                         setRalphDialogOpen(false);
-                        queueDispatch({ type: 'SELECT_QUEUE_TASK', id: processId, repoId: workspaceId });
+                        location.hash = '#repos/' + encodeURIComponent(workspaceId) + '/chats/' + encodeURIComponent(processId);
                     }}
                 />
             )}

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NotesSidebar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NotesSidebar.tsx
@@ -381,16 +381,15 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
     }, [workspaceId, refresh, onSelectPage, onNoteCreated]);
 
     const handleCreateNode = useCallback(async (parentPath: string, name: string, type: 'notebook' | 'section' | 'page') => {
-        await createNode(parentPath, name, type);
+        const created = await createNode(parentPath, name, type);
         if (type === 'page') {
-            const newPath = parentPath ? `${parentPath}/${name}.md` : `${name}.md`;
-            onNoteCreated?.(newPath);
+            onNoteCreated?.(created.path);
         }
     }, [createNode, onNoteCreated]);
 
     const handleRenameNode = useCallback(async (oldPath: string, newPath: string) => {
-        await renameNode(oldPath, newPath);
-        onNoteRenamed?.(oldPath, newPath);
+        const renamed = await renameNode(oldPath, newPath);
+        onNoteRenamed?.(renamed.oldPath, renamed.newPath);
     }, [renameNode, onNoteRenamed]);
 
     const handleDeleteNode = useCallback(async (path: string) => {
@@ -434,8 +433,8 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
 
             const newPath = `${target.path}/${dragged.name}`;
             try {
-                await renameNode(dragged.path, newPath);
-                onNoteRenamed?.(dragged.path, newPath);
+                const renamed = await renameNode(dragged.path, newPath);
+                onNoteRenamed?.(renamed.oldPath, renamed.newPath);
             } catch {
                 // Rename failed — tree already refreshed by renameNode
             }
@@ -489,8 +488,8 @@ export function NotesSidebar({ workspaceId, selectedPath, onSelectPage, onNoteRe
             // Cross-parent move: place dragged into target's parent directory
             const newPath = targetParent ? `${targetParent}/${dragged.name}` : dragged.name;
             try {
-                await renameNode(dragged.path, newPath);
-                onNoteRenamed?.(dragged.path, newPath);
+                const renamed = await renameNode(dragged.path, newPath);
+                onNoteRenamed?.(renamed.oldPath, renamed.newPath);
             } catch {
                 // Rename failed
             }

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/useNotesTree.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/useNotesTree.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { notesApi, type NoteTreeNode } from '../notesApi';
+import {
+    notesApi,
+    type CreateNoteNodeResponse,
+    type NoteTreeNode,
+    type RenameNoteNodeResponse,
+} from '../notesApi';
 
 export interface UseNotesTreeResult {
     tree: NoteTreeNode[] | null;
@@ -8,8 +13,8 @@ export interface UseNotesTreeResult {
     loading: boolean;
     error: string | null;
     refresh: () => void;
-    createNode: (parentPath: string, name: string, type: 'notebook' | 'section' | 'page') => Promise<void>;
-    renameNode: (oldPath: string, newPath: string) => Promise<void>;
+    createNode: (parentPath: string, name: string, type: 'notebook' | 'section' | 'page') => Promise<CreateNoteNodeResponse>;
+    renameNode: (oldPath: string, newPath: string) => Promise<RenameNoteNodeResponse>;
     deleteNode: (path: string) => Promise<void>;
     reorderNodes: (parentPath: string, order: string[]) => Promise<void>;
 }
@@ -52,13 +57,15 @@ export function useNotesTree(workspaceId: string, root?: string): UseNotesTreeRe
 
     const createNode = useCallback(async (parentPath: string, name: string, type: 'notebook' | 'section' | 'page') => {
         const nodePath = parentPath ? `${parentPath}/${name}` : name;
-        await notesApi.createNode(workspaceId, nodePath, type, root);
+        const created = await notesApi.createNode(workspaceId, nodePath, type, root);
         await fetchTree();
+        return created;
     }, [workspaceId, root, fetchTree]);
 
     const renameNode = useCallback(async (oldPath: string, newPath: string) => {
-        await notesApi.renameNode(workspaceId, oldPath, newPath, root);
+        const renamed = await notesApi.renameNode(workspaceId, oldPath, newPath, root);
         await fetchTree();
+        return renamed;
     }, [workspaceId, root, fetchTree]);
 
     const deleteNode = useCallback(async (path: string) => {

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -222,8 +222,8 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
 
     const aiSummary = useMemo(() => (pr ? getMockAiSummary(pr) : null), [pr]);
     const personaLenses = useMemo(() => getMockPersonaLenses(), []);
-    const timeline = useMemo(() => buildTimelineFromRealData(threads, commits, threadGroups), [threads, commits, threadGroups]);
     const threadGroups = useMemo(() => buildAiThreadGroupsFromThreads(threads), [threads]);
+    const timeline = useMemo(() => buildTimelineFromRealData(threads, commits, threadGroups), [threads, commits, threadGroups]);
     const commitRows = useMemo(() => buildCommitRowsFromPrCommits(commits), [commits]);
     const checkRows = useMemo(() => buildCheckRowsFromChecks(checks), [checks]);
     const mergeReadiness = useMemo(

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -46,10 +46,10 @@ import {
     buildCheckRowsFromChecks,
     buildCommitRowsFromPrCommits,
     buildMergeReadinessFromData,
+    buildTimelineFromRealData,
     getMockAiSummary,
     getMockPersonaLenses,
     getMockReviewSummaryText,
-    getMockTimeline,
     riskPillClass,
 } from './pr-mock-data';
 import type { PullRequest, PullRequestCommit, CommentThread, PullRequestCheck } from './pr-utils';
@@ -222,7 +222,7 @@ export function PullRequestDetail({ repoId, prId, onBack, isMobile = false }: Pu
 
     const aiSummary = useMemo(() => (pr ? getMockAiSummary(pr) : null), [pr]);
     const personaLenses = useMemo(() => getMockPersonaLenses(), []);
-    const timeline = useMemo(() => getMockTimeline(), []);
+    const timeline = useMemo(() => buildTimelineFromRealData(threads, commits, threadGroups), [threads, commits, threadGroups]);
     const threadGroups = useMemo(() => buildAiThreadGroupsFromThreads(threads), [threads]);
     const commitRows = useMemo(() => buildCommitRowsFromPrCommits(commits), [commits]);
     const checkRows = useMemo(() => buildCheckRowsFromChecks(checks), [checks]);

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/pr-mock-data.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/pr-mock-data.ts
@@ -458,6 +458,110 @@ export function getMockTimeline(): AiTimelineEvent[] {
     return TIMELINE_EVENTS;
 }
 
+/**
+ * Extract initials from a display name. Returns up to 2 characters.
+ * Falls back to '?' when the name is empty.
+ */
+function nameInitials(displayName: string | undefined): string {
+    const name = (displayName ?? '').trim();
+    if (!name) return '?';
+    const parts = name.split(/\s+/);
+    if (parts.length >= 2) {
+        return (parts[0][0]! + parts[parts.length - 1][0]!).toUpperCase();
+    }
+    return name.slice(0, 2).toUpperCase();
+}
+
+/**
+ * Build a conversation timeline from real PR data.
+ *
+ * Replaces the static `getMockTimeline()` fixture with events derived from
+ * actual threads and commits fetched by PullRequestDetail:
+ *
+ *  - If threads exist: one "AI grouped N threads into M topics" entry.
+ *  - One reviewer entry per unique commenter (up to `maxReviewerEvents`),
+ *    using the first comment body as the detail snippet.
+ *  - One author push entry per unique author group (up to `maxAuthorEvents`),
+ *    summarising the subjects of their commits.
+ *
+ * Returns an empty array when both inputs are empty so the panel renders
+ * cleanly without placeholder content.
+ */
+export function buildTimelineFromRealData(
+    threads: CommentThread[],
+    commits: PullRequestCommit[],
+    threadGroups: Array<{ id: string; title: string; count: number }>,
+    options: { maxReviewerEvents?: number; maxAuthorEvents?: number } = {},
+): AiTimelineEvent[] {
+    const { maxReviewerEvents = 2, maxAuthorEvents = 1 } = options;
+    const events: AiTimelineEvent[] = [];
+
+    // ── AI thread-grouping summary ─────────────────────────────────────
+    if (threads.length > 0) {
+        const nonEmpty = threadGroups.filter(g => g.count > 0);
+        const groupCount = nonEmpty.length;
+        const topicNames = nonEmpty
+            .slice(0, 3)
+            .map(g => g.title)
+            .join(', ');
+        const suffix = nonEmpty.length > 3 ? `, and ${nonEmpty.length - 3} more` : '';
+        events.push({
+            initials: 'AI',
+            kind: 'ai',
+            title: `AI grouped ${threads.length} review thread${threads.length === 1 ? '' : 's'} into ${groupCount} topic${groupCount === 1 ? '' : 's'}.`,
+            detail: topicNames ? `${topicNames}${suffix}.` : 'No notable topics.',
+        });
+    }
+
+    // ── Reviewer comment events ────────────────────────────────────────
+    let reviewerCount = 0;
+    for (const thread of threads) {
+        if (reviewerCount >= maxReviewerEvents) break;
+        const first = thread.comments?.[0];
+        if (!first?.author?.displayName || !first.body) continue;
+        const raw = first.body.replace(/[\n\r]+/g, ' ').trim();
+        const snippet = raw.length > 80 ? `${raw.slice(0, 80)}…` : raw;
+        events.push({
+            initials: nameInitials(first.author.displayName),
+            kind: 'reviewer',
+            title: `${first.author.displayName} left a comment.`,
+            detail: `"${snippet}"`,
+        });
+        reviewerCount++;
+    }
+
+    // ── Author push events (grouped by author name) ────────────────────
+    const byAuthor = new Map<string, { displayName: string; subjects: string[] }>();
+    for (const commit of commits) {
+        const name = commit.author?.displayName ?? commit.committer?.displayName ?? '';
+        if (!byAuthor.has(name)) {
+            byAuthor.set(name, { displayName: name, subjects: [] });
+        }
+        const subject =
+            commit.subject ||
+            (commit.message ? commit.message.split('\n', 1)[0] : '') ||
+            commit.shortId ||
+            commit.id;
+        if (subject) byAuthor.get(name)!.subjects.push(subject);
+    }
+
+    let authorCount = 0;
+    for (const [, group] of byAuthor) {
+        if (authorCount >= maxAuthorEvents) break;
+        const count = group.subjects.length;
+        const detail = group.subjects.slice(0, 3).join('; ');
+        events.push({
+            initials: nameInitials(group.displayName || undefined),
+            kind: 'author',
+            title: `${group.displayName || 'Author'} pushed ${count} commit${count === 1 ? '' : 's'}.`,
+            detail,
+        });
+        authorCount++;
+    }
+
+    return events;
+}
+
 export function getMockThreadGroups(): AiThreadGroup[] {
     return THREAD_GROUPS;
 }

--- a/packages/coc/src/server/spa/client/react/shared/RalphLaunchDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/RalphLaunchDialog.tsx
@@ -2,9 +2,13 @@
  * RalphLaunchDialog — lightweight dialog for launching Ralph from a goal file.
  * Used by the notes editor when editing a goal.md / *.goal.md file.
  */
-import { useState } from 'react';
-import { getApiBase, isRalphEnabled } from '../utils/config';
+import { useEffect, useState } from 'react';
+import { getApiBase, getDefaultProvider } from '../utils/config';
 import { useModels } from '../hooks/useModels';
+import { useAgentProviders } from '../hooks/useAgentProviders';
+import { getSpaCocClient } from '../api/cocClient';
+import { AgentSelectorChip } from '../features/chat/AgentSelectorChip';
+import type { ChatProvider } from '../features/chat/AgentSelectorChip';
 
 export interface RalphLaunchDialogProps {
     open: boolean;
@@ -20,6 +24,16 @@ export interface RalphLaunchDialogProps {
     onLaunched: (processId: string) => void;
 }
 
+function isChatProvider(value: unknown): value is ChatProvider {
+    return value === 'copilot' || value === 'codex' || value === 'claude';
+}
+
+function isSelectableProvider(provider: ChatProvider, providers: Array<{ id: string; enabled: boolean; available: boolean }>): boolean {
+    if (provider === 'copilot') return true;
+    const status = providers.find(p => p.id === provider);
+    return status?.enabled === true && status?.available === true;
+}
+
 export function RalphLaunchDialog({
     open,
     workspaceId,
@@ -30,10 +44,49 @@ export function RalphLaunchDialog({
     onLaunched,
 }: RalphLaunchDialogProps) {
     const { models } = useModels();
+    const { providers: agentProviders, loading: providersLoading } = useAgentProviders();
     const enabledModels = models.filter(m => m.enabled);
     const [selectedModel, setSelectedModel] = useState('');
+    const [selectedProvider, setSelectedProvider] = useState<ChatProvider>(() => getDefaultProvider());
     const [launching, setLaunching] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const getSelectableDefaultProvider = () => {
+        const configuredDefault = getDefaultProvider();
+        return isSelectableProvider(configuredDefault, agentProviders) ? configuredDefault : 'copilot';
+    };
+
+    useEffect(() => {
+        const fallbackProvider = getSelectableDefaultProvider();
+        let cancelled = false;
+        getSpaCocClient().preferences.getRepo(workspaceId)
+            .then((prefs: any) => {
+                if (cancelled) return;
+                const last = prefs?.lastChatProvider;
+                if (isChatProvider(last) && isSelectableProvider(last, agentProviders)) {
+                    setSelectedProvider(last);
+                    return;
+                }
+                setSelectedProvider(fallbackProvider);
+            })
+            .catch(() => {
+                if (!cancelled) setSelectedProvider(fallbackProvider);
+            });
+        return () => { cancelled = true; };
+    }, [workspaceId, agentProviders]);
+
+    useEffect(() => {
+        if (selectedProvider === 'copilot') return;
+        if (!isSelectableProvider(selectedProvider, agentProviders)) {
+            setSelectedProvider(getSelectableDefaultProvider());
+        }
+    }, [agentProviders, selectedProvider]);
+
+    function handleProviderChange(provider: ChatProvider) {
+        setSelectedProvider(provider);
+        getSpaCocClient().preferences.patchRepo(workspaceId, { lastChatProvider: provider })
+            .catch(() => { /* non-fatal */ });
+    }
 
     if (!open) return null;
 
@@ -46,7 +99,7 @@ export function RalphLaunchDialog({
         setLaunching(true);
         setError(null);
         try {
-            const body: Record<string, unknown> = { goalSpec: trimmed, workspaceId };
+            const body: Record<string, unknown> = { goalSpec: trimmed, workspaceId, provider: selectedProvider };
             if (folderPath) body.folderPath = folderPath;
             if (selectedModel) body.config = { model: selectedModel };
             const resp = await fetch(`${getApiBase()}/ralph-launch`, {
@@ -99,6 +152,22 @@ export function RalphLaunchDialog({
                     {/* Source label */}
                     <div className="text-xs text-[#848484]">
                         Goal source: <span className="font-medium text-[#1e1e1e] dark:text-[#cccccc]">{sourceLabel}</span>
+                    </div>
+
+                    {/* Provider selector */}
+                    <div>
+                        <div className="block text-xs text-[#848484] mb-1">
+                            Agent:
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <AgentSelectorChip
+                                providers={agentProviders}
+                                loading={providersLoading}
+                                selected={selectedProvider}
+                                onChange={handleProviderChange}
+                                disabled={launching}
+                            />
+                        </div>
                     </div>
 
                     {/* Model selector */}

--- a/packages/coc/src/server/streaming/websocket.ts
+++ b/packages/coc/src/server/streaming/websocket.ts
@@ -140,7 +140,7 @@ export type ServerMessage =
     | { type: 'turn-deleted'; processId: string; turnIndex: number; deletedAt: string | null }
     | { type: 'turn-pinned'; processId: string; turnIndex: number; pinnedAt: string | null }
     | { type: 'turn-archived'; processId: string; turnIndex: number; archived: boolean }
-    | { type: 'ralph-session-complete'; workspaceId: string; sessionId?: string; processId: string; totalIterations: number; reason: 'signal' | 'cap' }
+    | { type: 'ralph-session-complete'; workspaceId: string; sessionId?: string; processId: string; totalIterations: number; reason: 'signal' | 'cap' | string }
     | { type: 'loop-created' | 'loop-updated' | 'loop-paused' | 'loop-resumed' | 'loop-cancelled' | 'loop-expired' | 'loop-tick'; loopId: string; processId: string; status: string; workspaceId?: string; timestamp: number };
 
 /** Client → Server message types */

--- a/packages/coc/src/server/tasks/task-types.ts
+++ b/packages/coc/src/server/tasks/task-types.ts
@@ -223,6 +223,21 @@ export interface RalphContext {
     sessionId?: string;
     /** Current stage of the Ralph session. */
     phase?: 'grilling' | 'executing' | 'complete';
+    /**
+     * Present on final-check tasks only (AC-01/02). Identifies this as a
+     * read-only goal-gap checker task. When set, `enqueueRalphNextIteration`
+     * routes to the final-check orchestration path instead of the normal
+     * iteration continuation path.
+     */
+    finalCheck?: {
+        kind: 'goal-gap-check';
+        /** 1-based index of this check within the session. */
+        checkIndex: number;
+        /** Last iteration number of the loop that triggered this check. */
+        sourceIteration: number;
+        /** The loop index that triggered this check. */
+        loopIndex: number;
+    };
 }
 
 // ============================================================================

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -799,6 +799,8 @@ timeout: 300
                 '  enabled: true',
                 'ralph:',
                 '  enabled: true',
+                '  finalCheck:',
+                '    maxGapFixLoops: 5',
                 'vimNavigation:',
                 '  enabled: true',
                 'loops:',
@@ -1030,6 +1032,9 @@ timeout: 300
                   },
                   "ralph": {
                     "enabled": true,
+                    "finalCheck": {
+                      "maxGapFixLoops": 3,
+                    },
                   },
                   "scratchpad": {
                     "enabled": true,
@@ -1106,6 +1111,7 @@ timeout: 300
                   "pullRequests.enabled": "file",
                   "pullRequests.suggestions": "file",
                   "ralph.enabled": "file",
+                  "ralph.finalCheck.maxGapFixLoops": "default",
                   "scratchpad.enabled": "file",
                   "scratchpad.layout": "file",
                   "serve.dataDir": "file",

--- a/packages/coc/test/server/notes-handler.test.ts
+++ b/packages/coc/test/server/notes-handler.test.ts
@@ -515,6 +515,36 @@ describe('Notes Handler', () => {
             expect(JSON.parse(newRes.body).content).toBe('# Old Name');
         });
 
+        it('should auto-append .md when renaming a page without extension', async () => {
+            const srv = await startServer();
+            const sidecarData = JSON.stringify({ threads: { t1: { id: 't1' } } });
+            createNoteFiles({
+                'old-name.md': '# Old Name',
+                'old-name.md.comments.json': sidecarData,
+            });
+            await registerWorkspace(srv, workspaceDir);
+
+            const res = await patchJSON(`${srv.url}/api/workspaces/${wsId}/notes/path`, {
+                oldPath: 'old-name.md',
+                newPath: 'new-name',
+            });
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            expect(body.oldPath).toBe('old-name.md');
+            expect(body.newPath).toBe('new-name.md');
+
+            const oldRes = await request(`${srv.url}/api/workspaces/${wsId}/notes/content?path=old-name.md`);
+            expect(oldRes.status).toBe(404);
+
+            const newRes = await request(`${srv.url}/api/workspaces/${wsId}/notes/content?path=new-name.md`);
+            expect(newRes.status).toBe(200);
+            expect(JSON.parse(newRes.body).content).toBe('# Old Name');
+
+            const notesDir = getRepoDataPath(dataDir, wsId, 'notes');
+            expect(fs.existsSync(path.join(notesDir, 'new-name.md.comments.json'))).toBe(true);
+            expect(fs.existsSync(path.join(notesDir, 'old-name.md.comments.json'))).toBe(false);
+        });
+
         it('should rename directory', async () => {
             const srv = await startServer();
             createNoteFiles({
@@ -551,6 +581,26 @@ describe('Notes Handler', () => {
             expect(res.status).toBe(409);
             const body = JSON.parse(res.body);
             expect(body.error).toContain('already exists');
+        });
+
+        it('should return 409 when an implicit .md rename destination already exists', async () => {
+            const srv = await startServer();
+            createNoteFiles({
+                'file-a.md': '# A',
+                'file-b.md': '# B',
+            });
+            await registerWorkspace(srv, workspaceDir);
+
+            const res = await patchJSON(`${srv.url}/api/workspaces/${wsId}/notes/path`, {
+                oldPath: 'file-a.md',
+                newPath: 'file-b',
+            });
+            expect(res.status).toBe(409);
+            const body = JSON.parse(res.body);
+            expect(body.error).toContain('already exists');
+
+            const originalRes = await request(`${srv.url}/api/workspaces/${wsId}/notes/content?path=file-a.md`);
+            expect(originalRes.status).toBe(200);
         });
 
         it('should allow renaming a file when only casing changes', async () => {

--- a/packages/coc/test/server/notes-write-binding-cascade.test.ts
+++ b/packages/coc/test/server/notes-write-binding-cascade.test.ts
@@ -122,6 +122,20 @@ describe('Notes write — rename/delete binding cascade', { timeout: 30_000 }, (
         expect(JSON.parse(res.body).bindingsMoved).toBe(0);
     });
 
+    it('file rename without .md moves the binding row to the effective markdown path', async () => {
+        writeNote('old.md');
+        bindings.bind(wsId, 'old.md', 'task-1');
+
+        const res = await patchJSON(notesUrl('/notes/path'), { oldPath: 'old.md', newPath: 'new' });
+        expect(res.status).toBe(200);
+        const body = JSON.parse(res.body);
+        expect(body.newPath).toBe('new.md');
+        expect(body.bindingsMoved).toBe(1);
+
+        expect(bindings.get(wsId, 'old.md')).toBeUndefined();
+        expect(bindings.get(wsId, 'new.md')?.taskId).toBe('task-1');
+    });
+
     // ────────────────────────────────────────────────────────────────────────
     // Folder rename
     // ────────────────────────────────────────────────────────────────────────

--- a/packages/coc/test/server/pr-routes.test.ts
+++ b/packages/coc/test/server/pr-routes.test.ts
@@ -643,6 +643,69 @@ describe('GET /api/repos/:id/pull-requests/:prId/diff/files/:filePath', () => {
     });
 });
 
+// ── GET /api/repos/:id/pull-requests/:prId/diff/files/:path?fullContext=true (AC-02) ──
+
+describe('GET .../diff/files/:path?fullContext=true (AC-02)', () => {
+    const combinedDiff = [
+        'diff --git a/src/foo.ts b/src/foo.ts',
+        '--- a/src/foo.ts',
+        '+++ b/src/foo.ts',
+        '@@ -1,3 +1,4 @@',
+        ' line1',
+        '+added',
+    ].join('\n');
+
+    beforeEach(() => {
+        (mockSvc.getDiff as ReturnType<typeof vi.fn>).mockResolvedValue(combinedDiff);
+    });
+
+    it('without ?fullContext: returns normal diff, no fullContextUnavailable field', async () => {
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/foo.ts')}`);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { diff: string; fullContextUnavailable?: boolean };
+        expect(body.diff).toContain('diff --git a/src/foo.ts');
+        expect(body.fullContextUnavailable).toBeUndefined();
+    });
+
+    it('with ?fullContext=true and no cached PR detail: returns hunk diff with fullContextUnavailable=true', async () => {
+        // No prior GET /pull-requests/42 call, so prDetailCache is empty
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/foo.ts')}?fullContext=true`);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { diff: string; fullContextUnavailable: boolean };
+        expect(body.fullContextUnavailable).toBe(true);
+        // Should still include the hunk diff as fallback
+        expect(body.diff).toContain('diff --git a/src/foo.ts');
+    });
+
+    it('with ?fullContext=true and cached PR detail missing SHAs: returns fullContextUnavailable=true', async () => {
+        // Warm the PR detail cache (mockPr has no baseSha/headSha)
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42`);
+
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/foo.ts')}?fullContext=true`);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { diff: string; fullContextUnavailable: boolean };
+        expect(body.fullContextUnavailable).toBe(true);
+        // Fallback hunk diff still returned
+        expect(body.diff).toContain('diff --git a/src/foo.ts');
+    });
+
+    it('with ?fullContext=true and cached PR detail has SHAs but git fails: returns fullContextUnavailable=true', async () => {
+        // Override getPullRequest to return a PR with SHAs
+        const prWithShas = { ...mockPr, headSha: 'deadbeef111', baseSha: 'cafebabe222' };
+        (mockSvc.getPullRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(prWithShas);
+
+        // Warm the PR detail cache with SHAs
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42`);
+
+        // The repo.localPath is /tmp/repo which is not a real git repo, so git diff fails
+        const res = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/foo.ts')}?fullContext=true`);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { diff: string; fullContextUnavailable: boolean };
+        expect(body.fullContextUnavailable).toBe(true);
+        expect(body.diff).toContain('diff --git a/src/foo.ts');
+    });
+});
+
 // ── PR diff cache tests (AC-01) ───────────────────────────────────────────────
 
 describe('PR diff cache (AC-01)', () => {

--- a/packages/coc/test/server/pr-routes.test.ts
+++ b/packages/coc/test/server/pr-routes.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { createRouter } from '../../src/server/shared/router';
-import { registerPrRoutes, clearPrListCache, clearPrDetailCache } from '../../src/server/repos/pr-routes';
+import { registerPrRoutes, clearPrListCache, clearPrDetailCache, clearPrDiffCache } from '../../src/server/repos/pr-routes';
 import type { Route } from '../../src/server/types';
 import type { IPullRequestsService } from '@plusplusoneplusplus/forge';
 import type { PullRequest, CommentThread, Reviewer } from '@plusplusoneplusplus/forge';
@@ -137,6 +137,7 @@ async function stopServer(): Promise<void> {
 beforeEach(async () => {
     clearPrListCache();
     clearPrDetailCache();
+    clearPrDiffCache();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-routes-test-'));
     dataDir = path.join(tmpDir, 'data');
     fs.mkdirSync(dataDir, { recursive: true });
@@ -639,6 +640,100 @@ describe('GET /api/repos/:id/pull-requests/:prId/diff/files/:filePath', () => {
         expect(res.status).toBe(200);
         const body = await res.json() as { diff: string };
         expect(body.diff).toContain('path with spaces/file.ts');
+    });
+});
+
+// ── PR diff cache tests (AC-01) ───────────────────────────────────────────────
+
+describe('PR diff cache (AC-01)', () => {
+    const combinedDiff = [
+        'diff --git a/src/foo.ts b/src/foo.ts',
+        '--- a/src/foo.ts',
+        '+++ b/src/foo.ts',
+        '@@ -1,3 +1,4 @@',
+        ' line1',
+        '+added',
+        'diff --git a/src/bar.ts b/src/bar.ts',
+        '--- a/src/bar.ts',
+        '+++ b/src/bar.ts',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+    ].join('\n');
+
+    beforeEach(() => {
+        (mockSvc.getDiff as ReturnType<typeof vi.fn>).mockResolvedValue(combinedDiff);
+    });
+
+    it('caches the combined diff so /diff endpoint hits once on second request', async () => {
+        const r1 = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        expect(r1.status).toBe(200);
+
+        const r2 = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        expect(r2.status).toBe(200);
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches the combined diff so /diff/files endpoint hits once on second request', async () => {
+        const r1 = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/foo.ts')}`);
+        expect(r1.status).toBe(200);
+
+        const r2 = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/bar.ts')}`);
+        expect(r2.status).toBe(200);
+        // Both per-file requests share one upstream fetch
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(1);
+    });
+
+    it('full /diff and /diff/files requests share the same cached combined diff', async () => {
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff/files/${encodeURIComponent('src/foo.ts')}`);
+        // Second call should reuse the cache set by the first
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(1);
+    });
+
+    it('force-refreshing PR detail clears the diff cache and the next diff request refetches', async () => {
+        // Warm the diff cache via /diff
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(1);
+
+        // Force-refresh PR detail
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42?force=true`);
+
+        // Next diff request must refetch from provider
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses separate cache entries per PR so switching PRs does not cross-pollute', async () => {
+        const pr2Diff = 'diff --git a/other.ts b/other.ts\n';
+        (mockSvc.getDiff as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(combinedDiff)  // PR 42
+            .mockResolvedValueOnce(pr2Diff);        // PR 99
+
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        const r99 = await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/99/diff`);
+        const text99 = await r99.text();
+        expect(text99).toContain('other.ts');
+        expect(text99).not.toContain('src/foo.ts');
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(2);
+    });
+
+    it('force-refreshing one PR does not invalidate another PR diff cache', async () => {
+        const pr2Diff = 'diff --git a/other.ts b/other.ts\n';
+        (mockSvc.getDiff as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(combinedDiff) // PR 42 initial
+            .mockResolvedValueOnce(pr2Diff);     // PR 99
+
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42/diff`);
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/99/diff`);
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(2);
+
+        // Force-refresh PR 42 detail only
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/42?force=true`);
+
+        // PR 99 diff still cached
+        await fetch(`${baseUrl}/api/repos/${REPO_ID}/pull-requests/99/diff`);
+        expect(mockSvc.getDiff).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/packages/coc/test/server/ralph/enqueue-final-check.test.ts
+++ b/packages/coc/test/server/ralph/enqueue-final-check.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for enqueue-final-check.ts (AC-01).
+ *
+ * Covers:
+ *  - In-memory idempotency (wasFinalCheckEnqueued / markFinalCheckEnqueued)
+ *  - Persistent duplicate detection (sessionHasFinalCheckFor)
+ *  - nextCheckIndex computation
+ *  - buildFinalCheckTaskPayload structure
+ *  - buildFinalCheckStartRecord shape
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    finalCheckIdempotencyKey,
+    wasFinalCheckEnqueued,
+    markFinalCheckEnqueued,
+    _clearFinalCheckEnqueuedSet,
+    sessionHasFinalCheckFor,
+    nextCheckIndex,
+    buildFinalCheckTaskPayload,
+    buildFinalCheckStartRecord,
+} from '../../../src/server/ralph/enqueue-final-check';
+import type { RalphSessionRecord } from '../../../src/server/ralph/types';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeSession(overrides?: Partial<RalphSessionRecord>): RalphSessionRecord {
+    return {
+        sessionId: 'sess-01',
+        workspaceId: 'ws-01',
+        originalGoal: 'Do the thing.',
+        maxIterations: 20,
+        currentIteration: 4,
+        phase: 'complete',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        iterations: [],
+        ...overrides,
+    };
+}
+
+// ── In-memory idempotency ─────────────────────────────────────────────────────
+
+describe('finalCheckIdempotencyKey', () => {
+    it('returns "<sessionId>:<sourceIteration>"', () => {
+        expect(finalCheckIdempotencyKey('sess-01', 4)).toBe('sess-01:4');
+    });
+});
+
+describe('wasFinalCheckEnqueued / markFinalCheckEnqueued', () => {
+    beforeEach(() => { _clearFinalCheckEnqueuedSet(); });
+
+    it('returns false before any mark', () => {
+        expect(wasFinalCheckEnqueued('sess-01', 4)).toBe(false);
+    });
+
+    it('returns true after marking', () => {
+        markFinalCheckEnqueued('sess-01', 4);
+        expect(wasFinalCheckEnqueued('sess-01', 4)).toBe(true);
+    });
+
+    it('is scoped by sessionId', () => {
+        markFinalCheckEnqueued('sess-01', 4);
+        expect(wasFinalCheckEnqueued('sess-02', 4)).toBe(false);
+    });
+
+    it('is scoped by sourceIteration', () => {
+        markFinalCheckEnqueued('sess-01', 4);
+        expect(wasFinalCheckEnqueued('sess-01', 5)).toBe(false);
+    });
+
+    it('returns false after clear', () => {
+        markFinalCheckEnqueued('sess-01', 4);
+        _clearFinalCheckEnqueuedSet();
+        expect(wasFinalCheckEnqueued('sess-01', 4)).toBe(false);
+    });
+});
+
+// ── Persistent duplicate detection ───────────────────────────────────────────
+
+describe('sessionHasFinalCheckFor', () => {
+    it('returns false when finalChecks is absent (legacy session)', () => {
+        const session = makeSession();
+        expect(sessionHasFinalCheckFor(session, 4)).toBe(false);
+    });
+
+    it('returns false when finalChecks is empty', () => {
+        const session = makeSession({ finalChecks: [] });
+        expect(sessionHasFinalCheckFor(session, 4)).toBe(false);
+    });
+
+    it('returns true when a check with matching sourceIteration exists', () => {
+        const session = makeSession({
+            finalChecks: [{
+                checkIndex: 1, loopIndex: 1, sourceIteration: 4,
+                startedAt: '2026-01-01T00:00:00.000Z', status: 'completed',
+            }],
+        });
+        expect(sessionHasFinalCheckFor(session, 4)).toBe(true);
+    });
+
+    it('returns false when no check matches the given sourceIteration', () => {
+        const session = makeSession({
+            finalChecks: [{
+                checkIndex: 1, loopIndex: 1, sourceIteration: 4,
+                startedAt: '2026-01-01T00:00:00.000Z', status: 'completed',
+            }],
+        });
+        expect(sessionHasFinalCheckFor(session, 5)).toBe(false);
+    });
+});
+
+// ── nextCheckIndex ────────────────────────────────────────────────────────────
+
+describe('nextCheckIndex', () => {
+    it('returns 1 when finalChecks is absent', () => {
+        expect(nextCheckIndex(makeSession())).toBe(1);
+    });
+
+    it('returns 1 when finalChecks is empty', () => {
+        expect(nextCheckIndex(makeSession({ finalChecks: [] }))).toBe(1);
+    });
+
+    it('returns length + 1', () => {
+        const session = makeSession({
+            finalChecks: [
+                { checkIndex: 1, loopIndex: 1, sourceIteration: 4, startedAt: '', status: 'completed' },
+                { checkIndex: 2, loopIndex: 2, sourceIteration: 8, startedAt: '', status: 'completed' },
+            ],
+        });
+        expect(nextCheckIndex(session)).toBe(3);
+    });
+});
+
+// ── buildFinalCheckTaskPayload ────────────────────────────────────────────────
+
+describe('buildFinalCheckTaskPayload', () => {
+    it('produces a chat/ralph task with the correct context shape', () => {
+        const result = buildFinalCheckTaskPayload({
+            workspaceId: 'ws-01',
+            sessionId: 'sess-01',
+            originalGoal: 'Do the thing.',
+            checkIndex: 1,
+            sourceIteration: 4,
+            loopIndex: 1,
+            progressPath: '/home/user/.coc/repos/ws-01/ralph-sessions/sess-01/progress.md',
+        });
+
+        expect(result.type).toBe('chat');
+        expect(result.payload.kind).toBe('chat');
+        expect(result.payload.mode).toBe('ralph');
+        expect(result.payload.context.ralph.finalCheck).toMatchObject({
+            kind: 'goal-gap-check',
+            checkIndex: 1,
+            sourceIteration: 4,
+            loopIndex: 1,
+        });
+        expect(result.payload.context.ralph.sessionId).toBe('sess-01');
+        expect(result.payload.context.ralph.workspaceId ?? result.payload.workspaceId).toBe('ws-01');
+    });
+
+    it('includes the progress path in the prompt', () => {
+        const result = buildFinalCheckTaskPayload({
+            workspaceId: 'ws-01',
+            sessionId: 'sess-01',
+            originalGoal: 'Do the thing.',
+            checkIndex: 1,
+            sourceIteration: 4,
+            loopIndex: 1,
+            progressPath: '/home/user/.coc/repos/ws-01/ralph-sessions/sess-01/progress.md',
+        });
+        expect(result.payload.prompt).toContain('progress.md');
+    });
+
+    it('includes read-only instructions in the prompt', () => {
+        const result = buildFinalCheckTaskPayload({
+            workspaceId: 'ws-01',
+            sessionId: 'sess-01',
+            originalGoal: 'Do the thing.',
+            checkIndex: 1,
+            sourceIteration: 4,
+            loopIndex: 1,
+            progressPath: '/progress.md',
+        });
+        expect(result.payload.prompt).toContain('read-only');
+    });
+
+    it('sets displayName to include checkIndex and sessionId', () => {
+        const result = buildFinalCheckTaskPayload({
+            workspaceId: 'ws-01',
+            sessionId: 'sess-01',
+            originalGoal: 'Goal.',
+            checkIndex: 2,
+            sourceIteration: 8,
+            loopIndex: 2,
+            progressPath: '/progress.md',
+        });
+        expect(result.displayName).toContain('2');
+        expect(result.displayName).toContain('sess-01');
+    });
+});
+
+// ── buildFinalCheckStartRecord ────────────────────────────────────────────────
+
+describe('buildFinalCheckStartRecord', () => {
+    it('builds a running-status record', () => {
+        const nowIso = '2026-01-01T12:00:00.000Z';
+        const rec = buildFinalCheckStartRecord(1, 1, 4, 'task-123', 'proc-456', nowIso);
+        expect(rec.checkIndex).toBe(1);
+        expect(rec.loopIndex).toBe(1);
+        expect(rec.sourceIteration).toBe(4);
+        expect(rec.taskId).toBe('task-123');
+        expect(rec.processId).toBe('proc-456');
+        expect(rec.startedAt).toBe(nowIso);
+        expect(rec.status).toBe('running');
+        expect(rec.hasGaps).toBeUndefined();
+    });
+
+    it('uses current timestamp when nowIso is omitted', () => {
+        const before = Date.now();
+        const rec = buildFinalCheckStartRecord(1, 1, 4, 'task-123');
+        const after = Date.now();
+        const ts = new Date(rec.startedAt).getTime();
+        expect(ts).toBeGreaterThanOrEqual(before);
+        expect(ts).toBeLessThanOrEqual(after);
+    });
+});

--- a/packages/coc/test/server/ralph/final-check-result-parser.test.ts
+++ b/packages/coc/test/server/ralph/final-check-result-parser.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for parseFinalCheckResult (AC-02).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseFinalCheckResult, type FinalCheckResult } from '../../../src/server/ralph/final-check-result-parser';
+
+const MARKER = 'RALPH_FINAL_CHECK_RESULT';
+
+function makeCleanJson(): string {
+    return JSON.stringify({
+        marker: MARKER,
+        hasGaps: false,
+        summary: 'All acceptance criteria are satisfied.',
+        gaps: [],
+    }, null, 2);
+}
+
+function makeGapsJson(gapFixGoal?: string): string {
+    const obj: Record<string, unknown> = {
+        marker: MARKER,
+        hasGaps: true,
+        summary: 'Two gaps found.',
+        gaps: [
+            {
+                id: 'GAP-01',
+                title: 'Missing test coverage',
+                evidence: 'progress.md does not record test output.',
+                recommendedAction: 'Run npm test and record output.',
+                validation: 'npm run test',
+            },
+            {
+                id: 'GAP-02',
+                title: 'Build failure',
+                evidence: 'npm run build exits with errors.',
+                recommendedAction: 'Fix compilation errors.',
+            },
+        ],
+    };
+    if (gapFixGoal !== undefined) {
+        obj['gapFixGoal'] = gapFixGoal;
+    }
+    return JSON.stringify(obj, null, 2);
+}
+
+function wrap(json: string): string {
+    return `Some AI text.\n\n${MARKER}\n\`\`\`json\n${json}\n\`\`\`\n`;
+}
+
+function wrapBare(json: string): string {
+    return `Some AI text.\n\n${MARKER}\n${json}\n`;
+}
+
+// ============================================================================
+// Clean result
+// ============================================================================
+
+describe('parseFinalCheckResult — clean', () => {
+    it('parses a clean fenced result', () => {
+        const res = parseFinalCheckResult(wrap(makeCleanJson()));
+        expect(res.status).toBe('clean');
+        expect(res.hasGaps).toBe(false);
+        expect(res.gaps).toEqual([]);
+        expect(res.summary).toBe('All acceptance criteria are satisfied.');
+        expect(res.gapFixGoal).toBeUndefined();
+    });
+
+    it('parses a clean bare JSON result', () => {
+        const res = parseFinalCheckResult(wrapBare(makeCleanJson()));
+        expect(res.status).toBe('clean');
+        expect(res.hasGaps).toBe(false);
+    });
+
+    it('normalises CRLF line endings', () => {
+        const text = wrap(makeCleanJson()).replace(/\n/g, '\r\n');
+        expect(parseFinalCheckResult(text).status).toBe('clean');
+    });
+});
+
+// ============================================================================
+// Gaps result
+// ============================================================================
+
+describe('parseFinalCheckResult — gaps', () => {
+    it('parses a gaps result with explicit gapFixGoal', () => {
+        const res = parseFinalCheckResult(wrap(makeGapsJson('Fix the listed gaps.')));
+        expect(res.status).toBe('gaps');
+        expect(res.hasGaps).toBe(true);
+        expect(res.gaps).toHaveLength(2);
+        expect(res.gaps[0].id).toBe('GAP-01');
+        expect(res.gaps[0].title).toBe('Missing test coverage');
+        expect(res.gaps[0].validation).toBe('npm run test');
+        expect(res.gaps[1].validation).toBeUndefined();
+        expect(res.gapFixGoal).toBe('Fix the listed gaps.');
+        expect(res.goalSynthesized).toBeUndefined();
+    });
+
+    it('synthesizes gapFixGoal when absent', () => {
+        const res = parseFinalCheckResult(wrap(makeGapsJson()));
+        expect(res.status).toBe('gaps');
+        expect(res.hasGaps).toBe(true);
+        expect(res.goalSynthesized).toBe(true);
+        expect(typeof res.gapFixGoal).toBe('string');
+        expect(res.gapFixGoal!.length).toBeGreaterThan(0);
+        expect(res.gapFixGoal).toContain('Missing test coverage');
+        expect(res.gapFixGoal).toContain('Build failure');
+    });
+
+    it('synthesizes gapFixGoal when empty string', () => {
+        const res = parseFinalCheckResult(wrap(makeGapsJson('')));
+        expect(res.goalSynthesized).toBe(true);
+        expect(res.gapFixGoal).toBeTruthy();
+    });
+});
+
+// ============================================================================
+// Malformed / unparseable
+// ============================================================================
+
+describe('parseFinalCheckResult — unparseable', () => {
+    it('returns unparseable when marker is absent', () => {
+        const res = parseFinalCheckResult('No marker here.');
+        expect(res.status).toBe('unparseable');
+        expect(res.error).toContain('RALPH_FINAL_CHECK_RESULT marker');
+    });
+
+    it('returns unparseable when JSON is malformed', () => {
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n{ bad json }\n\`\`\``);
+        expect(res.status).toBe('unparseable');
+        expect(res.error).toMatch(/[Mm]alformed JSON|JSON/);
+    });
+
+    it('returns unparseable when no JSON block follows marker', () => {
+        const res = parseFinalCheckResult(`${MARKER}\nJust some text, no JSON.`);
+        expect(res.status).toBe('unparseable');
+    });
+
+    it('returns unparseable when marker field does not match', () => {
+        const json = JSON.stringify({ marker: 'WRONG', hasGaps: false, summary: '', gaps: [] });
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n${json}\n\`\`\``);
+        expect(res.status).toBe('unparseable');
+        expect(res.error).toContain('marker');
+    });
+
+    it('returns unparseable when hasGaps is not boolean', () => {
+        const json = JSON.stringify({ marker: MARKER, hasGaps: 'yes', summary: '', gaps: [] });
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n${json}\n\`\`\``);
+        expect(res.status).toBe('unparseable');
+    });
+
+    it('returns unparseable for array root', () => {
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n[]\n\`\`\``);
+        expect(res.status).toBe('unparseable');
+    });
+});
+
+// ============================================================================
+// Contradictory fields
+// ============================================================================
+
+describe('parseFinalCheckResult — invalid (contradictory)', () => {
+    it('flags hasGaps:false with non-empty gaps array', () => {
+        const json = JSON.stringify({
+            marker: MARKER,
+            hasGaps: false,
+            summary: 'All good.',
+            gaps: [{ id: 'GAP-01', title: 'Oops', evidence: 'e', recommendedAction: 'a' }],
+        });
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n${json}\n\`\`\``);
+        expect(res.status).toBe('invalid');
+        expect(res.error).toContain('non-empty');
+    });
+
+    it('flags hasGaps:true with empty gaps array', () => {
+        const json = JSON.stringify({
+            marker: MARKER,
+            hasGaps: true,
+            summary: 'There are gaps.',
+            gaps: [],
+            gapFixGoal: 'Fix them.',
+        });
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n${json}\n\`\`\``);
+        expect(res.status).toBe('invalid');
+        expect(res.error).toContain('empty');
+    });
+});
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+describe('parseFinalCheckResult — edge cases', () => {
+    it('handles gaps with missing optional fields gracefully', () => {
+        const json = JSON.stringify({
+            marker: MARKER,
+            hasGaps: true,
+            summary: 'Gap found.',
+            gaps: [{}],
+            gapFixGoal: 'Fix it.',
+        });
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n${json}\n\`\`\``);
+        expect(res.status).toBe('gaps');
+        expect(res.gaps[0].id).toBe('GAP-?');
+        expect(res.gaps[0].title).toBe('(untitled)');
+    });
+
+    it('uses content after the first RALPH_FINAL_CHECK_RESULT occurrence', () => {
+        const json = makeCleanJson();
+        const response = `Preamble text\n${MARKER}\n\`\`\`json\n${json}\n\`\`\`\nMore text`;
+        const res = parseFinalCheckResult(response);
+        expect(res.status).toBe('clean');
+    });
+
+    it('handles extra fields in JSON without error', () => {
+        const json = JSON.stringify({
+            marker: MARKER,
+            hasGaps: false,
+            summary: 'Clean.',
+            gaps: [],
+            extraField: 'ignored',
+        });
+        const res = parseFinalCheckResult(`${MARKER}\n\`\`\`json\n${json}\n\`\`\``);
+        expect(res.status).toBe('clean');
+    });
+});

--- a/packages/coc/test/server/ralph/orchestrate-final-check.test.ts
+++ b/packages/coc/test/server/ralph/orchestrate-final-check.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for orchestrate-final-check.ts (AC-03, AC-04, AC-05).
+ *
+ * Covers:
+ *  - Clean result → broadcastSessionComplete('signal')
+ *  - Gap result below cap → startNewLoop + enqueueTask + record gapLoopStarted
+ *  - Gap result at cap → broadcastSessionComplete('cap') + capReached: true
+ *  - Unparseable response → record status=failed + broadcastSessionComplete('final-check-failed')
+ *  - Missing gapFixGoal → synthesize from gaps (goalSynthesized flag)
+ *  - startNewLoop failure → record gapLoopStarted=false + broadcast
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { orchestrateFinalCheck, type OrchestrateFinalCheckDeps } from '../../../src/server/ralph/orchestrate-final-check';
+import type { RalphSessionRecord, RalphFinalCheckRecord } from '../../../src/server/ralph/types';
+
+// ── Shared test fixtures ──────────────────────────────────────────────────────
+
+const SESSION_ID = 'sess-01';
+const WORKSPACE_ID = 'ws-01';
+const PROCESS_ID = 'proc-01';
+const TASK_ID = 'task-01';
+const LOOP_INDEX = 1;
+const SOURCE_ITERATION = 4;
+const CHECK_INDEX = 1;
+const NOW = '2026-01-01T00:00:00.000Z';
+
+const MARKER = 'RALPH_FINAL_CHECK_RESULT';
+
+function makeCleanResponse(): string {
+    return `RALPH_FINAL_CHECK_RESULT\n\`\`\`json\n${JSON.stringify({
+        marker: MARKER,
+        hasGaps: false,
+        summary: 'All acceptance criteria are satisfied.',
+        gaps: [],
+    }, null, 2)}\n\`\`\``;
+}
+
+function makeGapsResponse(gapFixGoal?: string): string {
+    const obj: Record<string, unknown> = {
+        marker: MARKER,
+        hasGaps: true,
+        summary: 'Two gaps found.',
+        gaps: [
+            { id: 'GAP-01', title: 'Missing test', evidence: 'No test run.', recommendedAction: 'Run tests.' },
+        ],
+    };
+    if (gapFixGoal !== undefined) obj.gapFixGoal = gapFixGoal;
+    return `RALPH_FINAL_CHECK_RESULT\n\`\`\`json\n${JSON.stringify(obj, null, 2)}\n\`\`\``;
+}
+
+function makeSession(overrides?: Partial<RalphSessionRecord>): RalphSessionRecord {
+    return {
+        sessionId: SESSION_ID,
+        workspaceId: WORKSPACE_ID,
+        originalGoal: 'Do the thing.',
+        maxIterations: 20,
+        currentIteration: SOURCE_ITERATION,
+        phase: 'complete',
+        terminalReason: 'RALPH_COMPLETE',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        iterations: [],
+        ...overrides,
+    };
+}
+
+function makeDeps(overrides?: Partial<OrchestrateFinalCheckDeps>): OrchestrateFinalCheckDeps {
+    const upsertFinalCheckRecord = vi.fn().mockResolvedValue(makeSession());
+    const appendFinalCheckSection = vi.fn().mockResolvedValue(undefined);
+    const readSessionRecord = vi.fn().mockResolvedValue(makeSession());
+    const startNewLoop = vi.fn().mockResolvedValue(makeSession({
+        maxIterations: 40,
+        currentIteration: SOURCE_ITERATION,
+        phase: 'executing',
+        loops: [
+            { loopIndex: 1, goal: 'original', startIteration: 1, startedAt: NOW },
+            { loopIndex: 2, goal: 'gap-fix', startIteration: SOURCE_ITERATION + 1, startedAt: NOW },
+        ],
+    }));
+
+    const store = {
+        upsertFinalCheckRecord,
+        appendFinalCheckSection,
+        readSessionRecord: readSessionRecord as any,
+        startNewLoop: startNewLoop as any,
+    } as any;
+
+    return {
+        store,
+        enqueueTask: vi.fn().mockReturnValue('new-task-id'),
+        broadcastSessionComplete: vi.fn(),
+        maxGapFixLoops: 3,
+        ...overrides,
+    };
+}
+
+function makeInput(responseText: string, deps: OrchestrateFinalCheckDeps) {
+    return {
+        workspaceId: WORKSPACE_ID,
+        sessionId: SESSION_ID,
+        checkIndex: CHECK_INDEX,
+        loopIndex: LOOP_INDEX,
+        sourceIteration: SOURCE_ITERATION,
+        taskId: TASK_ID,
+        processId: PROCESS_ID,
+        responseText,
+        deps,
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('orchestrateFinalCheck', () => {
+
+    describe('clean result (hasGaps: false)', () => {
+        it('persists a completed/clean record', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeCleanResponse(), deps));
+
+            expect(deps.store.upsertFinalCheckRecord).toHaveBeenCalledWith(
+                WORKSPACE_ID, SESSION_ID, CHECK_INDEX,
+                expect.objectContaining({ status: 'completed', hasGaps: false, gapLoopStarted: false }),
+            );
+        });
+
+        it('broadcasts session-complete with reason "signal"', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeCleanResponse(), deps));
+
+            expect(deps.broadcastSessionComplete).toHaveBeenCalledWith(
+                expect.objectContaining({ reason: 'signal', sessionId: SESSION_ID }),
+            );
+        });
+
+        it('does not call enqueueTask', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeCleanResponse(), deps));
+            expect(deps.enqueueTask).not.toHaveBeenCalled();
+        });
+
+        it('does not call startNewLoop', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeCleanResponse(), deps));
+            expect(deps.store.startNewLoop).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('gaps result below cap', () => {
+        it('calls startNewLoop with a gap-focused goal', async () => {
+            const deps = makeDeps();
+            const gapFixGoal = 'Fix only the listed gaps.';
+            await orchestrateFinalCheck(makeInput(makeGapsResponse(gapFixGoal), deps));
+
+            expect(deps.store.startNewLoop).toHaveBeenCalledWith(
+                WORKSPACE_ID, SESSION_ID, gapFixGoal, expect.any(Number), expect.any(String),
+            );
+        });
+
+        it('enqueues a gap-fix iteration task', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+            expect(deps.enqueueTask).toHaveBeenCalledTimes(1);
+        });
+
+        it('persists record with gapLoopStarted=true and gapCount=1', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+
+            expect(deps.store.upsertFinalCheckRecord).toHaveBeenLastCalledWith(
+                WORKSPACE_ID, SESSION_ID, CHECK_INDEX,
+                expect.objectContaining({
+                    status: 'completed',
+                    hasGaps: true,
+                    gapCount: 1,
+                    gapLoopStarted: true,
+                }),
+            );
+        });
+
+        it('does NOT broadcast session-complete', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+            expect(deps.broadcastSessionComplete).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('gaps result at cap', () => {
+        it('does not call startNewLoop', async () => {
+            const session = makeSession({
+                finalChecks: [
+                    { checkIndex: 1, loopIndex: 1, sourceIteration: 2, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                    { checkIndex: 2, loopIndex: 2, sourceIteration: 6, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                    { checkIndex: 3, loopIndex: 3, sourceIteration: 10, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                ],
+            });
+            const deps = makeDeps();
+            (deps.store.readSessionRecord as Mock).mockResolvedValue(session);
+
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+
+            expect(deps.store.startNewLoop).not.toHaveBeenCalled();
+        });
+
+        it('persists capReached: true', async () => {
+            const session = makeSession({
+                finalChecks: [
+                    { checkIndex: 1, loopIndex: 1, sourceIteration: 2, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                    { checkIndex: 2, loopIndex: 2, sourceIteration: 6, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                    { checkIndex: 3, loopIndex: 3, sourceIteration: 10, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                ],
+            });
+            const deps = makeDeps();
+            (deps.store.readSessionRecord as Mock).mockResolvedValue(session);
+
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+
+            expect(deps.store.upsertFinalCheckRecord).toHaveBeenCalledWith(
+                WORKSPACE_ID, SESSION_ID, CHECK_INDEX,
+                expect.objectContaining({ capReached: true, gapLoopStarted: false }),
+            );
+        });
+
+        it('broadcasts session-complete with reason "cap"', async () => {
+            const session = makeSession({
+                finalChecks: [
+                    { checkIndex: 1, loopIndex: 1, sourceIteration: 2, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                    { checkIndex: 2, loopIndex: 2, sourceIteration: 6, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                    { checkIndex: 3, loopIndex: 3, sourceIteration: 10, startedAt: NOW, status: 'completed', gapLoopStarted: true },
+                ],
+            });
+            const deps = makeDeps();
+            (deps.store.readSessionRecord as Mock).mockResolvedValue(session);
+
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+
+            expect(deps.broadcastSessionComplete).toHaveBeenCalledWith(
+                expect.objectContaining({ reason: 'cap' }),
+            );
+        });
+    });
+
+    describe('unparseable response', () => {
+        it('records status=failed', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput('This is not a valid response', deps));
+
+            expect(deps.store.upsertFinalCheckRecord).toHaveBeenCalledWith(
+                WORKSPACE_ID, SESSION_ID, CHECK_INDEX,
+                expect.objectContaining({ status: 'failed' }),
+            );
+        });
+
+        it('broadcasts session-complete with reason "final-check-failed"', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput('Not parseable.', deps));
+
+            expect(deps.broadcastSessionComplete).toHaveBeenCalledWith(
+                expect.objectContaining({ reason: 'final-check-failed' }),
+            );
+        });
+
+        it('does not call enqueueTask', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput('Bad response.', deps));
+            expect(deps.enqueueTask).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('missing gapFixGoal', () => {
+        it('synthesizes a goal from gaps when gapFixGoal is absent', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeGapsResponse(), deps));
+
+            // The parser synthesizes the goal before orchestrate sees it
+            const callArg = (deps.store.startNewLoop as Mock).mock.calls[0][2] as string;
+            expect(callArg).toContain('Missing test');
+        });
+
+        it('sets goalSynthesized=true in the persisted record (from parser)', async () => {
+            const deps = makeDeps();
+            await orchestrateFinalCheck(makeInput(makeGapsResponse(), deps));
+
+            // The parser sets goalSynthesized: true; orchestrate passes it through
+            expect(deps.store.upsertFinalCheckRecord).toHaveBeenLastCalledWith(
+                WORKSPACE_ID, SESSION_ID, CHECK_INDEX,
+                expect.objectContaining({ goalSynthesized: true }),
+            );
+        });
+    });
+
+    describe('startNewLoop failure', () => {
+        it('persists gapLoopStarted=false and does not enqueue', async () => {
+            const deps = makeDeps();
+            (deps.store.startNewLoop as Mock).mockRejectedValue(new Error('Session not eligible'));
+
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+
+            expect(deps.enqueueTask).not.toHaveBeenCalled();
+            expect(deps.store.upsertFinalCheckRecord).toHaveBeenLastCalledWith(
+                WORKSPACE_ID, SESSION_ID, CHECK_INDEX,
+                expect.objectContaining({ gapLoopStarted: false }),
+            );
+        });
+    });
+
+    describe('legacy session (no finalChecks array)', () => {
+        it('correctly reports no existing gap loops (cap check passes)', async () => {
+            const session = makeSession(); // no finalChecks
+            const deps = makeDeps({ maxGapFixLoops: 3 });
+            (deps.store.readSessionRecord as Mock).mockResolvedValue(session);
+
+            await orchestrateFinalCheck(makeInput(makeGapsResponse('Fix it.'), deps));
+
+            // Should start a loop (not hit cap on first check)
+            expect(deps.store.startNewLoop).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/packages/coc/test/server/routes/ralph-launch-routes.test.ts
+++ b/packages/coc/test/server/routes/ralph-launch-routes.test.ts
@@ -148,6 +148,20 @@ describe('POST /api/ralph-launch', () => {
         expect(enqueueArg.payload.folderPath).toBe('/repos/myrepo');
     });
 
+    it('passes provider and model to the enqueued task', async () => {
+        const res = await post(baseUrl, '/api/ralph-launch', {
+            goalSpec: 'Build something',
+            workspaceId: 'ws-1',
+            provider: 'codex',
+            config: { model: 'gpt-5.3-codex' },
+        });
+
+        expect(res.status).toBe(200);
+        const enqueueArg = mockEnqueue.mock.calls[0][0];
+        expect(enqueueArg.payload.provider).toBe('codex');
+        expect(enqueueArg.config).toEqual({ model: 'gpt-5.3-codex' });
+    });
+
     it('initialises the per-session journal when workspaceId is provided', async () => {
         const res = await post(baseUrl, '/api/ralph-launch', {
             goalSpec: 'Build something',
@@ -206,6 +220,18 @@ describe('POST /api/ralph-launch', () => {
         });
 
         expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid provider', async () => {
+        const res = await post(baseUrl, '/api/ralph-launch', {
+            goalSpec: 'Build something',
+            workspaceId: 'ws-1',
+            provider: 'bad-provider',
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.json().error).toMatch(/Invalid provider/i);
+        expect(mockEnqueue).not.toHaveBeenCalled();
     });
 
     // -----------------------------------------------------------------------

--- a/packages/coc/test/server/spa/client/repos/RalphLaunchDialog.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/RalphLaunchDialog.test.tsx
@@ -14,6 +14,34 @@ vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
     isContainerMode: () => false,
     getApiBase: () => 'http://localhost:4000/api',
     isRalphEnabled: () => true,
+    getDefaultProvider: () => 'copilot',
+}));
+
+const {
+    mockGetRepoPreferences,
+    mockPatchRepoPreferences,
+    mockAgentProviders,
+} = vi.hoisted(() => ({
+    mockGetRepoPreferences: vi.fn().mockResolvedValue({}),
+    mockPatchRepoPreferences: vi.fn().mockResolvedValue({}),
+    mockAgentProviders: [
+        { id: 'copilot', label: 'Copilot', enabled: true, available: true, locked: true },
+        { id: 'codex', label: 'Codex', enabled: true, available: true },
+        { id: 'claude', label: 'Claude', enabled: false, available: false },
+    ],
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        preferences: {
+            getRepo: mockGetRepoPreferences,
+            patchRepo: mockPatchRepoPreferences,
+        },
+    }),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/hooks/useAgentProviders', () => ({
+    useAgentProviders: () => ({ providers: mockAgentProviders, loading: false, error: null, reload: vi.fn() }),
 }));
 
 const mockModels = [
@@ -49,6 +77,10 @@ describe('RalphLaunchDialog', () => {
     beforeEach(() => {
         defaultProps.onClose.mockClear();
         defaultProps.onLaunched.mockClear();
+        mockGetRepoPreferences.mockReset();
+        mockGetRepoPreferences.mockResolvedValue({});
+        mockPatchRepoPreferences.mockReset();
+        mockPatchRepoPreferences.mockResolvedValue({});
         vi.stubGlobal('fetch', vi.fn());
     });
 
@@ -119,6 +151,7 @@ describe('RalphLaunchDialog', () => {
         const body = JSON.parse(mockFetch.mock.calls[0][1].body);
         expect(body.goalSpec).toBe('## Goal\nRefactor auth module');
         expect(body.workspaceId).toBe('ws-123');
+        expect(body.provider).toBe('copilot');
     });
 
     it('includes model in config when selected', async () => {
@@ -142,6 +175,52 @@ describe('RalphLaunchDialog', () => {
 
         const body = JSON.parse(mockFetch.mock.calls[0][1].body);
         expect(body.config).toEqual({ model: 'model-b' });
+    });
+
+    it('includes selected provider in launch payload', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ processId: 'pid-provider' }),
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        render(<RalphLaunchDialog {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('agent-selector-chip-btn'));
+        fireEvent.click(screen.getByTestId('agent-option-codex'));
+        fireEvent.click(screen.getByTestId('ralph-launch-confirm-btn'));
+
+        await waitFor(() => {
+            expect(defaultProps.onLaunched).toHaveBeenCalledWith('pid-provider');
+        });
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(body.provider).toBe('codex');
+        expect(mockPatchRepoPreferences).toHaveBeenCalledWith('ws-123', { lastChatProvider: 'codex' });
+    });
+
+    it('uses last chat provider preference when selectable', async () => {
+        mockGetRepoPreferences.mockResolvedValue({ lastChatProvider: 'codex' });
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ processId: 'pid-last-provider' }),
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        render(<RalphLaunchDialog {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('agent-selector-chip-btn').textContent).toContain('Codex');
+        });
+
+        fireEvent.click(screen.getByTestId('ralph-launch-confirm-btn'));
+
+        await waitFor(() => {
+            expect(defaultProps.onLaunched).toHaveBeenCalledWith('pid-last-provider');
+        });
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(body.provider).toBe('codex');
     });
 
     it('includes folderPath when provided', async () => {

--- a/packages/coc/test/spa/admin/DbBrowserSection.test.tsx
+++ b/packages/coc/test/spa/admin/DbBrowserSection.test.tsx
@@ -5,8 +5,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, configure } from '@testing-library/react';
 import { type ReactNode } from 'react';
+
+// Slow Windows CI runners can take >1 s to flush two chained promise
+// resolutions (listTables → setSelectedTable → getTable → setTableData)
+// through React's state-update cycle. Raise the RTL async timeout for the
+// whole file so every waitFor call uses 5 s instead of the default 1 s.
+configure({ asyncUtilTimeout: 5000 });
 import { CocApiError } from '@plusplusoneplusplus/coc-client';
 import { AppProvider } from '../../../src/server/spa/client/react/contexts/AppContext';
 import { DbBrowserSection } from '../../../src/server/spa/client/react/admin/DbBrowserSection';

--- a/packages/coc/test/spa/react/notes-sidebar.test.tsx
+++ b/packages/coc/test/spa/react/notes-sidebar.test.tsx
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, waitFor, act, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import type { NoteTreeNode } from '../../../src/server/spa/client/react/features/notes/notesApi';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
@@ -67,9 +68,13 @@ const SAMPLE_TREE: NoteTreeNode[] = [
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-function renderSidebar(selectedPath: string | null = null, onSelectPage = vi.fn()) {
+function renderSidebar(
+    selectedPath: string | null = null,
+    onSelectPage = vi.fn(),
+    extraProps: Partial<ComponentProps<typeof NotesSidebar>> = {},
+) {
     return render(
-        <NotesSidebar workspaceId="ws1" selectedPath={selectedPath} onSelectPage={onSelectPage} />,
+        <NotesSidebar workspaceId="ws1" selectedPath={selectedPath} onSelectPage={onSelectPage} {...extraProps} />,
     );
 }
 
@@ -278,8 +283,10 @@ describe('NotesSidebar', () => {
         });
     });
 
-    it('creates a page via dialog and refreshes tree', async () => {
-        const { findByTestId } = renderSidebar();
+    it('creates a page via dialog and reports the server-returned path', async () => {
+        mockCreateNode.mockResolvedValueOnce({ path: 'Notebook1/NewPage.md', type: 'page' });
+        const onNoteCreated = vi.fn();
+        const { findByTestId } = renderSidebar(null, vi.fn(), { onNoteCreated });
         const nb1 = await findByTestId('notes-tree-item-Notebook1');
 
         // Open context menu → Create Page
@@ -303,6 +310,7 @@ describe('NotesSidebar', () => {
 
         await waitFor(() => {
             expect(mockCreateNode).toHaveBeenCalledWith('ws1', 'Notebook1/NewPage', 'page', undefined);
+            expect(onNoteCreated).toHaveBeenCalledWith('Notebook1/NewPage.md');
         });
 
         // Tree should refresh (getTree called again)
@@ -381,8 +389,13 @@ describe('NotesSidebar', () => {
         });
     });
 
-    it('renames a node and refreshes tree', async () => {
-        const { findByTestId } = renderSidebar();
+    it('renames a node and reports the server-returned path', async () => {
+        mockRenameNode.mockResolvedValueOnce({
+            oldPath: 'Notebook1/TopPage',
+            newPath: 'Notebook1/RenamedPage.md',
+        });
+        const onNoteRenamed = vi.fn();
+        const { findByTestId } = renderSidebar(null, vi.fn(), { onNoteRenamed });
 
         const nb1 = await findByTestId('notes-tree-item-Notebook1');
         fireEvent.click(nb1);
@@ -407,6 +420,7 @@ describe('NotesSidebar', () => {
 
         await waitFor(() => {
             expect(mockRenameNode).toHaveBeenCalledWith('ws1', 'Notebook1/TopPage', 'Notebook1/RenamedPage', undefined);
+            expect(onNoteRenamed).toHaveBeenCalledWith('Notebook1/TopPage', 'Notebook1/RenamedPage.md');
         });
     });
 

--- a/packages/coc/test/spa/react/notes/NoteEditor.test.tsx
+++ b/packages/coc/test/spa/react/notes/NoteEditor.test.tsx
@@ -1722,5 +1722,30 @@ describe('NoteEditor', () => {
 
             expect(screen.getByTestId('ralph-launch-dialog-stub')).toBeDefined();
         });
+
+        it('onLaunched navigates to chats hash and closes dialog', async () => {
+            mockLoadContent.mockResolvedValue({ content: '## Goal\nBuild feature', path: 'feature.goal.md' });
+            await act(async () => {
+                render(<NoteEditor workspaceId="ws-test" notePath="feature.goal.md" io={mockIo} />);
+            });
+            await waitFor(() => expect(mockSetContent).toHaveBeenCalled());
+
+            // Open the dialog
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('note-run-ralph-btn'));
+            });
+            expect(screen.getByTestId('ralph-launch-dialog-stub')).toBeDefined();
+
+            // Simulate the dialog calling onLaunched with a processId
+            const dialogProps = mockRalphLaunchDialogProps.mock.calls[mockRalphLaunchDialogProps.mock.calls.length - 1][0] as Record<string, unknown>;
+            await act(async () => {
+                (dialogProps.onLaunched as (id: string) => void)('queue_proc-123');
+            });
+
+            // Dialog should be closed
+            expect(screen.queryByTestId('ralph-launch-dialog-stub')).toBeNull();
+            // Hash should navigate to chats view with the process id
+            expect(location.hash).toBe('#repos/' + encodeURIComponent('ws-test') + '/chats/' + encodeURIComponent('queue_proc-123'));
+        });
     });
 });

--- a/packages/coc/test/spa/react/repos/FileDiffPanel.test.tsx
+++ b/packages/coc/test/spa/react/repos/FileDiffPanel.test.tsx
@@ -223,6 +223,21 @@ function makeCommitSource(overrides: Partial<DiffSource> = {}): DiffSource {
     };
 }
 
+function makePrSource(overrides: Partial<DiffSource> = {}): DiffSource {
+    return {
+        label: 'PR #42',
+        fileDiffUrl: (fp: string) => `/api/repos/repo1/pull-requests/42/diff/files/${fp}`,
+        fullContextFileDiffUrl: (fp: string) => `/api/repos/repo1/pull-requests/42/diff/files/${fp}?fullContext=true`,
+        fullDiffUrl: () => `/api/repos/repo1/pull-requests/42/diff`,
+        commentContext: (fp: string) => ({ repositoryId: 'ws1', filePath: fp, oldRef: 'pr-42-base', newRef: 'pr-42-head' }),
+        files: [],
+        chat: null,
+        supportsTruncation: false,
+        cacheKey: 'pr:repo1:42',
+        ...overrides,
+    };
+}
+
 // --- Tests ---
 
 describe('FileDiffPanel', () => {
@@ -708,5 +723,93 @@ describe('FileDiffPanel', () => {
 
         expect(screen.queryByTestId('inline-comment-popup')).toBeNull();
         expect(mockAddComment).not.toHaveBeenCalled();
+    });
+
+    // ── Full-context diff toggle (AC-02) ──
+
+    it('shows full-context toggle button when source supports fullContextFileDiffUrl', () => {
+        render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={makePrSource()} />);
+
+        expect(screen.getByTestId('full-context-toggle-btn')).toBeTruthy();
+    });
+
+    it('does not show full-context toggle button when source has no fullContextFileDiffUrl', () => {
+        render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={makeBranchSource()} />);
+
+        expect(screen.queryByTestId('full-context-toggle-btn')).toBeNull();
+    });
+
+    it('clicking full-context toggle fetches the full-context URL', async () => {
+        const prSource = makePrSource();
+        render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={prSource} />);
+
+        // Before toggle: standard URL
+        expect(mockUseFileDiff).toHaveBeenLastCalledWith(
+            `/api/repos/repo1/pull-requests/42/diff/files/src/foo.ts`,
+            null,
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('full-context-toggle-btn'));
+        });
+
+        // After toggle: full-context URL
+        expect(mockUseFileDiff).toHaveBeenLastCalledWith(
+            `/api/repos/repo1/pull-requests/42/diff/files/src/foo.ts?fullContext=true`,
+            null,
+        );
+    });
+
+    it('full-context toggle button shows active state when in full-context mode', async () => {
+        render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={makePrSource()} />);
+
+        const btn = screen.getByTestId('full-context-toggle-btn');
+        expect(btn.getAttribute('aria-pressed')).toBe('false');
+
+        await act(async () => {
+            fireEvent.click(btn);
+        });
+
+        expect(screen.getByTestId('full-context-toggle-btn').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('shows fullContextUnavailable banner when server reports unavailable', () => {
+        mockUseFileDiff.mockReturnValue(makeFileDiffHook({ fullContextUnavailable: true }));
+
+        render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={makePrSource()} />);
+
+        expect(screen.getByTestId('full-context-unavailable-banner')).toBeTruthy();
+        expect(screen.getByText(/Full-file context unavailable/)).toBeTruthy();
+    });
+
+    it('does not show fullContextUnavailable banner when not unavailable', () => {
+        mockUseFileDiff.mockReturnValue(makeFileDiffHook({ fullContextUnavailable: false }));
+
+        render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={makePrSource()} />);
+
+        expect(screen.queryByTestId('full-context-unavailable-banner')).toBeNull();
+    });
+
+    it('navigating to a new file resets full-context mode back to hunk-only', async () => {
+        const prSource = makePrSource();
+        const { rerender } = render(<FileDiffPanel workspaceId="ws1" filePath="src/foo.ts" source={prSource} />);
+
+        // Enable full-context
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('full-context-toggle-btn'));
+        });
+        expect(mockUseFileDiff).toHaveBeenLastCalledWith(
+            `/api/repos/repo1/pull-requests/42/diff/files/src/foo.ts?fullContext=true`,
+            null,
+        );
+
+        // Navigate to a different file
+        rerender(<FileDiffPanel workspaceId="ws1" filePath="src/bar.ts" source={prSource} />);
+
+        // Mode should reset — standard URL used again
+        expect(mockUseFileDiff).toHaveBeenLastCalledWith(
+            `/api/repos/repo1/pull-requests/42/diff/files/src/bar.ts`,
+            null,
+        );
     });
 });

--- a/packages/coc/test/spa/react/repos/UnifiedDiffViewerHunkCollapse.test.tsx
+++ b/packages/coc/test/spa/react/repos/UnifiedDiffViewerHunkCollapse.test.tsx
@@ -171,4 +171,81 @@ describe('UnifiedDiffViewer — AC-02 hunk collapse', () => {
         act(() => { fireEvent.click(screen.getByTestId('toggle-all')); });
         expect(screen.getAllByTestId('collapsed-hunk-summary')).toHaveLength(2);
     });
+
+    it('expanded hunk header shows compact classification badge with category and reason', () => {
+        // Filter to 'mechanical' → both logic and generated hunks collapse.
+        render(
+            <UnifiedDiffViewer
+                diff={TWO_HUNK_DIFF}
+                fileName="foo.ts"
+                filePath="foo.ts"
+                getHunkClassification={makeGetHunkClassification()}
+                activeFilters={new Set<HunkCategory>(['mechanical'])}
+            />,
+        );
+        // Expand the first (logic) hunk.
+        const summaries = screen.getAllByTestId('collapsed-hunk-summary');
+        const expandBtn = summaries[0].querySelector<HTMLButtonElement>('[data-testid="collapsed-hunk-expand"]')!;
+        act(() => { fireEvent.click(expandBtn); });
+
+        // The hunk is now expanded — only one collapsed summary remains (generated).
+        expect(screen.queryAllByTestId('collapsed-hunk-summary')).toHaveLength(1);
+        // The expanded hunk header should carry a compact classification badge.
+        const badges = screen.getAllByTestId('expanded-hunk-badge');
+        expect(badges).toHaveLength(1);
+        expect(badges[0]).toHaveTextContent('Logic');
+        // The badge title attribute carries the reason.
+        expect(badges[0].getAttribute('title')).toBe('Touches core logic path');
+    });
+
+    it('Collapse button on expanded hunk restores the collapsed summary row', () => {
+        render(
+            <UnifiedDiffViewer
+                diff={TWO_HUNK_DIFF}
+                fileName="foo.ts"
+                filePath="foo.ts"
+                getHunkClassification={makeGetHunkClassification()}
+                activeFilters={new Set<HunkCategory>(['mechanical'])}
+            />,
+        );
+        // Expand the first (logic) hunk.
+        let summaries = screen.getAllByTestId('collapsed-hunk-summary');
+        const expandBtn = summaries[0].querySelector<HTMLButtonElement>('[data-testid="collapsed-hunk-expand"]')!;
+        act(() => { fireEvent.click(expandBtn); });
+
+        // Badge now visible; one collapsed summary remains.
+        expect(screen.getAllByTestId('expanded-hunk-badge')).toHaveLength(1);
+        expect(screen.queryAllByTestId('collapsed-hunk-summary')).toHaveLength(1);
+
+        // Click Collapse.
+        const collapseBtn = screen.getByTestId('expanded-hunk-collapse');
+        act(() => { fireEvent.click(collapseBtn); });
+
+        // The hunk is collapsed again — two summary rows, no badge.
+        summaries = screen.getAllByTestId('collapsed-hunk-summary');
+        expect(summaries).toHaveLength(2);
+        expect(screen.queryByTestId('expanded-hunk-badge')).toBeNull();
+        expect(screen.queryByTestId('expanded-hunk-collapse')).toBeNull();
+    });
+
+    it('Collapse action does not affect global activeFilters (other hunk stays collapsed)', () => {
+        render(
+            <UnifiedDiffViewer
+                diff={TWO_HUNK_DIFF}
+                fileName="foo.ts"
+                filePath="foo.ts"
+                getHunkClassification={makeGetHunkClassification()}
+                activeFilters={new Set<HunkCategory>(['mechanical'])}
+            />,
+        );
+        // Expand the first (logic) hunk, then collapse it back.
+        let summaries = screen.getAllByTestId('collapsed-hunk-summary');
+        act(() => { fireEvent.click(summaries[0].querySelector<HTMLButtonElement>('[data-testid="collapsed-hunk-expand"]')!); });
+        act(() => { fireEvent.click(screen.getByTestId('expanded-hunk-collapse')); });
+
+        // Both hunks should be collapsed again (filter unchanged).
+        summaries = screen.getAllByTestId('collapsed-hunk-summary');
+        expect(summaries).toHaveLength(2);
+        expect(summaries[1]).toHaveTextContent('Generated');
+    });
 });

--- a/packages/coc/test/spa/react/repos/pull-requests/pr-mock-data.test.ts
+++ b/packages/coc/test/spa/react/repos/pull-requests/pr-mock-data.test.ts
@@ -8,6 +8,7 @@ import {
     buildCheckRowsFromChecks,
     buildCommitRowsFromPrCommits,
     buildMergeReadinessFromData,
+    buildTimelineFromRealData,
     checkStatusClass,
     commitIntentClass,
     findingTagClass,
@@ -526,5 +527,181 @@ describe('queue helpers', () => {
     it('excludes "foryou" filter by default', () => {
         const ids = getQueueFilterDefinitions().map(f => f.id);
         expect(ids).not.toContain('foryou');
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// buildTimelineFromRealData
+// ──────────────────────────────────────────────────────────────────────────────
+
+const threadGroups = [
+    { id: 'blocking',     title: 'Blocking concerns',     count: 2 },
+    { id: 'non-blocking', title: 'Non-blocking feedback', count: 1 },
+    { id: 'noise',        title: 'Nits and noise',        count: 0 },
+];
+
+const sampleThreads: CommentThread[] = [
+    {
+        id: 't1',
+        status: 'active',
+        comments: [
+            {
+                id: 'c1',
+                author: { displayName: 'Jordan Lee' },
+                body: 'Can we prove abort does not replay the final partial line?',
+            },
+        ],
+    },
+    {
+        id: 't2',
+        status: 'active',
+        comments: [
+            {
+                id: 'c2',
+                author: { displayName: 'Alex Kim' },
+                body: 'Style nit: rename variable.',
+            },
+        ],
+    },
+];
+
+const sampleCommits: PullRequestCommit[] = [
+    {
+        id: 'abc1',
+        shortId: 'abc1',
+        message: 'Added parser boundary docs',
+        subject: 'Added parser boundary docs',
+        author: { displayName: 'Morgan Ames' },
+    },
+    {
+        id: 'abc2',
+        shortId: 'abc2',
+        message: 'Replaced the old batch fixture helper',
+        subject: 'Replaced the old batch fixture helper',
+        author: { displayName: 'Morgan Ames' },
+    },
+    {
+        id: 'abc3',
+        shortId: 'abc3',
+        message: 'Fix cancellation edge case',
+        subject: 'Fix cancellation edge case',
+        author: { displayName: 'Morgan Ames' },
+    },
+];
+
+describe('buildTimelineFromRealData', () => {
+    it('returns an empty array when both threads and commits are empty', () => {
+        expect(buildTimelineFromRealData([], [], [])).toEqual([]);
+    });
+
+    it('emits an AI grouping event when threads are present', () => {
+        const events = buildTimelineFromRealData(sampleThreads, [], threadGroups);
+        const aiEvent = events.find(e => e.kind === 'ai');
+        expect(aiEvent).toBeDefined();
+        expect(aiEvent!.initials).toBe('AI');
+        expect(aiEvent!.title).toMatch(/AI grouped 2 review threads into 2 topics/);
+        expect(aiEvent!.detail).toMatch(/Blocking concerns/);
+        expect(aiEvent!.detail).toMatch(/Non-blocking feedback/);
+    });
+
+    it('omits AI event when there are no threads', () => {
+        const events = buildTimelineFromRealData([], sampleCommits, []);
+        expect(events.find(e => e.kind === 'ai')).toBeUndefined();
+    });
+
+    it('emits a reviewer event with initials derived from the commenter name', () => {
+        const events = buildTimelineFromRealData(sampleThreads, [], threadGroups);
+        const reviewerEvent = events.find(e => e.kind === 'reviewer');
+        expect(reviewerEvent).toBeDefined();
+        expect(reviewerEvent!.initials).toBe('JL');
+        expect(reviewerEvent!.title).toContain('Jordan Lee');
+        expect(reviewerEvent!.detail).toContain('abort');
+    });
+
+    it('emits an author push event with real commit subjects', () => {
+        const events = buildTimelineFromRealData([], sampleCommits, []);
+        const authorEvent = events.find(e => e.kind === 'author');
+        expect(authorEvent).toBeDefined();
+        expect(authorEvent!.initials).toBe('MA');
+        expect(authorEvent!.title).toContain('Morgan Ames');
+        expect(authorEvent!.title).toContain('3 commits');
+        expect(authorEvent!.detail).toContain('Added parser boundary docs');
+    });
+
+    it('respects maxReviewerEvents and maxAuthorEvents options', () => {
+        const events = buildTimelineFromRealData(
+            sampleThreads, sampleCommits, threadGroups,
+            { maxReviewerEvents: 1, maxAuthorEvents: 1 },
+        );
+        expect(events.filter(e => e.kind === 'reviewer')).toHaveLength(1);
+        expect(events.filter(e => e.kind === 'author')).toHaveLength(1);
+    });
+
+    it('limits reviewer events to maxReviewerEvents (default 2)', () => {
+        const manyThreads: CommentThread[] = Array.from({ length: 5 }, (_, i) => ({
+            id: `t${i}`,
+            status: 'active',
+            comments: [{ id: `c${i}`, author: { displayName: `Reviewer ${i}` }, body: `comment ${i}` }],
+        }));
+        const events = buildTimelineFromRealData(manyThreads, [], []);
+        expect(events.filter(e => e.kind === 'reviewer')).toHaveLength(2);
+    });
+
+    it('uses singular "thread" and "topic" when there is exactly one', () => {
+        const oneThread: CommentThread[] = [
+            {
+                id: 'x',
+                status: 'active',
+                comments: [{ id: 'cx', author: { displayName: 'Dev Dev' }, body: 'question' }],
+            },
+        ];
+        const oneGroup = [{ id: 'blocking', title: 'Blocking', count: 1 }];
+        const events = buildTimelineFromRealData(oneThread, [], oneGroup);
+        const aiEvent = events.find(e => e.kind === 'ai');
+        expect(aiEvent!.title).toMatch(/1 review thread into 1 topic/);
+    });
+
+    it('truncates long comment bodies to 80 chars with an ellipsis', () => {
+        const longBody = 'A'.repeat(100);
+        const longThread: CommentThread[] = [
+            {
+                id: 'long',
+                status: 'active',
+                comments: [{ id: 'cl', author: { displayName: 'Bob Builder' }, body: longBody }],
+            },
+        ];
+        const events = buildTimelineFromRealData(longThread, [], []);
+        const reviewerEvent = events.find(e => e.kind === 'reviewer');
+        expect(reviewerEvent!.detail).toHaveLength(83); // "  + 80 chars + … + " = 83
+        expect(reviewerEvent!.detail).toMatch(/…"$/);
+    });
+
+    it('skips threads with no author displayName or empty body', () => {
+        const badThreads: CommentThread[] = [
+            { id: 'b1', comments: [] },
+            { id: 'b2', comments: [{ id: 'c', body: '' }] },
+            { id: 'b3', comments: [{ id: 'c', author: { displayName: '' }, body: 'hi' }] },
+        ];
+        const events = buildTimelineFromRealData(badThreads, [], []);
+        expect(events.filter(e => e.kind === 'reviewer')).toHaveLength(0);
+    });
+
+    it('produces correct 2-letter initials for single-name authors', () => {
+        const commits: PullRequestCommit[] = [
+            { id: 'a', shortId: 'a', message: 'fix thing', subject: 'fix thing', author: { displayName: 'Zara' } },
+        ];
+        const events = buildTimelineFromRealData([], commits, []);
+        const authorEvent = events.find(e => e.kind === 'author');
+        expect(authorEvent!.initials).toBe('ZA');
+    });
+
+    it('falls back to "Author" when commit has no author name', () => {
+        const commits: PullRequestCommit[] = [
+            { id: 'a', shortId: 'a', message: 'fix thing', subject: 'fix thing' },
+        ];
+        const events = buildTimelineFromRealData([], commits, []);
+        const authorEvent = events.find(e => e.kind === 'author');
+        expect(authorEvent!.title).toContain('Author');
+        expect(authorEvent!.initials).toBe('?');
     });
 });

--- a/packages/coc/test/spa/react/repos/useFileDiff.test.ts
+++ b/packages/coc/test/spa/react/repos/useFileDiff.test.ts
@@ -212,4 +212,62 @@ describe('useFileDiff', () => {
         // Should not fetch again since fullUrl is null
         expect(mockFetchDiffFromSource).toHaveBeenCalledTimes(1);
     });
+
+    it('propagates fullContextUnavailable=true from server response', async () => {
+        mockFetchDiffFromSource.mockResolvedValue({
+            diff: 'hunk-only fallback diff',
+            truncated: false,
+            totalLines: 0,
+            fullContextUnavailable: true,
+        });
+
+        const { result } = renderHook(() => useFileDiff('/api/diff?fullContext=true'));
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.fullContextUnavailable).toBe(true);
+        expect(result.current.diff).toBe('hunk-only fallback diff');
+    });
+
+    it('fullContextUnavailable is undefined when not in server response', async () => {
+        mockFetchDiffFromSource.mockResolvedValue({
+            diff: 'normal diff',
+            truncated: false,
+            totalLines: 0,
+        });
+
+        const { result } = renderHook(() => useFileDiff('/api/diff'));
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.fullContextUnavailable).toBeUndefined();
+    });
+
+    it('resets fullContextUnavailable on URL change', async () => {
+        mockFetchDiffFromSource
+            .mockResolvedValueOnce({
+                diff: 'hunk fallback',
+                truncated: false,
+                totalLines: 0,
+                fullContextUnavailable: true,
+            })
+            .mockResolvedValueOnce({
+                diff: 'normal diff',
+                truncated: false,
+                totalLines: 0,
+            });
+
+        const { result, rerender } = renderHook(
+            ({ url }) => useFileDiff(url),
+            { initialProps: { url: '/api/diff?fullContext=true' as string } },
+        );
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.fullContextUnavailable).toBe(true);
+
+        rerender({ url: '/api/diff' });
+
+        await waitFor(() => expect(result.current.diff).toBe('normal diff'));
+        expect(result.current.fullContextUnavailable).toBeUndefined();
+    });
 });

--- a/packages/vscode-extension/src/test/suite/pipelines-viewer.test.ts
+++ b/packages/vscode-extension/src/test/suite/pipelines-viewer.test.ts
@@ -17,6 +17,7 @@ import {
 suite('Pipelines Viewer Tests (Package Structure)', () => {
     let tempDir: string;
     let pipelineManager: PipelineManager;
+    let originalCreateFileSystemWatcher: typeof vscode.workspace.createFileSystemWatcher;
 
     setup(() => {
         // Create temporary directory for testing
@@ -40,12 +41,57 @@ suite('Pipelines Viewer Tests (Package Structure)', () => {
             return originalGetConfiguration(section);
         };
 
+        // Mock vscode.workspace.createFileSystemWatcher with Node.js fs.watch so
+        // that the watcher fires reliably for temp-dir paths that are outside the
+        // VS Code workspace in the extension-host test environment.
+        originalCreateFileSystemWatcher = vscode.workspace.createFileSystemWatcher;
+        (vscode.workspace as any).createFileSystemWatcher = (
+            pattern: vscode.GlobPattern | vscode.RelativePattern
+        ) => {
+            const createHandlers: Array<() => void> = [];
+            const changeHandlers: Array<() => void> = [];
+            const deleteHandlers: Array<() => void> = [];
+            // RelativePattern exposes `.base` (string) or `.baseUri` (Uri)
+            const base: string | undefined =
+                (pattern as any)?.base ?? (pattern as any)?.baseUri?.fsPath;
+            let fsWatcher: fs.FSWatcher | undefined;
+            if (base && fs.existsSync(base)) {
+                fsWatcher = fs.watch(base, { persistent: false }, (eventType: string) => {
+                    if (eventType === 'rename') {
+                        createHandlers.forEach(h => h());
+                        deleteHandlers.forEach(h => h());
+                    } else {
+                        changeHandlers.forEach(h => h());
+                    }
+                });
+                fsWatcher.on('error', () => { /* ignore watch errors */ });
+            }
+            return {
+                onDidCreate: (handler: () => void) => {
+                    createHandlers.push(handler);
+                    return { dispose: () => {} };
+                },
+                onDidChange: (handler: () => void) => {
+                    changeHandlers.push(handler);
+                    return { dispose: () => {} };
+                },
+                onDidDelete: (handler: () => void) => {
+                    deleteHandlers.push(handler);
+                    return { dispose: () => {} };
+                },
+                dispose: () => { fsWatcher?.close(); }
+            };
+        };
+
         pipelineManager = new PipelineManager(tempDir);
     });
 
     teardown(() => {
         // Dispose pipeline manager
         pipelineManager.dispose();
+
+        // Restore mocked VS Code APIs
+        (vscode.workspace as any).createFileSystemWatcher = originalCreateFileSystemWatcher;
 
         // Clean up temporary directory
         if (fs.existsSync(tempDir)) {


### PR DESCRIPTION
- **fix(coc): append markdown suffix when renaming notes**
- **test(pipelines-viewer): mock createFileSystemWatcher with Node.js fs.watch**
- **feat(pr-routes): add in-memory diff cache for AC-01 (pr-review-diff-popout)**
- **feat(ralph): add final-check types, config, prompt builder, and result parser (AC-01/AC-02/AC-05 foundations)**
- **feat(AC-03): reversible classified hunk expansion in UnifiedDiffViewer**
- **fix(config): fix ralph.finalCheck source detection and update config tests**
- **feat(pr-review): AC-02 full-file-context diff toggle**
- **feat(pr-detail): wire conversation timeline to real thread and commit data**
- **Add provider selection to Ralph goal launch**
- **fix: navigate to chats tab after launching Ralph from notes**
- **feat(ralph): implement AC-01 through AC-06 final-check gap loop**
- **fix(pr-detail): move threadGroups declaration before timeline to fix TDZ error**
