### PR TITLE
pr/0df7d1d72 featcoc agent sdk add provider neutral c

### DIFF
--- a/.github/skills/coc-knowledge/references/llm-tools.md
+++ b/.github/skills/coc-knowledge/references/llm-tools.md
@@ -46,6 +46,17 @@ Exports: `DEFAULT_DISABLED_LLM_TOOLS`, `isLlmToolEnabled()`, `filterDisabledLlmT
 - Applies `applyLlmToolPreferences()` filtering from `prompt-builder.ts`
 - Filters by the effective disabled tools list
 
+## Provider Parity (Copilot / Codex / Claude)
+
+The assembled `Tool<any>[]` bundle is passed to every provider via
+`SendMessageOptions.tools`. Copilot consumes it natively; Codex and Claude consume
+the **same already-filtered array** through `coc-agent-sdk`'s provider-neutral MCP
+bridge (`CocToolRuntime` + `CocToolBridgeServer` + the `coc-llm-tools-mcp` stdio
+bridge). The runtime calls the same in-process handler closures, so workspace/process
+context and `ask_user` blocking are preserved across the bridge. See
+[sdk-wrapper.md](sdk-wrapper.md) → *CoC LLM Tools over MCP*. No executor changes are
+needed — providers opt in based on `options.tools`.
+
 ## Memory Read Tools
 
 `memory-read-tools.ts` provides opt-in read-side tools:

--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -40,6 +40,10 @@ Location: `packages/coc-agent-sdk/src/`
 | `internal/path-security.ts` | Internal: path traversal validation |
 | `internal/path-utils.ts` | Internal: path resolution utilities |
 | `internal/workspace-execution.ts` | Internal: workspace execution helpers |
+| `llm-tools/coc-tool-runtime.ts` | `CocToolRuntime` — provider-neutral runtime over a per-invocation `Tool<any>[]` bundle (`listTools`/`callTool`, result normalization, disposable) |
+| `llm-tools/bridge-server.ts` | `CocToolBridgeServer` + `cocToolBridgeServer` singleton — loopback IPC channel hosting per-invocation runtimes for the MCP bridge |
+| `llm-tools/bridge.ts` | `coc-llm-tools-mcp` — standalone hand-rolled stdio MCP server (child process) proxying `tools/list`/`tools/call` to the parent loopback endpoint |
+| `llm-tools/mcp-config.ts` | `buildCocLlmToolsMcpConfig()` + bridge-path resolution + server-name/env constants |
 | `index.ts` | Public API surface |
 
 ## SDKServiceRegistry
@@ -103,6 +107,8 @@ sdkServiceRegistry.register(SDK_PROVIDER_CODEX, svc);
 
 **Lazy loading:** No SDK module is loaded until the first `isAvailable()` or `sendMessage()` call.
 
+**CoC LLM tools:** when `options.tools` is present, a per-request `Codex` client is built with `config.mcp_servers.coc_llm_tools` pointing at the stdio bridge (see *CoC LLM Tools over MCP*).
+
 ## ClaudeSDKService Architecture
 
 `ClaudeSDKService` implements `ISDKService` backed by the **optional** `@anthropic-ai/claude-agent-sdk` peer dependency. It lazy-loads the SDK's `query` export, streams Claude messages into the common invocation result shape, and reports `{ available: false }` with install guidance when the package cannot be imported.
@@ -121,6 +127,8 @@ Claude session persistence uses the Claude Code SDK transcript session ID. New `
 Claude Code expects hyphenated model IDs for version aliases (for example, `claude-sonnet-4-6`). `ClaudeSDKService` normalizes CoC's shared dotted Claude registry IDs (`claude-sonnet-4.6`, `claude-haiku-4.5`, `claude-opus-4.6`) to that Claude Code form before passing `options.model` to the SDK. Non-Claude model IDs and `claude-provider-default` are omitted so Claude Code can use its configured default.
 
 Claude Code permission mode is mapped at the provider boundary: CoC `autopilot` sends `permissionMode: 'bypassPermissions'` plus `allowDangerouslySkipPermissions: true`, while CoC `plan` sends `permissionMode: 'plan'`. Interactive/ask mode leaves Claude Code's default permission behavior in place.
+
+`ClaudeSDKService` wires CoC LLM tools and any caller-provided `mcpServers` into `query({ options: { mcpServers } })`; CoC tools ride a stdio bridge entry (`coc_llm_tools`, `alwaysLoad: true`) and bridged `tool_use` names are de-namespaced (see *CoC LLM Tools over MCP*).
 
 ## RequestRunner — sendMessage() Flow (Copilot)
 
@@ -169,6 +177,46 @@ Code workspace config uses a top-level `servers` map, which is normalized into
 the `mcpServers` shape before passing configuration to the SDK.
 Config load results include source-scoped `success`/`error` metadata so callers
 can continue with valid sources when another source is malformed.
