### PR TITLE
pr/6e4e30251 featssh server ac 01 add sshremoteserver

### DIFF
--- a/.github/skills/coc-knowledge/references/ralph.md
+++ b/.github/skills/coc-knowledge/references/ralph.md
@@ -123,11 +123,30 @@ working-directory-relative `Plans/<area>/<feature>/` when none is given.
 
 Session resume endpoints share infrastructure in
 `packages/coc/src/server/routes/ralph-route-utils.ts`.
-`/continue` and `/new-loop` both use it for in-flight Ralph task scans,
-`additionalIterations` validation/default resolution, resume hard caps, and
-best-effort recovery of `workingDirectory` / `folderPath` from the latest
+`/continue`, `/new-loop`, and `/resume` all use it for in-flight Ralph task
+scans, `additionalIterations` validation/default resolution, resume hard caps,
+and best-effort recovery of `workingDirectory` / `folderPath` from the latest
 iteration process. Final-check gap-fix loops use the same additional-iteration
 resolver so per-repo `maxRalphIterations` fallback stays consistent.
+
+### Resume Stuck Executing Sessions
+
+`POST /api/workspaces/:workspaceId/ralph-sessions/:sessionId/resume`
+(`packages/coc/src/server/routes/ralph-resume-routes.ts`) handles sessions
+stuck in `phase=executing` with no in-flight task — the typical outcome when
+the last iteration's task failed/was cancelled or the server crashed mid-loop.
+
+Eligibility: `phase === 'executing'` AND `currentIteration < maxIterations`
+AND no queued/running task for this `sessionId`.
+
+The endpoint appends a resume marker to `progress.md` (via
+`appendResumeMarker`) and enqueues iteration `currentIteration + 1` without
+changing `maxIterations`. If the session has reached its cap, the endpoint
+returns 409 directing the user to `/continue` instead.
+
+The SPA `RalphWorkflowPane` shows a "Resume" button (amber) when it detects
+a stuck executing session (phase executing, iterations > 0, no iteration with
+status `running`). `coc-client` exposes `resumeRalphSession()`.
 
 ## Scheduled Ralph Runs
 

--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -83,7 +83,7 @@ CoC server exposes HTTP endpoints organized by domain. All routes are registered
 | POST | `/api/processes/:id/ralph-start` | Start Ralph execution after grilling |
 | POST | `/api/ralph-launch` | Direct Ralph launch (skip grilling) |
 | GET | `/api/workspaces/:wsId/ralph-sessions/:sessionId` | Read session journal (record + progress sections) |
-| POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/continue` | Extend cap-reached session by N iterations |
+| POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/continue` | Extend completed session (CAP_REACHED or NO_SIGNAL) by N iterations |
 | POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/new-loop` | New goal loop after RALPH_COMPLETE |
 | POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/resume` | Resume stuck executing session (no in-flight task) |
 

--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -76,6 +76,17 @@ CoC server exposes HTTP endpoints organized by domain. All routes are registered
 | POST | `/api/queue/:id/cancel` | Cancel queued task |
 | PATCH | `/api/queue/pause` | Pause/resume queue |
 
+## Ralph Sessions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/processes/:id/ralph-start` | Start Ralph execution after grilling |
+| POST | `/api/ralph-launch` | Direct Ralph launch (skip grilling) |
+| GET | `/api/workspaces/:wsId/ralph-sessions/:sessionId` | Read session journal (record + progress sections) |
+| POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/continue` | Extend cap-reached session by N iterations |
+| POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/new-loop` | New goal loop after RALPH_COMPLETE |
+| POST | `/api/workspaces/:wsId/ralph-sessions/:sessionId/resume` | Resume stuck executing session (no in-flight task) |
+
 ## Schedules
 
 | Method | Path | Description |

