### PR TITLE
fix(git-tab): always include branchName in onDefaultBranch responses and auto-refresh on git-changed

### DIFF
--- a/packages/coc-client/src/contracts/git.ts
+++ b/packages/coc-client/src/contracts/git.ts
@@ -48,6 +48,7 @@ export interface GitBranchRangeInfo {
 
 export interface GitDefaultBranchResponse {
   onDefaultBranch: true;
+  branchName?: string;
 }
 
 export type GitBranchRangeResponse = GitBranchRangeInfo | GitDefaultBranchResponse;

--- a/packages/coc/src/server/routes/api-git-branch-range-routes.ts
+++ b/packages/coc/src/server/routes/api-git-branch-range-routes.ts
@@ -64,7 +64,8 @@ export function registerGitBranchRangeRoutes(ctx: ApiRouteContext): void {
                 const rangeService = getGitRangeService();
                 const range = await rangeService.detectCommitRange(ws.rootPath);
                 if (!range) {
-                    const result = { onDefaultBranch: true };
+                    const branchName = await rangeService.getCurrentBranch(ws.rootPath);
+                    const result = { onDefaultBranch: true as const, branchName };
                     gitCache.set(cacheKey, result);
                     return sendJSON(res, 200, result);
                 }
@@ -75,7 +76,8 @@ export function registerGitBranchRangeRoutes(ctx: ApiRouteContext): void {
                 gitCache.set(cacheKey, result);
                 sendJSON(res, 200, result);
             } catch {
-                sendJSON(res, 200, { onDefaultBranch: true });
+                const branchName = await getGitRangeService().getCurrentBranch(ws.rootPath).catch(() => 'HEAD');
+                sendJSON(res, 200, { onDefaultBranch: true, branchName });
             }
         },
     });

--- a/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
@@ -276,12 +276,13 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                     setOnDefaultBranch(true);
                     setBranchRangeData(null);
                     setBranchRangeFiles([]);
-                    setBranchName(data.branchName || data.defaultBranch || 'main');
+                    const resolvedBranchName = data.branchName || data.defaultBranch || '';
+                    setBranchName(resolvedBranchName);
                     setAhead(0);
                     setBehind(0);
                     setBranchRangeCache(workspaceId, {
                         data: null, files: [], ahead: 0, behind: 0,
-                        branchName: data.branchName || data.defaultBranch || 'main',
+                        branchName: resolvedBranchName,
                         onDefaultBranch: true,
                     });
                     return null as BranchRangeInfo | null;
@@ -520,11 +521,16 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                     gitChangedDebounceRef.current = null;
                     // Snapshot current commits before the refresh overwrites them
                     prevCommitsRef.current = commits;
-                    // Re-fetch commits and working tree but NOT branch range (cached)
-                    fetchCommits(true, 0, searchQuery).then((newCommits: GitCommitItem[]) => {
+                    // Clear stale branch range cache so the next fetch returns current branch
+                    clearBranchRangeCache(workspaceId);
+                    // Re-fetch commits, working tree, and branch range
+                    Promise.all([
+                        fetchCommits(true, 0, searchQuery),
+                        fetchBranchRange(false),
+                    ]).then(([newCommits]) => {
                         setLastRefreshedAt(Date.now());
                         // Heuristic rebind: match old→new commits by identity
-                        const pairs = matchCommitsByIdentity(prevCommitsRef.current, newCommits);
+                        const pairs = matchCommitsByIdentity(prevCommitsRef.current, newCommits as GitCommitItem[]);
                         for (const { oldHash, newHash } of pairs) {
                             rebindCommitChat(workspaceId, oldHash, newHash);
                         }
@@ -546,7 +552,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                         .catch(() => {});
                 }
             }
-        }, [workspaceId, commits, fetchCommits, searchQuery]),
+        }, [workspaceId, commits, fetchCommits, fetchBranchRange, searchQuery]),
     });
 
     // Pull job polling helpers

--- a/packages/coc/test/server/git-branch-range-api.test.ts
+++ b/packages/coc/test/server/git-branch-range-api.test.ts
@@ -27,6 +27,7 @@ import { gitCache } from '../../src/server/git/git-cache';
 const mockDetectCommitRange = vi.fn();
 const mockGetRangeDiff = vi.fn();
 const mockGetFileDiff = vi.fn();