+
+## CoC LLM Tools over MCP (provider parity)
+
+CoC LLM tools are assembled in the coc package as Copilot SDK-native `Tool<any>[]`
+(via `buildChatToolBundle()` / `applyLlmToolPreferences()`) and passed to every
+provider through `SendMessageOptions.tools`. Copilot consumes them natively; Codex
+and Claude consume the **same already-filtered array** through a provider-neutral
+MCP bridge so features like `ask_user`, conversation search, work-item/bug
+creation, wakeups/loops, Tavily, comments, and memory tools work uniformly.
+
+Pipeline (all in `coc-agent-sdk/src/llm-tools/`):
+1. `CocToolRuntime` wraps the per-invocation `Tool<any>[]` → `listTools()` (JSON-schema
+   descriptors) + `callTool()` (invokes the original in-process handler, normalizes
+   results to MCP `CallToolResult`). Exposes exactly the tools it is given, so
+   per-repo preference filtering upstream means only enabled tools surface.
+2. `CocToolBridgeServer` (`cocToolBridgeServer` singleton) registers each runtime
+   under a random bearer token on a lazily-started `127.0.0.1` HTTP server and
+   serves `POST /list` / `POST /call`. `/call` awaits `callTool` with no server-side
+   timeout, so blocking tools (`ask_user`) keep the request open until the SPA
+   answers — preserving blocking/resume across the process boundary. Reference-
+   counted: torn down when the last runtime unregisters (no idle server, no caching).
+3. `bridge.ts` (`coc-llm-tools-mcp`) is a dependency-free hand-rolled MCP **stdio**
+   server spawned as a child by the provider's MCP client. It reads
+   `COC_LLM_TOOLS_ENDPOINT` / `COC_LLM_TOOLS_TOKEN` from env and proxies
+   `initialize`/`tools/list`/`tools/call` to the loopback endpoint.
+4. `buildCocLlmToolsMcpConfig()` emits the `{ command, args, env }` stdio spec; bridge
+   path resolves to the dist-adjacent `bridge.js`, overridable via
+   `setCocLlmToolsBridgePath()` / `COC_LLM_TOOLS_BRIDGE_PATH` for bundled hosts.
+
+Provider wiring (per request, only when `options.tools` is non-empty; disposed in
+`finally`):
+- **Copilot:** native `SendMessageOptions.tools` (unchanged; no bridge).
+- **Codex:** a fresh `Codex` client is built with
+  `config.mcp_servers.coc_llm_tools = { command, args, env }`. Bridged calls arrive
+  as `mcp_tool_call` items and report bare tool names via existing normalization.
+- **Claude:** the stdio bridge entry is injected into `query({ options: { mcpServers } })`
+  under `coc_llm_tools` with `alwaysLoad: true`; caller-provided `mcpServers` are
+  also forwarded (normalized to Claude's shape). `tool_use` blocks named
+  `mcp__coc_llm_tools__<tool>` are de-namespaced to `<tool>` so `onToolEvent` /
+  tool-call capture / the timeline see the bare CoC tool name.
 
 ## Model Resolution
 

--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -128,7 +128,7 @@ Claude Code expects hyphenated model IDs for version aliases (for example, `clau
 
 Claude Code permission mode is mapped at the provider boundary: CoC `autopilot` sends `permissionMode: 'bypassPermissions'` plus `allowDangerouslySkipPermissions: true`, while CoC `plan` sends `permissionMode: 'plan'`. Interactive/ask mode leaves Claude Code's default permission behavior in place.
 
-`ClaudeSDKService` wires CoC LLM tools and any caller-provided `mcpServers` into `query({ options: { mcpServers } })`; CoC tools ride a stdio bridge entry (`coc_llm_tools`, `alwaysLoad: true`) and bridged `tool_use` names are de-namespaced (see *CoC LLM Tools over MCP*).
+`ClaudeSDKService` wires CoC LLM tools and any caller-provided `mcpServers` into `query({ options: { mcpServers } })`; CoC tools ride a stdio bridge entry (`coc_llm_tools`, `alwaysLoad: true`), are pre-approved via `options.allowedTools` (`mcp__coc_llm_tools__<tool>`) so Claude Code never prompts for them, and bridged `tool_use` names are de-namespaced (see *CoC LLM Tools over MCP*).
 
 ## RequestRunner — sendMessage() Flow (Copilot)
 
@@ -214,7 +214,10 @@ Provider wiring (per request, only when `options.tools` is non-empty; disposed i
   as `mcp_tool_call` items and report bare tool names via existing normalization.
 - **Claude:** the stdio bridge entry is injected into `query({ options: { mcpServers } })`
   under `coc_llm_tools` with `alwaysLoad: true`; caller-provided `mcpServers` are
-  also forwarded (normalized to Claude's shape). `tool_use` blocks named
+  also forwarded (normalized to Claude's shape). Each bridged tool is added to
+  `options.allowedTools` as `mcp__coc_llm_tools__<tool>` so Claude Code does not
+  prompt for (or block) CoC's own first-party tools — parity with Copilot, which
+  runs the same bundle without permission prompts. `tool_use` blocks named
   `mcp__coc_llm_tools__<tool>` are de-namespaced to `<tool>` so `onToolEvent` /
   tool-call capture / the timeline see the bare CoC tool name.
 

--- a/packages/coc-agent-sdk/src/claude-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/claude-sdk-service.ts
@@ -134,6 +134,8 @@ interface ClaudeQueryOptions {
         appendSystemPrompt?: string;
         permissionMode?: ClaudePermissionMode;
         allowDangerouslySkipPermissions?: boolean;
+        /** Tool names auto-allowed without a permission prompt (CoC bridge tools). */
+        allowedTools?: string[];
         /** MCP servers to expose to the Claude Code session (CoC LLM-tool bridge + caller servers). */
         mcpServers?: Record<string, ClaudeMcpServerConfig>;
         /** Resume a persisted Claude Code transcript session. */
@@ -392,7 +394,7 @@ export class ClaudeSDKService implements ISDKService {
         try {
             const model = this.normalizeClaudeModel(options.model);
             const permissionOptions = this.resolveClaudePermissionOptions(options.mode);
-            const { servers: mcpServers, cleanup } = await this.buildClaudeMcpServers(options);
+            const { servers: mcpServers, allowedTools, cleanup } = await this.buildClaudeMcpServers(options);
             mcpCleanup = cleanup;
             const queryOptions: ClaudeQueryOptions = {
                 prompt: options.prompt ?? '',
@@ -403,6 +405,7 @@ export class ClaudeSDKService implements ISDKService {
                     ...(options.systemMessage?.mode === 'append' ? { appendSystemPrompt: options.systemMessage.content } : {}),
                     ...(options.systemMessage?.mode === 'replace' ? { customSystemPrompt: options.systemMessage.content } : {}),
                     ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+                    ...(allowedTools.length > 0 ? { allowedTools } : {}),
                     ...(options.sessionId ? { resume: options.sessionId } : { sessionId }),
                     ...permissionOptions,
                 },
@@ -482,7 +485,7 @@ export class ClaudeSDKService implements ISDKService {
      */
     private async buildClaudeMcpServers(
         options: SendMessageOptions,
-    ): Promise<{ servers: Record<string, ClaudeMcpServerConfig>; cleanup: () => void }> {
+    ): Promise<{ servers: Record<string, ClaudeMcpServerConfig>; allowedTools: string[]; cleanup: () => void }> {
         const servers: Record<string, ClaudeMcpServerConfig> = {};
 
         if (options.mcpServers) {
@@ -494,7 +497,7 @@ export class ClaudeSDKService implements ISDKService {
 
         const tools = options.tools;
         if (!tools || tools.length === 0) {
-            return { servers, cleanup: () => {} };
+            return { servers, allowedTools: [], cleanup: () => {} };
         }
 
         const runtime = new CocToolRuntime(tools, { sessionId: options.sessionId });
@@ -510,8 +513,16 @@ export class ClaudeSDKService implements ISDKService {
             env: mcpConfig.env,
             alwaysLoad: true,
         };
+        // Pre-approve CoC's own first-party tools so Claude Code does not prompt
+        // for (or block) them — parity with Copilot, which runs the same bundle
+        // without permission prompts. Each tool is allowed under its namespaced
+        // MCP name (`mcp__<server>__<tool>`).
+        const allowedTools = runtime.listTools().map(
+            tool => `mcp__${COC_LLM_TOOLS_MCP_SERVER_NAME}__${tool.name}`,
+        );
         return {
             servers,
+            allowedTools,
             cleanup: () => {
                 registration.unregister();
                 runtime.dispose();

--- a/packages/coc-agent-sdk/src/claude-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/claude-sdk-service.ts
@@ -28,7 +28,7 @@
  * themselves.
  */
 
-import type { SendMessageOptions } from './types';
+import type { SendMessageOptions, MCPServerConfig, MCPLocalServerConfig } from './types';
 import type { ToolEvent } from './types';
 import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult } from './sdk-service-interface';
 import type { IAccountQuotaResult, IAccountQuotaSnapshot } from './copilot-sdk-service';
@@ -36,6 +36,9 @@ import type { ToolCall } from './tool-call';
 import { sdkServiceRegistry, CLAUDE_PROVIDER } from './sdk-service-registry';
 import { dynamicImportModule } from './sdk-esm-loader';
 import { getSDKLogger } from './logger';
+import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
+import { cocToolBridgeServer } from './llm-tools/bridge-server';
+import { buildCocLlmToolsMcpConfig, COC_LLM_TOOLS_MCP_SERVER_NAME } from './llm-tools/mcp-config';
 import * as crypto from 'crypto';
 
 // ============================================================================
@@ -110,6 +113,17 @@ interface ClaudeRateLimitEvent {
 type ClaudeSDKMessage = ClaudeAssistantMessage | ClaudeResultMessage | ClaudeSystemMessage | ClaudeRateLimitEvent | Record<string, unknown>;
 type ClaudePermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto';
 
+/**
+ * MCP server config accepted by Claude Code's `query({ options: { mcpServers } })`.
+ * Mirrors the published `McpStdioServerConfig | McpHttpServerConfig | McpSSEServerConfig`
+ * union (the in-process SDK-server variant is not used here — CoC tools are
+ * exposed through the stdio bridge so they round-trip raw JSON Schema).
+ */
+type ClaudeMcpServerConfig =
+    | { type?: 'stdio'; command: string; args?: string[]; env?: Record<string, string>; alwaysLoad?: boolean }
+    | { type: 'http'; url: string; headers?: Record<string, string> }
+    | { type: 'sse'; url: string; headers?: Record<string, string> };
+
 interface ClaudeQueryOptions {
     prompt: string;
     abortController?: AbortController;
@@ -120,6 +134,8 @@ interface ClaudeQueryOptions {
         appendSystemPrompt?: string;
         permissionMode?: ClaudePermissionMode;
         allowDangerouslySkipPermissions?: boolean;
+        /** MCP servers to expose to the Claude Code session (CoC LLM-tool bridge + caller servers). */
+        mcpServers?: Record<string, ClaudeMcpServerConfig>;
         /** Resume a persisted Claude Code transcript session. */
         resume?: string;
         /** Use a stable UUID for a newly-created Claude Code transcript session. */
@@ -370,9 +386,14 @@ export class ClaudeSDKService implements ISDKService {
             options.onSessionCreated?.(providerSessionId);
         };
 
+        // Releases the per-invocation CoC LLM-tool MCP bridge (no-op when no tools).
+        let mcpCleanup: () => void = () => {};
+
         try {
             const model = this.normalizeClaudeModel(options.model);
             const permissionOptions = this.resolveClaudePermissionOptions(options.mode);
+            const { servers: mcpServers, cleanup } = await this.buildClaudeMcpServers(options);
+            mcpCleanup = cleanup;
             const queryOptions: ClaudeQueryOptions = {
                 prompt: options.prompt ?? '',
                 abortController,
@@ -381,6 +402,7 @@ export class ClaudeSDKService implements ISDKService {
                     ...(model ? { model } : {}),
                     ...(options.systemMessage?.mode === 'append' ? { appendSystemPrompt: options.systemMessage.content } : {}),
                     ...(options.systemMessage?.mode === 'replace' ? { customSystemPrompt: options.systemMessage.content } : {}),
+                    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
                     ...(options.sessionId ? { resume: options.sessionId } : { sessionId }),
                     ...permissionOptions,
                 },
@@ -441,9 +463,60 @@ export class ClaudeSDKService implements ISDKService {
             return { success: false, error: message, sessionId: currentSessionId };
         } finally {
             signalCleanup?.();
+            mcpCleanup();
             this.sessions.delete(currentSessionId);
             if (currentSessionId !== sessionId) this.sessions.delete(sessionId);
         }
+    }
+
+    /**
+     * Build the `mcpServers` map for the Claude Code session.
+     *
+     * Combines any caller-provided `options.mcpServers` (normalized from forge's
+     * MCP config shape to Claude Code's) with the CoC LLM-tool bridge: when the
+     * caller supplies CoC tools, a per-invocation {@link CocToolRuntime} is
+     * registered on the loopback {@link cocToolBridgeServer} and exposed as a
+     * stdio MCP server (`alwaysLoad: true` so the tools are not deferred behind
+     * tool search). The returned `cleanup` disposes the runtime and unregisters
+     * the bridge route after the turn — no caching.
+     */
+    private async buildClaudeMcpServers(
+        options: SendMessageOptions,
+    ): Promise<{ servers: Record<string, ClaudeMcpServerConfig>; cleanup: () => void }> {
+        const servers: Record<string, ClaudeMcpServerConfig> = {};
+
+        if (options.mcpServers) {
+            for (const [name, cfg] of Object.entries(options.mcpServers)) {
+                const mapped = mapForgeMcpServerToClaude(cfg);
+                if (mapped) servers[name] = mapped;
+            }
+        }
+
+        const tools = options.tools;
+        if (!tools || tools.length === 0) {
+            return { servers, cleanup: () => {} };
+        }
+
+        const runtime = new CocToolRuntime(tools, { sessionId: options.sessionId });
+        const registration = await cocToolBridgeServer.register(runtime);
+        const mcpConfig = buildCocLlmToolsMcpConfig({
+            endpoint: registration.endpoint,
+            token: registration.token,
+        });
+        servers[COC_LLM_TOOLS_MCP_SERVER_NAME] = {
+            type: 'stdio',
+            command: mcpConfig.command,
+            args: mcpConfig.args,
+            env: mcpConfig.env,
+            alwaysLoad: true,
+        };
+        return {
+            servers,
+            cleanup: () => {
+                registration.unregister();
+                runtime.dispose();
+            },
+        };
     }
 
     private extractSessionId(msg: ClaudeSDKMessage): string | undefined {
@@ -487,7 +560,7 @@ export class ClaudeSDKService implements ISDKService {
         startedToolCalls: Set<string>,
     ): void {
         const id = block.id ?? crypto.randomUUID();
-        const toolName = block.name ?? 'unknown_tool';
+        const toolName = normalizeBridgedToolName(block.name ?? 'unknown_tool');
         const parameters = (typeof block.input === 'object' && block.input !== null)
             ? (block.input as Record<string, unknown>)
             : {};
@@ -670,6 +743,36 @@ export function registerClaudeSDKService(): ClaudeSDKService {
     const svc = new ClaudeSDKService();
     sdkServiceRegistry.register(CLAUDE_PROVIDER, svc);
     return svc;
+}
+
+/**
+ * Strip the `mcp__<server>__` prefix Claude Code prepends to MCP tool names so
+ * CoC's bridged tools (e.g. `mcp__coc_llm_tools__ask_user`) surface to
+ * `onToolEvent`, tool-call capture, and the process timeline as their bare names
+ * (`ask_user`) — matching how Copilot and Codex report the same tools.
+ */
+function normalizeBridgedToolName(name: string): string {
+    const prefix = `mcp__${COC_LLM_TOOLS_MCP_SERVER_NAME}__`;
+    return name.startsWith(prefix) ? name.slice(prefix.length) : name;
+}
+
+/**
+ * Normalize a forge `MCPServerConfig` into the Claude Code `mcpServers` shape.
+ * Returns `undefined` for configs missing the fields Claude requires.
+ */
+function mapForgeMcpServerToClaude(cfg: MCPServerConfig): ClaudeMcpServerConfig | undefined {
+    if (cfg.type === 'http' || cfg.type === 'sse') {
+        if (!cfg.url) return undefined;
+        return { type: cfg.type, url: cfg.url, ...(cfg.headers ? { headers: cfg.headers } : {}) };
+    }
+    const local = cfg as MCPLocalServerConfig;
+    if (!local.command) return undefined;
+    return {
+        type: 'stdio',
+        command: local.command,
+        args: local.args ?? [],
+        ...(local.env ? { env: local.env } : {}),
+    };
 }
 
 export function mapClaudeRateLimitInfoToQuota(info: ClaudeRateLimitInfo): IAccountQuotaResult {

--- a/packages/coc-agent-sdk/src/codex-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/codex-sdk-service.ts
@@ -25,6 +25,9 @@ import type { ToolCall } from './tool-call';
 import { sdkServiceRegistry, CODEX_PROVIDER } from './sdk-service-registry';
 import { dynamicImportModule } from './sdk-esm-loader';
 import { execFileAsync } from './internal/exec-utils';
+import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
+import { cocToolBridgeServer } from './llm-tools/bridge-server';
+import { buildCocLlmToolsMcpConfig, COC_LLM_TOOLS_MCP_SERVER_NAME } from './llm-tools/mcp-config';
 import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import * as readline from 'readline';
@@ -142,10 +145,23 @@ interface CodexClient {
     resumeThread(threadId: string, options?: CodexStartThreadOptions): CodexThread;
 }
 
+/**
+ * Constructor options accepted by the `Codex` client. Only `config` is used by
+ * this adapter — to inject `mcp_servers` CLI overrides for the CoC LLM-tool
+ * bridge. Mirrors `CodexOptions.config` (a JSON object flattened by the SDK into
+ * `--config key=value` TOML overrides).
+ */
+interface CodexConstructorOptions {
+    config?: Record<string, unknown>;
+}
+
+/** Constructs a Codex client. The published SDK accepts optional `CodexOptions`. */
+type CodexClientCtor = new (options?: CodexConstructorOptions) => CodexClient;
+
 /** Subset of the @openai/codex-sdk API used by this adapter. */
 interface CodexSDKModule {
-    Codex?: new () => CodexClient;
-    default?: { Codex?: new () => CodexClient } | (new () => CodexClient);
+    Codex?: CodexClientCtor;
+    default?: { Codex?: CodexClientCtor } | CodexClientCtor;
 }
 
 interface CodexStartThreadOptions {
@@ -224,6 +240,8 @@ interface ActiveCodexSession {
 export class CodexSDKService implements ISDKService {
     private availabilityCache: IAvailabilityResult | null = null;
     private sdk: CodexClient | null = null;
+    /** Cached Codex constructor, used to build per-request clients carrying MCP config. */
+    private codexCtor: CodexClientCtor | null = null;
     private disposed = false;
     private authChecker: CodexAuthChecker | null = null;
 
@@ -260,6 +278,7 @@ export class CodexSDKService implements ISDKService {
             if (!CodexCtor) {
                 throw new Error('Codex SDK did not export Codex');
             }
+            this.codexCtor = CodexCtor;
             this.sdk = new CodexCtor();
             this.availabilityCache = { available: true };
         } catch {
@@ -280,6 +299,52 @@ export class CodexSDKService implements ISDKService {
     public clearAvailabilityCache(): void {
         this.availabilityCache = null;
         this.sdk = null;
+        this.codexCtor = null;
+    }
+
+    /**
+     * Resolve the Codex client to use for a single request.
+     *
+     * When the caller supplies CoC LLM tools, those are exposed to Codex through
+     * an MCP bridge: a per-invocation {@link CocToolRuntime} is registered on the
+     * loopback {@link cocToolBridgeServer}, and a fresh Codex client is built with
+     * `config.mcp_servers` pointing at the bridge. The returned `cleanup` disposes
+     * the runtime and unregisters the bridge route after the turn — no caching.
+     *
+     * With no tools (the common case) the shared `this.sdk` client is reused.
+     */
+    private async resolveRequestClient(
+        options: SendMessageOptions,
+    ): Promise<{ client: CodexClient; cleanup: () => void }> {
+        const tools = options.tools;
+        if (!tools || tools.length === 0 || !this.codexCtor) {
+            return { client: this.sdk!, cleanup: () => {} };
+        }
+
+        const runtime = new CocToolRuntime(tools, { sessionId: options.sessionId });
+        const registration = await cocToolBridgeServer.register(runtime);
+        const mcpConfig = buildCocLlmToolsMcpConfig({
+            endpoint: registration.endpoint,
+            token: registration.token,
+        });
+        const client = new this.codexCtor({
+            config: {
+                mcp_servers: {
+                    [COC_LLM_TOOLS_MCP_SERVER_NAME]: {
+                        command: mcpConfig.command,
+                        args: mcpConfig.args,
+                        env: mcpConfig.env,
+                    },
+                },
+            },
+        });
+        return {
+            client,
+            cleanup: () => {
+                registration.unregister();
+                runtime.dispose();
+            },
+        };
     }
 
     // ── Model discovery ───────────────────────────────────────────────────────
@@ -479,7 +544,6 @@ export class CodexSDKService implements ISDKService {
             return { success: false, error: avail.error };
         }
 
-        const sdk = this.sdk!;
         const abortController = new AbortController();
 
         // Propagate caller's AbortSignal into our internal controller so
@@ -495,8 +559,15 @@ export class CodexSDKService implements ISDKService {
         let sessionCreatedNotified = false;
         const toolCalls = new Map<string, ToolCall>();
         const startedToolCalls = new Set<string>();
+        // Releases the per-invocation CoC LLM-tool MCP bridge (no-op when no tools).
+        let mcpCleanup: () => void = () => {};
 
         try {
+            // Resolve the client for this request. With CoC LLM tools present this
+            // builds a fresh client carrying the bridge's mcp_servers config.
+            const { client: sdk, cleanup } = await this.resolveRequestClient(options);
+            mcpCleanup = cleanup;
+
             let thread: CodexThread;
             const threadOptions = this.buildThreadOptions(options);
             if (options.sessionId) {
@@ -562,6 +633,7 @@ export class CodexSDKService implements ISDKService {
             return { success: false, error: message, sessionId: options.sessionId ?? threadId };
         } finally {
             signalCleanup?.();
+            mcpCleanup();
             if (threadId) this.sessions.delete(threadId);
         }
     }
@@ -819,6 +891,7 @@ export class CodexSDKService implements ISDKService {
         this.sessions.clear();
         this.availabilityCache = null;
         this.sdk = null;
+        this.codexCtor = null;
     }
 
     public dispose(): void {

--- a/packages/coc-agent-sdk/src/index.ts
+++ b/packages/coc-agent-sdk/src/index.ts
@@ -169,3 +169,17 @@ export {
 } from './tool-call';
 
 export { initSDKLogger, resetSDKLogger, getSDKLogger } from './logger';
+
+export {
+    CocToolRuntime,
+    resolveInputSchema,
+    normalizeToolResult,
+    errorResult,
+} from './llm-tools';
+
+export type {
+    RuntimeToolDescriptor,
+    RuntimeToolResult,
+    RuntimeToolResultContent,
+    CocToolRuntimeContext,
+} from './llm-tools';

--- a/packages/coc-agent-sdk/src/index.ts
+++ b/packages/coc-agent-sdk/src/index.ts
@@ -183,3 +183,25 @@ export type {
     RuntimeToolResultContent,
     CocToolRuntimeContext,
 } from './llm-tools';
+
+export {
+    CocToolBridgeServer,
+    cocToolBridgeServer,
+    COC_LLM_TOOLS_MCP_SERVER_NAME,
+    COC_LLM_TOOLS_ENDPOINT_ENV,
+    COC_LLM_TOOLS_TOKEN_ENV,
+    COC_LLM_TOOLS_BRIDGE_PATH_ENV,
+    buildCocLlmToolsMcpConfig,
+    resolveCocLlmToolsBridgePath,
+    setCocLlmToolsBridgePath,
+    createBridgeHandlers,
+    createHttpTransport,
+    runBridge,
+} from './llm-tools';
+
+export type {
+    CocToolBridgeRegistration,
+    CocLlmToolsMcpServerConfig,
+    BridgeTransport,
+    BridgeHandlerOptions,
+} from './llm-tools';

--- a/packages/coc-agent-sdk/src/llm-tools/bridge-server.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/bridge-server.ts
@@ -1,0 +1,216 @@
+/**
+ * CocToolBridgeServer — parent-process loopback IPC channel for the CoC LLM-tool
+ * MCP bridge.
+ *
+ * The MCP bridge (`bridge.ts`) runs as a child process spawned by Codex's CLI or
+ * Claude Code, so it cannot call the in-process CoC tool handlers directly. This
+ * server hosts the per-invocation {@link CocToolRuntime}s and exposes them over a
+ * `127.0.0.1` HTTP endpoint that the bridge proxies to:
+ *
+ *   POST /list  { }                       → { tools: RuntimeToolDescriptor[] }
+ *   POST /call  { name, arguments }        → RuntimeToolResult ({ content, isError })
+ *
+ * Each registered runtime gets a random bearer token; the bridge presents it on
+ * every request. `/call` awaits `runtime.callTool()` with no server-side timeout,
+ * so blocking tools such as `ask_user` keep the HTTP request open until the SPA
+ * submits an answer — preserving blocking/resume semantics across the process
+ * boundary.
+ *
+ * Isolation & lifecycle:
+ * - One shared server per process ({@link cocToolBridgeServer}), reference-counted
+ *   by active registrations. It binds lazily on first registration and shuts down
+ *   when the last runtime unregisters — no idle server, no session caching.
+ * - Bound to loopback only and token-gated; never exposed off-host.
+ */
+
+import * as http from 'http';
+import * as crypto from 'crypto';
+import type { AddressInfo } from 'net';
+import { getSDKLogger } from '../logger';
+import { CocToolRuntime } from './coc-tool-runtime';
+
+/** Handle returned from {@link CocToolBridgeServer.register}. */
+export interface CocToolBridgeRegistration {
+    /** Bearer token the bridge must present on every request. */
+    token: string;
+    /** Base endpoint URL (e.g. `http://127.0.0.1:54321`). */
+    endpoint: string;
+    /** Remove this runtime and tear the server down if it was the last one. */
+    unregister: () => void;
+}
+
+const MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+export class CocToolBridgeServer {
+    private server: http.Server | null = null;
+    private startPromise: Promise<void> | null = null;
+    private port = 0;
+    private readonly runtimes = new Map<string, CocToolRuntime>();
+
+    /** Number of currently registered runtimes. */
+    public get activeCount(): number {
+        return this.runtimes.size;
+    }
+
+    /** Base endpoint while the server is listening, otherwise `null`. */
+    public get endpoint(): string | null {
+        return this.server ? `http://127.0.0.1:${this.port}` : null;
+    }
+
+    /**
+     * Register a per-invocation runtime, starting the loopback server if needed.
+     * Returns the endpoint + token to embed in the bridge MCP config, and an
+     * `unregister()` to call when the turn completes or aborts.
+     */
+    public async register(runtime: CocToolRuntime): Promise<CocToolBridgeRegistration> {
+        await this.ensureStarted();
+        const token = crypto.randomBytes(24).toString('hex');
+        this.runtimes.set(token, runtime);
+        getSDKLogger().debug({ activeCount: this.runtimes.size, port: this.port }, '[CocToolBridge] runtime registered');
+        return {
+            token,
+            endpoint: `http://127.0.0.1:${this.port}`,
+            unregister: () => this.unregister(token),
+        };
+    }
+
+    private unregister(token: string): void {
+        if (!this.runtimes.delete(token)) return;
+        getSDKLogger().debug({ activeCount: this.runtimes.size }, '[CocToolBridge] runtime unregistered');
+        if (this.runtimes.size === 0) {
+            this.stop();
+        }
+    }
+
+    private ensureStarted(): Promise<void> {
+        if (this.server) return Promise.resolve();
+        if (this.startPromise) return this.startPromise;
+
+        this.startPromise = new Promise<void>((resolve, reject) => {
+            const server = http.createServer((req, res) => {
+                void this.handleRequest(req, res);
+            });
+            // Disable the request-receive timeout so a long-blocking tools/call
+            // (e.g. ask_user awaiting the user) is never force-closed.
+            server.requestTimeout = 0;
+            server.headersTimeout = 0;
+            server.once('error', (err) => {
+                this.startPromise = null;
+                reject(err);
+            });
+            server.listen(0, '127.0.0.1', () => {
+                this.port = (server.address() as AddressInfo).port;
+                this.server = server;
+                getSDKLogger().debug({ port: this.port }, '[CocToolBridge] loopback server started');
+                resolve();
+            });
+        });
+        return this.startPromise;
+    }
+
+    private stop(): void {
+        const server = this.server;
+        this.server = null;
+        this.startPromise = null;
+        this.port = 0;
+        if (server) {
+            server.close(() => {});
+            getSDKLogger().debug('[CocToolBridge] loopback server stopped');
+        }
+    }
+
+    /** Force-stop the server and drop all runtimes (test/teardown helper). */
+    public closeAll(): void {
+        this.runtimes.clear();
+        this.stop();
+    }
+
+    private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+        try {
+            if (req.method !== 'POST') {
+                return sendJson(res, 405, { error: 'Method not allowed' });
+            }
+
+            const runtime = this.resolveRuntime(req);
+            if (!runtime) {
+                return sendJson(res, 401, { error: 'Unknown or missing bridge token' });
+            }
+
+            const url = req.url ?? '';
+            if (url === '/list') {
+                await readJsonBody(req); // drain body
+                return sendJson(res, 200, { tools: runtime.listTools() });
+            }
+
+            if (url === '/call') {
+                const body = await readJsonBody(req) as { name?: unknown; arguments?: unknown };
+                const name = typeof body?.name === 'string' ? body.name : '';
+                if (!name) {
+                    return sendJson(res, 400, { error: 'Missing tool name' });
+                }
+                const result = await runtime.callTool(name, body?.arguments ?? {});
+                return sendJson(res, 200, result);
+            }
+
+            return sendJson(res, 404, { error: `Unknown path: ${url}` });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            getSDKLogger().debug({ err: message }, '[CocToolBridge] request failed');
+            try {
+                sendJson(res, 500, { error: message });
+            } catch {
+                // response may already be partially written; nothing to do.
+            }
+        }
+    }
+
+    private resolveRuntime(req: http.IncomingMessage): CocToolRuntime | undefined {
+        const auth = req.headers['authorization'];
+        const header = Array.isArray(auth) ? auth[0] : auth;
+        if (!header) return undefined;
+        const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+        const token = match ? match[1] : header.trim();
+        return this.runtimes.get(token);
+    }
+}
+
+/** Process-wide shared bridge server, reference-counted by active registrations. */
+export const cocToolBridgeServer = new CocToolBridgeServer();
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function sendJson(res: http.ServerResponse, status: number, payload: unknown): void {
+    const body = JSON.stringify(payload);
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(body);
+}
+
+function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+        let size = 0;
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > MAX_BODY_BYTES) {
+                reject(new Error('Request body too large'));
+                req.destroy();
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on('end', () => {
+            if (chunks.length === 0) {
+                resolve({});
+                return;
+            }
+            try {
+                resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+            } catch (err) {
+                reject(err instanceof Error ? err : new Error(String(err)));
+            }
+        });
+        req.on('error', reject);
+    });
+}