--- a/packages/coc-client/src/contracts/servers.ts
+++ b/packages/coc-client/src/contracts/servers.ts
@@ -1,4 +1,4 @@
-export type RemoteServerKind = 'url' | 'devtunnel';
+export type RemoteServerKind = 'url' | 'devtunnel' | 'ssh';
 export type RemoteServerRuntimeStatus = 'idle' | 'connecting' | 'online' | 'offline' | 'failed';
 
 export interface BaseRemoteServer {
@@ -25,15 +25,23 @@ export interface DevTunnelRemoteServer extends BaseRemoteServer {
   tunnelId: string;
 }
 
-export type RemoteServer = UrlRemoteServer | DevTunnelRemoteServer;
+export interface SshRemoteServer extends BaseRemoteServer {
+  kind: 'ssh';
+  host: string;       // SSH config alias, e.g. "ubuntu-arm"
+  localPort: number;  // forwarded local port, e.g. 4000
+}
+
+export type RemoteServer = UrlRemoteServer | DevTunnelRemoteServer | SshRemoteServer;
 
 export type RemoteServerInput =
   | { kind: 'url'; label: string; url: string }
-  | { kind: 'devtunnel'; label: string; tunnelId: string };
+  | { kind: 'devtunnel'; label: string; tunnelId: string }
+  | { kind: 'ssh'; label: string; host: string; localPort: number };
 
 export type RemoteServerPatch =
   | { label?: string; kind?: 'url'; url?: string }
-  | { label?: string; kind?: 'devtunnel'; tunnelId?: string };
+  | { label?: string; kind?: 'devtunnel'; tunnelId?: string }
+  | { label?: string; kind?: 'ssh'; host?: string; localPort?: number };
 
 export interface RemoteServerHealth {
   serverId: string;

--- a/packages/coc-client/src/contracts/workspaces.ts
+++ b/packages/coc-client/src/contracts/workspaces.ts
@@ -394,3 +394,12 @@ export interface RalphNewLoopResponse {
   nextIteration: number;
   newMaxIterations: number;
 }
+
+export interface RalphResumeResponse {
+  resumed: true;
+  sessionId: string;
+  workspaceId: string;
+  taskId: string;
+  nextIteration: number;
+  maxIterations: number;
+}

--- a/packages/coc-client/src/domains/workspaces.ts
+++ b/packages/coc-client/src/domains/workspaces.ts
@@ -18,6 +18,7 @@ import type {
   MyWorkSyncResponse,
   RalphContinueResponse,
   RalphNewLoopResponse,
+  RalphResumeResponse,
   RalphSessionResponse,
   RegisterWorkspaceRequest,
   TerminalPinResponse,
@@ -265,6 +266,21 @@ export class WorkspacesClient {
     return this.transport.request<RalphNewLoopResponse>(
       `/workspaces/${encodePathSegment(workspaceId)}/ralph-sessions/${encodePathSegment(sessionId)}/new-loop`,
       { method: 'POST', body },
+    );
+  }
+
+  /**
+   * Resume a Ralph session stuck in `executing` phase with no in-flight task
+   * (e.g. after a task failure or server crash). Enqueues the next iteration
+   * without changing the iteration cap.
+   */
+  resumeRalphSession(
+    workspaceId: string,
+    sessionId: string,
+  ): Promise<RalphResumeResponse> {
+    return this.transport.request<RalphResumeResponse>(
+      `/workspaces/${encodePathSegment(workspaceId)}/ralph-sessions/${encodePathSegment(sessionId)}/resume`,
+      { method: 'POST' },
     );
   }
 

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -50,6 +50,7 @@ import { NotesGitTimerManager } from './notes/git/notes-git-timer-manager';
 import { migrateWorkspaceRegistryIfNeeded } from './storage/startup-workspace-migration';
 import { migrateProcessHistoryIfNeeded } from './storage/startup-process-migration';
 import { DevTunnelConnector } from './servers/devtunnel-connector';
+import { SshConnector } from './servers/ssh-connector';
 import { RemoteServerStore } from './servers/remote-server-store';
 import { pruneAllStaleClassifications } from './repos/classification-store';
 import { SyncEngine } from './sync/sync-engine';
@@ -78,6 +79,7 @@ interface CloseHandlerDeps {
     terminalWsServer?: { closeAll(): void };
     terminalSessionManager?: { destroyAll(): void };
     remoteServerConnector: { dispose(): void };
+    remoteServerSshConnector: { dispose(): void };
     loopExecutor?: { shutdownAll(): void };
     loopInfraDispose?: () => void;
     mcpOauthDispose?: () => void;
@@ -124,6 +126,7 @@ function buildCloseHandler(deps: CloseHandlerDeps): (opts?: ServerCloseOptions) 
         deps.terminalSessionManager?.destroyAll();
         deps.terminalWsServer?.closeAll();
         deps.remoteServerConnector.dispose();
+        deps.remoteServerSshConnector.dispose();
         wsServer.closeAll();
         for (const socket of activeSockets) {
             socket.destroy();
@@ -467,6 +470,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     const notesGitTimerManager = new NotesGitTimerManager();
     const remoteServerStore = new RemoteServerStore(dataDir);
     const remoteServerConnector = new DevTunnelConnector();
+    const remoteServerSshConnector = new SshConnector();
 
     // Sync engines — one per virtual workspace, only active when gitRemote is configured.
     const syncEngines = new Map<string, SyncEngine>();
@@ -493,6 +497,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         runtimeConfigService,
         remoteServerStore,
         remoteServerConnector,
+        remoteServerSshConnector,
         loopStore: loopInfra?.loopStore,
         loopExecutor: loopInfra?.loopExecutor,
         mcpOauthManager: mcpOauthInfra?.manager,
@@ -619,8 +624,9 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     await new Promise<void>((resolve, reject) => { server.on('error', reject); server.listen(port, host, resolve); });
     try {
         void remoteServerConnector.connectConfigured(remoteServerStore.list());
+        void remoteServerSshConnector.connectConfigured(remoteServerStore.list());
     } catch (error) {
-        process.stderr.write(`[servers] Failed to start DevTunnel connectors: ${error instanceof Error ? error.message : String(error)}\n`);
+        process.stderr.write(`[servers] Failed to start remote server connectors: ${error instanceof Error ? error.message : String(error)}\n`);
     }
     cleanupAllStalePasteFiles(dataDir).catch(() => { /* best-effort */ });
     try {
@@ -674,6 +680,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
             terminalWsServer: terminalInfra?.terminalWsServer,
             terminalSessionManager: terminalInfra?.terminalSessionManager,
             remoteServerConnector,
+            remoteServerSshConnector,
             loopExecutor: loopInfra?.loopExecutor,
             loopInfraDispose: loopInfra?.dispose,
             mcpOauthDispose: mcpOauthInfra?.dispose,

--- a/packages/coc/src/server/ralph/ralph-session-store.ts
+++ b/packages/coc/src/server/ralph/ralph-session-store.ts
@@ -384,6 +384,45 @@ export class RalphSessionStore {
     }
 
     /**
+     * Append a "Session resumed at <ts> — picking up from iteration <N>" banner
+     * to `progress.md`. Idempotent against double-appends within the same tick.
+     */
+    async appendResumeMarker(
+        workspaceId: string,
+        sessionId: string,
+        lastIteration: number,
+        nowIso?: string,
+    ): Promise<void> {
+        const dir = this.getSessionDir(workspaceId, sessionId);
+        await fs.promises.mkdir(dir, { recursive: true });
+        const progressPath = this.getProgressPath(workspaceId, sessionId);
+        const ts = nowIso ?? new Date().toISOString();
+        const marker = `\n---\n## Session resumed at ${ts} — picking up from iteration ${lastIteration}\n`;
+
+        try {
+            const stat = await fs.promises.stat(progressPath);
+            const readBytes = Math.min(stat.size, 1024);
+            if (readBytes > 0) {
+                const fd = await fs.promises.open(progressPath, 'r');
+                try {
+                    const buf = Buffer.alloc(readBytes);
+                    await fd.read(buf, 0, readBytes, stat.size - readBytes);
+                    const tail = buf.toString('utf-8');
+                    if (tail.includes(`## Session resumed at ${ts} — picking up from iteration ${lastIteration}`)) {
+                        return;
+                    }
+                } finally {
+                    await fd.close();
+                }
+            }
+        } catch {
+            // Missing file — fall through and append (which will create it).
+        }
+
+        await fs.promises.appendFile(progressPath, marker, 'utf-8');
+    }
+
+    /**
      * Append a final-check section to `progress.md`.
      *
      * The `content` is raw Markdown. The caller is responsible for formatting

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -78,6 +78,7 @@ import type { TerminalSessionManager } from '../terminal/index';
 import { registerRemoteServerRoutes } from '../servers/remote-server-routes';
 import { RemoteServerStore } from '../servers/remote-server-store';
 import { DevTunnelConnector } from '../servers/devtunnel-connector';
+import type { SshConnector } from '../servers/ssh-connector';
 import { registerRalphRoutes } from './queue-ralph-routes';
 import { registerRalphSessionRoutes } from './ralph-session-routes';
 import { registerRalphContinueRoutes } from './ralph-continue-routes';
@@ -141,6 +142,7 @@ export interface RegisterRoutesOptions {
     runtimeConfigService?: RuntimeConfigService;
     remoteServerStore?: RemoteServerStore;
     remoteServerConnector?: DevTunnelConnector;
+    remoteServerSshConnector?: SshConnector;
     loopStore?: LoopStore;
     loopExecutor?: LoopExecutor;
     mcpOauthManager?: McpOauthManager;
@@ -187,6 +189,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerRemoteServerRoutes(routes, {
         store: opts.remoteServerStore ?? new RemoteServerStore(dataDir),
         connector: opts.remoteServerConnector ?? new DevTunnelConnector(),
+        sshConnector: opts.remoteServerSshConnector,
     });
     registerProviderRoutes(routes, dataDir);
     // Provider SDK install routes (on-demand install of @openai/codex-sdk and @anthropic-ai/claude-agent-sdk).

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -84,6 +84,7 @@ import { registerRalphContinueRoutes } from './ralph-continue-routes';
 import { registerRalphNewLoopRoutes } from './ralph-new-loop-routes';
 import { registerRalphPromoteRoutes } from './ralph-promote-routes';
 import { registerRalphLaunchRoutes } from './ralph-launch-routes';
+import { registerRalphResumeRoutes } from './ralph-resume-routes';
 import { registerLoopRoutes } from '../loops/loop-handler';
 import type { LoopStore } from '../loops/loop-store';
 import type { LoopExecutor, LoopEventEmit } from '../loops/loop-executor';
@@ -428,6 +429,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerRalphNewLoopRoutes(routes, { bridge, store, dataDir });
     registerRalphPromoteRoutes(routes, { bridge, store, dataDir });
     registerRalphLaunchRoutes(routes, { bridge, dataDir });
+    registerRalphResumeRoutes(routes, { bridge, store, dataDir });
 
     // Work item routes
     const workItemStore = new FileWorkItemStore({ dataDir });

--- a/packages/coc/src/server/routes/ralph-continue-routes.ts
+++ b/packages/coc/src/server/routes/ralph-continue-routes.ts
@@ -1,11 +1,13 @@
 /**
  * POST /api/workspaces/:workspaceId/ralph-sessions/:sessionId/continue
  *
- * Extends a Ralph session that hit its iteration cap (terminalReason
- * `CAP_REACHED`, or `NO_SIGNAL` with `currentIteration === maxIterations`)
- * by N additional iterations. Same `sessionId`, same `progress.md` and
- * `session.json` — appends a continuation banner and enqueues iteration
- * `currentIteration + 1`.
+ * Extends a completed Ralph session by N additional iterations. Covers:
+ *   - `CAP_REACHED` — agent wanted to continue but hit the iteration cap
+ *   - `NO_SIGNAL` — agent stopped without emitting RALPH_NEXT / RALPH_COMPLETE
+ *     (either at the cap or due to an agent failure mid-run)
+ *
+ * Same `sessionId`, same `progress.md` and `session.json` — appends a
+ * continuation banner and enqueues iteration `currentIteration + 1`.
  */
 
 import { sendJSON, sendError, parseBody } from '../core/api-handler';
@@ -39,8 +41,7 @@ export function isResumableTerminalState(record: RalphSessionRecord): boolean {
     if (record.terminalReason === 'CAP_REACHED') {
         return true;
     }
-    if (record.terminalReason === 'NO_SIGNAL'
-        && record.currentIteration >= record.maxIterations) {
+    if (record.terminalReason === 'NO_SIGNAL') {
         return true;
     }
     return false;
@@ -87,8 +88,6 @@ export function registerRalphContinueRoutes(routes: Route[], ctx: RalphContinueR
                     detail = 'Session was marked RALPH_COMPLETE; start a new loop instead';
                 } else if (record.terminalReason === 'CANCELLED') {
                     detail = 'Session was cancelled; start a new loop instead';
-                } else if (record.terminalReason === 'NO_SIGNAL') {
-                    detail = 'NO_SIGNAL session has not yet reached its iteration cap';
                 }
                 return sendError(res, 409, detail);
             }

--- a/packages/coc/src/server/routes/ralph-resume-routes.ts
+++ b/packages/coc/src/server/routes/ralph-resume-routes.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /api/workspaces/:workspaceId/ralph-sessions/:sessionId/resume
+ *
+ * Resumes a Ralph session that is stuck in `phase=executing` with no
+ * in-flight task (i.e. the last iteration failed, was cancelled, or the
+ * server crashed mid-loop). Re-enqueues the next iteration without
+ * changing `maxIterations`.
+ *
+ * Contrast with `/continue` which extends a completed-at-cap session.
+ */
+
+import { sendJSON, sendError, parseBody } from '../core/api-handler';
+import type { Route } from '../types';
+import type { MultiRepoQueueRouter } from '../queue/multi-repo-queue-router';
+import type { ProcessStore } from '@plusplusoneplusplus/forge';
+import { getLogger, LogCategory } from '@plusplusoneplusplus/forge';
+import { RalphSessionStore } from '../ralph/ralph-session-store';
+import { buildRalphIterationTask } from '../ralph/enqueue-iteration';
+import {
+    findInFlightRalphTask,
+    recoverIterationPaths,
+} from './ralph-route-utils';
+
+export interface RalphResumeRouteContext {
+    bridge: MultiRepoQueueRouter;
+    store: ProcessStore;
+    dataDir: string;
+}
+
+export function registerRalphResumeRoutes(routes: Route[], ctx: RalphResumeRouteContext): void {
+    const { bridge, store, dataDir } = ctx;
+
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/workspaces\/([^/]+)\/ralph-sessions\/([^/]+)\/resume$/,
+        handler: async (req, res, match) => {
+            const workspaceId = match?.[1] ? decodeURIComponent(match[1]) : undefined;
+            const sessionId = match?.[2] ? decodeURIComponent(match[2]) : undefined;
+            if (!workspaceId || !sessionId) {
+                return sendError(res, 400, 'Missing workspaceId or sessionId');
+            }
+
+            // Accept but ignore an empty body for consistency with /continue.
+            try { await parseBody(req); } catch { /* ignore */ }
+
+            const journal = new RalphSessionStore({ dataDir });
+            const record = await journal.readSessionRecord(workspaceId, sessionId);
+            if (!record) {
+                return sendError(res, 404, 'Ralph session not found');
+            }
+
+            if (record.phase !== 'executing') {
+                return sendError(
+                    res,
+                    409,
+                    `Session phase is "${record.phase}"; resume is only for stuck executing sessions`,
+                );
+            }
+
+            if (record.currentIteration >= record.maxIterations) {
+                return sendError(
+                    res,
+                    409,
+                    'Session has reached its iteration cap; use /continue instead to extend the cap',
+                );
+            }
+
+            const inFlight = findInFlightRalphTask(bridge, sessionId);
+            if (inFlight) {
+                return sendError(res, 409, `A Ralph task for this session is still ${inFlight.status}`);
+            }
+
+            const { workingDirectory, folderPath } = await recoverIterationPaths(record, store, workspaceId);
+
+            const nowIso = new Date().toISOString();
+            try {
+                await journal.appendResumeMarker(workspaceId, sessionId, record.currentIteration, nowIso);
+            } catch (err) {
+                getLogger().debug(
+                    LogCategory.AI,
+                    `[Ralph] appendResumeMarker failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+
+            const nextIteration = record.currentIteration + 1;
+            const taskInput = buildRalphIterationTask({
+                workspaceId,
+                workingDirectory,
+                folderPath,
+                sessionId,
+                originalGoal: record.originalGoal,
+                iteration: nextIteration,
+                maxIterations: record.maxIterations,
+                dataDir,
+            });
+
+            let taskId: string;
+            try {
+                taskId = await bridge.enqueue(taskInput as any);
+            } catch (err) {
+                getLogger().warn(
+                    LogCategory.AI,
+                    `[Ralph] resume enqueue failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+                return sendError(res, 500, 'Failed to enqueue next iteration');
+            }
+
+            sendJSON(res, 200, {
+                resumed: true,
+                sessionId,
+                workspaceId,
+                taskId,
+                nextIteration,
+                maxIterations: record.maxIterations,
+            });
+        },
+    });
+}

--- a/packages/coc/src/server/servers/remote-server-routes.ts
+++ b/packages/coc/src/server/servers/remote-server-routes.ts
@@ -1,6 +1,7 @@
 import type { Route } from '../types';
 import { readJsonBody, send400, send404, send500, sendError, sendJson } from '../shared/router';
 import type { DevTunnelConnector } from './devtunnel-connector';
+import type { SshConnector, SshConnectionState } from './ssh-connector';
 import { checkRemoteServerHealth } from './remote-server-health';
 import type {
     DevTunnelRemoteServer,
@@ -15,9 +16,10 @@ import { RemoteServerStore } from './remote-server-store';
 export interface RegisterRemoteServerRoutesOptions {
     store: RemoteServerStore;
     connector: DevTunnelConnector;
+    sshConnector?: SshConnector;
 }
 
-function toRuntime(server: RemoteServer, connector: DevTunnelConnector): RemoteServerRuntime {
+function toRuntime(server: RemoteServer, connector: DevTunnelConnector, sshConnector?: SshConnector): RemoteServerRuntime {
     if (server.kind === 'url') {
         return {
             serverId: server.id,
@@ -27,12 +29,15 @@ function toRuntime(server: RemoteServer, connector: DevTunnelConnector): RemoteS
         };
     }
     if (server.kind === 'ssh') {
-        // SSH connector is registered separately; runtime managed by SshConnector (AC-02).
+        const state: SshConnectionState | undefined = sshConnector?.getState(server.id);
         return {
             serverId: server.id,
             kind: 'ssh',
-            status: 'idle',
+            effectiveUrl: state?.effectiveUrl,
+            status: state?.status ?? 'idle',
             localPort: server.localPort,
+            lastChecked: state?.lastChecked,
+            lastError: state?.lastError,
         };
     }
     const state = connector.getState(server.tunnelId);
@@ -49,8 +54,8 @@ function toRuntime(server: RemoteServer, connector: DevTunnelConnector): RemoteS
     };
 }
 
-function decorate(server: RemoteServer, connector: DevTunnelConnector): RemoteServerWithRuntime {
-    const runtime = toRuntime(server, connector);
+function decorate(server: RemoteServer, connector: DevTunnelConnector, sshConnector?: SshConnector): RemoteServerWithRuntime {
+    const runtime = toRuntime(server, connector, sshConnector);
     return {
         ...server,
         effectiveUrl: runtime.effectiveUrl,
@@ -74,6 +79,17 @@ async function connectIfDevTunnel(server: RemoteServer, connector: DevTunnelConn
     }
 }
 
+async function connectIfSsh(server: RemoteServer, sshConnector?: SshConnector): Promise<void> {
+    if (server.kind !== 'ssh' || !sshConnector) {
+        return;
+    }
+    try {
+        await sshConnector.connect(server);
+    } catch {
+        // The failed state is stored on the connector and returned to the caller.
+    }
+}
+
 function disconnectIfUnusedTunnel(tunnelId: string, store: RemoteServerStore, connector: DevTunnelConnector): void {
     const stillUsed = store.list().some(server => server.kind === 'devtunnel' && server.tunnelId === tunnelId);
     if (!stillUsed) {
@@ -81,11 +97,14 @@ function disconnectIfUnusedTunnel(tunnelId: string, store: RemoteServerStore, co
     }
 }
 
-async function healthForServer(server: RemoteServer, connector: DevTunnelConnector) {
+async function healthForServer(server: RemoteServer, connector: DevTunnelConnector, sshConnector?: SshConnector) {
     if (server.kind === 'devtunnel') {
         await connectIfDevTunnel(server, connector);
     }
-    const runtime = toRuntime(server, connector);
+    if (server.kind === 'ssh') {
+        await connectIfSsh(server, sshConnector);
+    }
+    const runtime = toRuntime(server, connector, sshConnector);
     const baseUrl = server.kind === 'url' ? server.url : runtime.effectiveUrl;
     return checkRemoteServerHealth({
         serverId: server.id,
@@ -101,14 +120,14 @@ export function registerRemoteServerRoutes(
     routes: Route[],
     options: RegisterRemoteServerRoutesOptions,
 ): void {
-    const { store, connector } = options;
+    const { store, connector, sshConnector } = options;
 
     routes.push({
         method: 'GET',
         pattern: '/api/servers',
         handler: (_req, res) => {
             try {
-                sendJson(res, store.list().map(server => decorate(server, connector)));
+                sendJson(res, store.list().map(server => decorate(server, connector, sshConnector)));
             } catch (error) {
                 send500(res, error instanceof Error ? error.message : String(error));
             }
@@ -122,7 +141,8 @@ export function registerRemoteServerRoutes(
             try {
                 const server = store.create(await readJsonBody(req));
                 await connectIfDevTunnel(server, connector);
-                sendJson(res, decorate(server, connector), 201);
+                await connectIfSsh(server, sshConnector);
+                sendJson(res, decorate(server, connector, sshConnector), 201);
             } catch (error) {
                 send400(res, error instanceof Error ? error.message : String(error));
             }
@@ -144,8 +164,12 @@ export function registerRemoteServerRoutes(
                 if (before.kind === 'devtunnel' && (updated.kind !== 'devtunnel' || updated.tunnelId !== before.tunnelId)) {
                     disconnectIfUnusedTunnel(before.tunnelId, store, connector);
                 }
+                if (before.kind === 'ssh' && updated.kind !== 'ssh') {
+                    sshConnector?.disconnect(before.id);
+                }
                 await connectIfDevTunnel(updated, connector);
-                sendJson(res, decorate(updated, connector));
+                await connectIfSsh(updated, sshConnector);
+                sendJson(res, decorate(updated, connector, sshConnector));
             } catch (error) {
                 send400(res, error instanceof Error ? error.message : String(error));
             }
@@ -164,6 +188,9 @@ export function registerRemoteServerRoutes(
             }
             if (removed.kind === 'devtunnel') {
                 disconnectIfUnusedTunnel(removed.tunnelId, store, connector);
+            }
+            if (removed.kind === 'ssh') {
+                sshConnector?.disconnect(removed.id);
             }
             sendJson(res, { ok: true });
         },
@@ -192,7 +219,7 @@ export function registerRemoteServerRoutes(
                         addedAt: Date.now(),
                         updatedAt: Date.now(),
                     };
-                    sendJson(res, await healthForServer(server, connector));
+                    sendJson(res, await healthForServer(server, connector, sshConnector));
                     return;
                 }
                 // ssh kind: health check against the local forwarded port (no spawn at test time)
@@ -205,7 +232,7 @@ export function registerRemoteServerRoutes(
                     addedAt: Date.now(),
                     updatedAt: Date.now(),
                 };
-                sendJson(res, await healthForServer(server, connector));
+                sendJson(res, await healthForServer(server, connector, sshConnector));
             } catch (error) {
                 send400(res, error instanceof Error ? error.message : String(error));
             }
@@ -222,12 +249,17 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            if (server.kind !== 'devtunnel') {
+            if (server.kind === 'url') {
                 sendError(res, 400, 'Direct URL servers do not support connect');
                 return;
             }
+            if (server.kind === 'ssh') {
+                await connectIfSsh(server, sshConnector);
+                sendJson(res, toRuntime(server, connector, sshConnector));
+                return;
+            }
             await connectIfDevTunnel(server, connector);
-            sendJson(res, toRuntime(server, connector));
+            sendJson(res, toRuntime(server, connector, sshConnector));
         },
     });
 
@@ -241,8 +273,13 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            if (server.kind !== 'devtunnel') {
+            if (server.kind === 'url') {
                 sendError(res, 400, 'Direct URL servers do not support disconnect');
+                return;
+            }
+            if (server.kind === 'ssh') {
+                const state = sshConnector?.disconnect(server.id) ?? { serverId: server.id, host: server.host, localPort: server.localPort, status: 'idle' as const };
+                sendJson(res, { kind: 'ssh' as const, ...state });
                 return;
             }
             sendJson(res, {
@@ -263,8 +300,19 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            if (server.kind !== 'devtunnel') {
+            if (server.kind === 'url') {
                 sendError(res, 400, 'Direct URL servers do not support reconnect');
+                return;
+            }
+            if (server.kind === 'ssh') {
+                if (sshConnector) {
+                    try {
+                        await sshConnector.reconnect(server);
+                    } catch {
+                        // Failed state is stored on the connector.
+                    }
+                }
+                sendJson(res, toRuntime(server, connector, sshConnector));
                 return;
             }
             try {
@@ -272,7 +320,7 @@ export function registerRemoteServerRoutes(
             } catch {
                 // The failed state is stored on the connector and returned below.
             }
-            sendJson(res, toRuntime(server, connector));
+            sendJson(res, toRuntime(server, connector, sshConnector));
         },
     });
 
@@ -286,7 +334,7 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            sendJson(res, await healthForServer(server, connector));
+            sendJson(res, await healthForServer(server, connector, sshConnector));
         },
     });
 
@@ -300,7 +348,7 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            sendJson(res, toRuntime(server, connector));
+            sendJson(res, toRuntime(server, connector, sshConnector));
         },
     });
 }

--- a/packages/coc/src/server/servers/remote-server-routes.ts
+++ b/packages/coc/src/server/servers/remote-server-routes.ts
@@ -8,6 +8,7 @@ import type {
     RemoteServerCreateInput,
     RemoteServerRuntime,
     RemoteServerWithRuntime,
+    SshRemoteServer,
 } from './remote-server-types';
 import { RemoteServerStore } from './remote-server-store';
 
@@ -23,6 +24,15 @@ function toRuntime(server: RemoteServer, connector: DevTunnelConnector): RemoteS
             kind: 'url',
             effectiveUrl: server.url,
             status: 'idle',
+        };
+    }
+    if (server.kind === 'ssh') {
+        // SSH connector is registered separately; runtime managed by SshConnector (AC-02).
+        return {
+            serverId: server.id,
+            kind: 'ssh',
+            status: 'idle',
+            localPort: server.localPort,
         };
     }
     const state = connector.getState(server.tunnelId);
@@ -173,11 +183,25 @@ export function registerRemoteServerRoutes(
                     }));
                     return;
                 }
-                const server: DevTunnelRemoteServer = {
+                if (input.kind === 'devtunnel') {
+                    const server: DevTunnelRemoteServer = {
+                        id: 'test',
+                        label: input.label,
+                        kind: 'devtunnel',
+                        tunnelId: input.tunnelId,
+                        addedAt: Date.now(),
+                        updatedAt: Date.now(),
+                    };
+                    sendJson(res, await healthForServer(server, connector));
+                    return;
+                }
+                // ssh kind: health check against the local forwarded port (no spawn at test time)
+                const server: SshRemoteServer = {
                     id: 'test',
                     label: input.label,
-                    kind: 'devtunnel',
-                    tunnelId: input.tunnelId,
+                    kind: 'ssh',
+                    host: input.host,
+                    localPort: input.localPort,
                     addedAt: Date.now(),
                     updatedAt: Date.now(),
                 };

--- a/packages/coc/src/server/servers/remote-server-store.ts
+++ b/packages/coc/src/server/servers/remote-server-store.ts
@@ -6,6 +6,7 @@ import type {
     RemoteServer,
     RemoteServerCreateInput,
     RemoteServerUpdateInput,
+    SshRemoteServer,
     UrlRemoteServer,
 } from './remote-server-types';
 
@@ -67,6 +68,25 @@ export function normalizeTunnelId(value: unknown): string {
     return trimmed;
 }
 
+export function normalizeSshHost(value: unknown): string {
+    if (typeof value !== 'string') {
+        throw new Error('host must be a string');
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        throw new Error('host is required');
+    }
+    return trimmed;
+}
+
+export function normalizeSshLocalPort(value: unknown): number {
+    const num = typeof value === 'string' ? parseInt(value, 10) : value;
+    if (typeof num !== 'number' || !Number.isInteger(num) || num < 1 || num > 65535) {
+        throw new Error('localPort must be an integer between 1 and 65535');
+    }
+    return num;
+}
+
 function parseRemoteServer(value: unknown): RemoteServer | undefined {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
         return undefined;
@@ -97,6 +117,17 @@ function parseRemoteServer(value: unknown): RemoteServer | undefined {
             updatedAt,
         };
     }
+    if (item.kind === 'ssh') {
+        return {
+            id: item.id,
+            label: item.label,
+            kind: 'ssh',
+            host: normalizeSshHost(item.host),
+            localPort: normalizeSshLocalPort(item.localPort),
+            addedAt,
+            updatedAt,
+        };
+    }
     return undefined;
 }
 
@@ -109,7 +140,10 @@ function buildCreateInput(value: unknown): RemoteServerCreateInput {
     if (kind === 'devtunnel') {
         return { kind, label: normalizeLabel(body.label), tunnelId: normalizeTunnelId(body.tunnelId) };
     }
-    throw new Error('kind must be "url" or "devtunnel"');
+    if (kind === 'ssh') {
+        return { kind, label: normalizeLabel(body.label), host: normalizeSshHost(body.host), localPort: normalizeSshLocalPort(body.localPort) };
+    }
+    throw new Error('kind must be "url", "devtunnel", or "ssh"');
 }
 
 function buildUpdateInput(value: unknown): RemoteServerUpdateInput {
@@ -119,8 +153,8 @@ function buildUpdateInput(value: unknown): RemoteServerUpdateInput {
         patch.label = normalizeLabel(body.label);
     }
     if ('kind' in body) {
-        if (body.kind !== 'url' && body.kind !== 'devtunnel') {
-            throw new Error('kind must be "url" or "devtunnel"');
+        if (body.kind !== 'url' && body.kind !== 'devtunnel' && body.kind !== 'ssh') {
+            throw new Error('kind must be "url", "devtunnel", or "ssh"');
         }
         patch.kind = body.kind;
     }
@@ -130,7 +164,13 @@ function buildUpdateInput(value: unknown): RemoteServerUpdateInput {
     if ('tunnelId' in body) {
         (patch as { tunnelId?: string }).tunnelId = normalizeTunnelId(body.tunnelId);
     }
-    if (!('label' in patch) && !('kind' in patch) && !('url' in patch) && !('tunnelId' in patch)) {
+    if ('host' in body) {
+        (patch as { host?: string }).host = normalizeSshHost(body.host);
+    }
+    if ('localPort' in body) {
+        (patch as { localPort?: number }).localPort = normalizeSshLocalPort(body.localPort);
+    }
+    if (!('label' in patch) && !('kind' in patch) && !('url' in patch) && !('tunnelId' in patch) && !('host' in patch) && !('localPort' in patch)) {
         throw new Error('Request body must contain at least one editable field');
     }
     return patch;
@@ -162,9 +202,14 @@ export class RemoteServerStore {
     create(value: unknown): RemoteServer {
         const input = buildCreateInput(value);
         const now = Date.now();
-        const server: RemoteServer = input.kind === 'url'
-            ? { id: randomUUID(), kind: 'url', label: input.label, url: input.url, addedAt: now, updatedAt: now }
-            : { id: randomUUID(), kind: 'devtunnel', label: input.label, tunnelId: input.tunnelId, addedAt: now, updatedAt: now };
+        let server: RemoteServer;
+        if (input.kind === 'url') {
+            server = { id: randomUUID(), kind: 'url', label: input.label, url: input.url, addedAt: now, updatedAt: now };
+        } else if (input.kind === 'devtunnel') {
+            server = { id: randomUUID(), kind: 'devtunnel', label: input.label, tunnelId: input.tunnelId, addedAt: now, updatedAt: now };
+        } else {
+            server = { id: randomUUID(), kind: 'ssh', label: input.label, host: input.host, localPort: input.localPort, addedAt: now, updatedAt: now };
+        }
         this.save([...this.list(), server]);
         return server;
     }
@@ -190,11 +235,23 @@ export class RemoteServerStore {
                 }
                 return { id: server.id, kind, label, url, addedAt: server.addedAt, updatedAt: Date.now() } satisfies UrlRemoteServer;
             }
-            const tunnelId = (patch as { tunnelId?: string }).tunnelId ?? (server.kind === 'devtunnel' ? server.tunnelId : undefined);
-            if (!tunnelId) {
-                throw new Error('tunnelId is required when kind is "devtunnel"');
+            if (kind === 'devtunnel') {
+                const tunnelId = (patch as { tunnelId?: string }).tunnelId ?? (server.kind === 'devtunnel' ? server.tunnelId : undefined);
+                if (!tunnelId) {
+                    throw new Error('tunnelId is required when kind is "devtunnel"');
+                }
+                return { id: server.id, kind, label, tunnelId, addedAt: server.addedAt, updatedAt: Date.now() } satisfies DevTunnelRemoteServer;
             }
-            return { id: server.id, kind, label, tunnelId, addedAt: server.addedAt, updatedAt: Date.now() } satisfies DevTunnelRemoteServer;
+            // kind === 'ssh'
+            const host = (patch as { host?: string }).host ?? (server.kind === 'ssh' ? server.host : undefined);
+            if (!host) {
+                throw new Error('host is required when kind is "ssh"');
+            }
+            const localPort = (patch as { localPort?: number }).localPort ?? (server.kind === 'ssh' ? server.localPort : undefined);
+            if (localPort === undefined) {
+                throw new Error('localPort is required when kind is "ssh"');
+            }
+            return { id: server.id, kind, label, host, localPort, addedAt: server.addedAt, updatedAt: Date.now() } satisfies SshRemoteServer;
         });
         if (!found) {
             throw new Error(`Remote server not found: ${id}`);

--- a/packages/coc/src/server/servers/remote-server-types.ts
+++ b/packages/coc/src/server/servers/remote-server-types.ts
@@ -1,4 +1,4 @@
-export type RemoteServerKind = 'url' | 'devtunnel';
+export type RemoteServerKind = 'url' | 'devtunnel' | 'ssh';
 
 export type RemoteServerRuntimeStatus = 'idle' | 'connecting' | 'online' | 'offline' | 'failed';
 
@@ -20,7 +20,13 @@ export interface DevTunnelRemoteServer extends BaseRemoteServer {
     tunnelId: string;
 }
 
-export type RemoteServer = UrlRemoteServer | DevTunnelRemoteServer;
+export interface SshRemoteServer extends BaseRemoteServer {
+    kind: 'ssh';
+    host: string;       // SSH config alias, e.g. "ubuntu-arm"
+    localPort: number;  // forwarded local port, e.g. 4000
+}
+
+export type RemoteServer = UrlRemoteServer | DevTunnelRemoteServer | SshRemoteServer;
 
 export interface RemoteServerRuntime {
     serverId: string;
@@ -38,11 +44,13 @@ export type RemoteServerWithRuntime = RemoteServer & Partial<Omit<RemoteServerRu
 
 export type RemoteServerCreateInput =
     | { kind: 'url'; label: string; url: string }
-    | { kind: 'devtunnel'; label: string; tunnelId: string };
+    | { kind: 'devtunnel'; label: string; tunnelId: string }
+    | { kind: 'ssh'; label: string; host: string; localPort: number };
 
 export type RemoteServerUpdateInput =
     | { label?: string; kind?: 'url'; url?: string }
-    | { label?: string; kind?: 'devtunnel'; tunnelId?: string };
+    | { label?: string; kind?: 'devtunnel'; tunnelId?: string }
+    | { label?: string; kind?: 'ssh'; host?: string; localPort?: number };
 
 export interface RemoteServerHealth {
     serverId: string;

--- a/packages/coc/src/server/servers/ssh-connector.ts
+++ b/packages/coc/src/server/servers/ssh-connector.ts
@@ -17,6 +17,8 @@ export interface SshConnectorOptions {
     healthChecker?: SshHealthChecker;
     readinessTimeoutMs?: number;
     readinessPollMs?: number;
+    initialReconnectBackoffMs?: number;
+    maxReconnectBackoffMs?: number;
 }
 
 export interface SshConnectionState {
@@ -35,6 +37,8 @@ interface ManagedSshConnection {
     child?: SshChildProcess;
     pending?: Promise<SshConnectionState>;
     intentionalStop?: boolean;
+    reconnectBackoffMs?: number;
+    reconnectTimer?: ReturnType<typeof setTimeout>;
 }
 
 function startProcess(command: string, args: string[]): SshChildProcess {
@@ -83,12 +87,16 @@ export class SshConnector {
     private readonly healthChecker: SshHealthChecker;
     private readonly readinessTimeoutMs: number;
     private readonly readinessPollMs: number;
+    private readonly initialReconnectBackoffMs: number;
+    private readonly maxReconnectBackoffMs: number;
 
     constructor(options: SshConnectorOptions = {}) {
         this.processStarter = options.processStarter ?? startProcess;
         this.healthChecker = options.healthChecker ?? defaultHealthChecker;
         this.readinessTimeoutMs = options.readinessTimeoutMs ?? 15_000;
         this.readinessPollMs = options.readinessPollMs ?? 500;
+        this.initialReconnectBackoffMs = options.initialReconnectBackoffMs ?? 2_000;
+        this.maxReconnectBackoffMs = options.maxReconnectBackoffMs ?? 30_000;
     }
 
     getState(serverId: string): SshConnectionState | undefined {
@@ -128,6 +136,10 @@ export class SshConnector {
         const entry = this.getOrCreateConnection(server);
 
         entry.intentionalStop = true;
+        if (entry.reconnectTimer) {
+            clearTimeout(entry.reconnectTimer);
+            entry.reconnectTimer = undefined;
+        }
         if (entry.child) {
             entry.child.kill();
             entry.child = undefined;
@@ -154,6 +166,10 @@ export class SshConnector {
             return { serverId, host: '', localPort: 0, status: 'idle' };
         }
         entry.intentionalStop = true;
+        if (entry.reconnectTimer) {
+            clearTimeout(entry.reconnectTimer);
+            entry.reconnectTimer = undefined;
+        }
         if (entry.child) {
             entry.child.kill();
             entry.child = undefined;
@@ -204,6 +220,7 @@ export class SshConnector {
                         lastError: `ssh process exited unexpectedly${code !== null ? ` with code ${code}` : ''}${signal ? ` signal ${signal}` : ''}`,
                         lastChecked: Date.now(),
                     };
+                    this.scheduleReconnect(server, entry);
                 });
                 child.once('error', (error) => {
                     if (entry.child !== child) {
@@ -250,6 +267,27 @@ export class SshConnector {
             };
             throw new Error(message);
         }
+    }
+
+    private scheduleReconnect(server: SshRemoteServer, entry: ManagedSshConnection): void {
+        if (entry.intentionalStop) return;
+        if (entry.reconnectTimer) {
+            clearTimeout(entry.reconnectTimer);
+        }
+        const backoff = entry.reconnectBackoffMs ?? this.initialReconnectBackoffMs;
+        entry.reconnectTimer = setTimeout(() => {
+            entry.reconnectTimer = undefined;
+            if (entry.intentionalStop || entry.pending) return;
+            entry.reconnectBackoffMs = Math.min(backoff * 2, this.maxReconnectBackoffMs);
+            entry.pending = this.connectInternal(server, entry)
+                .then(state => {
+                    entry.reconnectBackoffMs = this.initialReconnectBackoffMs;
+                    return state;
+                })
+                .finally(() => {
+                    entry.pending = undefined;
+                });
+        }, backoff);
     }
 
     private getOrCreateConnection(server: SshRemoteServer): ManagedSshConnection {

--- a/packages/coc/src/server/servers/ssh-connector.ts
+++ b/packages/coc/src/server/servers/ssh-connector.ts
@@ -1,0 +1,270 @@
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import type { RemoteServer, RemoteServerRuntimeStatus, SshRemoteServer } from './remote-server-types';
+
+export type SshProcessStarter = (command: string, args: string[]) => SshChildProcess;
+export type SshHealthChecker = (url: string, signal?: AbortSignal) => Promise<boolean>;
+
+export interface SshChildProcess {
+    pid?: number;
+    kill(signal?: NodeJS.Signals | number): boolean;
+    once(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+    once(event: 'error', listener: (error: Error) => void): this;
+}
+
+export interface SshConnectorOptions {
+    processStarter?: SshProcessStarter;
+    healthChecker?: SshHealthChecker;
+    readinessTimeoutMs?: number;
+    readinessPollMs?: number;
+}
+
+export interface SshConnectionState {
+    serverId: string;
+    host: string;
+    localPort: number;
+    effectiveUrl?: string;
+    status: RemoteServerRuntimeStatus;
+    lastError?: string;
+    startedAt?: number;
+    lastChecked?: number;
+}
+
+interface ManagedSshConnection {
+    state: SshConnectionState;
+    child?: SshChildProcess;
+    pending?: Promise<SshConnectionState>;
+    intentionalStop?: boolean;
+}
+
+function startProcess(command: string, args: string[]): SshChildProcess {
+    return spawn(command, args, {
+        windowsHide: true,
+        stdio: 'ignore',
+    }) as ChildProcess as SshChildProcess;
+}
+
+async function defaultHealthChecker(url: string, signal?: AbortSignal): Promise<boolean> {
+    const res = await fetch(`${url}/api/health`, { signal });
+    return res.ok;
+}
+
+async function waitForHealth(
+    url: string,
+    checker: SshHealthChecker,
+    timeoutMs: number,
+    pollMs: number,
+): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let lastError = '';
+    while (Date.now() <= deadline) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), Math.min(pollMs, 2_000));
+        try {
+            if (await checker(url, controller.signal)) {
+                clearTimeout(timer);
+                return;
+            }
+        } catch (err) {
+            lastError = err instanceof Error ? err.message : String(err);
+        } finally {
+            clearTimeout(timer);
+        }
+        await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+    throw new Error(lastError
+        ? `SSH tunnel did not become healthy within ${timeoutMs}ms: ${lastError}`
+        : 'SSH tunnel did not become healthy within 15s');
+}
+
+export class SshConnector {
+    private readonly connections = new Map<string, ManagedSshConnection>();
+    private readonly processStarter: SshProcessStarter;
+    private readonly healthChecker: SshHealthChecker;
+    private readonly readinessTimeoutMs: number;
+    private readonly readinessPollMs: number;
+
+    constructor(options: SshConnectorOptions = {}) {
+        this.processStarter = options.processStarter ?? startProcess;
+        this.healthChecker = options.healthChecker ?? defaultHealthChecker;
+        this.readinessTimeoutMs = options.readinessTimeoutMs ?? 15_000;
+        this.readinessPollMs = options.readinessPollMs ?? 500;
+    }
+
+    getState(serverId: string): SshConnectionState | undefined {
+        const entry = this.connections.get(serverId);
+        return entry ? { ...entry.state } : undefined;
+    }
+
+    getStates(): SshConnectionState[] {
+        return Array.from(this.connections.values()).map(entry => ({ ...entry.state }));
+    }
+
+    async connect(server: SshRemoteServer): Promise<SshConnectionState> {
+        const entry = this.getOrCreateConnection(server);
+        if (entry.pending) {
+            return entry.pending;
+        }
+        if (entry.state.status === 'online' && entry.child && entry.state.effectiveUrl) {
+            return { ...entry.state };
+        }
+
+        entry.pending = this.connectInternal(server, entry).finally(() => {
+            entry.pending = undefined;
+        });
+        return entry.pending;
+    }
+
+    async connectConfigured(servers: RemoteServer[]): Promise<SshConnectionState[]> {
+        const sshServers = servers.filter((s): s is SshRemoteServer => s.kind === 'ssh');
+        return Promise.all(
+            sshServers.map(s =>
+                this.connect(s).catch(() => this.getOrCreateConnection(s).state),
+            ),
+        );
+    }
+
+    async reconnect(server: SshRemoteServer): Promise<SshConnectionState> {
+        const entry = this.getOrCreateConnection(server);
+
+        entry.intentionalStop = true;
+        if (entry.child) {
+            entry.child.kill();
+            entry.child = undefined;
+        }
+        entry.pending = undefined;
+
+        entry.state = {
+            serverId: server.id,
+            host: server.host,
+            localPort: server.localPort,
+            status: 'connecting',
+            lastChecked: Date.now(),
+        };
+
+        entry.pending = this.connectInternal(server, entry).finally(() => {
+            entry.pending = undefined;
+        });
+        return entry.pending;
+    }
+
+    disconnect(serverId: string): SshConnectionState {
+        const entry = this.connections.get(serverId);
+        if (!entry) {
+            return { serverId, host: '', localPort: 0, status: 'idle' };
+        }
+        entry.intentionalStop = true;
+        if (entry.child) {
+            entry.child.kill();
+            entry.child = undefined;
+        }
+        entry.state = {
+            ...entry.state,
+            status: 'idle',
+            lastChecked: Date.now(),
+        };
+        entry.pending = undefined;
+        return { ...entry.state };
+    }
+
+    dispose(): void {
+        for (const [serverId] of this.connections) {
+            this.disconnect(serverId);
+        }
+        this.connections.clear();
+    }
+
+    private async connectInternal(server: SshRemoteServer, entry: ManagedSshConnection): Promise<SshConnectionState> {
+        entry.state = {
+            ...entry.state,
+            serverId: server.id,
+            host: server.host,
+            localPort: server.localPort,
+            status: 'connecting',
+            lastError: undefined,
+            lastChecked: Date.now(),
+        };
+
+        const effectiveUrl = `http://127.0.0.1:${server.localPort}`;
+
+        try {
+            if (!entry.child) {
+                entry.intentionalStop = false;
+                const child = this.processStarter('ssh', ['-N', server.host]);
+                entry.child = child;
+
+                child.once('exit', (code, signal) => {
+                    if (entry.intentionalStop || entry.child !== child) {
+                        return;
+                    }
+                    entry.child = undefined;
+                    entry.state = {
+                        ...entry.state,
+                        status: 'failed',
+                        lastError: `ssh process exited unexpectedly${code !== null ? ` with code ${code}` : ''}${signal ? ` signal ${signal}` : ''}`,
+                        lastChecked: Date.now(),
+                    };
+                });
+                child.once('error', (error) => {
+                    if (entry.child !== child) {
+                        return;
+                    }
+                    entry.child = undefined;
+                    const message = (error as NodeJS.ErrnoException).code === 'ENOENT'
+                        ? 'ssh binary not found on PATH'
+                        : error.message;
+                    entry.state = {
+                        ...entry.state,
+                        status: 'failed',
+                        lastError: message,
+                        lastChecked: Date.now(),
+                    };
+                });
+            }
+
+            await waitForHealth(effectiveUrl, this.healthChecker, this.readinessTimeoutMs, this.readinessPollMs);
+
+            entry.state = {
+                serverId: server.id,
+                host: server.host,
+                localPort: server.localPort,
+                effectiveUrl,
+                status: 'online',
+                startedAt: entry.state.startedAt ?? Date.now(),
+                lastChecked: Date.now(),
+            };
+            return { ...entry.state };
+        } catch (error) {
+            if (entry.child) {
+                entry.intentionalStop = true;
+                entry.child.kill();
+                entry.child = undefined;
+            }
+            // Prefer a process-level error (e.g. ENOENT) that was already captured on entry.state
+            const message = entry.state.lastError ?? (error instanceof Error ? error.message : String(error));
+            entry.state = {
+                ...entry.state,
+                status: 'failed',
+                lastError: message,
+                lastChecked: Date.now(),
+            };
+            throw new Error(message);
+        }
+    }
+
+    private getOrCreateConnection(server: SshRemoteServer): ManagedSshConnection {
+        let entry = this.connections.get(server.id);
+        if (!entry) {
+            entry = {
+                state: {
+                    serverId: server.id,
+                    host: server.host,
+                    localPort: server.localPort,
+                    status: 'idle',
+                },
+            };
+            this.connections.set(server.id, entry);
+        }
+        return entry;
+    }
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPane.tsx
@@ -48,6 +48,8 @@ export interface RalphWorkflowPaneProps {
     newLoopDefaultIterations?: number;
     /** Override the new-loop handler (used by tests). When omitted, falls back to the API call. */
     onNewLoop?: (newGoal: string, additionalIterations: number) => Promise<void>;
+    /** Override the resume handler (used by tests). When omitted, calls the API directly. */
+    onResume?: () => Promise<void>;
 }
 
 const PHASE_BADGE: Record<RalphSessionRecord['phase'], { label: string; cls: string }> = {
@@ -79,6 +81,7 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
         onContinue,
         newLoopDefaultIterations,
         onNewLoop,
+        onResume,
     } = props;
 
     const [continueState, setContinueState] = useState<'idle' | 'confirm' | 'submitting'>('idle');
@@ -87,6 +90,9 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
     const [newLoopState, setNewLoopState] = useState<'idle' | 'confirm' | 'submitting'>('idle');
     const [newLoopGoal, setNewLoopGoal] = useState('');
     const [newLoopError, setNewLoopError] = useState<string | null>(null);
+
+    const [resumeState, setResumeState] = useState<'idle' | 'confirm' | 'submitting'>('idle');
+    const [resumeError, setResumeError] = useState<string | null>(null);
 
     if (view === undefined) {
         return (
@@ -133,6 +139,26 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
 
     const isRalphComplete = record.phase === 'complete'
         && record.terminalReason === 'RALPH_COMPLETE';
+
+    const isStuckExecuting = record.phase === 'executing'
+        && record.currentIteration > 0
+        && !record.iterations.some(i => i.status === 'running');
+
+    const handleResumeConfirmed = async () => {
+        setResumeState('submitting');
+        setResumeError(null);
+        try {
+            if (onResume) {
+                await onResume();
+            } else {
+                await getSpaCocClient().workspaces.resumeRalphSession(workspaceId, sessionId);
+            }
+            setResumeState('idle');
+        } catch (err) {
+            setResumeError(err instanceof Error ? err.message : String(err));
+            setResumeState('confirm');
+        }
+    };
 
     const handleContinueConfirmed = async () => {
         setContinueState('submitting');
@@ -230,6 +256,16 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
                                 ↻ Continue loop
                             </button>
                         )}
+                        {isStuckExecuting && resumeState === 'idle' && (
+                            <button
+                                type="button"
+                                onClick={() => { setResumeError(null); setResumeState('confirm'); }}
+                                data-testid="ralph-workflow-resume"
+                                className="rounded border border-amber-500 bg-amber-50 px-2 py-0.5 text-[11px] text-amber-700 hover:bg-amber-100 dark:border-amber-400 dark:bg-amber-900/30 dark:text-amber-200 dark:hover:bg-amber-900/50"
+                            >
+                                ↻ Resume
+                            </button>
+                        )}
                         {RALPH_MULTI_LOOP && isRalphComplete && newLoopState === 'idle' && (
                             <button
                                 type="button"
@@ -267,6 +303,45 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
 
             {/* Timeline */}
             <div className="flex-1 overflow-y-auto px-4 py-3" data-testid="ralph-workflow-timeline">
+                {isStuckExecuting && resumeState !== 'idle' && (
+                    <div
+                        className="mb-3 rounded border border-amber-300 bg-amber-50 p-3 text-xs dark:border-amber-700 dark:bg-amber-950/40"
+                        data-testid="ralph-workflow-resume-confirm"
+                    >
+                        <p className="mb-2 font-semibold text-amber-900 dark:text-amber-100">
+                            Resume this Ralph session?
+                        </p>
+                        <p className="mb-2 text-amber-800 dark:text-amber-200">
+                            The session appears stuck (no task is running). Resuming will enqueue
+                            iteration {record.currentIteration + 1} to pick up where it left off.
+                        </p>
+                        {resumeError && (
+                            <p className="mb-2 text-red-700 dark:text-red-300" data-testid="ralph-workflow-resume-error">
+                                {resumeError}
+                            </p>
+                        )}
+                        <div className="flex justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => { setResumeState('idle'); setResumeError(null); }}
+                                disabled={resumeState === 'submitting'}
+                                className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                                data-testid="ralph-workflow-resume-cancel"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleResumeConfirmed}
+                                disabled={resumeState === 'submitting'}
+                                className="rounded border border-amber-500 bg-amber-600 px-2 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+                                data-testid="ralph-workflow-resume-confirm-button"
+                            >
+                                {resumeState === 'submitting' ? 'Resuming…' : 'Resume'}
+                            </button>
+                        </div>
+                    </div>
+                )}
                 {isCapHit && continueState !== 'idle' && (
                     <div
                         className="mb-3 rounded border border-blue-300 bg-blue-50 p-3 text-xs dark:border-blue-700 dark:bg-blue-950/40"

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPane.tsx
@@ -132,10 +132,9 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
         ...sections.map(s => s.iteration),
     ])).sort((a, b) => a - b);
 
-    const isCapHit = record.phase === 'complete'
+    const isContinuable = record.phase === 'complete'
         && (record.terminalReason === 'CAP_REACHED'
-            || (record.terminalReason === 'NO_SIGNAL'
-                && record.currentIteration >= record.maxIterations));
+            || record.terminalReason === 'NO_SIGNAL');
 
     const isRalphComplete = record.phase === 'complete'
         && record.terminalReason === 'RALPH_COMPLETE';
@@ -246,7 +245,7 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
                                 {formatRelativeTime(record.completedAt)}
                             </span>
                         )}
-                        {isCapHit && continueState === 'idle' && (
+                        {isContinuable && continueState === 'idle' && (
                             <button
                                 type="button"
                                 onClick={() => { setContinueError(null); setContinueState('confirm'); }}
@@ -342,7 +341,7 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
                         </div>
                     </div>
                 )}
-                {isCapHit && continueState !== 'idle' && (
+                {isContinuable && continueState !== 'idle' && (
                     <div
                         className="mb-3 rounded border border-blue-300 bg-blue-50 p-3 text-xs dark:border-blue-700 dark:bg-blue-950/40"
                         data-testid="ralph-workflow-continue-confirm"

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPaneContainer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPaneContainer.tsx
@@ -55,6 +55,14 @@ export function RalphWorkflowPaneContainer(
         [workspaceId, sessionId, refresh],
     );
 
+    const handleResume = useCallback(
+        async () => {
+            await getSpaCocClient().workspaces.resumeRalphSession(workspaceId, sessionId);
+            refresh();
+        },
+        [workspaceId, sessionId, refresh],
+    );
+
     return (
         <RalphWorkflowPane
             workspaceId={workspaceId}
@@ -63,6 +71,7 @@ export function RalphWorkflowPaneContainer(
             onClose={onClose}
             onSelectIteration={onSelectIteration ? handleSelectIteration : undefined}
             onNewLoop={handleNewLoop}
+            onResume={handleResume}
             now={now}
         />
     );

--- a/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
@@ -634,6 +634,9 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
                 queueDispatch({ type: 'SELECT_QUEUE_TASK', id: null, repoId: workspaceId });
                 setSelectedTask(null);
                 selectedTaskRef.current = null;
+                setSelectedRalphSessionId(null);
+                const tabSegment = mode === 'tasks' ? 'tasks' : mode === 'chats' ? 'chats' : 'activity';
+                location.hash = '#repos/' + encodeURIComponent(workspaceId) + '/' + tabSegment;
                 if (isMobile) setMobileShowDetail(true);
             }}
         />

--- a/packages/coc/src/server/spa/client/react/features/servers/AddServerDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/servers/AddServerDialog.tsx
@@ -25,7 +25,7 @@ function stripTrailingSlash(url: string): string {
     return url.replace(/\/+$/, '');
 }
 
-function buildInput(kind: ConnectionKind, label: string, url: string, tunnelId: string): RemoteServerInput | undefined {
+function buildInput(kind: ConnectionKind, label: string, url: string, tunnelId: string, sshHost: string, sshPort: string): RemoteServerInput | undefined {
     if (kind === 'url') {
         const cleanedUrl = stripTrailingSlash(url.trim());
         if (!cleanedUrl) {
@@ -33,20 +33,36 @@ function buildInput(kind: ConnectionKind, label: string, url: string, tunnelId: 
         }
         return { kind, label: label.trim() || cleanedUrl, url: cleanedUrl };
     }
-    const cleanedTunnelId = tunnelId.trim();
-    if (!cleanedTunnelId) {
+    if (kind === 'devtunnel') {
+        const cleanedTunnelId = tunnelId.trim();
+        if (!cleanedTunnelId) {
+            return undefined;
+        }
+        return { kind, label: label.trim() || cleanedTunnelId, tunnelId: cleanedTunnelId };
+    }
+    // ssh
+    const cleanedHost = sshHost.trim();
+    if (!cleanedHost) {
         return undefined;
     }
-    return { kind, label: label.trim() || cleanedTunnelId, tunnelId: cleanedTunnelId };
+    const port = parseInt(sshPort.trim(), 10);
+    if (!sshPort.trim() || isNaN(port) || port < 1 || port > 65535) {
+        return undefined;
+    }
+    return { kind, label: label.trim() || cleanedHost, host: cleanedHost, localPort: port };
 }
 
 function inputFromServer(server?: RemoteServer): RemoteServerInput | undefined {
     if (!server) {
         return undefined;
     }
-    return server.kind === 'url'
-        ? { kind: 'url', label: server.label, url: server.url }
-        : { kind: 'devtunnel', label: server.label, tunnelId: server.tunnelId };
+    if (server.kind === 'url') {
+        return { kind: 'url', label: server.label, url: server.url };
+    }
+    if (server.kind === 'devtunnel') {
+        return { kind: 'devtunnel', label: server.label, tunnelId: server.tunnelId };
+    }
+    return { kind: 'ssh', label: server.label, host: server.host, localPort: server.localPort };
 }
 
 interface ServerFormDialogProps {
@@ -62,10 +78,14 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
     const initialLabel = initialInput?.label ?? '';
     const initialUrl = initialInput?.kind === 'url' ? initialInput.url : '';
     const initialTunnelId = initialInput?.kind === 'devtunnel' ? initialInput.tunnelId : '';
+    const initialSshHost = initialInput?.kind === 'ssh' ? initialInput.host : '';
+    const initialSshPort = initialInput?.kind === 'ssh' ? String(initialInput.localPort) : '';
     const [kind, setKind] = useState<ConnectionKind>(initialKind);
     const [label, setLabel] = useState(initialLabel);
     const [url, setUrl] = useState(initialUrl);
     const [tunnelId, setTunnelId] = useState(initialTunnelId);
+    const [sshHost, setSshHost] = useState(initialSshHost);
+    const [sshPort, setSshPort] = useState(initialSshPort);
     const [testState, setTestState] = useState<TestState>('idle');
     const [testLabel, setTestLabel] = useState('');
     const [submitting, setSubmitting] = useState(false);
@@ -86,11 +106,13 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
         setLabel(open ? initialLabel : '');
         setUrl(open ? initialUrl : '');
         setTunnelId(open ? initialTunnelId : '');
+        setSshHost(open ? initialSshHost : '');
+        setSshPort(open ? initialSshPort : '');
         setTestState('idle');
         setTestLabel('');
         setSubmitting(false);
         setSubmitError('');
-    }, [open, initialKind, initialLabel, initialUrl, initialTunnelId]);
+    }, [open, initialKind, initialLabel, initialUrl, initialTunnelId, initialSshHost, initialSshPort]);
 
     useEffect(() => {
         if (!open) {
@@ -102,7 +124,7 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
             debounceRef.current = null;
         }
 
-        const input = buildInput(kind, label, url, tunnelId);
+        const input = buildInput(kind, label, url, tunnelId, sshHost, sshPort);
         if (!input) {
             setTestState('idle');
             setTestLabel('');
@@ -123,7 +145,7 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
                 const desc = [
                     health.serverName ? `CoC @ ${health.serverName}` : null,
                     typeof health.version === 'string' && health.version ? `v${health.version}` : null,
-                    input.kind === 'devtunnel' && health.localPort ? `localhost:${health.localPort}` : null,
+                    (input.kind === 'devtunnel' || input.kind === 'ssh') && health.localPort ? `localhost:${health.localPort}` : null,
                 ].filter(Boolean).join(' · ');
 
                 setTestState('ok');
@@ -140,9 +162,9 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
                 debounceRef.current = null;
             }
         };
-    }, [open, kind, label, url, tunnelId]);
+    }, [open, kind, label, url, tunnelId, sshHost, sshPort]);
 
-    const input = buildInput(kind, label, url, tunnelId);
+    const input = buildInput(kind, label, url, tunnelId, sshHost, sshPort);
     const submitDisabled = !input || submitting;
 
     const handleSubmit = async () => {
@@ -220,6 +242,17 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
                             />
                             DevTunnel ID
                         </label>
+                        <label className="inline-flex items-center gap-1.5">
+                            <input
+                                type="radio"
+                                name={`${testIdPrefix}-server-kind`}
+                                value="ssh"
+                                checked={kind === 'ssh'}
+                                onChange={() => setKind('ssh')}
+                                data-testid={`${testIdPrefix}-server-kind-ssh`}
+                            />
+                            SSH Tunnel
+                        </label>
                     </div>
                 </fieldset>
 
@@ -238,7 +271,7 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
                             autoFocus
                         />
                     </div>
-                ) : (
+                ) : kind === 'devtunnel' ? (
                     <div className="flex flex-col gap-1">
                         <label className="text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc]">
                             Tunnel ID <span className="text-[#f14c4c]">*</span>
@@ -253,12 +286,47 @@ function ServerFormDialog({ open, mode, initialInput, onClose, onSubmit }: Serve
                             autoFocus
                         />
                     </div>
+                ) : (
+                    <>
+                        <div className="flex flex-col gap-1">
+                            <label className="text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc]">
+                                Host alias <span className="text-[#f14c4c]">*</span>
+                            </label>
+                            <input
+                                type="text"
+                                data-testid={`${testIdPrefix}-server-ssh-host-input`}
+                                value={sshHost}
+                                onChange={e => setSshHost(e.target.value)}
+                                placeholder="ubuntu-arm"
+                                className="px-3 py-1.5 text-sm rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-white dark:bg-[#3c3c3c] text-[#1e1e1e] dark:text-[#cccccc] focus:outline-none focus:ring-1 focus:ring-[#0078d4] placeholder:text-[#848484] dark:placeholder:text-[#666]"
+                                autoFocus
+                            />
+                            <p className="text-xs text-[#848484] dark:text-[#999]">
+                                Alias defined in <code>~/.ssh/config</code> with a <code>LocalForward</code> entry.
+                            </p>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <label className="text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc]">
+                                Local port <span className="text-[#f14c4c]">*</span>
+                            </label>
+                            <input
+                                type="number"
+                                data-testid={`${testIdPrefix}-server-ssh-port-input`}
+                                value={sshPort}
+                                onChange={e => setSshPort(e.target.value)}
+                                placeholder="4000"
+                                min={1}
+                                max={65535}
+                                className="px-3 py-1.5 text-sm rounded border border-[#e0e0e0] dark:border-[#3c3c3c] bg-white dark:bg-[#3c3c3c] text-[#1e1e1e] dark:text-[#cccccc] focus:outline-none focus:ring-1 focus:ring-[#0078d4] placeholder:text-[#848484] dark:placeholder:text-[#666]"
+                            />
+                        </div>
+                    </>
                 )}
 
                 {input && (
                     <div className="text-xs" data-testid={`${testIdPrefix}-server-test-indicator`}>
                         {testState === 'testing' && (
-                            <span className="text-[#848484] dark:text-[#999]">○ {kind === 'devtunnel' ? 'Connecting tunnel...' : 'Testing...'}</span>
+                            <span className="text-[#848484] dark:text-[#999]">○ {kind === 'devtunnel' ? 'Connecting tunnel...' : kind === 'ssh' ? 'Connecting SSH...' : 'Testing...'}</span>
                         )}
                         {testState === 'ok' && (
                             <span className="text-[#16c060]">🟢 {testLabel}</span>

--- a/packages/coc/test/server/ralph/ralph-session-store.test.ts
+++ b/packages/coc/test/server/ralph/ralph-session-store.test.ts
@@ -464,3 +464,42 @@ describe('normaliseSessionRecord', () => {
         expect(read!.iterations[0].loopIndex).toBe(1);
     });
 });
+
+describe('RalphSessionStore — appendResumeMarker', () => {
+    it('appends a resume marker to progress.md', async () => {
+        await store.initSession(WS, SID, { originalGoal: 'g', maxIterations: 10 });
+        await store.appendResumeMarker(WS, SID, 3, '2026-06-01T10:00:00Z');
+
+        const md = await store.readProgress(WS, SID);
+        expect(md).toContain('## Session resumed at 2026-06-01T10:00:00Z — picking up from iteration 3');
+    });
+
+    it('is idempotent for same timestamp and iteration', async () => {
+        await store.initSession(WS, SID, { originalGoal: 'g', maxIterations: 10 });
+        await store.appendResumeMarker(WS, SID, 5, '2026-06-01T12:00:00Z');
+        await store.appendResumeMarker(WS, SID, 5, '2026-06-01T12:00:00Z');
+
+        const md = await store.readProgress(WS, SID);
+        const markers = md.match(/Session resumed at/g) ?? [];
+        expect(markers).toHaveLength(1);
+    });
+
+    it('appends a second marker with a different timestamp', async () => {
+        await store.initSession(WS, SID, { originalGoal: 'g', maxIterations: 10 });
+        await store.appendResumeMarker(WS, SID, 3, '2026-06-01T10:00:00Z');
+        await store.appendResumeMarker(WS, SID, 5, '2026-06-01T14:00:00Z');
+
+        const md = await store.readProgress(WS, SID);
+        const markers = md.match(/Session resumed at/g) ?? [];
+        expect(markers).toHaveLength(2);
+    });
+
+    it('creates progress.md if it does not exist', async () => {
+        const dir = store.getSessionDir(WS, SID);
+        await fs.promises.mkdir(dir, { recursive: true });
+        await store.appendResumeMarker(WS, SID, 1, '2026-06-01T08:00:00Z');
+
+        const md = await store.readProgress(WS, SID);
+        expect(md).toContain('Session resumed at 2026-06-01T08:00:00Z');
+    });
+});

--- a/packages/coc/test/server/remote-server-routes.test.ts
+++ b/packages/coc/test/server/remote-server-routes.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRouter } from '../../src/server/shared/router';
 import type { Route } from '../../src/server/types';
 import { DevTunnelConnector, type DevTunnelChildProcess } from '../../src/server/servers/devtunnel-connector';
+import { SshConnector } from '../../src/server/servers/ssh-connector';
 import { registerRemoteServerRoutes } from '../../src/server/servers/remote-server-routes';
 import { RemoteServerStore } from '../../src/server/servers/remote-server-store';
 import { createExecutionServer } from '../../src/server';
@@ -66,11 +67,12 @@ describe('remote server routes', () => {
         vi.restoreAllMocks();
     });
 
-    async function startApi(connector: DevTunnelConnector): Promise<string> {
+    async function startApi(connector: DevTunnelConnector, sshConnector?: SshConnector): Promise<string> {
         const routes: Route[] = [];
         registerRemoteServerRoutes(routes, {
             store: new RemoteServerStore(dataDir),
             connector,
+            sshConnector,
         });
         apiServer = http.createServer(createRouter({ routes, spaHtml: '' }));
         return (await start(apiServer)).baseUrl;
@@ -207,6 +209,92 @@ describe('remote server routes', () => {
         expect(res.status).toBe(400);
     });
 
+    describe('ssh-kind routes', () => {
+        function makeSshConnector() {
+            const children: FakeChild[] = [];
+            const processStarter = vi.fn(() => {
+                const c = new FakeChild();
+                children.push(c);
+                return c;
+            });
+            const connector = new SshConnector({
+                processStarter,
+                healthChecker: async () => true,
+                readinessPollMs: 1,
+                initialReconnectBackoffMs: 100_000, // prevent auto-reconnect during tests
+            });
+            return { connector, children, processStarter };
+        }
+
+        it('POST /connect calls sshConnector.connect and returns online state', async () => {
+            const { connector: sshConnector } = makeSshConnector();
+            const connectSpy = vi.spyOn(sshConnector, 'connect');
+            const baseUrl = await startApi(new DevTunnelConnector(), sshConnector);
+
+            const created = await request(baseUrl, 'POST', '/api/servers', {
+                kind: 'ssh', label: 'My SSH', host: 'ubuntu-arm', localPort: 4000,
+            });
+            expect(created.status).toBe(201);
+            // Creation auto-connects; reset spy to isolate POST /connect behavior
+            connectSpy.mockClear();
+
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/connect`);
+            expect(res.status).toBe(200);
+            expect(connectSpy).toHaveBeenCalledOnce();
+            expect(res.body).toMatchObject({ kind: 'ssh', status: 'online', effectiveUrl: 'http://127.0.0.1:4000' });
+        });
+
+        it('POST /disconnect calls sshConnector.disconnect and returns idle state', async () => {
+            const { connector: sshConnector } = makeSshConnector();
+            const disconnectSpy = vi.spyOn(sshConnector, 'disconnect');
+            const baseUrl = await startApi(new DevTunnelConnector(), sshConnector);
+
+            const created = await request(baseUrl, 'POST', '/api/servers', {
+                kind: 'ssh', label: 'My SSH', host: 'ubuntu-arm', localPort: 4000,
+            });
+            await request(baseUrl, 'POST', `/api/servers/${created.body.id}/connect`);
+
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/disconnect`);
+            expect(res.status).toBe(200);
+            expect(disconnectSpy).toHaveBeenCalledWith(created.body.id);
+            expect(res.body).toMatchObject({ kind: 'ssh', status: 'idle' });
+        });
+
+        it('POST /reconnect (success) calls sshConnector.reconnect and returns online state', async () => {
+            const { connector: sshConnector } = makeSshConnector();
+            const reconnectSpy = vi.spyOn(sshConnector, 'reconnect');
+            const baseUrl = await startApi(new DevTunnelConnector(), sshConnector);
+
+            const created = await request(baseUrl, 'POST', '/api/servers', {
+                kind: 'ssh', label: 'My SSH', host: 'ubuntu-arm', localPort: 4000,
+            });
+            await request(baseUrl, 'POST', `/api/servers/${created.body.id}/connect`);
+
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/reconnect`);
+            expect(res.status).toBe(200);
+            expect(reconnectSpy).toHaveBeenCalledOnce();
+            expect(res.body).toMatchObject({ kind: 'ssh', status: 'online', effectiveUrl: 'http://127.0.0.1:4000' });
+        });
+
+        it('POST /reconnect (failure) returns failed state when connector throws', async () => {
+            const sshConnector = new SshConnector({
+                processStarter: vi.fn(() => new FakeChild()),
+                healthChecker: async () => false, // always fail health
+                readinessTimeoutMs: 20,
+                readinessPollMs: 5,
+                initialReconnectBackoffMs: 100_000,
+            });
+            const baseUrl = await startApi(new DevTunnelConnector(), sshConnector);
+
+            const created = await request(baseUrl, 'POST', '/api/servers', {
+                kind: 'ssh', label: 'My SSH', host: 'ubuntu-arm', localPort: 4000,
+            });
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/reconnect`);
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ kind: 'ssh', status: 'failed' });
+        });
+    });
+
     it('reconnect returns runtime with online status on success', async () => {
         const portListJson = JSON.stringify({
             ports: [{ portNumber: 4000, protocol: 'http', portUri: 'https://t-4000.usw2.devtunnels.ms' }],
@@ -282,6 +370,27 @@ describe('createExecutionServer remote server lifecycle', () => {
 
         expect(connectSpy).toHaveBeenCalledWith(expect.arrayContaining([
             expect.objectContaining({ kind: 'devtunnel', tunnelId: 'my-remote-coc' }),
+        ]));
+        expect(disposeSpy).toHaveBeenCalled();
+    });
+
+    it('autoconnects configured SSH entries and disposes SshConnector on close', async () => {
+        const store = new RemoteServerStore(dataDir);
+        store.create({ kind: 'ssh', label: 'My SSH Box', host: 'ubuntu-arm', localPort: 4000 });
+        const connectSpy = vi.spyOn(SshConnector.prototype, 'connectConfigured').mockResolvedValue([]);
+        const disposeSpy = vi.spyOn(SshConnector.prototype, 'dispose').mockImplementation(() => {});
+
+        const server = await createExecutionServer({
+            port: 0,
+            host: '127.0.0.1',
+            dataDir,
+            queue: { autoStart: false },
+            fileConfig: { skills: { autoUpdate: false, defaultSkills: [] } },
+        });
+        await server.close();
+
+        expect(connectSpy).toHaveBeenCalledWith(expect.arrayContaining([
+            expect.objectContaining({ kind: 'ssh', host: 'ubuntu-arm', localPort: 4000 }),
         ]));
         expect(disposeSpy).toHaveBeenCalled();
     });

--- a/packages/coc/test/server/remote-server-store.test.ts
+++ b/packages/coc/test/server/remote-server-store.test.ts
@@ -46,16 +46,42 @@ describe('RemoteServerStore', () => {
         expect(store.list()).toEqual([]);
     });
 
+    it('creates, lists, updates, and deletes SSH entries', () => {
+        const created = store.create({ kind: 'ssh', label: 'Dev VM', host: 'ubuntu-arm', localPort: 4000 });
+        expect(created).toMatchObject({ kind: 'ssh', label: 'Dev VM', host: 'ubuntu-arm', localPort: 4000 });
+        expect(created.updatedAt).toBe(created.addedAt);
+
+        const updated = store.update(created.id, { label: 'Dev VM 2', host: 'ubuntu-x86', localPort: 5000 });
+        expect(updated).toMatchObject({ kind: 'ssh', label: 'Dev VM 2', host: 'ubuntu-x86', localPort: 5000 });
+        expect(updated.addedAt).toBe(created.addedAt);
+        expect(updated.updatedAt).toBeGreaterThanOrEqual(created.updatedAt);
+
+        expect(store.list()).toHaveLength(1);
+        expect(store.remove(created.id)?.id).toBe(created.id);
+        expect(store.list()).toEqual([]);
+    });
+
     it('rejects invalid URL and DevTunnel inputs', () => {
         expect(() => store.create({ kind: 'url', label: 'Bad', url: 'ftp://example.com' })).toThrow(/http or https/);
         expect(() => store.create({ kind: 'devtunnel', label: 'Bad', tunnelId: '../bad' })).toThrow(/tunnelId/);
         expect(() => store.create({ kind: 'url', label: '', url: 'http://example.com' })).toThrow(/label/);
     });
 
-    it('persists the registry under the global data directory', () => {
+    it('rejects invalid SSH inputs', () => {
+        expect(() => store.create({ kind: 'ssh', label: 'Bad', host: '', localPort: 4000 })).toThrow(/host/);
+        expect(() => store.create({ kind: 'ssh', label: 'Bad', host: 'myhost', localPort: 0 })).toThrow(/localPort/);
+        expect(() => store.create({ kind: 'ssh', label: 'Bad', host: 'myhost', localPort: 65536 })).toThrow(/localPort/);
+        expect(() => store.create({ kind: 'ssh', label: 'Bad', host: 'myhost', localPort: 1.5 })).toThrow(/localPort/);
+    });    it('persists the registry under the global data directory', () => {
         const created = store.create({ kind: 'url', label: 'A', url: 'http://a.example.com' });
         const reloaded = new RemoteServerStore(dataDir);
         expect(reloaded.list()[0]).toEqual(created);
         expect(fs.existsSync(path.join(dataDir, 'remote-servers.json'))).toBe(true);
+    });
+
+    it('persists SSH entries across store reloads', () => {
+        const created = store.create({ kind: 'ssh', label: 'Arm Box', host: 'ubuntu-arm', localPort: 4000 });
+        const reloaded = new RemoteServerStore(dataDir);
+        expect(reloaded.list()[0]).toEqual(created);
     });
 });

--- a/packages/coc/test/server/routes/ralph-continue-routes.test.ts
+++ b/packages/coc/test/server/routes/ralph-continue-routes.test.ts
@@ -239,15 +239,20 @@ describe('POST /api/workspaces/:wsId/ralph-sessions/:sessionId/continue', () => 
         expect(res.json().error).toMatch(/cancelled/i);
     });
 
-    it('rejects NO_SIGNAL when currentIteration < maxIterations', async () => {
+    it('continues a NO_SIGNAL session before the cap (early agent failure)', async () => {
         await seedSession(dataDir, 'ws-7', 'sess-mid', {
             terminalReason: 'NO_SIGNAL',
             currentIteration: 4,
             maxIterations: 10,
         });
-        const res = await post(baseUrl, '/api/workspaces/ws-7/ralph-sessions/sess-mid/continue', {});
-        expect(res.status).toBe(409);
-        expect(res.json().error).toMatch(/NO_SIGNAL/);
+        const res = await post(baseUrl, '/api/workspaces/ws-7/ralph-sessions/sess-mid/continue', {
+            additionalIterations: 5,
+        });
+        expect(res.status).toBe(200);
+        const data = res.json();
+        expect(data.resumed).toBe(true);
+        expect(data.nextIteration).toBe(5);
+        expect(data.newMaxIterations).toBe(15);
     });
 
     // -----------------------------------------------------------------------

--- a/packages/coc/test/server/routes/ralph-resume-routes.test.ts
+++ b/packages/coc/test/server/routes/ralph-resume-routes.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for POST /api/workspaces/:workspaceId/ralph-sessions/:sessionId/resume
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as pathMod from 'path';
+import { createRouter } from '../../../src/server/shared/router';
+import { registerRalphResumeRoutes } from '../../../src/server/routes/ralph-resume-routes';
+import type { Route } from '../../../src/server/types';
+import { createMockProcessStore, type MockProcessStore } from '../helpers/mock-process-store';
+import { RalphSessionStore } from '../../../src/server/ralph/ralph-session-store';
+import type { RalphSessionRecord, RalphTerminalReason } from '../../../src/server/ralph/types';
+
+function request(
+    baseUrl: string,
+    urlPath: string,
+    options: { method?: string; body?: string; headers?: Record<string, string> } = {},
+): Promise<{ status: number; body: string; json: () => any }> {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(urlPath, baseUrl);
+        const req = http.request(
+            {
+                hostname: parsed.hostname,
+                port: parsed.port,
+                path: parsed.pathname + parsed.search,
+                method: options.method || 'GET',
+                headers: { 'Content-Type': 'application/json', ...options.headers },
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk) => chunks.push(chunk));
+                res.on('end', () => {
+                    const bodyStr = Buffer.concat(chunks).toString('utf-8');
+                    resolve({
+                        status: res.statusCode || 0,
+                        body: bodyStr,
+                        json: () => JSON.parse(bodyStr),
+                    });
+                });
+            },
+        );
+        req.on('error', reject);
+        if (options.body) req.write(options.body);
+        req.end();
+    });
+}
+
+function post(baseUrl: string, urlPath: string, body?: unknown) {
+    return request(baseUrl, urlPath, {
+        method: 'POST',
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+}
+
+function makeBridgeStub(opts: { tasks?: any[] } = {}) {
+    const tasks = opts.tasks ?? [];
+    const enqueue = vi.fn().mockResolvedValue('new-task-id');
+    const bridge: any = {
+        enqueue,
+        registry: {
+            getAllQueues: () => new Map([['repo-1', { getAll: () => tasks }]]),
+        },
+    };
+    return { bridge, enqueue };
+}
+
+async function seedSession(
+    dataDir: string,
+    workspaceId: string,
+    sessionId: string,
+    overrides: Partial<RalphSessionRecord> = {},
+): Promise<RalphSessionRecord> {
+    const journal = new RalphSessionStore({ dataDir });
+    await journal.initSession(workspaceId, sessionId, {
+        originalGoal: 'Original goal',
+        maxIterations: 10,
+        startedAt: '2026-05-11T00:00:00Z',
+    });
+    return journal.updateSessionRecord(workspaceId, sessionId, (rec) => ({
+        ...(rec as RalphSessionRecord),
+        currentIteration: 3,
+        phase: 'executing',
+        iterations: [
+            { iteration: 1, loopIndex: 1, taskId: 't1', processId: 'queue_p1', startedAt: '2026-05-11T01:00:00Z', endedAt: '2026-05-11T01:10:00Z', status: 'completed' },
+            { iteration: 2, loopIndex: 1, taskId: 't2', processId: 'queue_p2', startedAt: '2026-05-11T01:10:00Z', endedAt: '2026-05-11T01:20:00Z', status: 'completed' },
+            { iteration: 3, loopIndex: 1, taskId: 't3', processId: 'queue_p3', startedAt: '2026-05-11T01:20:00Z', endedAt: '2026-05-11T01:30:00Z', status: 'completed' },
+        ],
+        ...overrides,
+    }));
+}
+
+describe('POST /api/workspaces/:wsId/ralph-sessions/:sessionId/resume', () => {
+    let server: http.Server;
+    let baseUrl: string;
+    let store: MockProcessStore;
+    let dataDir: string;
+    let bridgeStub: ReturnType<typeof makeBridgeStub>;
+
+    beforeAll(async () => {
+        store = createMockProcessStore();
+        dataDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'ralph-resume-test-'));
+        bridgeStub = makeBridgeStub();
+
+        const routes: Route[] = [];
+        registerRalphResumeRoutes(routes, { bridge: bridgeStub.bridge, store, dataDir });
+
+        const router = createRouter({ routes, spaHtml: '' });
+        server = http.createServer(router);
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+        const addr = server.address() as { port: number };
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    beforeEach(async () => {
+        store.processes.clear();
+        bridgeStub.enqueue.mockClear();
+        try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        fs.mkdirSync(dataDir, { recursive: true });
+    });
+
+    // -----------------------------------------------------------------------
+    // Happy paths
+    // -----------------------------------------------------------------------
+
+    it('resumes a stuck executing session and enqueues iteration 4', async () => {
+        await seedSession(dataDir, 'ws-1', 'sess-stuck');
+
+        const res = await post(baseUrl, '/api/workspaces/ws-1/ralph-sessions/sess-stuck/resume', {});
+        expect(res.status).toBe(200);
+        const data = res.json();
+        expect(data.resumed).toBe(true);
+        expect(data.nextIteration).toBe(4);
+        expect(data.maxIterations).toBe(10);
+        expect(data.sessionId).toBe('sess-stuck');
+
+        expect(bridgeStub.enqueue).toHaveBeenCalledOnce();
+        const enqueueArg = bridgeStub.enqueue.mock.calls[0][0];
+        expect(enqueueArg.payload.context.ralph.sessionId).toBe('sess-stuck');
+        expect(enqueueArg.payload.context.ralph.currentIteration).toBe(4);
+        expect(enqueueArg.payload.context.ralph.maxIterations).toBe(10);
+        expect(enqueueArg.payload.mode).toBe('ralph');
+
+        const progressPath = pathMod.join(dataDir, 'repos', 'ws-1', 'ralph-sessions', 'sess-stuck', 'progress.md');
+        const md = fs.readFileSync(progressPath, 'utf-8');
+        expect(md).toMatch(/Session resumed at .* picking up from iteration 3/);
+    });
+
+    it('resumes a session where last iteration failed', async () => {
+        await seedSession(dataDir, 'ws-2', 'sess-failed', {
+            currentIteration: 2,
+            iterations: [
+                { iteration: 1, loopIndex: 1, taskId: 't1', processId: 'p1', startedAt: '2026-05-11T01:00:00Z', endedAt: '2026-05-11T01:10:00Z', status: 'completed' },
+                { iteration: 2, loopIndex: 1, taskId: 't2', processId: 'p2', startedAt: '2026-05-11T01:10:00Z', endedAt: '2026-05-11T01:20:00Z', status: 'failed' },
+            ],
+        });
+
+        const res = await post(baseUrl, '/api/workspaces/ws-2/ralph-sessions/sess-failed/resume', {});
+        expect(res.status).toBe(200);
+        expect(res.json().nextIteration).toBe(3);
+    });
+
+    it('works with an empty request body', async () => {
+        await seedSession(dataDir, 'ws-3', 'sess-empty-body');
+        const res = await post(baseUrl, '/api/workspaces/ws-3/ralph-sessions/sess-empty-body/resume');
+        expect(res.status).toBe(200);
+    });
+
+    // -----------------------------------------------------------------------
+    // 404
+    // -----------------------------------------------------------------------
+
+    it('returns 404 when the session does not exist', async () => {
+        const res = await post(baseUrl, '/api/workspaces/ws-x/ralph-sessions/nope/resume', {});
+        expect(res.status).toBe(404);
+    });
+
+    // -----------------------------------------------------------------------
+    // 409 — wrong phase
+    // -----------------------------------------------------------------------
+
+    it('rejects when phase is complete', async () => {
+        await seedSession(dataDir, 'ws-4', 'sess-complete', {
+            phase: 'complete',
+            completedAt: '2026-05-11T03:00:00Z',
+            terminalReason: 'CAP_REACHED' as RalphTerminalReason,
+        });
+        const res = await post(baseUrl, '/api/workspaces/ws-4/ralph-sessions/sess-complete/resume', {});
+        expect(res.status).toBe(409);
+        expect(res.json().error).toMatch(/phase/i);
+    });
+
+    it('rejects when phase is grilling', async () => {
+        await seedSession(dataDir, 'ws-5', 'sess-grill', {
+            phase: 'grilling',
+        });
+        const res = await post(baseUrl, '/api/workspaces/ws-5/ralph-sessions/sess-grill/resume', {});
+        expect(res.status).toBe(409);
+        expect(res.json().error).toMatch(/phase/i);
+    });
+
+    // -----------------------------------------------------------------------
+    // 409 — at cap (should use /continue instead)
+    // -----------------------------------------------------------------------
+
+    it('rejects when currentIteration >= maxIterations', async () => {
+        await seedSession(dataDir, 'ws-6', 'sess-at-cap', {
+            currentIteration: 10,
+            maxIterations: 10,
+        });
+        const res = await post(baseUrl, '/api/workspaces/ws-6/ralph-sessions/sess-at-cap/resume', {});
+        expect(res.status).toBe(409);
+        expect(res.json().error).toMatch(/cap/i);
+    });
+
+    // -----------------------------------------------------------------------
+    // 409 — in-flight task
+    // -----------------------------------------------------------------------
+
+    it('rejects when a task with this sessionId is still queued', async () => {
+        await seedSession(dataDir, 'ws-7', 'sess-busy');
+        const inFlightTasks = [{
+            id: 't-busy',
+            status: 'queued',
+            payload: { context: { ralph: { sessionId: 'sess-busy' } } },
+        }];
+        const localBridge = makeBridgeStub({ tasks: inFlightTasks });
+        const localRoutes: Route[] = [];
+        registerRalphResumeRoutes(localRoutes, { bridge: localBridge.bridge, store, dataDir });
+        const localRouter = createRouter({ routes: localRoutes, spaHtml: '' });
+        const localServer = http.createServer(localRouter);
+        try {
+            await new Promise<void>(r => localServer.listen(0, '127.0.0.1', () => r()));
+            const port = (localServer.address() as { port: number }).port;
+            const res = await post(`http://127.0.0.1:${port}`, '/api/workspaces/ws-7/ralph-sessions/sess-busy/resume', {});
+            expect(res.status).toBe(409);
+            expect(res.json().error).toMatch(/queued|running/);
+        } finally {
+            await new Promise<void>(r => localServer.close(() => r()));
+        }
+    });
+
+    it('rejects when a task with this sessionId is running', async () => {
+        await seedSession(dataDir, 'ws-8', 'sess-running');
+        const inFlightTasks = [{
+            id: 't-running',
+            status: 'running',
+            payload: { context: { ralph: { sessionId: 'sess-running' } } },
+        }];
+        const localBridge = makeBridgeStub({ tasks: inFlightTasks });
+        const localRoutes: Route[] = [];
+        registerRalphResumeRoutes(localRoutes, { bridge: localBridge.bridge, store, dataDir });
+        const localRouter = createRouter({ routes: localRoutes, spaHtml: '' });
+        const localServer = http.createServer(localRouter);
+        try {
+            await new Promise<void>(r => localServer.listen(0, '127.0.0.1', () => r()));
+            const port = (localServer.address() as { port: number }).port;
+            const res = await post(`http://127.0.0.1:${port}`, '/api/workspaces/ws-8/ralph-sessions/sess-running/resume', {});
+            expect(res.status).toBe(409);
+            expect(res.json().error).toMatch(/running/);
+        } finally {
+            await new Promise<void>(r => localServer.close(() => r()));
+        }
+    });
+
+    // -----------------------------------------------------------------------
+    // Resume marker idempotency
+    // -----------------------------------------------------------------------
+
+    it('appends resume marker to progress.md', async () => {
+        await seedSession(dataDir, 'ws-9', 'sess-marker');
+        const res = await post(baseUrl, '/api/workspaces/ws-9/ralph-sessions/sess-marker/resume', {});
+        expect(res.status).toBe(200);
+
+        const progressPath = pathMod.join(dataDir, 'repos', 'ws-9', 'ralph-sessions', 'sess-marker', 'progress.md');
+        const md = fs.readFileSync(progressPath, 'utf-8');
+        const markers = md.match(/Session resumed at/g) ?? [];
+        expect(markers).toHaveLength(1);
+    });
+});

--- a/packages/coc/test/server/ssh-connector.test.ts
+++ b/packages/coc/test/server/ssh-connector.test.ts
@@ -1,0 +1,269 @@
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi } from 'vitest';
+import { SshConnector, type SshChildProcess } from '../../src/server/servers/ssh-connector';
+import type { SshRemoteServer } from '../../src/server/servers/remote-server-types';
+
+function makeServer(overrides?: Partial<SshRemoteServer>): SshRemoteServer {
+    return {
+        id: 'srv-1',
+        label: 'My SSH Server',
+        kind: 'ssh',
+        host: 'ubuntu-arm',
+        localPort: 4000,
+        addedAt: 0,
+        updatedAt: 0,
+        ...overrides,
+    };
+}
+
+class FakeChild extends EventEmitter implements SshChildProcess {
+    killed = false;
+    kill(): boolean {
+        this.killed = true;
+        return true;
+    }
+    override once(event: 'exit' | 'error', listener: (...args: any[]) => void): this {
+        return super.once(event, listener);
+    }
+}
+
+describe('SshConnector', () => {
+    it('connect-success: spawns ssh -N and resolves online when health passes', async () => {
+        const child = new FakeChild();
+        const processStarter = vi.fn(() => child);
+        const connector = new SshConnector({
+            processStarter,
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        const state = await connector.connect(server);
+
+        expect(processStarter).toHaveBeenCalledWith('ssh', ['-N', 'ubuntu-arm']);
+        expect(state.status).toBe('online');
+        expect(state.effectiveUrl).toBe('http://127.0.0.1:4000');
+        expect(state.serverId).toBe('srv-1');
+        expect(state.host).toBe('ubuntu-arm');
+        expect(state.localPort).toBe(4000);
+    });
+
+    it('deduplicates concurrent connect attempts for the same server', async () => {
+        const child = new FakeChild();
+        let healthCalls = 0;
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => {
+                healthCalls++;
+                await new Promise(resolve => setTimeout(resolve, 10));
+                return true;
+            },
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        const [a, b] = await Promise.all([
+            connector.connect(server),
+            connector.connect(server),
+        ]);
+
+        expect(a).toMatchObject({ status: 'online', effectiveUrl: 'http://127.0.0.1:4000' });
+        expect(b).toEqual(a);
+    });
+
+    it('connect-timeout: marks failed when health never passes', async () => {
+        const child = new FakeChild();
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => false,
+            readinessTimeoutMs: 20,
+            readinessPollMs: 5,
+        });
+
+        const server = makeServer();
+        await expect(connector.connect(server)).rejects.toThrow(/did not become healthy/);
+        expect(connector.getState('srv-1')?.status).toBe('failed');
+        expect(connector.getState('srv-1')?.lastError).toMatch(/did not become healthy/);
+        expect(child.killed).toBe(true);
+    });
+
+    it('binary-not-found: surfaces "ssh binary not found on PATH" when process emits ENOENT error', async () => {
+        const child = new FakeChild();
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => false,
+            readinessTimeoutMs: 50,
+            readinessPollMs: 5,
+        });
+
+        const server = makeServer();
+        // Emit ENOENT error in the next tick (simulating missing binary)
+        setTimeout(() => {
+            child.emit('error', Object.assign(new Error('spawn ssh ENOENT'), { code: 'ENOENT' }));
+        }, 1);
+
+        await expect(connector.connect(server)).rejects.toThrow('ssh binary not found on PATH');
+        expect(connector.getState('srv-1')?.status).toBe('failed');
+        expect(connector.getState('srv-1')?.lastError).toBe('ssh binary not found on PATH');
+    });
+
+    it('unexpected-exit: marks failed when ssh process exits after connect', async () => {
+        const child = new FakeChild();
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        expect(connector.getState('srv-1')?.status).toBe('online');
+
+        child.emit('exit', 1, null);
+
+        expect(connector.getState('srv-1')?.status).toBe('failed');
+        expect(connector.getState('srv-1')?.lastError).toMatch(/exited unexpectedly/);
+    });
+
+    it('reconnect: kills prior child and reconnects successfully', async () => {
+        const child1 = new FakeChild();
+        const child2 = new FakeChild();
+        let childIdx = 0;
+        const children = [child1, child2];
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => children[childIdx++]),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        expect(child1.killed).toBe(false);
+
+        const state = await connector.reconnect(server);
+        expect(child1.killed).toBe(true);
+        expect(state.status).toBe('online');
+        expect(state.effectiveUrl).toBe('http://127.0.0.1:4000');
+    });
+
+    it('old exit listener cannot clobber state after reconnect', async () => {
+        const child1 = new FakeChild();
+        const child2 = new FakeChild();
+        let childIdx = 0;
+        const children = [child1, child2];
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => children[childIdx++]),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        await connector.reconnect(server);
+
+        // Old child exits after reconnect — must NOT flip state to failed
+        child1.emit('exit', 1, null);
+        expect(connector.getState('srv-1')?.status).toBe('online');
+    });
+
+    it('disconnect: kills child and sets status to idle', async () => {
+        const child = new FakeChild();
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        const state = connector.disconnect('srv-1');
+        expect(child.killed).toBe(true);
+        expect(state.status).toBe('idle');
+    });
+
+    it('disconnect on unknown serverId returns idle state gracefully', () => {
+        const connector = new SshConnector();
+        const state = connector.disconnect('unknown');
+        expect(state.status).toBe('idle');
+        expect(state.serverId).toBe('unknown');
+    });
+
+    it('getState returns undefined for unknown serverId', () => {
+        const connector = new SshConnector();
+        expect(connector.getState('missing')).toBeUndefined();
+    });
+
+    it('getStates returns all connection states', async () => {
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => new FakeChild()),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const s1 = makeServer({ id: 'srv-1', host: 'host1', localPort: 4001 });
+        const s2 = makeServer({ id: 'srv-2', host: 'host2', localPort: 4002 });
+        await connector.connect(s1);
+        await connector.connect(s2);
+
+        const states = connector.getStates();
+        expect(states).toHaveLength(2);
+        expect(states.map(s => s.serverId)).toContain('srv-1');
+        expect(states.map(s => s.serverId)).toContain('srv-2');
+    });
+
+    it('dispose: kills all children and clears state', async () => {
+        const child = new FakeChild();
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        connector.dispose();
+        expect(child.killed).toBe(true);
+        expect(connector.getStates()).toEqual([]);
+    });
+
+    it('connectConfigured connects all ssh-kind servers', async () => {
+        const children: FakeChild[] = [];
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => {
+                const c = new FakeChild();
+                children.push(c);
+                return c;
+            }),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        const servers = [
+            makeServer({ id: 'srv-1', host: 'host1', localPort: 4001 }),
+            makeServer({ id: 'srv-2', host: 'host2', localPort: 4002 }),
+            { id: 'srv-3', label: 'url-server', kind: 'url' as const, url: 'http://example.com', addedAt: 0, updatedAt: 0 },
+        ];
+        const states = await connector.connectConfigured(servers);
+        expect(states).toHaveLength(2);
+        expect(states.every(s => s.status === 'online')).toBe(true);
+        expect(children).toHaveLength(2);
+    });
+
+    it('returns connected state immediately when already online', async () => {
+        const child = new FakeChild();
+        let healthCalls = 0;
+        const connector = new SshConnector({
+            processStarter: vi.fn(() => child),
+            healthChecker: async () => { healthCalls++; return true; },
+            readinessPollMs: 1,
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        const callsAfterFirst = healthCalls;
+
+        await connector.connect(server);
+        // Second connect should not spawn a new process or re-poll health
+        expect(healthCalls).toBe(callsAfterFirst);
+    });
+});

--- a/packages/coc/test/server/ssh-connector.test.ts
+++ b/packages/coc/test/server/ssh-connector.test.ts
@@ -113,6 +113,7 @@ describe('SshConnector', () => {
             processStarter: vi.fn(() => child),
             healthChecker: async () => true,
             readinessPollMs: 1,
+            initialReconnectBackoffMs: 100_000, // disable auto-reconnect in this test
         });
 
         const server = makeServer();
@@ -123,6 +124,35 @@ describe('SshConnector', () => {
 
         expect(connector.getState('srv-1')?.status).toBe('failed');
         expect(connector.getState('srv-1')?.lastError).toMatch(/exited unexpectedly/);
+    });
+
+    it('auto-reconnects after unexpected exit', async () => {
+        const child1 = new FakeChild();
+        const child2 = new FakeChild();
+        let childIdx = 0;
+        const children = [child1, child2];
+        const processStarter = vi.fn(() => children[childIdx++]);
+        const connector = new SshConnector({
+            processStarter,
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+            initialReconnectBackoffMs: 10, // very short for testing
+        });
+
+        const server = makeServer();
+        await connector.connect(server);
+        expect(connector.getState('srv-1')?.status).toBe('online');
+
+        // Simulate unexpected process exit
+        child1.emit('exit', 1, null);
+        expect(connector.getState('srv-1')?.status).toBe('failed');
+
+        // Wait for auto-reconnect to fire and complete
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(connector.getState('srv-1')?.status).toBe('online');
+        expect(processStarter).toHaveBeenCalledTimes(2);
+        expect(child2.killed).toBe(false);
     });
 
     it('reconnect: kills prior child and reconnects successfully', async () => {

--- a/packages/coc/test/spa/react/features/servers/AddServerDialog.test.tsx
+++ b/packages/coc/test/spa/react/features/servers/AddServerDialog.test.tsx
@@ -54,6 +54,7 @@ describe('AddServerDialog', () => {
         render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
         expect(screen.getByTestId('add-server-kind-url')).toBeTruthy();
         expect(screen.getByTestId('add-server-kind-devtunnel')).toBeTruthy();
+        expect(screen.getByTestId('add-server-kind-ssh')).toBeTruthy();
         expect(screen.getByTestId('add-server-url-input')).toBeTruthy();
         expect(screen.getByTestId('add-server-label-input')).toBeTruthy();
         expect(screen.getByTestId('add-server-submit-btn')).toBeTruthy();
@@ -64,6 +65,8 @@ describe('AddServerDialog', () => {
         render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
         expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(true);
         fireEvent.click(screen.getByTestId('add-server-kind-devtunnel'));
+        expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
         expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(true);
     });
 
@@ -279,5 +282,86 @@ describe('AddServerDialog', () => {
         expect(onClose).not.toHaveBeenCalled();
         expect(screen.getByTestId('edit-server-submit-error').textContent).toContain('update failed');
         expect((screen.getByTestId('edit-server-url-input') as HTMLInputElement).value).toBe('https://edited.example.com/');
+    });
+
+    it('shows SSH Tunnel fields when SSH Tunnel radio is selected', () => {
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        expect(screen.getByTestId('add-server-ssh-host-input')).toBeTruthy();
+        expect(screen.getByTestId('add-server-ssh-port-input')).toBeTruthy();
+        expect(screen.queryByTestId('add-server-url-input')).toBeNull();
+        expect(screen.queryByTestId('add-server-tunnel-id-input')).toBeNull();
+    });
+
+    it('disables submit when SSH host is filled but port is missing', () => {
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        fireEvent.change(screen.getByTestId('add-server-ssh-host-input'), { target: { value: 'ubuntu-arm' } });
+        expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('disables submit when SSH host is empty but port is filled', () => {
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        fireEvent.change(screen.getByTestId('add-server-ssh-port-input'), { target: { value: '4000' } });
+        expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('disables submit when SSH port is out of range', () => {
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        fireEvent.change(screen.getByTestId('add-server-ssh-host-input'), { target: { value: 'ubuntu-arm' } });
+        fireEvent.change(screen.getByTestId('add-server-ssh-port-input'), { target: { value: '99999' } });
+        expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('enables submit when SSH host and valid port are both filled', () => {
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        fireEvent.change(screen.getByTestId('add-server-ssh-host-input'), { target: { value: 'ubuntu-arm' } });
+        fireEvent.change(screen.getByTestId('add-server-ssh-port-input'), { target: { value: '4000' } });
+        expect((screen.getByTestId('add-server-submit-btn') as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('submit calls onAdd with SSH kind, host, and localPort', async () => {
+        const onAdd = vi.fn().mockResolvedValue(undefined);
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={onAdd} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        fireEvent.change(screen.getByTestId('add-server-ssh-host-input'), { target: { value: '  ubuntu-arm  ' } });
+        fireEvent.change(screen.getByTestId('add-server-ssh-port-input'), { target: { value: '4000' } });
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('add-server-submit-btn'));
+        });
+        expect(onAdd).toHaveBeenCalledWith({
+            kind: 'ssh',
+            label: 'ubuntu-arm',
+            host: 'ubuntu-arm',
+            localPort: 4000,
+        });
+    });
+
+    it('shows "Connecting SSH..." indicator when SSH fields are filled', () => {
+        vi.useFakeTimers();
+        render(<AddServerDialog open={true} onClose={() => {}} onAdd={() => {}} />);
+        fireEvent.click(screen.getByTestId('add-server-kind-ssh'));
+        fireEvent.change(screen.getByTestId('add-server-ssh-host-input'), { target: { value: 'ubuntu-arm' } });
+        fireEvent.change(screen.getByTestId('add-server-ssh-port-input'), { target: { value: '4000' } });
+        expect(screen.getByTestId('add-server-test-indicator').textContent).toContain('Connecting SSH');
+    });
+
+    it('EditServerDialog pre-populates SSH fields for ssh-kind server', () => {
+        const server: RemoteServer = {
+            id: 's1',
+            kind: 'ssh',
+            label: 'My SSH Box',
+            host: 'ubuntu-arm',
+            localPort: 4000,
+            addedAt: 1,
+            updatedAt: 1,
+        };
+        render(<EditServerDialog open={true} server={server} onClose={() => {}} onSave={() => {}} />);
+        expect((screen.getByTestId('edit-server-ssh-host-input') as HTMLInputElement).value).toBe('ubuntu-arm');
+        expect((screen.getByTestId('edit-server-ssh-port-input') as HTMLInputElement).value).toBe('4000');
+        expect((screen.getByTestId('edit-server-kind-ssh') as HTMLInputElement).checked).toBe(true);
     });
 });

--- a/packages/coc/test/spa/react/repos/RalphWorkflowPane.test.tsx
+++ b/packages/coc/test/spa/react/repos/RalphWorkflowPane.test.tsx
@@ -322,6 +322,121 @@ describe('RalphWorkflowPane', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Resume UI (stuck executing session)
+// ---------------------------------------------------------------------------
+
+describe('RalphWorkflowPane — resume stuck executing session', () => {
+    function makeStuckView(overrides: Partial<RalphSessionRecord> = {}): RalphSessionView {
+        return {
+            record: makeRecord({
+                phase: 'executing',
+                currentIteration: 3,
+                iterations: [
+                    makeIter(1),
+                    makeIter(2),
+                    makeIter(3),
+                ],
+                ...overrides,
+            }),
+            sections: [makeSection(1), makeSection(2), makeSection(3)],
+        };
+    }
+
+    it('shows Resume button when session is stuck executing', () => {
+        const view = makeStuckView();
+        render(<RalphWorkflowPane workspaceId="ws-1" sessionId="sess-1" view={view} />);
+        expect(screen.getByTestId('ralph-workflow-resume')).toBeInTheDocument();
+    });
+
+    it('does not show Resume when an iteration is still running', () => {
+        const view = makeStuckView({
+            iterations: [
+                makeIter(1),
+                makeIter(2),
+                makeIter(3, 'running'),
+            ],
+        });
+        render(<RalphWorkflowPane workspaceId="ws-1" sessionId="sess-1" view={view} />);
+        expect(screen.queryByTestId('ralph-workflow-resume')).toBeNull();
+    });
+
+    it('does not show Resume when currentIteration is 0', () => {
+        const view = makeStuckView({ currentIteration: 0, iterations: [] });
+        render(<RalphWorkflowPane workspaceId="ws-1" sessionId="sess-1" view={view} />);
+        expect(screen.queryByTestId('ralph-workflow-resume')).toBeNull();
+    });
+
+    it('does not show Resume when phase is complete', () => {
+        const view: RalphSessionView = {
+            record: makeRecord({
+                phase: 'complete',
+                currentIteration: 3,
+                completedAt: new Date().toISOString(),
+                terminalReason: 'RALPH_COMPLETE',
+                iterations: [makeIter(1), makeIter(2), makeIter(3)],
+            }),
+            sections: [makeSection(1), makeSection(2), makeSection(3)],
+        };
+        render(<RalphWorkflowPane workspaceId="ws-1" sessionId="sess-1" view={view} />);
+        expect(screen.queryByTestId('ralph-workflow-resume')).toBeNull();
+    });
+
+    it('shows confirmation panel and calls onResume on confirm', async () => {
+        const user = userEvent.setup();
+        const onResume = vi.fn().mockResolvedValue(undefined);
+        const view = makeStuckView();
+        render(
+            <RalphWorkflowPane
+                workspaceId="ws-1"
+                sessionId="sess-1"
+                view={view}
+                onResume={onResume}
+            />,
+        );
+        await user.click(screen.getByTestId('ralph-workflow-resume'));
+        expect(screen.getByTestId('ralph-workflow-resume-confirm')).toBeInTheDocument();
+        expect(screen.getByText(/iteration 4/)).toBeInTheDocument();
+        await user.click(screen.getByTestId('ralph-workflow-resume-confirm-button'));
+        expect(onResume).toHaveBeenCalledOnce();
+    });
+
+    it('cancel button hides the resume confirmation panel', async () => {
+        const user = userEvent.setup();
+        const onResume = vi.fn().mockResolvedValue(undefined);
+        const view = makeStuckView();
+        render(
+            <RalphWorkflowPane
+                workspaceId="ws-1"
+                sessionId="sess-1"
+                view={view}
+                onResume={onResume}
+            />,
+        );
+        await user.click(screen.getByTestId('ralph-workflow-resume'));
+        await user.click(screen.getByTestId('ralph-workflow-resume-cancel'));
+        expect(screen.queryByTestId('ralph-workflow-resume-confirm')).toBeNull();
+        expect(onResume).not.toHaveBeenCalled();
+    });
+
+    it('shows error when resume fails', async () => {
+        const user = userEvent.setup();
+        const onResume = vi.fn().mockRejectedValue(new Error('Network error'));
+        const view = makeStuckView();
+        render(
+            <RalphWorkflowPane
+                workspaceId="ws-1"
+                sessionId="sess-1"
+                view={view}
+                onResume={onResume}
+            />,
+        );
+        await user.click(screen.getByTestId('ralph-workflow-resume'));
+        await user.click(screen.getByTestId('ralph-workflow-resume-confirm-button'));
+        expect(await screen.findByTestId('ralph-workflow-resume-error')).toHaveTextContent('Network error');
+    });
+});
+
+// ---------------------------------------------------------------------------
 // New Loop UI (requires RALPH_MULTI_LOOP=true, tested in isolation)
 // ---------------------------------------------------------------------------
 

--- a/packages/coc/test/spa/react/repos/RalphWorkflowPane.test.tsx
+++ b/packages/coc/test/spa/react/repos/RalphWorkflowPane.test.tsx
@@ -249,7 +249,7 @@ describe('RalphWorkflowPane', () => {
         expect(screen.queryByTestId('ralph-workflow-continue')).toBeNull();
     });
 
-    it('hides the Continue loop button when NO_SIGNAL did not reach the cap', () => {
+    it('shows the Continue loop button when NO_SIGNAL did not reach the cap (early agent failure)', () => {
         const view: RalphSessionView = {
             record: makeRecord({
                 phase: 'complete',
@@ -262,7 +262,7 @@ describe('RalphWorkflowPane', () => {
             sections: [makeSection(4)],
         };
         render(<RalphWorkflowPane workspaceId="ws-1" sessionId="sess-1" view={view} />);
-        expect(screen.queryByTestId('ralph-workflow-continue')).toBeNull();
+        expect(screen.getByTestId('ralph-workflow-continue')).toBeInTheDocument();
     });
 
     it('opens a confirmation panel and calls onContinue when confirmed', async () => {

--- a/packages/coc/test/spa/react/repos/RepoChatTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoChatTab.test.tsx
@@ -28,6 +28,7 @@ import { toQueueProcessId } from '../../../../src/server/spa/client/react/utils/
 
 const mockListPane = vi.fn();
 const mockDetailPane = vi.fn();
+const mockRalphPane = vi.fn();
 
 vi.mock('../../../../src/server/spa/client/react/features/chat/ChatListPane', () => ({
     ChatListPane: (props: any) => {
@@ -70,6 +71,30 @@ vi.mock('../../../../src/server/spa/client/react/features/chat/ChatListPane', ()
                 'data-testid': 'dialog-btn',
                 onClick: props.onOpenDialog,
             }, 'Dialog'),
+            props.onNewChat && React.createElement('button', {
+                'data-testid': 'new-chat-btn',
+                onClick: props.onNewChat,
+            }, 'New Chat'),
+            props.onSelectRalphSession && React.createElement('button', {
+                'data-testid': 'select-ralph-btn',
+                onClick: () => props.onSelectRalphSession('ralph-session-1'),
+            }, 'Select Ralph'),
+        );
+    },
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/RalphWorkflowPaneContainer', () => ({
+    RalphWorkflowPaneContainer: (props: any) => {
+        mockRalphPane(props);
+        return React.createElement('div', {
+            'data-testid': 'mock-ralph-pane',
+            'data-session-id': props.sessionId,
+        },
+            `Ralph: ${props.sessionId}`,
+            props.onClose && React.createElement('button', {
+                'data-testid': 'ralph-close-btn',
+                onClick: props.onClose,
+            }, 'Close Ralph'),
         );
     },
 }));
@@ -1579,5 +1604,124 @@ describe('RepoChatTab: reactive title updates from AppContext', () => {
 
         const propsAfter = mockListPane.mock.calls.at(-1)?.[0]?.history;
         expect(propsAfter).toBe(propsBefore);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// RALPH SESSION + NEW CHAT INTERACTION
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('RepoChatTab: Ralph session and new chat', () => {
+    it('selecting a Ralph session shows the Ralph pane instead of ChatDetailPane', async () => {
+        setupFetchMock();
+        await renderTab();
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('select-ralph-btn'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mock-ralph-pane')).toBeTruthy();
+            expect(screen.getByTestId('mock-ralph-pane').getAttribute('data-session-id')).toBe('ralph-session-1');
+        });
+    });
+
+    it('clicking new chat while a Ralph session is selected clears the Ralph pane', async () => {
+        setupFetchMock();
+        await renderTab();
+
+        // Select a Ralph session first
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('select-ralph-btn'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mock-ralph-pane')).toBeTruthy();
+        });
+
+        // Click new chat — should clear Ralph pane and show ChatDetailPane
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('new-chat-btn'));
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('mock-ralph-pane')).toBeNull();
+            expect(screen.getByTestId('mock-detail-pane')).toBeTruthy();
+            expect(screen.getByText('No selection')).toBeTruthy();
+        });
+    });
+
+    it('clicking new chat while a Ralph session is selected updates the URL hash', async () => {
+        setupFetchMock();
+        await renderTab();
+
+        // Select a Ralph session — sets hash to /activity/ralph/<id>
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('select-ralph-btn'));
+        });
+
+        await waitFor(() => {
+            expect(location.hash).toContain('/ralph/ralph-session-1');
+        });
+
+        // Click new chat — hash should no longer contain /ralph/
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('new-chat-btn'));
+        });
+
+        await waitFor(() => {
+            expect(location.hash).not.toContain('/ralph/');
+            expect(location.hash).toContain('#repos/ws-1/activity');
+        });
+    });
+
+    it('clicking new chat in mode="chats" writes /chats path (not /activity/) to URL', async () => {
+        setupFetchMock();
+        await renderTab('ws-1', 'chats');
+
+        // Select Ralph session
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('select-ralph-btn'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mock-ralph-pane')).toBeTruthy();
+        });
+
+        // Click new chat
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('new-chat-btn'));
+        });
+
+        await waitFor(() => {
+            expect(location.hash).toContain('#repos/ws-1/chats');
+            expect(location.hash).not.toContain('/ralph/');
+            expect(location.hash).not.toContain('/activity/');
+        });
+    });
+
+    it('selecting a Ralph session then selecting a chat task clears the Ralph pane', async () => {
+        const r1 = makeRunningTask('r1');
+        setupFetchMock({ running: [r1] });
+        await renderTab();
+
+        // Select Ralph session
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('select-ralph-btn'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mock-ralph-pane')).toBeTruthy();
+        });
+
+        // Select a regular chat task — Ralph pane should be dismissed
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('task-r1'));
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('mock-ralph-pane')).toBeNull();
+            expect(screen.getByTestId('mock-detail-pane')).toBeTruthy();
+        });
     });
 });


### PR DESCRIPTION
- **feat(ssh-server): AC-01 — add SshRemoteServer data model**
- **fix(dashboard): clear Ralph session pane when clicking New Chat**
- **feat(ralph): add resume route for stuck executing sessions**
- **fix(ralph): allow /continue for NO_SIGNAL sessions regardless of cap position**
- **feat(servers): implement SshConnector for SSH tunnel remote servers (AC-02)**
- **feat(servers): add SSH Tunnel radio and fields to AddServerDialog**
- **feat(coc): auto-reconnect on unexpected SSH exit + SSH route integration tests**