+const mockGetCurrentBranch = vi.fn().mockResolvedValue('feature/foo');
 
 const mockExecSync = vi.fn();
 vi.mock('child_process', function () { return ({
@@ -41,6 +42,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             detectCommitRange: mockDetectCommitRange,
             getRangeDiff: mockGetRangeDiff,
             getFileDiff: mockGetFileDiff,
+            getCurrentBranch: mockGetCurrentBranch,
         }); }),
     };
 });
@@ -161,6 +163,7 @@ describe('Git Branch Range API endpoints', () => {
         mockGetRangeDiff.mockReset();
         mockGetFileDiff.mockReset();
         mockExecSync.mockReset();
+        mockGetCurrentBranch.mockResolvedValue('feature/foo');
         gitCache.clear();
     });
 
@@ -184,20 +187,22 @@ describe('Git Branch Range API endpoints', () => {
             expect(data.deletions).toBe(2);
         });
 
-        it('returns onDefaultBranch when detectCommitRange returns null', async () => {
+        it('returns onDefaultBranch with branchName when detectCommitRange returns null', async () => {
             mockDetectCommitRange.mockReturnValue(null);
+            mockGetCurrentBranch.mockResolvedValue('pr/some-feature-branch');
 
             const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/git/branch-range`);
             expect(res.status).toBe(200);
-            expect(res.json()).toEqual({ onDefaultBranch: true });
+            expect(res.json()).toEqual({ onDefaultBranch: true, branchName: 'pr/some-feature-branch' });
         });
 
-        it('returns onDefaultBranch on git error', async () => {
+        it('returns onDefaultBranch with branchName on git error', async () => {
             mockDetectCommitRange.mockImplementation(() => { throw new Error('not a git repo'); });
+            mockGetCurrentBranch.mockResolvedValue('my-branch');
 
             const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/git/branch-range`);
             expect(res.status).toBe(200);
-            expect(res.json()).toEqual({ onDefaultBranch: true });
+            expect(res.json()).toEqual({ onDefaultBranch: true, branchName: 'my-branch' });
         });
 
         it('returns 404 for unknown workspace', async () => {

--- a/packages/coc/test/server/git-branch-range-edge.test.ts
+++ b/packages/coc/test/server/git-branch-range-edge.test.ts
@@ -43,7 +43,6 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             detectCommitRange: mockDetectCommitRange,
             getRangeDiff: mockGetRangeDiff,
             getFileDiff: mockGetFileDiff,
-            getCurrentBranch: vi.fn().mockReturnValue('main'),
             getCurrentBranch: vi.fn().mockResolvedValue('main'),
         }); }),
     };
@@ -163,7 +162,7 @@ describe('Git Branch Range Edge Cases', () => {
             );
 
             expect(res.status).toBe(200);
-            expect(res.json()).toEqual({ onDefaultBranch: true });
+            expect(res.json()).toEqual({ onDefaultBranch: true, branchName: 'main' });
         });
 
         it('returns onDefaultBranch when base ref does not exist', async () => {
@@ -178,7 +177,7 @@ describe('Git Branch Range Edge Cases', () => {
 
             // API returns onDefaultBranch on any git error (documented behavior)
             expect(res.status).toBe(200);
-            expect(res.json()).toEqual({ onDefaultBranch: true });
+            expect(res.json()).toEqual({ onDefaultBranch: true, branchName: 'main' });
         });
     });
 


### PR DESCRIPTION
- Server: when detectCommitRange returns null or throws, call getCurrentBranch()
  and include the result as branchName in the { onDefaultBranch: true } response.
  This eliminates the hardcoded 'main' fallback on the client when the user is on
  any non-default branch.

- Client type (GitDefaultBranchResponse): add optional branchName field.

- Client (RepoGitTab): remove hardcoded 'main' last-resort fallback; use empty
  string so the UI shows the real branch or nothing rather than a misleading name.

- Client (WebSocket git-changed handler): clear the client-side branch range cache
  and re-fetch branch range alongside commits so branch switches are reflected
  immediately without requiring a manual Refresh click.

- Tests: add getCurrentBranch mock to GitRangeService, update assertions in both
  git-branch-range-api.test.ts and git-branch-range-edge.test.ts to expect
  branchName in onDefaultBranch responses, add new test cases for the two
  onDefaultBranch scenarios (null range and git error).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