--- a/packages/coc-agent-sdk/src/llm-tools/bridge.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/bridge.ts
@@ -1,0 +1,263 @@
+/**
+ * coc-llm-tools-mcp — standalone stdio MCP bridge for CoC LLM tools.
+ *
+ * Spawned as a child process by a provider's MCP client (Codex CLI, Claude Code).
+ * Speaks the MCP stdio protocol (newline-delimited JSON-RPC 2.0 on stdin/stdout,
+ * logs on stderr) and proxies `tools/list` / `tools/call` to the parent CoC
+ * process's {@link CocToolBridgeServer} loopback endpoint identified by env vars
+ * `COC_LLM_TOOLS_ENDPOINT` and `COC_LLM_TOOLS_TOKEN`.
+ *
+ * The handler logic ({@link createBridgeHandlers}) is decoupled from stdio/HTTP so
+ * it can be unit-tested with an injected transport. `tools/call` is awaited with no
+ * client-side timeout, so blocking tools (`ask_user`) resolve only when the parent
+ * runtime resolves.
+ */
+
+import * as http from 'http';
+import { COC_LLM_TOOLS_ENDPOINT_ENV, COC_LLM_TOOLS_TOKEN_ENV } from './mcp-config';
+
+const BRIDGE_NAME = 'coc-llm-tools';
+const BRIDGE_VERSION = '0.1.0';
+const DEFAULT_PROTOCOL_VERSION = '2025-06-18';
+
+// ── JSON-RPC message shapes ──────────────────────────────────────────────────
+
+interface JsonRpcMessage {
+    jsonrpc?: string;
+    id?: string | number | null;
+    method?: string;
+    params?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+interface JsonRpcResponse {
+    jsonrpc: '2.0';
+    id: string | number | null;
+    result?: unknown;
+    error?: { code: number; message: string; data?: unknown };
+}
+
+/** POSTs a JSON payload to the parent and resolves the parsed JSON response. */
+export type BridgeTransport = (path: '/list' | '/call', body: unknown) => Promise<unknown>;
+
+export interface BridgeHandlerOptions {
+    transport: BridgeTransport;
+    name?: string;
+    version?: string;
+}
+
+const METHOD_NOT_FOUND = -32601;
+const INTERNAL_ERROR = -32603;
+
+/**
+ * Build the JSON-RPC message handler for the bridge.
+ *
+ * `handleMessage` returns the JSON-RPC response to write back, or `null` for
+ * notifications (messages without an `id`) which must not be answered.
+ */
+export function createBridgeHandlers(options: BridgeHandlerOptions) {
+    const name = options.name ?? BRIDGE_NAME;
+    const version = options.version ?? BRIDGE_VERSION;
+
+    async function handleMessage(message: JsonRpcMessage): Promise<JsonRpcResponse | null> {
+        const id = message.id ?? null;
+        const isNotification = message.id === undefined || message.id === null;
+        const method = message.method;
+
+        // Notifications (no id) are acknowledged by silence.
+        if (isNotification) {
+            return null;
+        }
+
+        try {
+            switch (method) {
+                case 'initialize': {
+                    const requested = typeof message.params?.protocolVersion === 'string'
+                        ? message.params.protocolVersion
+                        : DEFAULT_PROTOCOL_VERSION;
+                    return ok(id, {
+                        protocolVersion: requested,
+                        capabilities: { tools: {} },
+                        serverInfo: { name, version },
+                    });
+                }
+                case 'ping':
+                    return ok(id, {});
+                case 'tools/list': {
+                    const response = await options.transport('/list', {}) as { tools?: unknown };
+                    return ok(id, { tools: Array.isArray(response?.tools) ? response.tools : [] });
+                }
+                case 'tools/call': {
+                    const toolName = typeof message.params?.name === 'string' ? message.params.name : '';
+                    if (!toolName) {
+                        return fail(id, INTERNAL_ERROR, 'tools/call missing tool name');
+                    }
+                    const args = (message.params?.arguments && typeof message.params.arguments === 'object')
+                        ? message.params.arguments
+                        : {};
+                    const result = await options.transport('/call', { name: toolName, arguments: args });
+                    return ok(id, normalizeCallResult(result));
+                }
+                default:
+                    return fail(id, METHOD_NOT_FOUND, `Method not found: ${method ?? '(none)'}`);
+            }
+        } catch (err) {
+            const messageText = err instanceof Error ? err.message : String(err);
+            // For tool calls, surface transport failures to the model as an error
+            // result rather than a protocol error so the turn can continue.
+            if (method === 'tools/call') {
+                return ok(id, {
+                    content: [{ type: 'text', text: `coc-llm-tools bridge error: ${messageText}` }],
+                    isError: true,
+                });
+            }
+            return fail(id, INTERNAL_ERROR, messageText);
+        }
+    }
+
+    return { handleMessage };
+}
+
+function ok(id: string | number | null, result: unknown): JsonRpcResponse {
+    return { jsonrpc: '2.0', id, result };
+}
+
+function fail(id: string | number | null, code: number, message: string): JsonRpcResponse {
+    return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+/** Coerce a parent `/call` response into a valid MCP CallToolResult. */
+function normalizeCallResult(result: unknown): { content: unknown[]; isError: boolean } {
+    if (result && typeof result === 'object' && Array.isArray((result as { content?: unknown }).content)) {
+        const r = result as { content: unknown[]; isError?: unknown };
+        return { content: r.content, isError: r.isError === true };
+    }
+    return {
+        content: [{ type: 'text', text: typeof result === 'string' ? result : JSON.stringify(result ?? '') }],
+        isError: false,
+    };
+}
+
+// ============================================================================
+// Real HTTP transport (parent loopback)
+// ============================================================================
+
+/** Build the HTTP transport that talks to the parent {@link CocToolBridgeServer}. */
+export function createHttpTransport(endpoint: string, token: string): BridgeTransport {
+    const base = new URL(endpoint);
+    return (path, body) => new Promise<unknown>((resolve, reject) => {
+        const payload = Buffer.from(JSON.stringify(body ?? {}), 'utf8');
+        const req = http.request(
+            {
+                hostname: base.hostname,
+                port: base.port,
+                path,
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    'content-length': payload.length,
+                    authorization: `Bearer ${token}`,
+                },
+                // No timeout: blocking tools (ask_user) may take arbitrarily long.
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    const text = Buffer.concat(chunks).toString('utf8');
+                    if ((res.statusCode ?? 0) >= 400) {
+                        reject(new Error(`Bridge endpoint ${path} returned ${res.statusCode}: ${text}`));
+                        return;
+                    }
+                    try {
+                        resolve(text ? JSON.parse(text) : {});
+                    } catch (err) {
+                        reject(err instanceof Error ? err : new Error(String(err)));
+                    }
+                });
+            },
+        );
+        req.on('error', reject);
+        req.write(payload);
+        req.end();
+    });
+}
+
+// ============================================================================
+// stdio main loop
+// ============================================================================
+
+/**
+ * Run the bridge against the given stdin/stdout streams. Reads newline-delimited
+ * JSON-RPC messages, dispatches them concurrently (so a blocking `tools/call`
+ * never stalls other messages), and writes each response as a single line.
+ */
+export function runBridge(options: {
+    transport: BridgeTransport;
+    stdin: NodeJS.ReadableStream;
+    stdout: NodeJS.WritableStream;
+    onError?: (err: unknown) => void;
+}): void {
+    const { handleMessage } = createBridgeHandlers({ transport: options.transport });
+    let buffer = '';
+
+    const writeResponse = (response: JsonRpcResponse | null) => {
+        if (!response) return;
+        options.stdout.write(JSON.stringify(response) + '\n');
+    };
+
+    const dispatchLine = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        let message: JsonRpcMessage;
+        try {
+            message = JSON.parse(trimmed) as JsonRpcMessage;
+        } catch (err) {
+            options.onError?.(err);
+            return;
+        }
+        handleMessage(message).then(writeResponse).catch((err) => options.onError?.(err));
+    };
+
+    options.stdin.setEncoding('utf8');
+    options.stdin.on('data', (chunk: string) => {
+        buffer += chunk;
+        let newlineIndex = buffer.indexOf('\n');
+        while (newlineIndex !== -1) {
+            const line = buffer.slice(0, newlineIndex);
+            buffer = buffer.slice(newlineIndex + 1);
+            dispatchLine(line);
+            newlineIndex = buffer.indexOf('\n');
+        }
+    });
+    options.stdin.on('end', () => {
+        if (buffer.trim()) dispatchLine(buffer);
+    });
+}
+
+/** Entry point when run as a child process. */
+function main(): void {
+    const endpoint = process.env[COC_LLM_TOOLS_ENDPOINT_ENV];
+    const token = process.env[COC_LLM_TOOLS_TOKEN_ENV];
+    if (!endpoint || !token) {
+        process.stderr.write(
+            `[coc-llm-tools] missing ${COC_LLM_TOOLS_ENDPOINT_ENV}/${COC_LLM_TOOLS_TOKEN_ENV}; exiting\n`,
+        );
+        process.exit(1);
+        return;
+    }
+    runBridge({
+        transport: createHttpTransport(endpoint, token),
+        stdin: process.stdin,
+        stdout: process.stdout,
+        onError: (err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`[coc-llm-tools] ${message}\n`);
+        },
+    });
+}
+
+// Only run the stdio loop when executed directly (not when imported by tests).
+if (require.main === module) {
+    main();
+}

