### PR TITLE
test(forge): update sandbox mode assertion to workspace-write for interactive mode

### DIFF
--- a/packages/forge/test/copilot-sdk-wrapper/codex-sdk-service.test.ts
+++ b/packages/forge/test/copilot-sdk-wrapper/codex-sdk-service.test.ts
@@ -537,7 +537,7 @@ describe('CodexSDKService — SDK mocked', () => {
         );
     });
 
-    it('sendMessage starts interactive Codex threads with read-only sandbox', async () => {
+    it('sendMessage starts interactive Codex threads with workspace-write sandbox', async () => {
         const codexMock = svc['sdk'] as ReturnType<typeof makeCodexSdkMock>;
 
         await svc.sendMessage({ prompt: 'ask mode', mode: 'interactive' });
@@ -545,7 +545,7 @@ describe('CodexSDKService — SDK mocked', () => {
         expect(codexMock.startThread).toHaveBeenCalledOnce();
         expect(codexMock.startThread.mock.calls[0][0]).toEqual(expect.objectContaining({
             approvalPolicy: 'never',
-            sandboxMode: 'read-only',
+            sandboxMode: 'workspace-write',
             networkAccessEnabled: false,
         }));
     });


### PR DESCRIPTION
The commit 245582e98 changed the Codex sandbox from read-only to
workspace-write for interactive/ask mode but missed updating the
parallel test in packages/forge. This caused forge-test CI to fail on
all platforms.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
