### PR TITLE
pr/a999be10f featadmin merge 5 settings sidebar items

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -75,6 +75,9 @@ spa/client/react/
 `ProviderBadge` (the chat-header agent pill) shares the same provider
 palette and mirrors `ChatStatusPill`'s "Thinking" style: rounded-full
 bordered pill with a leading colored dot followed by the provider label.
+Running chat-list rows do not render separate provider pills; their leading
+status dot uses the provider palette (Copilot green, Claude coral, Codex
+indigo) and falls back to Copilot green when provider metadata is missing.
 Task-tree queue activity badges reuse the provider dot palette from
 `ProviderBadge`: queued/running items carry `payload.provider` through
 `useQueueChat`, and file/folder "in progress" badges fall back to Copilot

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -1084,7 +1084,6 @@ export function AdminPanel() {
                     testId: 'settings-nav-configure',
                     action: { kind: 'settings', subTab: DEFAULT_SETTINGS_SUBTAB } as AdminNavAction,
                 },
-                toolNavItem('models'),
                 ...nonContainerAgentsNavItem,
             ],
         },

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -1077,12 +1077,15 @@ export function AdminPanel() {
         {
             label: 'Configure',
             items: [
-                settingsNavItem('ai'),
+                {
+                    key: 'settings:configure',
+                    label: 'Configure',
+                    icon: '✦',
+                    testId: 'settings-nav-configure',
+                    action: { kind: 'settings', subTab: DEFAULT_SETTINGS_SUBTAB } as AdminNavAction,
+                },
+                toolNavItem('models'),
                 ...nonContainerAgentsNavItem,
-                settingsNavItem('chat'),
-                settingsNavItem('appearance'),
-                settingsNavItem('features'),
-                settingsNavItem('integrations'),
             ],
         },
         {
@@ -1144,7 +1147,7 @@ export function AdminPanel() {
     const activeNavKey = isToolEmbedded
         ? `tool:${activeDashboardTab}`
         : activeTab === 'settings'
-            ? `settings:${settingsSubTab}`
+            ? (settingsSubTab === 'advanced' ? 'settings:advanced' : 'settings:configure')
             : `admin:${activeTab}`;
     const activeTabLabel = activeTab === 'settings'
         ? getSettingsSubTabMeta(settingsSubTab).label
@@ -1300,6 +1303,25 @@ export function AdminPanel() {
                         {/* ── Settings tab ── */}
                 {activeTab === 'settings' && (
                     <div className="space-y-3" data-testid="settings-cards">
+                        {/* Sub-tab bar — shown for the 5 main settings sections (not advanced) */}
+                        {settingsSubTab !== 'advanced' && (
+                            <nav className="ar-subtab-row" role="tablist" aria-label="Settings sections">
+                                {SETTINGS_SUBTABS.filter(t => t.id !== 'advanced').map(tab => (
+                                    <button
+                                        key={tab.id}
+                                        type="button"
+                                        role="tab"
+                                        className={`ar-subtab${(!isToolEmbedded && settingsSubTab === tab.id) ? ' is-active' : ''}`}
+                                        onClick={() => handleSettingsSubTabChange(tab.id)}
+                                        data-testid={`settings-subtab-${tab.id}`}
+                                        aria-selected={!isToolEmbedded && settingsSubTab === tab.id}
+                                    >
+                                        <span className="ar-subtab-icon">{tab.icon}</span>
+                                        {tab.label}
+                                    </button>
+                                ))}
+                            </nav>
+                        )}
                         {configLoading ? (
                             <section className="ar-card">
                                 <div className="ar-section ar-hstack ar-muted"><Spinner size="sm" /> Loading…</div>

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -34,7 +34,7 @@ import { getListModeConfig } from './list-mode-config';
 import { useAllLoops, type ProcessLoopState } from './hooks/useAllLoops';
 import { LoopIcon } from './icons/LoopIcon';
 import { isRalphTask } from '../../../../../tasks/task-types';
-import { ProviderBadge } from './ProviderBadge';
+import { getProviderDotClasses, getTaskChatProvider } from './ProviderBadge';
 
 /** Primary task types surfaced as individual filter options. */
 export const TASK_TYPE_LABELS: Record<string, string> = {
@@ -1221,6 +1221,7 @@ export function ChatListPane({
             || (awaitingInputProcessIds?.has(task.id) ?? false)
             || askUserCountOnTask > 0
         );
+        const taskProvider = getTaskChatProvider(task);
 
         const modeKey = getTaskModeKey(task);
         const modeLabel = getTaskModeLabel(task);
@@ -1273,7 +1274,8 @@ export function ChatListPane({
         const dotClasses = cn(
             'w-2 h-2 rounded-full justify-self-center transition-shadow',
             isRunning && isAwaitingInput && 'bg-amber-500 dark:bg-amber-400 shadow-[0_0_0_3px_rgba(245,158,11,0.28)]',
-            isRunning && !isAwaitingInput && 'bg-[#0078d4] dark:bg-[#3794ff] animate-pulse shadow-[0_0_0_3px_rgba(0,120,212,0.22)]',
+            isRunning && !isAwaitingInput && getProviderDotClasses(taskProvider),
+            isRunning && !isAwaitingInput && 'animate-pulse shadow-[0_0_0_3px_rgba(0,120,212,0.22)]',
             !isRunning && isFailed && 'bg-red-500 shadow-[0_0_0_2px_rgba(239,68,68,0.20)]',
             !isRunning && isQueued && !isFailed && 'bg-[#dcdcdc] dark:bg-[#6b6b6b]',
             !isRunning && !isQueued && !isFailed && 'bg-[#bbbbbb] dark:bg-[#5c5c5c]',
@@ -1396,13 +1398,6 @@ export function ChatListPane({
                                     <LoopIcon className="w-3.5 h-3.5" />
                                 </span>
                             );
-                        })()}
-                        {(() => {
-                            // Show provider badge for non-default providers (codex, claude).
-                            // Copilot is the default and would add noise to every chat row.
-                            const provider = task.provider ?? task.metadata?.provider ?? task.payload?.provider;
-                            if (provider !== 'codex' && provider !== 'claude') return null;
-                            return <ProviderBadge provider={provider} />;
                         })()}
                     </span>
                     <span className={cn('flex items-center gap-1', isAwaitingInput ? 'text-amber-700 dark:text-amber-300 font-medium' : 'text-[#848484] dark:text-[#999]')}>

--- a/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
@@ -53,6 +53,13 @@ const PROVIDER_VARIANTS: Record<ChatProvider, ProviderColorVariant> = {
     },
 };
 
+export function getTaskChatProvider(task: any): ChatProvider | undefined {
+    const provider = task?.provider ?? task?.metadata?.provider ?? task?.payload?.provider;
+    return provider === 'copilot' || provider === 'codex' || provider === 'claude'
+        ? provider
+        : undefined;
+}
+
 /**
  * Returns the Tailwind class string for the round assistant-turn avatar that
  * corresponds to the given provider. Falls back to Copilot's palette for

--- a/packages/coc/test/e2e/admin.spec.ts
+++ b/packages/coc/test/e2e/admin.spec.ts
@@ -71,7 +71,6 @@ test.describe('Admin Panel (008)', () => {
         ]);
         expect(byLabel.Configure).toEqual([
             'Configure',
-            'Models',
             'AI Provider',
         ]);
         expect(byLabel.Knowledge).toEqual(['Memory', 'Skills']);
@@ -99,7 +98,7 @@ test.describe('Admin Panel (008)', () => {
         );
         const byLabel = Object.fromEntries(groups.map(group => [group.label, group.values]));
 
-        expect(byLabel.Configure).toEqual(expect.arrayContaining(['settings:configure', 'tool:models', 'admin:agents']));
+        expect(byLabel.Configure).toEqual(expect.arrayContaining(['settings:configure', 'admin:agents']));
         expect(byLabel.Knowledge).toEqual(expect.arrayContaining(['tool:memory', 'tool:skills']));
         expect(byLabel.Connections).toEqual(expect.arrayContaining(['admin:providers']));
         expect(byLabel.Operations).toEqual(expect.arrayContaining(['tool:stats', 'tool:logs', 'admin:data']));

--- a/packages/coc/test/e2e/admin.spec.ts
+++ b/packages/coc/test/e2e/admin.spec.ts
@@ -70,12 +70,9 @@ test.describe('Admin Panel (008)', () => {
             'Developer / Internals',
         ]);
         expect(byLabel.Configure).toEqual([
-            'AI & Execution',
+            'Configure',
+            'Models',
             'AI Provider',
-            'Chat',
-            'Appearance',
-            'Features',
-            'Integrations',
         ]);
         expect(byLabel.Knowledge).toEqual(['Memory', 'Skills']);
         expect(byLabel.Connections).toEqual(expect.arrayContaining(['Providers']));
@@ -102,16 +99,16 @@ test.describe('Admin Panel (008)', () => {
         );
         const byLabel = Object.fromEntries(groups.map(group => [group.label, group.values]));
 
-        expect(byLabel.Configure).toEqual(expect.arrayContaining(['settings:features', 'admin:agents']));
+        expect(byLabel.Configure).toEqual(expect.arrayContaining(['settings:configure', 'tool:models', 'admin:agents']));
         expect(byLabel.Knowledge).toEqual(expect.arrayContaining(['tool:memory', 'tool:skills']));
         expect(byLabel.Connections).toEqual(expect.arrayContaining(['admin:providers']));
         expect(byLabel.Operations).toEqual(expect.arrayContaining(['tool:stats', 'tool:logs', 'admin:data']));
         expect(byLabel['Developer / Internals']).toEqual(expect.arrayContaining(['admin:prompts', 'admin:database', 'settings:advanced']));
 
-        await picker.selectOption('settings:features');
+        await picker.selectOption('settings:configure');
         await expect(page.locator('.ar-breadcrumb')).toContainText('Configure');
-        await expect(page.locator('.ar-breadcrumb')).toContainText('Features');
-        await expect(page.getByTestId('settings-features')).toBeVisible({ timeout: 5000 });
+        await expect(page.locator('.ar-breadcrumb')).toContainText('AI & Execution');
+        await expect(page.getByTestId('settings-ai-execution')).toBeVisible({ timeout: 5000 });
 
         await picker.selectOption('tool:stats');
         await expect(page.locator('[data-testid="admin-tool-embed-stats"]')).toBeVisible({ timeout: 5000 });

--- a/packages/coc/test/server/spa/client/repos/ProviderBadge.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ProviderBadge.test.tsx
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { ProviderBadge, getProviderAvatarClasses, getProviderDotClasses } from '../../../../../src/server/spa/client/react/features/chat/ProviderBadge';
+import { ProviderBadge, getProviderAvatarClasses, getProviderDotClasses, getTaskChatProvider } from '../../../../../src/server/spa/client/react/features/chat/ProviderBadge';
 
 describe('ProviderBadge', () => {
     describe('rendering', () => {
@@ -160,5 +160,25 @@ describe('getProviderDotClasses', () => {
 
     it('falls back to the copilot dot palette for unknown runtime provider values', () => {
         expect(getProviderDotClasses('future-provider' as any)).toBe(getProviderDotClasses('copilot'));
+    });
+});
+
+describe('getTaskChatProvider', () => {
+    it('prefers the top-level task provider', () => {
+        expect(getTaskChatProvider({
+            provider: 'claude',
+            metadata: { provider: 'codex' },
+            payload: { provider: 'copilot' },
+        })).toBe('claude');
+    });
+
+    it('falls back to metadata provider and then payload provider', () => {
+        expect(getTaskChatProvider({ metadata: { provider: 'codex' } })).toBe('codex');
+        expect(getTaskChatProvider({ payload: { provider: 'claude' } })).toBe('claude');
+    });
+
+    it('returns undefined for missing or unknown provider values', () => {
+        expect(getTaskChatProvider({})).toBeUndefined();
+        expect(getTaskChatProvider({ provider: 'future-provider' })).toBeUndefined();
     });
 });

--- a/packages/coc/test/spa/react/admin/AdminPanel-tools-sidebar.test.tsx
+++ b/packages/coc/test/spa/react/admin/AdminPanel-tools-sidebar.test.tsx
@@ -215,18 +215,18 @@ describe('AdminPanel — embedded tools render in the right panel', () => {
         await act(async () => { renderAdmin(); });
         await waitFor(() => expect(document.getElementById('skills-toggle')).toBeTruthy());
 
-        // Default admin sub-section is AI & Execution; before clicking a tool,
-        // that promoted settings row is active.
-        const aiRow = document.querySelector<HTMLButtonElement>('[data-testid="settings-subtab-ai"]')!;
-        expect(aiRow.className).toContain('is-active');
+        // Default admin sub-section is settings; before clicking a tool,
+        // the single "Configure" sidebar item is active.
+        const configureRow = document.querySelector<HTMLButtonElement>('[data-testid="settings-nav-configure"]')!;
+        expect(configureRow.className).toContain('is-active');
 
         await act(async () => {
             fireEvent.click(document.getElementById('skills-toggle')!);
         });
 
         await waitFor(() => {
-            // Once a tool is embedded, no admin/settings row should show as active.
-            expect(document.querySelector<HTMLButtonElement>('[data-testid="settings-subtab-ai"]')!.className).not.toContain('is-active');
+            // Once a tool is embedded, the Configure sidebar item should no longer be active.
+            expect(document.querySelector<HTMLButtonElement>('[data-testid="settings-nav-configure"]')!.className).not.toContain('is-active');
         });
     });
 
@@ -245,7 +245,7 @@ describe('AdminPanel — embedded tools render in the right panel', () => {
         expect(crumb!.textContent).toContain('Skills');
     });
 
-    it('clicking a settings row after an embedded tool view restores the admin page', async () => {
+    it('clicking the Configure sidebar item after an embedded tool view restores the admin page', async () => {
         await act(async () => { renderAdmin(); });
         await waitFor(() => expect(document.getElementById('skills-toggle')).toBeTruthy());
 
@@ -254,17 +254,23 @@ describe('AdminPanel — embedded tools render in the right panel', () => {
         });
         await waitFor(() => expect(document.querySelector('[data-testid="admin-tool-embed-skills"]')).toBeTruthy());
 
-        // Click the Chat settings row — embed should unmount and the standard
-        // admin settings card view should render.
+        // Click the "Configure" sidebar item — embed should unmount and the settings
+        // page should render with the sub-tab bar and default (ai) card.
         await act(async () => {
-            fireEvent.click(document.querySelector<HTMLButtonElement>('[data-testid="settings-subtab-chat"]')!);
+            fireEvent.click(document.querySelector<HTMLButtonElement>('[data-testid="settings-nav-configure"]')!);
         });
 
         await waitFor(() => expect(document.querySelector('[data-testid="admin-tool-embed-skills"]')).toBeNull());
         // Settings cards container is back.
         expect(document.querySelector('[data-testid="settings-cards"]')).toBeTruthy();
-        expect(document.querySelector('[data-testid="settings-chat"]')).toBeTruthy();
-        // Chat row is active.
+        // Default (AI & Execution) card is visible.
+        expect(document.querySelector('[data-testid="settings-ai-execution"]')).toBeTruthy();
+        // The in-page sub-tab bar is rendered; clicking Chat switches to that section.
+        await act(async () => {
+            fireEvent.click(document.querySelector<HTMLButtonElement>('[data-testid="settings-subtab-chat"]')!);
+        });
+        await waitFor(() => expect(document.querySelector('[data-testid="settings-chat"]')).toBeTruthy());
+        // Chat tab is now marked active.
         expect(document.querySelector<HTMLButtonElement>('[data-testid="settings-subtab-chat"]')!.className).toContain('is-active');
     });
 });

--- a/packages/coc/test/spa/react/repos/ChatListPane-provider.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane-provider.test.tsx
@@ -1,12 +1,12 @@
 /**
- * Tests for provider badge rendering in ChatListPane.
- * - Shows ProviderBadge for codex tasks
- * - Does NOT show ProviderBadge for copilot-only tasks (default)
+ * Tests for provider rendering in ChatListPane.
+ * - Provider badges are not rendered for list rows.
+ * - Running row status dots use provider color classes.
  * - Reads provider from task.provider (HistorySummary top-level), metadata.provider, or payload.provider
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, cleanup as testingCleanup } from '@testing-library/react';
 
 // --- Mocks (same as ChatListPane-loops pattern) ---
 
@@ -149,6 +149,7 @@ vi.mock('../../../../src/server/spa/client/react/tasks/comments/ContextMenu', ()
 }));
 
 import { ChatListPane } from '../../../../src/server/spa/client/react/features/chat/ChatListPane';
+import { getProviderDotClasses } from '../../../../src/server/spa/client/react/features/chat/ProviderBadge';
 
 function makeTask(overrides: Record<string, any> = {}) {
     return {
@@ -185,34 +186,52 @@ describe('ChatListPane provider badge', () => {
         vi.clearAllMocks();
     });
 
+    const renderRunningTask = async (task: Record<string, any>) => {
+        testingCleanup();
+        await act(async () => {
+            render(<ChatListPane {...defaultProps} running={[makeTask({ status: 'running', ...task })]} />);
+        });
+        const row = screen.getByTestId('running-task-row');
+        const dot = row.querySelector('[aria-label="status: running"]');
+        expect(dot).not.toBeNull();
+        return dot as HTMLElement;
+    };
+
+    const expectProviderDot = (dot: HTMLElement, provider: 'copilot' | 'codex' | 'claude') => {
+        for (const className of getProviderDotClasses(provider).split(' ')) {
+            expect(dot.className).toContain(className);
+        }
+    };
+
     describe('codex provider', () => {
-        it('shows provider-badge for task with provider="codex" at top level', async () => {
+        it('does NOT show provider-badge for task with provider="codex" at top level', async () => {
             const tasks = [makeTask({ id: 'task-a', displayName: 'Codex Chat', provider: 'codex' })];
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges.length).toBeGreaterThan(0);
-            expect(badges[0].getAttribute('data-provider')).toBe('codex');
-            expect(badges[0].textContent).toBe('Codex');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
 
-        it('shows provider-badge for task with metadata.provider="codex"', async () => {
+        it('does NOT show provider-badge for task with metadata.provider="codex"', async () => {
             const tasks = [makeTask({ id: 'task-b', displayName: 'Codex Meta Chat', metadata: { provider: 'codex' } })];
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
 
-        it('shows provider-badge for task with payload.provider="codex"', async () => {
+        it('does NOT show provider-badge for task with payload.provider="codex"', async () => {
             const tasks = [makeTask({ id: 'task-c', displayName: 'Codex Payload Chat', payload: { mode: 'ask', provider: 'codex' } })];
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
+        });
+
+        it('uses codex color for a running task from top-level, metadata, and payload providers', async () => {
+            expectProviderDot(await renderRunningTask({ id: 'task-codex-top', provider: 'codex' }), 'codex');
+            expectProviderDot(await renderRunningTask({ id: 'task-codex-meta', metadata: { provider: 'codex' } }), 'codex');
+            expectProviderDot(await renderRunningTask({ id: 'task-codex-payload', payload: { mode: 'ask', provider: 'codex' } }), 'codex');
         });
     });
 
@@ -222,7 +241,6 @@ describe('ChatListPane provider badge', () => {
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            // Copilot is the default — no badge shown to avoid visual noise
             expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
 
@@ -233,10 +251,14 @@ describe('ChatListPane provider badge', () => {
             });
             expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
+
+        it('uses copilot color for a running task with missing provider metadata', async () => {
+            expectProviderDot(await renderRunningTask({ id: 'task-default' }), 'copilot');
+        });
     });
 
     describe('mixed provider list', () => {
-        it('shows badge only for codex tasks in a mixed list', async () => {
+        it('shows no badges for a mixed copilot/codex/no-provider list', async () => {
             const tasks = [
                 makeTask({ id: 'task-1', displayName: 'Copilot Chat', provider: 'copilot' }),
                 makeTask({ id: 'task-2', displayName: 'Codex Chat', provider: 'codex' }),
@@ -245,13 +267,10 @@ describe('ChatListPane provider badge', () => {
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            // Only the codex task should have a badge
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges).toHaveLength(1);
-            expect(badges[0].getAttribute('data-provider')).toBe('codex');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
 
-        it('shows badges for both codex and claude tasks in a mixed list', async () => {
+        it('shows no badges for a mixed copilot/codex/claude list', async () => {
             const tasks = [
                 makeTask({ id: 'task-1', displayName: 'Copilot Chat', provider: 'copilot' }),
                 makeTask({ id: 'task-2', displayName: 'Codex Chat', provider: 'codex' }),
@@ -260,42 +279,39 @@ describe('ChatListPane provider badge', () => {
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges).toHaveLength(2);
-            const providers = badges.map(b => b.getAttribute('data-provider'));
-            expect(providers).toContain('codex');
-            expect(providers).toContain('claude');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
     });
 
     describe('claude provider', () => {
-        it('shows provider-badge for task with provider="claude" at top level', async () => {
+        it('does NOT show provider-badge for task with provider="claude" at top level', async () => {
             const tasks = [makeTask({ id: 'task-f', displayName: 'Claude Chat', provider: 'claude' })];
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges.length).toBeGreaterThan(0);
-            expect(badges[0].getAttribute('data-provider')).toBe('claude');
-            expect(badges[0].textContent).toBe('Claude');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
 
-        it('shows provider-badge for task with metadata.provider="claude"', async () => {
+        it('does NOT show provider-badge for task with metadata.provider="claude"', async () => {
             const tasks = [makeTask({ id: 'task-g', displayName: 'Claude Meta Chat', metadata: { provider: 'claude' } })];
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges[0].getAttribute('data-provider')).toBe('claude');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
         });
 
-        it('shows provider-badge for task with payload.provider="claude"', async () => {
+        it('does NOT show provider-badge for task with payload.provider="claude"', async () => {
             const tasks = [makeTask({ id: 'task-h', displayName: 'Claude Payload Chat', payload: { mode: 'ask', provider: 'claude' } })];
             await act(async () => {
                 render(<ChatListPane {...defaultProps} history={tasks} />);
             });
-            const badges = screen.getAllByTestId('provider-badge');
-            expect(badges[0].getAttribute('data-provider')).toBe('claude');
+            expect(screen.queryByTestId('provider-badge')).toBeNull();
+        });
+
+        it('uses claude color for a running task from top-level, metadata, and payload providers', async () => {
+            expectProviderDot(await renderRunningTask({ id: 'task-claude-top', provider: 'claude' }), 'claude');
+            expectProviderDot(await renderRunningTask({ id: 'task-claude-meta', metadata: { provider: 'claude' } }), 'claude');
+            expectProviderDot(await renderRunningTask({ id: 'task-claude-payload', payload: { mode: 'ask', provider: 'claude' } }), 'claude');
         });
     });
 });


### PR DESCRIPTION
- **feat(admin): merge 5 settings sidebar items into single Configure item**
- **test(coc): align admin e2e expectations with unified Configure nav**
- **fix(admin): align configure nav with current model route**
- **Use provider color for running task dots**