--- a/packages/coc-agent-sdk/src/llm-tools/coc-tool-runtime.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/coc-tool-runtime.ts
@@ -1,0 +1,271 @@
+/**
+ * CocToolRuntime — provider-neutral CoC LLM-tool runtime.
+ *
+ * Adapts the existing Copilot SDK-native `Tool<any>[]` bundle (assembled by
+ * `buildChatToolBundle()` / `applyLlmToolPreferences()` in the coc package) into
+ * a provider-neutral internal shape so the same tools can be exposed to Codex
+ * and Claude through MCP, not just to Copilot through native `SendMessageOptions.tools`.
+ *
+ * Design constraints (mirrors the CoC LLM-tool invariants):
+ * - **Per-invocation:** Construct one runtime per AI call from that call's
+ *   already-filtered tool bundle. The runtime never caches across requests.
+ * - **Pre-bound context:** CoC tool factories bake workspace/commit/process
+ *   context into their handler closures at creation time. The runtime invokes
+ *   those exact closures, so calls automatically run with the correct
+ *   workspace/process context — the runtime only supplies the per-call
+ *   `ToolInvocation` envelope (session id, tool-call id, arguments).
+ * - **Filtering is upstream:** The runtime exposes exactly the tools it is
+ *   given. Enable/disable filtering already happened in the coc package via
+ *   `applyLlmToolPreferences()`, so `listTools()` reflecting the input array is
+ *   equivalent to "only enabled tools are exposed".
+ * - **No event emission here:** Tool lifecycle events (`onToolEvent`) are
+ *   emitted by each provider from its own message stream (Copilot natively,
+ *   Codex from `mcp_tool_call` items, Claude from `tool_use` blocks). The
+ *   runtime only *executes* handlers, so wiring it into a provider does not
+ *   double-emit timeline/capture events.
+ */
+
+import * as crypto from 'crypto';
+import type { Tool, ToolInvocation, ToolResultObject } from '../types';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+/**
+ * Provider-neutral description of a single tool, suitable for an MCP
+ * `tools/list` response or any other tool-advertisement surface.
+ */
+export interface RuntimeToolDescriptor {
+    /** Tool name (e.g. `ask_user`). */
+    name: string;
+    /** Human-readable description shown to the model. */
+    description: string;
+    /** JSON Schema describing the tool's arguments (always an object schema). */
+    inputSchema: Record<string, unknown>;
+}
+
+/** A single text content block in a normalized tool result. */
+export interface RuntimeToolResultContent {
+    type: 'text';
+    text: string;
+}
+
+/**
+ * Normalized tool-call result, shaped like an MCP `CallToolResult` so it can be
+ * returned directly from an MCP bridge without further transformation.
+ */
+export interface RuntimeToolResult {
+    content: RuntimeToolResultContent[];
+    /** True when the tool failed (handler threw or returned a failure result). */
+    isError: boolean;
+}
+
+/**
+ * Per-invocation context propagated into each synthesized `ToolInvocation`.
+ * All fields are optional; CoC tool handlers generally pre-bind the context
+ * they need, so these are primarily for logging and the invocation envelope.
+ */
+export interface CocToolRuntimeContext {
+    /** AI session id for this turn, if known. */
+    sessionId?: string;
+    /** Workspace id this turn is scoped to, if known. */
+    workspaceId?: string;
+    /** Process id (AIProcess) this turn belongs to, if known. */
+    processId?: string;
+}
+
+// ============================================================================
+// CocToolRuntime
+// ============================================================================
+
+/**
+ * Provider-neutral runtime over a per-invocation CoC tool bundle.
+ *
+ * @example
+ * ```ts
+ * const runtime = new CocToolRuntime(ctx.tools, { sessionId, workspaceId, processId });
+ * const descriptors = runtime.listTools();           // → MCP tools/list
+ * const result = await runtime.callTool('ask_user', args); // → MCP tools/call
+ * runtime.dispose();
+ * ```
+ */
+export class CocToolRuntime {
+    private readonly toolsByName = new Map<string, Tool<any>>();
+    private readonly context: CocToolRuntimeContext;
+    private disposed = false;
+
+    constructor(tools: ReadonlyArray<Tool<any>>, context: CocToolRuntimeContext = {}) {
+        this.context = context;
+        for (const tool of tools) {
+            if (!tool || typeof tool.name !== 'string' || !tool.name) continue;
+            // Last definition wins on duplicate names, mirroring how the SDK
+            // would resolve a duplicate tool registration.
+            this.toolsByName.set(tool.name, tool);
+        }
+    }
+
+    /** Number of tools exposed by this runtime. */
+    public get size(): number {
+        return this.toolsByName.size;
+    }
+
+    /** Returns true when a tool with the given name is exposed. */
+    public hasTool(name: string): boolean {
+        return this.toolsByName.has(name);
+    }
+
+    /**
+     * Provider-neutral tool descriptors for advertisement (e.g. MCP tools/list).
+     * Reflects exactly the (already-filtered) tools the runtime was constructed
+     * with, so only enabled tools are ever exposed.
+     */
+    public listTools(): RuntimeToolDescriptor[] {
+        return Array.from(this.toolsByName.values()).map(tool => ({
+            name: tool.name,
+            description: tool.description ?? '',
+            inputSchema: resolveInputSchema(tool),
+        }));
+    }
+
+    /**
+     * Execute a tool by name with the given arguments, returning a normalized
+     * MCP-style result. Never throws — handler errors are captured into an
+     * `isError: true` result so an MCP bridge can relay them to the model.
+     *
+     * Blocking handlers (e.g. `ask_user`) are awaited as-is: because the runtime
+     * runs the original in-process closure, the handler's Promise resolves when
+     * the SPA submits an answer, exactly as on the native Copilot path.
+     */
+    public async callTool(name: string, args: unknown): Promise<RuntimeToolResult> {
+        if (this.disposed) {
+            return errorResult(`CocToolRuntime has been disposed; cannot call tool "${name}"`);
+        }
+
+        const tool = this.toolsByName.get(name);
+        if (!tool) {
+            return errorResult(`Unknown tool: ${name}`);
+        }
+
+        const invocation: ToolInvocation = {
+            sessionId: this.context.sessionId ?? '',
+            toolCallId: crypto.randomUUID(),
+            toolName: name,
+            arguments: args,
+        };
+
+        try {
+            const raw = await tool.handler(args as never, invocation);
+            return normalizeToolResult(raw);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return errorResult(message);
+        }
+    }
+
+    /**
+     * Release the runtime. After disposal `callTool` returns an error result and
+     * `listTools` returns an empty list. Safe to call multiple times.
+     */
+    public dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        this.toolsByName.clear();
+    }
+}
+
+// ============================================================================
+// Helpers (exported for unit testing)
+// ============================================================================
+
+/**
+ * Resolve a tool's `parameters` into a JSON Schema object suitable for MCP.
+ *
+ * Handles all three shapes allowed by the SDK `Tool` type:
+ * - A Zod-like schema exposing `toJSONSchema()` → call it.
+ * - A raw JSON Schema object → use as-is.
+ * - Omitted → empty object schema.
+ *
+ * The result is always normalized to a top-level object schema so MCP clients
+ * (which require `type: "object"`) accept it.
+ */
+export function resolveInputSchema(tool: Pick<Tool<any>, 'parameters'>): Record<string, unknown> {
+    const params = tool.parameters as unknown;
+
+    let schema: Record<string, unknown>;
+    if (params && typeof params === 'object' && typeof (params as { toJSONSchema?: unknown }).toJSONSchema === 'function') {
+        try {
+            const generated = (params as { toJSONSchema: () => Record<string, unknown> }).toJSONSchema();
+            schema = generated && typeof generated === 'object' ? { ...generated } : {};
+        } catch {
+            schema = {};
+        }
+    } else if (params && typeof params === 'object') {
+        schema = { ...(params as Record<string, unknown>) };
+    } else {
+        schema = {};
+    }
+
+    // MCP requires an object schema at the top level.
+    if (schema.type !== 'object') {
+        schema.type = 'object';
+    }
+    if (typeof schema.properties !== 'object' || schema.properties === null) {
+        schema.properties = {};
+    }
+    return schema;
+}
+
+/**
+ * Normalize an arbitrary tool-handler return value into a `RuntimeToolResult`.
+ *
+ * - `string` → single text block.
+ * - `ToolResultObject` (`{ textResultForLlm, resultType, error }`) → text from
+ *   `textResultForLlm`, `isError` derived from `resultType`/`error`.
+ * - `null` / `undefined` → empty success result.
+ * - Anything else (objects, arrays — e.g. `ask_user`'s `AskUserResponse[]`) →
+ *   JSON-stringified text block.
+ */
+export function normalizeToolResult(value: unknown): RuntimeToolResult {
+    if (value === null || value === undefined) {
+        return { content: [{ type: 'text', text: '' }], isError: false };
+    }
+
+    if (typeof value === 'string') {
+        return { content: [{ type: 'text', text: value }], isError: false };
+    }
+
+    if (isToolResultObject(value)) {
+        const isError = isErrorResultType(value.resultType) || typeof value.error === 'string';
+        const text = value.textResultForLlm ?? value.error ?? '';
+        return { content: [{ type: 'text', text }], isError };
+    }
+
+    return { content: [{ type: 'text', text: safeStringify(value) }], isError: false };
+}
+
+/** Build a failure result carrying a single error message. */
+export function errorResult(message: string): RuntimeToolResult {
+    return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+function isToolResultObject(value: unknown): value is ToolResultObject {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as ToolResultObject).textResultForLlm === 'string' &&
+        typeof (value as ToolResultObject).resultType === 'string'
+    );
+}
+
+function isErrorResultType(resultType: string): boolean {
+    return resultType === 'failure' || resultType === 'rejected' || resultType === 'denied' || resultType === 'timeout';
+}
+
+function safeStringify(value: unknown): string {
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}

--- a/packages/coc-agent-sdk/src/llm-tools/index.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/index.ts
@@ -19,3 +19,30 @@ export type {
     RuntimeToolResultContent,
     CocToolRuntimeContext,
 } from './coc-tool-runtime';
+
+export {
+    CocToolBridgeServer,
+    cocToolBridgeServer,
+} from './bridge-server';
+
+export type { CocToolBridgeRegistration } from './bridge-server';
+
+export {
+    COC_LLM_TOOLS_MCP_SERVER_NAME,
+    COC_LLM_TOOLS_ENDPOINT_ENV,
+    COC_LLM_TOOLS_TOKEN_ENV,
+    COC_LLM_TOOLS_BRIDGE_PATH_ENV,
+    buildCocLlmToolsMcpConfig,
+    resolveCocLlmToolsBridgePath,
+    setCocLlmToolsBridgePath,
+} from './mcp-config';
+
+export type { CocLlmToolsMcpServerConfig } from './mcp-config';
+
+export {
+    createBridgeHandlers,
+    createHttpTransport,
+    runBridge,
+} from './bridge';
+
+export type { BridgeTransport, BridgeHandlerOptions } from './bridge';

--- a/packages/coc-agent-sdk/src/llm-tools/index.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Provider-neutral CoC LLM-tool runtime + MCP bridge wiring.
+ *
+ * This module adapts the existing Copilot SDK-native `Tool<any>[]` bundle into a
+ * provider-neutral shape so the same CoC tools can be exposed to Codex and
+ * Claude through MCP, not just to Copilot through native tools.
+ */
+
+export {
+    CocToolRuntime,
+    resolveInputSchema,
+    normalizeToolResult,
+    errorResult,
+} from './coc-tool-runtime';
+
+export type {
+    RuntimeToolDescriptor,
+    RuntimeToolResult,
+    RuntimeToolResultContent,
+    CocToolRuntimeContext,
+} from './coc-tool-runtime';

--- a/packages/coc-agent-sdk/src/llm-tools/mcp-config.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/mcp-config.ts
@@ -1,0 +1,72 @@
+/**
+ * Provider-neutral MCP config generation for the CoC LLM-tool bridge.
+ *
+ * Produces the `{ command, args, env }` stdio MCP server spec that points a
+ * provider's MCP client (Codex CLI `mcp_servers`, Claude Code `mcpServers`) at
+ * the bundled bridge process, wiring the bridge back to a {@link CocToolBridgeServer}
+ * registration via env vars.
+ */
+
+import * as path from 'path';
+
+/** MCP server name CoC tools are exposed under. Kept identifier-safe for Codex/Claude. */
+export const COC_LLM_TOOLS_MCP_SERVER_NAME = 'coc_llm_tools';
+
+/** Env var carrying the parent loopback endpoint to the bridge process. */
+export const COC_LLM_TOOLS_ENDPOINT_ENV = 'COC_LLM_TOOLS_ENDPOINT';
+/** Env var carrying the per-invocation bearer token to the bridge process. */
+export const COC_LLM_TOOLS_TOKEN_ENV = 'COC_LLM_TOOLS_TOKEN';
+/** Optional env var overriding the resolved bridge script path. */
+export const COC_LLM_TOOLS_BRIDGE_PATH_ENV = 'COC_LLM_TOOLS_BRIDGE_PATH';
+
+/** Provider-neutral stdio MCP server spec for the bridge. */
+export interface CocLlmToolsMcpServerConfig {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+}
+
+let bridgePathOverride: string | undefined;
+
+/**
+ * Override the resolved bridge script path. Useful when the host bundles the SDK
+ * (e.g. webpack) so the compiled `bridge.js` is not adjacent to this module.
+ */
+export function setCocLlmToolsBridgePath(scriptPath: string | undefined): void {
+    bridgePathOverride = scriptPath;
+}
+
+/**
+ * Resolve the absolute path to the compiled bridge script.
+ *
+ * Resolution order: explicit override → `COC_LLM_TOOLS_BRIDGE_PATH` env →
+ * `bridge.js` adjacent to this module (the tsc-compiled `dist/llm-tools/bridge.js`).
+ */
+export function resolveCocLlmToolsBridgePath(): string {
+    if (bridgePathOverride) return bridgePathOverride;
+    const fromEnv = process.env[COC_LLM_TOOLS_BRIDGE_PATH_ENV];
+    if (fromEnv) return fromEnv;
+    return path.join(__dirname, 'bridge.js');
+}
+
+/**
+ * Build the stdio MCP server config that launches the bridge for a given
+ * {@link CocToolBridgeServer} registration.
+ */
+export function buildCocLlmToolsMcpConfig(options: {
+    endpoint: string;
+    token: string;
+    /** Node executable to launch the bridge with. Defaults to `process.execPath`. */
+    command?: string;
+    /** Explicit bridge script path. Defaults to {@link resolveCocLlmToolsBridgePath}. */
+    bridgePath?: string;
+}): CocLlmToolsMcpServerConfig {
+    return {
+        command: options.command ?? process.execPath,
+        args: [options.bridgePath ?? resolveCocLlmToolsBridgePath()],
+        env: {
+            [COC_LLM_TOOLS_ENDPOINT_ENV]: options.endpoint,
+            [COC_LLM_TOOLS_TOKEN_ENV]: options.token,
+        },
+    };
+}

--- a/packages/coc-agent-sdk/test/ai/claude-sdk-mcp-tools.test.ts
+++ b/packages/coc-agent-sdk/test/ai/claude-sdk-mcp-tools.test.ts
@@ -82,6 +82,28 @@ describe('ClaudeSDKService MCP tool wiring', () => {
         expect(entry.env[COC_LLM_TOOLS_TOKEN_ENV].length).toBeGreaterThan(0);
     });
 
+    it('pre-approves the bridged CoC tools via allowedTools (no permission prompt)', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+        await svc.sendMessage({ prompt: 'hi', tools: [tool('ask_user'), tool('search_conversations')] });
+
+        const opts = (queryFn.mock.calls[0][0] as any).options;
+        expect(opts.allowedTools).toEqual(
+            expect.arrayContaining([
+                `mcp__${COC_LLM_TOOLS_MCP_SERVER_NAME}__ask_user`,
+                `mcp__${COC_LLM_TOOLS_MCP_SERVER_NAME}__search_conversations`,
+            ]),
+        );
+        // Names match the namespaced form Claude Code blocks by default.
+        expect(opts.allowedTools).toContain('mcp__coc_llm_tools__ask_user');
+    });
+
+    it('does not set allowedTools when there are no CoC tools', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+        await svc.sendMessage({ prompt: 'hi' });
+        const opts = (queryFn.mock.calls[0][0] as any).options;
+        expect(opts.allowedTools).toBeUndefined();
+    });
+
     it('tears down the bridge registration after the turn', async () => {
         queryFn.mockReturnValue(makeHandle([SUCCESS]));
         expect(cocToolBridgeServer.activeCount).toBe(0);

--- a/packages/coc-agent-sdk/test/ai/claude-sdk-mcp-tools.test.ts
+++ b/packages/coc-agent-sdk/test/ai/claude-sdk-mcp-tools.test.ts
@@ -1,0 +1,152 @@
+/**
+ * ClaudeSDKService MCP tool-wiring tests
+ *
+ * Covers exposing CoC LLM tools to Claude Code through the stdio MCP bridge:
+ * - query() receives a mcpServers map with the coc_llm_tools bridge entry
+ * - caller-provided mcpServers are forwarded (normalized to Claude's shape)
+ * - no tools / no servers → no mcpServers passed
+ * - the bridge registration is torn down after the turn
+ * - bridged tool-use events are de-namespaced (mcp__coc_llm_tools__X -> X)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/sdk-esm-loader', () => ({
+    dynamicImportModule: vi.fn(),
+}));
+
+import { ClaudeSDKService } from '../../src/claude-sdk-service';
+import { dynamicImportModule } from '../../src/sdk-esm-loader';
+import { cocToolBridgeServer } from '../../src/llm-tools/bridge-server';
+import {
+    COC_LLM_TOOLS_MCP_SERVER_NAME,
+    COC_LLM_TOOLS_ENDPOINT_ENV,
+    COC_LLM_TOOLS_TOKEN_ENV,
+} from '../../src/llm-tools/mcp-config';
+import type { Tool } from '../../src/types';
+
+const mockDynamicImport = vi.mocked(dynamicImportModule);
+
+function makeHandle(messages: object[]) {
+    return {
+        [Symbol.asyncIterator]() {
+            return (async function* () { for (const m of messages) yield m; })();
+        },
+        accountInfo: vi.fn(async () => ({})),
+        return: vi.fn(async () => ({ done: true as const, value: undefined })),
+    };
+}
+
+function tool(name: string): Tool<any> {
+    return {
+        name,
+        description: `desc ${name}`,
+        parameters: { type: 'object', properties: {} },
+        handler: vi.fn(async () => 'ok'),
+    } as Tool<any>;
+}
+
+const SUCCESS = { type: 'result', subtype: 'success', result: 'ok', session_id: 's1' };
+
+describe('ClaudeSDKService MCP tool wiring', () => {
+    let svc: ClaudeSDKService;
+    const queryFn = vi.fn();
+
+    beforeEach(() => {
+        queryFn.mockReset();
+        mockDynamicImport.mockResolvedValue({ query: queryFn });
+        svc = new ClaudeSDKService();
+    });
+
+    afterEach(() => {
+        svc.dispose();
+        cocToolBridgeServer.closeAll();
+    });
+
+    it('passes a mcpServers map with the coc bridge entry when tools are present', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+
+        const result = await svc.sendMessage({ prompt: 'hi', tools: [tool('ask_user'), tool('create_work_item')] });
+        expect(result.success).toBe(true);
+
+        const callOptions = queryFn.mock.calls[0][0] as { options?: { mcpServers?: Record<string, any> } };
+        const servers = callOptions.options?.mcpServers;
+        expect(servers).toBeDefined();
+        const entry = servers![COC_LLM_TOOLS_MCP_SERVER_NAME];
+        expect(entry.type).toBe('stdio');
+        expect(entry.command).toBe(process.execPath);
+        expect(Array.isArray(entry.args)).toBe(true);
+        expect(entry.alwaysLoad).toBe(true);
+        expect(entry.env[COC_LLM_TOOLS_ENDPOINT_ENV]).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+        expect(typeof entry.env[COC_LLM_TOOLS_TOKEN_ENV]).toBe('string');
+        expect(entry.env[COC_LLM_TOOLS_TOKEN_ENV].length).toBeGreaterThan(0);
+    });
+
+    it('tears down the bridge registration after the turn', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+        expect(cocToolBridgeServer.activeCount).toBe(0);
+        await svc.sendMessage({ prompt: 'hi', tools: [tool('ask_user')] });
+        expect(cocToolBridgeServer.activeCount).toBe(0);
+        expect(cocToolBridgeServer.endpoint).toBeNull();
+    });
+
+    it('does not pass mcpServers when there are no tools and no caller servers', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+        await svc.sendMessage({ prompt: 'hi' });
+        const callOptions = queryFn.mock.calls[0][0] as { options?: { mcpServers?: unknown } };
+        expect(callOptions.options?.mcpServers).toBeUndefined();
+    });
+
+    it('forwards caller-provided mcpServers, normalized to Claude shape', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+        await svc.sendMessage({
+            prompt: 'hi',
+            mcpServers: {
+                myhttp: { type: 'http', url: 'https://example.com/mcp', headers: { 'x-key': '1' } },
+                mylocal: { command: 'node', args: ['server.js'], env: { A: 'b' } },
+            },
+        });
+        const servers = (queryFn.mock.calls[0][0] as any).options.mcpServers;
+        expect(servers.myhttp).toEqual({ type: 'http', url: 'https://example.com/mcp', headers: { 'x-key': '1' } });
+        expect(servers.mylocal).toEqual({ type: 'stdio', command: 'node', args: ['server.js'], env: { A: 'b' } });
+        // No coc entry since no tools were passed.
+        expect(servers[COC_LLM_TOOLS_MCP_SERVER_NAME]).toBeUndefined();
+    });
+
+    it('combines caller servers with the coc bridge entry when both are present', async () => {
+        queryFn.mockReturnValue(makeHandle([SUCCESS]));
+        await svc.sendMessage({
+            prompt: 'hi',
+            tools: [tool('ask_user')],
+            mcpServers: { myhttp: { type: 'sse', url: 'https://example.com/sse' } },
+        });
+        const servers = (queryFn.mock.calls[0][0] as any).options.mcpServers;
+        expect(servers.myhttp).toEqual({ type: 'sse', url: 'https://example.com/sse' });
+        expect(servers[COC_LLM_TOOLS_MCP_SERVER_NAME].type).toBe('stdio');
+    });
+
+    it('de-namespaces bridged tool-use events to bare CoC tool names', async () => {
+        const onToolEvent = vi.fn();
+        queryFn.mockReturnValue(makeHandle([
+            {
+                type: 'assistant',
+                message: {
+                    content: [
+                        { type: 'tool_use', id: 't1', name: `mcp__${COC_LLM_TOOLS_MCP_SERVER_NAME}__ask_user`, input: { questions: [] } },
+                        { type: 'tool_use', id: 't2', name: 'mcp__other_server__some_tool', input: {} },
+                    ],
+                },
+                session_id: 's1',
+            },
+            SUCCESS,
+        ]));
+
+        await svc.sendMessage({ prompt: 'x', tools: [tool('ask_user')], onToolEvent });
+
+        const startEvents = onToolEvent.mock.calls.map(c => c[0]).filter((e: any) => e.type === 'tool-start');
+        const cocEvent = startEvents.find((e: any) => e.toolCallId === 't1');
+        const otherEvent = startEvents.find((e: any) => e.toolCallId === 't2');
+        expect(cocEvent.toolName).toBe('ask_user'); // stripped
+        expect(otherEvent.toolName).toBe('mcp__other_server__some_tool'); // untouched
+    });
+});

--- a/packages/coc-agent-sdk/test/ai/coc-tool-bridge.test.ts
+++ b/packages/coc-agent-sdk/test/ai/coc-tool-bridge.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as http from 'http';
+import { CocToolRuntime } from '../../src/llm-tools/coc-tool-runtime';
+import { CocToolBridgeServer } from '../../src/llm-tools/bridge-server';
+import {
+    createBridgeHandlers,
+    createHttpTransport,
+    runBridge,
+} from '../../src/llm-tools/bridge';
+import {
+    buildCocLlmToolsMcpConfig,
+    resolveCocLlmToolsBridgePath,
+    setCocLlmToolsBridgePath,
+    COC_LLM_TOOLS_ENDPOINT_ENV,
+    COC_LLM_TOOLS_TOKEN_ENV,
+    COC_LLM_TOOLS_MCP_SERVER_NAME,
+} from '../../src/llm-tools/mcp-config';
+import type { Tool } from '../../src/types';
+
+function tool(name: string, handler: Tool<any>['handler']): Tool<any> {
+    return {
+        name,
+        description: `desc ${name}`,
+        parameters: { type: 'object', properties: { x: { type: 'string' } } },
+        handler,
+    } as Tool<any>;
+}
+
+/** Minimal raw POST helper that returns { status, json }. */
+function postJson(endpoint: string, path: string, token: string | undefined, body: unknown): Promise<{ status: number; json: any }> {
+    const base = new URL(endpoint);
+    const payload = Buffer.from(JSON.stringify(body), 'utf8');
+    return new Promise((resolve, reject) => {
+        const headers: Record<string, string | number> = {
+            'content-type': 'application/json',
+            'content-length': payload.length,
+        };
+        if (token) headers.authorization = `Bearer ${token}`;
+        const req = http.request({ hostname: base.hostname, port: base.port, path, method: 'POST', headers }, (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (c: Buffer) => chunks.push(c));
+            res.on('end', () => {
+                const text = Buffer.concat(chunks).toString('utf8');
+                resolve({ status: res.statusCode ?? 0, json: text ? JSON.parse(text) : undefined });
+            });
+        });
+        req.on('error', reject);
+        req.write(payload);
+        req.end();
+    });
+}
+
+describe('CocToolBridgeServer', () => {
+    let server: CocToolBridgeServer | undefined;
+
+    afterEach(() => {
+        server?.closeAll();
+        server = undefined;
+    });
+
+    it('exposes only the enabled tools the runtime was constructed with', async () => {
+        server = new CocToolBridgeServer();
+        const runtime = new CocToolRuntime([
+            tool('ask_user', async () => 'a'),
+            tool('search_conversations', async () => 'b'),
+        ]);
+        const reg = await server.register(runtime);
+
+        const res = await postJson(reg.endpoint, '/list', reg.token, {});
+        expect(res.status).toBe(200);
+        const names = res.json.tools.map((t: { name: string }) => t.name).sort();
+        expect(names).toEqual(['ask_user', 'search_conversations']);
+        expect(res.json.tools[0]).toHaveProperty('inputSchema.type', 'object');
+    });
+
+    it('routes /call to the original handler with the provided arguments', async () => {
+        server = new CocToolBridgeServer();
+        const handler = vi.fn(async (args: { title?: string }) => `created ${args.title}`);
+        const runtime = new CocToolRuntime([tool('create_work_item', handler as Tool<any>['handler'])], {
+            workspaceId: 'ws-1',
+            processId: 'proc-1',
+        });
+        const reg = await server.register(runtime);
+
+        const res = await postJson(reg.endpoint, '/call', reg.token, { name: 'create_work_item', arguments: { title: 'Hi' } });
+        expect(res.status).toBe(200);
+        expect(res.json).toEqual({ content: [{ type: 'text', text: 'created Hi' }], isError: false });
+        expect(handler).toHaveBeenCalledWith({ title: 'Hi' }, expect.objectContaining({ toolName: 'create_work_item' }));
+    });
+
+    it('blocks /call until a deferred (ask_user) handler resolves, then returns the answer', async () => {
+        server = new CocToolBridgeServer();
+        let resolveAnswer!: (value: unknown) => void;
+        const pending = new Promise(resolve => { resolveAnswer = resolve; });
+        const runtime = new CocToolRuntime([tool('ask_user', async () => pending)]);
+        const reg = await server.register(runtime);
+
+        const callPromise = postJson(reg.endpoint, '/call', reg.token, { name: 'ask_user', arguments: { questions: [] } });
+
+        let settled = false;
+        void callPromise.then(() => { settled = true; });
+        await new Promise(r => setTimeout(r, 30));
+        expect(settled).toBe(false); // still awaiting the user
+
+        resolveAnswer([{ questionId: 'q1', answer: 'yes', skipped: false }]);
+        const res = await callPromise;
+        expect(res.status).toBe(200);
+        expect(res.json.isError).toBe(false);
+        expect(JSON.parse(res.json.content[0].text)).toEqual([{ questionId: 'q1', answer: 'yes', skipped: false }]);
+    });
+
+    it('rejects requests with an unknown/missing token', async () => {
+        server = new CocToolBridgeServer();
+        const reg = await server.register(new CocToolRuntime([tool('ask_user', async () => 'a')]));
+
+        const bad = await postJson(reg.endpoint, '/list', 'not-a-real-token', {});
+        expect(bad.status).toBe(401);
+        const missing = await postJson(reg.endpoint, '/list', undefined, {});
+        expect(missing.status).toBe(401);
+    });
+
+    it('isolates runtimes by token (one token cannot see another runtime tools)', async () => {
+        server = new CocToolBridgeServer();
+        const regA = await server.register(new CocToolRuntime([tool('only_a', async () => 'a')]));
+        const regB = await server.register(new CocToolRuntime([tool('only_b', async () => 'b')]));
+
+        const listA = await postJson(regA.endpoint, '/list', regA.token, {});
+        const listB = await postJson(regB.endpoint, '/list', regB.token, {});
+        expect(listA.json.tools.map((t: { name: string }) => t.name)).toEqual(['only_a']);
+        expect(listB.json.tools.map((t: { name: string }) => t.name)).toEqual(['only_b']);
+    });
+
+    it('reference-counts and tears down when the last runtime unregisters', async () => {
+        server = new CocToolBridgeServer();
+        const regA = await server.register(new CocToolRuntime([tool('a', async () => 'a')]));
+        const regB = await server.register(new CocToolRuntime([tool('b', async () => 'b')]));
+        expect(server.activeCount).toBe(2);
+        expect(server.endpoint).not.toBeNull();
+
+        regA.unregister();
+        expect(server.activeCount).toBe(1);
+        expect(server.endpoint).not.toBeNull(); // still serving regB
+
+        regB.unregister();
+        expect(server.activeCount).toBe(0);
+        expect(server.endpoint).toBeNull(); // torn down
+    });
+
+    it('works end-to-end through the bridge HTTP transport', async () => {
+        server = new CocToolBridgeServer();
+        const runtime = new CocToolRuntime([tool('echo', async (a: { v?: string }) => `echo:${a.v}`)]);
+        const reg = await server.register(runtime);
+
+        const transport = createHttpTransport(reg.endpoint, reg.token);
+        const list = await transport('/list', {}) as { tools: { name: string }[] };
+        expect(list.tools.map(t => t.name)).toEqual(['echo']);
+        const call = await transport('/call', { name: 'echo', arguments: { v: 'hi' } });
+        expect(call).toEqual({ content: [{ type: 'text', text: 'echo:hi' }], isError: false });
+    });
+});
+
+describe('bridge JSON-RPC handlers', () => {
+    it('answers initialize echoing the requested protocol version', async () => {
+        const { handleMessage } = createBridgeHandlers({ transport: vi.fn() });
+        const res = await handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } });
+        expect(res).toMatchObject({
+            jsonrpc: '2.0',
+            id: 1,
+            result: { protocolVersion: '2025-06-18', capabilities: { tools: {} }, serverInfo: { name: 'coc-llm-tools' } },
+        });
+    });
+
+    it('returns null for notifications (no id)', async () => {
+        const { handleMessage } = createBridgeHandlers({ transport: vi.fn() });
+        const res = await handleMessage({ jsonrpc: '2.0', method: 'notifications/initialized' });
+        expect(res).toBeNull();
+    });
+
+    it('proxies tools/list to the transport', async () => {
+        const transport = vi.fn(async () => ({ tools: [{ name: 'ask_user', description: '', inputSchema: { type: 'object' } }] }));
+        const { handleMessage } = createBridgeHandlers({ transport });
+        const res = await handleMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+        expect(transport).toHaveBeenCalledWith('/list', {});
+        expect((res as any).result.tools).toHaveLength(1);
+    });
+
+    it('proxies tools/call to the transport and returns the CallToolResult', async () => {
+        const transport = vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }], isError: false }));
+        const { handleMessage } = createBridgeHandlers({ transport });
+        const res = await handleMessage({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'ask_user', arguments: { q: 1 } } });
+        expect(transport).toHaveBeenCalledWith('/call', { name: 'ask_user', arguments: { q: 1 } });
+        expect((res as any).result).toEqual({ content: [{ type: 'text', text: 'ok' }], isError: false });
+    });
+
+    it('surfaces a transport failure on tools/call as an isError result (not a protocol error)', async () => {
+        const transport = vi.fn(async () => { throw new Error('connection refused'); });
+        const { handleMessage } = createBridgeHandlers({ transport });
+        const res = await handleMessage({ jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'ask_user' } });
+        expect((res as any).error).toBeUndefined();
+        expect((res as any).result.isError).toBe(true);
+        expect((res as any).result.content[0].text).toContain('connection refused');
+    });
+
+    it('returns method-not-found for unknown methods', async () => {
+        const { handleMessage } = createBridgeHandlers({ transport: vi.fn() });
+        const res = await handleMessage({ jsonrpc: '2.0', id: 5, method: 'resources/list' });
+        expect((res as any).error.code).toBe(-32601);
+    });
+
+    it('runBridge reads newline-delimited messages and writes responses', async () => {
+        const { Readable, Writable } = await import('stream');
+        const written: string[] = [];
+        const stdout = new Writable({
+            write(chunk, _enc, cb) { written.push(chunk.toString()); cb(); },
+        });
+        const stdin = new Readable({ read() {} });
+        runBridge({ transport: vi.fn(async () => ({ tools: [] })), stdin, stdout });
+
+        stdin.push(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }) + '\n');
+        stdin.push(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+        stdin.push(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }) + '\n');
+        await new Promise(r => setTimeout(r, 30));
+
+        const responses = written.join('').trim().split('\n').map(l => JSON.parse(l));
+        // initialize + tools/list answered; notification produced no output.
+        expect(responses.map(r => r.id)).toEqual([1, 2]);
+    });
+});
+
+describe('buildCocLlmToolsMcpConfig', () => {
+    afterEach(() => {
+        setCocLlmToolsBridgePath(undefined);
+        delete process.env.COC_LLM_TOOLS_BRIDGE_PATH;
+    });
+
+    it('produces a stdio server spec with endpoint+token env vars', () => {
+        const config = buildCocLlmToolsMcpConfig({ endpoint: 'http://127.0.0.1:5000', token: 'tok123', bridgePath: '/x/bridge.js' });
+        expect(config.command).toBe(process.execPath);
+        expect(config.args).toEqual(['/x/bridge.js']);
+        expect(config.env).toEqual({
+            [COC_LLM_TOOLS_ENDPOINT_ENV]: 'http://127.0.0.1:5000',
+            [COC_LLM_TOOLS_TOKEN_ENV]: 'tok123',
+        });
+    });
+
+    it('honors an explicit bridge-path override', () => {
+        setCocLlmToolsBridgePath('/override/bridge.js');
+        expect(resolveCocLlmToolsBridgePath()).toBe('/override/bridge.js');
+    });
+
+    it('falls back to COC_LLM_TOOLS_BRIDGE_PATH env, then dist-adjacent default', () => {
+        process.env.COC_LLM_TOOLS_BRIDGE_PATH = '/env/bridge.js';
+        expect(resolveCocLlmToolsBridgePath()).toBe('/env/bridge.js');
+        delete process.env.COC_LLM_TOOLS_BRIDGE_PATH;
+        expect(resolveCocLlmToolsBridgePath()).toMatch(/bridge\.js$/);
+    });
+
+    it('exposes an identifier-safe MCP server name', () => {
+        expect(COC_LLM_TOOLS_MCP_SERVER_NAME).toBe('coc_llm_tools');
+        expect(COC_LLM_TOOLS_MCP_SERVER_NAME).toMatch(/^[a-z0-9_]+$/);
+    });
+});

--- a/packages/coc-agent-sdk/test/ai/coc-tool-runtime.test.ts
+++ b/packages/coc-agent-sdk/test/ai/coc-tool-runtime.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    CocToolRuntime,
+    resolveInputSchema,
+    normalizeToolResult,
+    errorResult,
+} from '../../src/llm-tools/coc-tool-runtime';
+import type { Tool, ToolInvocation } from '../../src/types';
+
+function tool(name: string, overrides: Partial<Tool<any>> = {}): Tool<any> {
+    return {
+        name,
+        description: `desc for ${name}`,
+        parameters: { type: 'object', properties: { foo: { type: 'string' } }, required: ['foo'] },
+        handler: vi.fn(async () => `handled ${name}`),
+        ...overrides,
+    } as Tool<any>;
+}
+
+describe('CocToolRuntime', () => {
+    describe('listTools', () => {
+        it('exposes exactly the (already-filtered) tools it was constructed with', () => {
+            const runtime = new CocToolRuntime([tool('ask_user'), tool('search_conversations')]);
+            const names = runtime.listTools().map(d => d.name).sort();
+            expect(names).toEqual(['ask_user', 'search_conversations']);
+            expect(runtime.size).toBe(2);
+            expect(runtime.hasTool('ask_user')).toBe(true);
+            expect(runtime.hasTool('not_enabled')).toBe(false);
+        });
+
+        it('does not expose a tool that was filtered out upstream', () => {
+            // Only the enabled tool is passed in (preference filtering happens in coc).
+            const runtime = new CocToolRuntime([tool('ask_user')]);
+            expect(runtime.hasTool('tavily_web_search')).toBe(false);
+            expect(runtime.listTools()).toHaveLength(1);
+        });
+
+        it('carries name, description and JSON-schema inputSchema', () => {
+            const runtime = new CocToolRuntime([tool('ask_user')]);
+            const [descriptor] = runtime.listTools();
+            expect(descriptor.name).toBe('ask_user');
+            expect(descriptor.description).toBe('desc for ask_user');
+            expect(descriptor.inputSchema).toMatchObject({
+                type: 'object',
+                properties: { foo: { type: 'string' } },
+                required: ['foo'],
+            });
+        });
+
+        it('returns an empty list after disposal', () => {
+            const runtime = new CocToolRuntime([tool('ask_user')]);
+            runtime.dispose();
+            expect(runtime.listTools()).toEqual([]);
+            expect(runtime.size).toBe(0);
+        });
+    });
+
+    describe('callTool', () => {
+        it('invokes the original handler with a synthesized invocation envelope', async () => {
+            const handler = vi.fn(async () => 'ok');
+            const runtime = new CocToolRuntime(
+                [tool('create_work_item', { handler })],
+                { sessionId: 'sess-1', workspaceId: 'ws-1', processId: 'proc-1' },
+            );
+
+            const result = await runtime.callTool('create_work_item', { title: 'x' });
+
+            expect(result).toEqual({ content: [{ type: 'text', text: 'ok' }], isError: false });
+            expect(handler).toHaveBeenCalledTimes(1);
+            const [args, invocation] = handler.mock.calls[0] as [unknown, ToolInvocation];
+            expect(args).toEqual({ title: 'x' });
+            expect(invocation.sessionId).toBe('sess-1');
+            expect(invocation.toolName).toBe('create_work_item');
+            expect(typeof invocation.toolCallId).toBe('string');
+            expect(invocation.arguments).toEqual({ title: 'x' });
+        });
+
+        it('preserves the pre-bound workspace/process context closure', async () => {
+            // CoC factories bake context into the closure; the runtime must call
+            // that exact closure rather than re-binding context.
+            const captured: string[] = [];
+            const boundWorkspace = 'ws-pre-bound';
+            const factory = () => tool('add_diff_comment', {
+                handler: async () => { captured.push(boundWorkspace); return 'done'; },
+            });
+            const runtime = new CocToolRuntime([factory()]);
+
+            await runtime.callTool('add_diff_comment', {});
+            expect(captured).toEqual(['ws-pre-bound']);
+        });
+
+        it('returns an error result for an unknown tool without throwing', async () => {
+            const runtime = new CocToolRuntime([tool('ask_user')]);
+            const result = await runtime.callTool('nope', {});
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Unknown tool: nope');
+        });
+
+        it('captures handler exceptions as an error result', async () => {
+            const runtime = new CocToolRuntime([
+                tool('boom', { handler: async () => { throw new Error('kaboom'); } }),
+            ]);
+            const result = await runtime.callTool('boom', {});
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toBe('kaboom');
+        });
+
+        it('JSON-stringifies structured handler results (e.g. ask_user responses)', async () => {
+            const responses = [{ questionId: 'q1', answer: 'yes', skipped: false }];
+            const runtime = new CocToolRuntime([
+                tool('ask_user', { handler: async () => responses }),
+            ]);
+            const result = await runtime.callTool('ask_user', { questions: [] });
+            expect(result.isError).toBe(false);
+            expect(JSON.parse(result.content[0].text)).toEqual(responses);
+        });
+
+        it('blocks until a deferred (ask_user-style) handler resolves, then returns the answer', async () => {
+            // Mirror ask_user: the handler returns a Promise resolved externally.
+            let resolveAnswer!: (value: unknown) => void;
+            const pending = new Promise(resolve => { resolveAnswer = resolve; });
+            const runtime = new CocToolRuntime([
+                tool('ask_user', { handler: async () => pending }),
+            ]);
+
+            const callPromise = runtime.callTool('ask_user', { questions: [{ q: 'go?' }] });
+
+            let settled = false;
+            void callPromise.then(() => { settled = true; });
+            await Promise.resolve();
+            expect(settled).toBe(false); // still blocked, no answer yet
+
+            resolveAnswer([{ questionId: 'q1', answer: true, skipped: false }]);
+            const result = await callPromise;
+            expect(result.isError).toBe(false);
+            expect(JSON.parse(result.content[0].text)).toEqual([
+                { questionId: 'q1', answer: true, skipped: false },
+            ]);
+        });
+
+        it('returns an error result after disposal', async () => {
+            const runtime = new CocToolRuntime([tool('ask_user')]);
+            runtime.dispose();
+            const result = await runtime.callTool('ask_user', {});
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('disposed');
+        });
+    });
+
+    describe('resolveInputSchema', () => {
+        it('passes through a raw JSON-schema object and normalizes to an object schema', () => {
+            const schema = resolveInputSchema({ parameters: { type: 'object', properties: { a: { type: 'number' } } } });
+            expect(schema).toEqual({ type: 'object', properties: { a: { type: 'number' } } });
+        });
+
+        it('forces type:object and properties for a non-object schema', () => {
+            const schema = resolveInputSchema({ parameters: { description: 'no type' } as Record<string, unknown> });
+            expect(schema.type).toBe('object');
+            expect(schema.properties).toEqual({});
+        });
+
+        it('defaults to an empty object schema when parameters are omitted', () => {
+            const schema = resolveInputSchema({ parameters: undefined });
+            expect(schema).toEqual({ type: 'object', properties: {} });
+        });
+
+        it('calls toJSONSchema() for Zod-like schemas', () => {
+            const zodLike = {
+                _output: undefined,
+                toJSONSchema: () => ({ type: 'object', properties: { z: { type: 'boolean' } } }),
+            };
+            const schema = resolveInputSchema({ parameters: zodLike as never });
+            expect(schema).toEqual({ type: 'object', properties: { z: { type: 'boolean' } } });
+        });
+    });
+
+    describe('normalizeToolResult', () => {
+        it('wraps strings', () => {
+            expect(normalizeToolResult('hi')).toEqual({ content: [{ type: 'text', text: 'hi' }], isError: false });
+        });
+
+        it('maps a ToolResultObject success', () => {
+            expect(normalizeToolResult({ textResultForLlm: 'done', resultType: 'success' }))
+                .toEqual({ content: [{ type: 'text', text: 'done' }], isError: false });
+        });
+
+        it('maps a ToolResultObject failure to isError', () => {
+            const r = normalizeToolResult({ textResultForLlm: 'bad', resultType: 'failure', error: 'nope' });
+            expect(r.isError).toBe(true);
+            expect(r.content[0].text).toBe('bad');
+        });
+
+        it('treats null/undefined as empty success', () => {
+            expect(normalizeToolResult(null)).toEqual({ content: [{ type: 'text', text: '' }], isError: false });
+            expect(normalizeToolResult(undefined)).toEqual({ content: [{ type: 'text', text: '' }], isError: false });
+        });
+
+        it('builds an error result via errorResult()', () => {
+            expect(errorResult('x')).toEqual({ content: [{ type: 'text', text: 'x' }], isError: true });
+        });
+    });
+});

--- a/packages/coc-agent-sdk/test/ai/codex-sdk-mcp-tools.test.ts
+++ b/packages/coc-agent-sdk/test/ai/codex-sdk-mcp-tools.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CodexSDKService } from '../../src/codex-sdk-service';
+import { cocToolBridgeServer } from '../../src/llm-tools/bridge-server';
+import {
+    COC_LLM_TOOLS_MCP_SERVER_NAME,
+    COC_LLM_TOOLS_ENDPOINT_ENV,
+    COC_LLM_TOOLS_TOKEN_ENV,
+} from '../../src/llm-tools/mcp-config';
+import type { Tool } from '../../src/types';
+
+function makeThread(threadId = 'thread-1') {
+    return {
+        id: threadId,
+        runStreamed: vi.fn(async () => ({
+            events: (async function* () {
+                yield { type: 'thread.started' as const, thread_id: threadId };
+                yield { type: 'item.completed' as const, item: { id: 'i1', type: 'agent_message', text: 'ok' } };
+            })(),
+        })),
+    };
+}
+
+/** A Codex client constructor mock that records the options it was built with. */
+function makeCodexCtor() {
+    const instances: Array<{ options: unknown; client: { startThread: ReturnType<typeof vi.fn>; resumeThread: ReturnType<typeof vi.fn> } }> = [];
+    const ctor = vi.fn(function (this: unknown, options?: unknown) {
+        const client = {
+            startThread: vi.fn(() => makeThread()),
+            resumeThread: vi.fn(() => makeThread()),
+        };
+        instances.push({ options, client });
+        return client;
+    }) as unknown as new (options?: unknown) => unknown;
+    return { ctor, instances };
+}
+
+function tool(name: string): Tool<any> {
+    return {
+        name,
+        description: `desc ${name}`,
+        parameters: { type: 'object', properties: {} },
+        handler: vi.fn(async () => 'ok'),
+    } as Tool<any>;
+}
+
+describe('CodexSDKService MCP tool wiring', () => {
+    let svc: CodexSDKService | undefined;
+
+    afterEach(() => {
+        svc?.dispose();
+        svc = undefined;
+        cocToolBridgeServer.closeAll();
+    });
+
+    it('builds a per-request Codex client with generated mcp_servers config when tools are present', async () => {
+        svc = new CodexSDKService();
+        const { ctor, instances } = makeCodexCtor();
+        // Default (no-MCP) client used when no tools.
+        const defaultClient = { startThread: vi.fn(() => makeThread()), resumeThread: vi.fn() };
+        (svc as unknown as { sdk: unknown }).sdk = defaultClient;
+        (svc as unknown as { codexCtor: unknown }).codexCtor = ctor;
+        (svc as unknown as { availabilityCache: unknown }).availabilityCache = { available: true };
+
+        const result = await svc.sendMessage({ prompt: 'hi', tools: [tool('ask_user'), tool('create_work_item')] });
+        expect(result.success).toBe(true);
+
+        // A fresh client was constructed for this request (not the default one).
+        expect(ctor).toHaveBeenCalledTimes(1);
+        expect(instances).toHaveLength(1);
+        const built = instances[0].options as { config?: { mcp_servers?: Record<string, any> } };
+        const servers = built.config?.mcp_servers;
+        expect(servers).toBeDefined();
+        const entry = servers![COC_LLM_TOOLS_MCP_SERVER_NAME];
+        expect(entry).toBeDefined();
+        expect(entry.command).toBe(process.execPath);
+        expect(Array.isArray(entry.args)).toBe(true);
+        expect(entry.env[COC_LLM_TOOLS_ENDPOINT_ENV]).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+        expect(typeof entry.env[COC_LLM_TOOLS_TOKEN_ENV]).toBe('string');
+        expect(entry.env[COC_LLM_TOOLS_TOKEN_ENV].length).toBeGreaterThan(0);
+
+        // The per-request client (not the default) ran the thread.
+        expect(instances[0].client.startThread).toHaveBeenCalledTimes(1);
+        expect(defaultClient.startThread).not.toHaveBeenCalled();
+    });
+
+    it('tears down the bridge registration after the turn completes', async () => {
+        svc = new CodexSDKService();
+        const { ctor } = makeCodexCtor();
+        (svc as unknown as { sdk: unknown }).sdk = { startThread: vi.fn(() => makeThread()), resumeThread: vi.fn() };
+        (svc as unknown as { codexCtor: unknown }).codexCtor = ctor;
+        (svc as unknown as { availabilityCache: unknown }).availabilityCache = { available: true };
+
+        expect(cocToolBridgeServer.activeCount).toBe(0);
+        await svc.sendMessage({ prompt: 'hi', tools: [tool('ask_user')] });
+        // Registration is disposed in finally → server torn down.
+        expect(cocToolBridgeServer.activeCount).toBe(0);
+        expect(cocToolBridgeServer.endpoint).toBeNull();
+    });
+
+    it('reuses the shared client and skips MCP wiring when no tools are passed', async () => {
+        svc = new CodexSDKService();
+        const { ctor } = makeCodexCtor();
+        const defaultClient = { startThread: vi.fn(() => makeThread()), resumeThread: vi.fn() };
+        (svc as unknown as { sdk: unknown }).sdk = defaultClient;
+        (svc as unknown as { codexCtor: unknown }).codexCtor = ctor;
+        (svc as unknown as { availabilityCache: unknown }).availabilityCache = { available: true };
+
+        await svc.sendMessage({ prompt: 'hi' });
+        expect(ctor).not.toHaveBeenCalled();
+        expect(defaultClient.startThread).toHaveBeenCalledTimes(1);
+        expect(cocToolBridgeServer.activeCount).toBe(0);
+    });
+});


### PR DESCRIPTION
- **feat(coc-agent-sdk): add provider-neutral CocToolRuntime**
- **feat(coc-agent-sdk): add stdio MCP bridge + loopback IPC for CoC tools**
- **feat(coc-agent-sdk): expose CoC LLM tools to Codex via MCP bridge**
- **feat(coc-agent-sdk): expose CoC LLM tools to Claude via MCP bridge**
- **fix(coc-agent-sdk): pre-approve CoC bridge tools in Claude (allowedTools)**
