### PR TITLE
Add WSL dev tunnel workflow + tunnel ownership diagnostics

### DIFF
--- a/.github/skills/coc-knowledge/references/remote-servers.md
+++ b/.github/skills/coc-knowledge/references/remote-servers.md
@@ -156,6 +156,7 @@ Use reconnect when the managed CLI/`ssh` process is stale, the local listener st
 | Health is offline with no effective endpoint | The connector failed before local URL resolution | The offline error now surfaces the underlying connector error (auth, CLI missing, readiness timeout); check it and verify `devtunnel port list <id>` works |
 | Health is offline with an HTTP or fetch error | The tunnel connected, but CoC is not reachable through the resolved port | Verify the host is running `coc serve` on the configured tunnel port |
 | Manual `devtunnel connect <id>` works (forwards to `127.0.0.1:<local>`) but CoC still reports offline | The connector health-checks the wrong local port | Resolved: CoC now parses the forwarded local port from `devtunnel connect` output instead of assuming local port equals the configured HTTP port |
+| Same-machine WSL tunnel connects but a remote-node tunnel reports offline | Health requests over a WAN DevTunnel relay exceed the per-attempt timeout | Resolved: each health attempt now has its own budget (`healthRequestTimeoutMs`, default 5s) within a longer readiness window (default 20s) instead of being clamped to the poll interval |
 
 ## Implementation map
 

--- a/.github/skills/coc-knowledge/references/remote-servers.md
+++ b/.github/skills/coc-knowledge/references/remote-servers.md
@@ -44,6 +44,17 @@ For a persistent Windows service, use:
 
 `Manage-CoCService.ps1 install -TunnelId <id>` wraps the same serve loop in a scheduled task. Do not pass `-Port` with `-TunnelId`; the port belongs to the DevTunnel binding and must be configured with `config-devtunnel.ps1`.
 
+### Linux/WSL equivalents
+
+The bash ports mirror the PowerShell scripts one-to-one and share `scripts/devtunnel-utils.sh`:
+
+```bash
+./scripts/config-devtunnel.sh --tunnel-id my-remote-coc
+./scripts/coc-serve-loop.sh --tunnel-id my-remote-coc
+```
+
+`--tunnel-id`/`-t` maps to `-TunnelId` and `--port`/`-p` maps to `-Port`; the default tunnel ID is `<hostname-lowercased>-coc`. `config-devtunnel.sh` installs the Linux or macOS `devtunnel` build when missing. If the tunnel ID is owned by a different account (devtunnel reports `Tunnel not found` / `request not permitted` / `unauthorized tunnel access`), both scripts print "owned by a different account or in use elsewhere" and exit `2` instead of a confusing not-found message — log in as the tunnel's owner or pick a different `--tunnel-id`.
+
 ## Dashboard-side registration
 
 In the CoC dashboard, the Servers view is enabled by default through `servers.enabled` and supports two remote server kinds:
@@ -138,7 +149,8 @@ Use reconnect when the managed CLI/`ssh` process is stale, the local listener st
 | `devtunnel CLI is not authenticated` | The CLI cannot access the tunnel | Run `devtunnel user login` |
 | `No HTTP ports are configured for this DevTunnel` | The tunnel exists but has no HTTP binding | Run `.\scripts\config-devtunnel.ps1 -TunnelId <id>` on the host side |
 | `Multiple HTTP ports are configured for this DevTunnel` | CoC cannot choose a single local endpoint | Remove extra HTTP ports or recreate the tunnel |
-| Health is offline with no effective endpoint | The connector failed before local URL resolution | Check the connector error and verify `devtunnel port list <id>` works |
+| `... is not accessible to the current account` / `owned by a different account` | The tunnel ID is owned by a different identity (the host and dashboard logged in with different accounts) | Log in as the tunnel's owner with `devtunnel user login`, or use a different tunnel ID |
+| Health is offline with no effective endpoint | The connector failed before local URL resolution | The offline error now surfaces the underlying connector error (auth, CLI missing, readiness timeout); check it and verify `devtunnel port list <id>` works |
 | Health is offline with an HTTP or fetch error | The tunnel connected, but CoC is not reachable through the resolved port | Verify the host is running `coc serve` on the configured tunnel port |
 
 ## Implementation map
@@ -155,6 +167,7 @@ Key files:
 - `packages\forge\src\connectors\ssh-connector.ts` manages `ssh -N` child processes with auto-reconnect.
 - `packages\forge\src\connectors\devtunnel-connector.ts` manages `devtunnel connect` child processes and readiness polling.
 - `packages\forge\src\connectors\devtunnel-port-parser.ts` parses `devtunnel port list` output.
+- `scripts/config-devtunnel.sh`, `scripts/coc-serve-loop.sh`, `scripts/devtunnel-utils.sh` are the Linux/WSL equivalents of the host-side PowerShell scripts.
 - `packages\coc\src\server\servers\remote-server-store.ts` validates and persists remote server entries.
 - `packages\coc\src\server\servers\remote-server-health.ts` probes remote CoC health and metadata.
 - `packages\coc\src\server\servers\remote-server-routes.ts` exposes the REST API.

--- a/.github/skills/coc-knowledge/references/remote-servers.md
+++ b/.github/skills/coc-knowledge/references/remote-servers.md
@@ -84,11 +84,12 @@ The registry file is `~/.coc/remote-servers.json`.
 When a DevTunnel remote server is created, tested, health-checked, or explicitly connected, CoC runs this sequence:
 
 1. Runs `devtunnel port list <tunnelId>`.
-2. Parses the output and requires exactly one HTTP port.
+2. Parses the output and requires exactly one HTTP port (the remote/host port).
 3. Starts `devtunnel connect <tunnelId>` if CoC is not already managing a child process for that tunnel.
-4. Builds the effective local URL as `http://127.0.0.1:<http-port>`.
-5. Polls `GET /api/health` on that local URL until it is ready or the readiness timeout expires.
-6. Marks the runtime state as `online` and records the local port, effective URL, and public URL if the CLI output includes one.
+4. Reads the **forwarded local port** from the `devtunnel connect` stdout/stderr (it parses lines such as `Forwarding from 127.0.0.1:<local> to host port <host>`), because `devtunnel connect` forwards the remote HTTP port to a possibly-different, often random, local port. If no forwarding line appears within `forwardReadyTimeoutMs` (default 10s), it falls back to the configured HTTP port.
+5. Builds the effective local URL as `http://127.0.0.1:<forwarded-local-port>`.
+6. Polls `GET /api/health` on that local URL until it is ready or the readiness timeout expires.
+7. Marks the runtime state as `online` and records the local port, effective URL, and public URL if the CLI output includes one.
 
 Multiple registered remote servers can point at the same tunnel ID. CoC deduplicates the managed tunnel connection by tunnel ID.
 
@@ -100,7 +101,7 @@ The persisted server entry contains durable configuration only. Runtime fields a
 | --- | --- |
 | `status` | `idle`, `connecting`, `online`, `offline`, or `failed` |
 | `effectiveUrl` | Local URL used by the current dashboard server, for example `http://127.0.0.1:51234` |
-| `localPort` | HTTP port resolved from `devtunnel port list` |
+| `localPort` | Forwarded local port from `devtunnel connect` (falls back to the `devtunnel port list` HTTP port) |
 | `publicUrl` | Public DevTunnel URL when available from CLI output |
 | `lastChecked` | Last runtime state or health check timestamp |
 | `lastError` | Last connector error, if any |
@@ -154,6 +155,7 @@ Use reconnect when the managed CLI/`ssh` process is stale, the local listener st
 | `... is not accessible to the current account` / `owned by a different account` | The tunnel ID is owned by a different identity (the host and dashboard logged in with different accounts) | Log in as the tunnel's owner with `devtunnel user login`, or use a different tunnel ID |
 | Health is offline with no effective endpoint | The connector failed before local URL resolution | The offline error now surfaces the underlying connector error (auth, CLI missing, readiness timeout); check it and verify `devtunnel port list <id>` works |
 | Health is offline with an HTTP or fetch error | The tunnel connected, but CoC is not reachable through the resolved port | Verify the host is running `coc serve` on the configured tunnel port |
+| Manual `devtunnel connect <id>` works (forwards to `127.0.0.1:<local>`) but CoC still reports offline | The connector health-checks the wrong local port | Resolved: CoC now parses the forwarded local port from `devtunnel connect` output instead of assuming local port equals the configured HTTP port |
 
 ## Implementation map
 

--- a/.github/skills/coc-knowledge/references/remote-servers.md
+++ b/.github/skills/coc-knowledge/references/remote-servers.md
@@ -42,6 +42,8 @@ For a persistent Windows service, use:
 - Starts `coc serve --no-open --port <configured-port>`.
 - Stops the hosted tunnel process when the serve loop exits.
 
+In tunnel mode the loop hosts the tunnel **before** announcing the serve step. If `devtunnel host` fails to start or does not publish a public URL within `COC_DEVTUNNEL_URL_TIMEOUT` seconds (default 30), the loop prints the captured `devtunnel host` output, skips `coc serve`, and exits non-zero (`1`) rather than silently serving on localhost with no working tunnel. (On PowerShell 7 for Linux/macOS the host process is launched without the Windows-only `-WindowStyle Hidden`, which otherwise throws and prevents hosting.)
+
 `Manage-CoCService.ps1 install -TunnelId <id>` wraps the same serve loop in a scheduled task. Do not pass `-Port` with `-TunnelId`; the port belongs to the DevTunnel binding and must be configured with `config-devtunnel.ps1`.
 
 ### Linux/WSL equivalents

--- a/packages/coc/src/server/servers/devtunnel-port-parser.ts
+++ b/packages/coc/src/server/servers/devtunnel-port-parser.ts
@@ -1,2 +1,2 @@
-export { parseDevTunnelHttpPortInfo, parseDevTunnelHttpPort, DevTunnelPortParseError } from '@plusplusoneplusplus/forge/connectors';
+export { parseDevTunnelHttpPortInfo, parseDevTunnelHttpPort, parseDevTunnelForwardedPort, DevTunnelPortParseError } from '@plusplusoneplusplus/forge/connectors';
 export type { DevTunnelPortParseErrorCode, ParsedHttpPort } from '@plusplusoneplusplus/forge/connectors';

--- a/packages/coc/src/server/servers/remote-server-health.ts
+++ b/packages/coc/src/server/servers/remote-server-health.ts
@@ -9,6 +9,7 @@ interface HealthTarget {
     tunnelId?: string;
     localPort?: number;
     publicUrl?: string;
+    lastError?: string;
 }
 
 async function fetchOptionalServerName(baseUrl: string): Promise<string | undefined> {
@@ -36,7 +37,7 @@ export async function checkRemoteServerHealth(target: HealthTarget): Promise<Rem
             localPort: target.localPort,
             publicUrl: target.publicUrl,
             lastChecked,
-            error: 'No effective endpoint is available',
+            error: target.lastError ?? 'No effective endpoint is available',
         };
     }
 

--- a/packages/coc/src/server/servers/remote-server-routes.ts
+++ b/packages/coc/src/server/servers/remote-server-routes.ts
@@ -113,6 +113,7 @@ async function healthForServer(server: RemoteServer, connector: DevTunnelConnect
         tunnelId: server.kind === 'devtunnel' ? server.tunnelId : undefined,
         localPort: runtime.localPort,
         publicUrl: runtime.publicUrl,
+        lastError: runtime.lastError,
     });
 }
 

--- a/packages/coc/test/coc-service-scripts.test.ts
+++ b/packages/coc/test/coc-service-scripts.test.ts
@@ -57,7 +57,7 @@ const runPowerShellFile = (scriptName: string, args: string[], env: NodeJS.Proce
   );
 };
 
-const createFakeDevTunnel = (mode: 'none' | 'one' | 'multi' | 'host-wrong-first') => {
+const createFakeDevTunnel = (mode: 'none' | 'one' | 'multi' | 'host-wrong-first' | 'not-owned') => {
   const dir = mkdtempSync(join(tmpdir(), 'coc-devtunnel-test-'));
   const logPath = join(dir, 'devtunnel.log');
   const cocLogPath = join(dir, 'coc.log');
@@ -88,6 +88,9 @@ if (args[0] === 'port' && args[1] === 'list') {
     console.log('Port Number  Protocol');
     console.log('4000         http');
     console.log('51234        http');
+  } else if (mode === 'not-owned') {
+    console.error('Tunnel not found: ' + (args[2] || ''));
+    process.exit(11);
   } else {
     console.log('No ports found');
   }
@@ -496,6 +499,11 @@ describe('CoC service bash scripts', () => {
     expect(configDevTunnelSh).not.toContain('host "$TUNNEL_ID"');
   });
 
+  it('config-devtunnel.sh detects when the tunnel id is owned by a different account', () => {
+    expect(configDevTunnelSh).toContain('is_devtunnel_not_owned_error');
+    expect(configDevTunnelSh).toContain('owned by a different account or in use elsewhere');
+  });
+
   it('coc-serve-loop.sh uses --tunnel-id as the only tunnel selector and rejects --port with it', () => {
     expect(serveLoopSh).toContain('-t|--tunnel-id)');
     expect(serveLoopSh).toContain(
@@ -657,6 +665,21 @@ describeBash('CoC service bash script behavior', () => {
       expect(result.status, output).toBe(2);
       expect(output).toContain("Dev tunnel 'ambiguous-coc' has multiple HTTP ports (4000 51234).");
       expect(readDevTunnelLog(fake.logPath).some((line) => line.startsWith('port\tcreate\tambiguous-coc'))).toBe(false);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('config-devtunnel.sh reports a clear hint when the tunnel id is owned by another account', () => {
+    const fake = createFakeDevTunnel('not-owned');
+    try {
+      const result = runBashFile('config-devtunnel.sh', ['--tunnel-id', 'foreign-coc'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(2);
+      expect(output).toContain("Dev tunnel 'foreign-coc' is not accessible to the current account");
+      expect(output).toContain('owned by a different account or in use elsewhere');
+      expect(output).toContain('rerun with a different --tunnel-id');
+      expect(readDevTunnelLog(fake.logPath).some((line) => line.startsWith('port\tcreate\tforeign-coc'))).toBe(false);
     } finally {
       fake.cleanup();
     }

--- a/packages/coc/test/coc-service-scripts.test.ts
+++ b/packages/coc/test/coc-service-scripts.test.ts
@@ -57,7 +57,9 @@ const runPowerShellFile = (scriptName: string, args: string[], env: NodeJS.Proce
   );
 };
 
-const createFakeDevTunnel = (mode: 'none' | 'one' | 'multi' | 'host-wrong-first' | 'not-owned' | 'create-not-owned') => {
+const createFakeDevTunnel = (
+  mode: 'none' | 'one' | 'multi' | 'host-wrong-first' | 'not-owned' | 'create-not-owned' | 'host-fails' | 'host-hangs'
+) => {
   const dir = mkdtempSync(join(tmpdir(), 'coc-devtunnel-test-'));
   const logPath = join(dir, 'devtunnel.log');
   const cocLogPath = join(dir, 'coc.log');
@@ -82,7 +84,7 @@ if (args[0] === 'create') {
   process.exit(0);
 }
 if (args[0] === 'port' && args[1] === 'list') {
-  if (mode === 'one') {
+  if (mode === 'one' || mode === 'host-fails' || mode === 'host-hangs') {
     console.log('Port Number  Protocol');
     console.log('51234        http');
   } else if (mode === 'host-wrong-first') {
@@ -104,7 +106,12 @@ if (args[0] === 'port' && args[1] === 'create') {
   process.exit(0);
 }
 if (args[0] === 'host') {
-  if (mode === 'host-wrong-first') {
+  if (mode === 'host-fails') {
+    console.error('Tunnel host failed: unauthorized tunnel access');
+    process.exit(1);
+  } else if (mode === 'host-hangs') {
+    console.log('Hosting tunnel (no public URL emitted)');
+  } else if (mode === 'host-wrong-first') {
     console.log('Connect via https://fake.devtunnels.ms:4000');
     console.log('Connect via https://fake.devtunnels.ms:53910');
   } else {
@@ -258,10 +265,28 @@ describe('CoC service PowerShell scripts', () => {
       expect(serveLoop).toContain('function Start-DevTunnel');
       expect(serveLoop).toContain('function Select-DevTunnelUrl');
       expect(serveLoop).toContain('function Test-DevTunnelUrlMatchesPort');
-      expect(serveLoop).toContain("Start-Process $devTunnelCommand -ArgumentList @('host', $TunnelId)");
+      expect(serveLoop).toContain("ArgumentList           = @('host', $TunnelId)");
+      expect(serveLoop).toContain('$proc = Start-Process @startArgs');
       expect(serveLoop).toContain('Start-DevTunnel -TunnelId $TunnelId -Port $Port');
       expect(serveLoop).toContain("https://[^\\s,]+devtunnels\\.ms[^\\s,]*");
       expect(serveLoop).toContain('Dev tunnel URL:');
+    });
+
+    it('only requests a hidden window on Windows so Linux/macOS hosting works', () => {
+      expect(serveLoop).toContain('$isWindowsHost = ($null -eq $IsWindows) -or $IsWindows');
+      expect(serveLoop).toContain("if ($isWindowsHost) { $startArgs['WindowStyle'] = 'Hidden' }");
+      expect(serveLoop).not.toContain('-WindowStyle Hidden');
+    });
+
+    it('aborts startup instead of serving locally when the tunnel host fails', () => {
+      expect(serveLoop).toContain('Aborting startup instead of serving locally without a working tunnel.');
+      expect(serveLoop).toContain('devtunnel host output:');
+      expect(serveLoop).not.toContain('Continuing with local serving');
+      expect(serveLoop.indexOf('Stop-DevTunnel -TunnelSession $tunnelSession')).toBeGreaterThan(0);
+      // The tunnel must be hosted before announcing the serve step.
+      expect(serveLoop.indexOf('Start-DevTunnel -TunnelId $TunnelId -Port $Port')).toBeLessThan(
+        serveLoop.indexOf('=== Starting coc serve')
+      );
     });
 
     it('can launch a devtunnel CLI installed by the config script fallback', () => {
@@ -513,6 +538,40 @@ if ($errors.Count -gt 0) {
       fake.cleanup();
     }
   });
+
+  it('aborts tunnel mode without serving when the dev tunnel host fails', () => {
+    const fake = createFakeDevTunnel('host-fails');
+    try {
+      const result = runPowerShellFile('coc-serve-loop.ps1', ['-TunnelId', 'existing-coc', '-SkipInitialBuild'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("Failed to host dev tunnel 'existing-coc'");
+      expect(output).toContain('Aborting startup instead of serving locally without a working tunnel.');
+      expect(output).toContain('Tunnel host failed: unauthorized tunnel access');
+      expect(output).not.toContain('=== Starting coc serve');
+      expect(readLogLines(fake.cocLogPath)).toEqual([]);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('aborts tunnel mode when the host never publishes a public URL', () => {
+    const fake = createFakeDevTunnel('host-hangs');
+    try {
+      const result = runPowerShellFile(
+        'coc-serve-loop.ps1',
+        ['-TunnelId', 'existing-coc', '-SkipInitialBuild'],
+        { ...fake.env, COC_DEVTUNNEL_URL_TIMEOUT: '1' }
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("Failed to host dev tunnel 'existing-coc' within 1 seconds.");
+      expect(output).not.toContain('=== Starting coc serve');
+      expect(readLogLines(fake.cocLogPath)).toEqual([]);
+    } finally {
+      fake.cleanup();
+    }
+  });
 });
 
 describe('CoC service bash scripts', () => {
@@ -561,6 +620,17 @@ describe('CoC service bash scripts', () => {
     expect(serveLoopSh).toContain('port list "$id"');
     expect(serveLoopSh.indexOf('stop_devtunnel_host')).toBeGreaterThan(serveLoopSh.indexOf('coc serve --no-open'));
     expect(serveLoopSh).not.toContain('port create');
+  });
+
+  it('coc-serve-loop.sh aborts startup instead of serving locally when the tunnel host fails', () => {
+    expect(serveLoopSh).toContain('if ! start_devtunnel_host "$TUNNEL_ID" "$PORT"; then');
+    expect(serveLoopSh).toContain('Aborting startup instead of serving locally without a working tunnel.');
+    expect(serveLoopSh).toContain('devtunnel host output:');
+    expect(serveLoopSh).not.toContain('Continuing with local serving');
+    // The tunnel must be hosted before announcing the serve step.
+    expect(serveLoopSh.indexOf('start_devtunnel_host "$TUNNEL_ID" "$PORT"')).toBeLessThan(
+      serveLoopSh.indexOf('=== Starting coc serve')
+    );
   });
 });
 
@@ -660,6 +730,40 @@ describeBash('CoC service bash script behavior', () => {
       expect(output).not.toContain('Dev tunnel URL: https://fake.devtunnels.ms:4000');
       expect(readLogLines(fake.cocLogPath)).toContain('serve\t--no-open\t--port\t53910\t--host\t127.0.0.1');
       expect(readDevTunnelLog(fake.logPath)).toEqual(['port\tlist\texisting-coc', 'host\texisting-coc']);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('aborts tunnel mode without serving when the dev tunnel host fails', () => {
+    const fake = createFakeDevTunnel('host-fails');
+    try {
+      const result = runBashFile('coc-serve-loop.sh', ['--tunnel-id', 'existing-coc', '--skip-initial-build'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("Failed to host dev tunnel 'existing-coc'.");
+      expect(output).toContain('Aborting startup instead of serving locally without a working tunnel.');
+      expect(output).toContain('Tunnel host failed: unauthorized tunnel access');
+      expect(output).not.toContain('=== Starting coc serve');
+      expect(readLogLines(fake.cocLogPath)).toEqual([]);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('aborts tunnel mode when the host never publishes a public URL', () => {
+    const fake = createFakeDevTunnel('host-hangs');
+    try {
+      const result = runBashFile(
+        'coc-serve-loop.sh',
+        ['--tunnel-id', 'existing-coc', '--skip-initial-build'],
+        { ...fake.env, COC_DEVTUNNEL_URL_TIMEOUT: '1' }
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("Failed to host dev tunnel 'existing-coc'.");
+      expect(output).not.toContain('=== Starting coc serve');
+      expect(readLogLines(fake.cocLogPath)).toEqual([]);
     } finally {
       fake.cleanup();
     }

--- a/packages/coc/test/coc-service-scripts.test.ts
+++ b/packages/coc/test/coc-service-scripts.test.ts
@@ -261,6 +261,15 @@ describe('CoC service PowerShell scripts', () => {
       expect(serveLoop).not.toContain("'port', 'create', $TunnelId");
     });
 
+    it('surfaces a not-owned tunnel at serve time', () => {
+      expect(serveLoop).toContain('Test-DevTunnelNotOwnedError');
+      expect(serveLoop).toContain('is not accessible to the current account');
+      // The ownership check must run before the generic exit-code failure path.
+      expect(serveLoop.indexOf('Test-DevTunnelNotOwnedError $portList.Output')).toBeLessThan(
+        serveLoop.indexOf('Failed to list dev tunnel ports')
+      );
+    });
+
     it('hosts devtunnel as a subprocess and parses the public URL from output', () => {
       expect(serveLoop).toContain('function Start-DevTunnel');
       expect(serveLoop).toContain('function Select-DevTunnelUrl');
@@ -297,6 +306,8 @@ describe('CoC service PowerShell scripts', () => {
     it('stops the devtunnel process tree after every serve iteration', () => {
       expect(serveLoop).toContain('function Stop-ProcessTree');
       expect(serveLoop).toContain('Where-Object { $_.ParentProcessId -eq $ProcessId }');
+      // On pwsh-for-Linux, Win32_Process is unavailable, so the tree is killed via .NET Kill($true).
+      expect(serveLoop).toContain('(Get-Process -Id $ProcessId -ErrorAction Stop).Kill($true)');
       expect(serveLoop).toContain('Stop-DevTunnel -TunnelSession $tunnelSession');
       expect(serveLoop).toContain('} finally {');
       expect(serveLoop.indexOf('Stop-DevTunnel -TunnelSession $tunnelSession')).toBeLessThan(
@@ -620,6 +631,15 @@ describe('CoC service bash scripts', () => {
     expect(serveLoopSh).toContain('port list "$id"');
     expect(serveLoopSh.indexOf('stop_devtunnel_host')).toBeGreaterThan(serveLoopSh.indexOf('coc serve --no-open'));
     expect(serveLoopSh).not.toContain('port create');
+  });
+
+  it('coc-serve-loop.sh surfaces a not-owned tunnel at serve time', () => {
+    expect(serveLoopSh).toContain('is_devtunnel_not_owned_error');
+    expect(serveLoopSh).toContain('is not accessible to the current account');
+    // The ownership check must run before the generic "Failed to list" fallback.
+    expect(serveLoopSh.indexOf('is_devtunnel_not_owned_error')).toBeLessThan(
+      serveLoopSh.indexOf('Failed to list dev tunnel ports')
+    );
   });
 
   it('coc-serve-loop.sh aborts startup instead of serving locally when the tunnel host fails', () => {

--- a/packages/coc/test/coc-service-scripts.test.ts
+++ b/packages/coc/test/coc-service-scripts.test.ts
@@ -57,7 +57,7 @@ const runPowerShellFile = (scriptName: string, args: string[], env: NodeJS.Proce
   );
 };
 
-const createFakeDevTunnel = (mode: 'none' | 'one' | 'multi' | 'host-wrong-first' | 'not-owned') => {
+const createFakeDevTunnel = (mode: 'none' | 'one' | 'multi' | 'host-wrong-first' | 'not-owned' | 'create-not-owned') => {
   const dir = mkdtempSync(join(tmpdir(), 'coc-devtunnel-test-'));
   const logPath = join(dir, 'devtunnel.log');
   const cocLogPath = join(dir, 'coc.log');
@@ -75,6 +75,10 @@ if (logPath) {
 }
 const mode = process.env.FAKE_DEVTUNNEL_MODE || 'none';
 if (args[0] === 'create') {
+  if (mode === 'create-not-owned') {
+    console.error('Unauthorized tunnel access: Request not permitted.');
+    process.exit(11);
+  }
   process.exit(0);
 }
 if (args[0] === 'port' && args[1] === 'list') {
@@ -410,6 +414,19 @@ if ($errors.Count -gt 0) {
     }
   });
 
+  it('reports ownership conflicts raised by create itself (not as an auth error)', () => {
+    const fake = createFakeDevTunnel('create-not-owned');
+    try {
+      const result = runPowerShellFile('config-devtunnel.ps1', ['-TunnelId', 'foreign-coc'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(2);
+      expect(output).toContain('owned by a different account or in use elsewhere');
+      expect(output).not.toContain('devtunnel is not authenticated');
+    } finally {
+      fake.cleanup();
+    }
+  });
+
   it('rejects Port with TunnelId before building', () => {
     const result = runPowerShellFile('coc-serve-loop.ps1', ['-TunnelId', 'my-remote-coc', '-Port', '51234', '-SkipInitialBuild']);
     const output = `${result.stdout}\n${result.stderr}`;
@@ -700,6 +717,19 @@ describeBash('CoC service bash script behavior', () => {
       expect(output).toContain('owned by a different account or in use elsewhere');
       expect(output).toContain('rerun with a different --tunnel-id');
       expect(readDevTunnelLog(fake.logPath).some((line) => line.startsWith('port\tcreate\tforeign-coc'))).toBe(false);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('config-devtunnel.sh reports ownership conflicts raised by create itself (not as an auth error)', () => {
+    const fake = createFakeDevTunnel('create-not-owned');
+    try {
+      const result = runBashFile('config-devtunnel.sh', ['--tunnel-id', 'foreign-coc'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(2);
+      expect(output).toContain('owned by a different account or in use elsewhere');
+      expect(output).not.toContain('devtunnel is not authenticated');
     } finally {
       fake.cleanup();
     }

--- a/packages/coc/test/coc-service-scripts.test.ts
+++ b/packages/coc/test/coc-service-scripts.test.ts
@@ -207,6 +207,11 @@ describe('CoC service PowerShell scripts', () => {
       expect(configDevTunnel).not.toContain("@('host', $TunnelId)");
       expect(configDevTunnel).not.toContain('Start-Process devtunnel');
     });
+
+    it('detects when the tunnel id is owned by a different account', () => {
+      expect(configDevTunnel).toContain('Test-DevTunnelNotOwnedError');
+      expect(configDevTunnel).toContain('owned by a different account or in use elsewhere');
+    });
   });
 
   describe('devtunnel-utils.ps1', () => {
@@ -385,6 +390,21 @@ if ($errors.Count -gt 0) {
       expect(result.status, output).toBe(2);
       expect(output).toContain("Dev tunnel 'ambiguous-coc' has multiple HTTP ports (4000, 51234).");
       expect(readDevTunnelLog(fake.logPath).some((line) => line.startsWith('port\tcreate\tambiguous-coc'))).toBe(false);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('reports a clear hint when the tunnel id is owned by another account', () => {
+    const fake = createFakeDevTunnel('not-owned');
+    try {
+      const result = runPowerShellFile('config-devtunnel.ps1', ['-TunnelId', 'foreign-coc'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(2);
+      expect(output).toContain("Dev tunnel 'foreign-coc' is not accessible to the current account");
+      expect(output).toContain('owned by a different account or in use elsewhere');
+      expect(output).toContain('rerun with a different -TunnelId');
+      expect(readDevTunnelLog(fake.logPath).some((line) => line.startsWith('port\tcreate\tforeign-coc'))).toBe(false);
     } finally {
       fake.cleanup();
     }

--- a/packages/coc/test/coc-service-scripts.test.ts
+++ b/packages/coc/test/coc-service-scripts.test.ts
@@ -29,6 +29,17 @@ const findPowerShell = () => {
 const powerShellCommand = findPowerShell();
 const describePowerShell = powerShellCommand ? describe : describe.skip;
 
+const hasBash = spawnSync('bash', ['-c', 'exit 0'], { encoding: 'utf-8', stdio: 'pipe' }).status === 0;
+const describeBash = process.platform !== 'win32' && hasBash ? describe : describe.skip;
+
+const runBashFile = (scriptName: string, args: string[], env: NodeJS.ProcessEnv = {}) =>
+  spawnSync('bash', [resolve(scriptsRoot, scriptName), ...args], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+    timeout: 20_000,
+  });
+
 const runPowerShellFile = (scriptName: string, args: string[], env: NodeJS.ProcessEnv = {}) => {
   if (!powerShellCommand) {
     throw new Error('PowerShell is not available');
@@ -458,6 +469,194 @@ if ($errors.Count -gt 0) {
       expect(output).not.toContain('Dev tunnel URL: https://fake.devtunnels.ms:4000');
       expect(readLogLines(fake.cocLogPath)).toContain('serve\t--no-open\t--port\t53910\t--host\t127.0.0.1');
       expect(readDevTunnelLog(fake.logPath)).toEqual(['port\tlist\texisting-coc', 'host\texisting-coc']);
+    } finally {
+      fake.cleanup();
+    }
+  });
+});
+
+describe('CoC service bash scripts', () => {
+  const serveLoopSh = readScript('coc-serve-loop.sh');
+  const configDevTunnelSh = readScript('config-devtunnel.sh');
+  const devTunnelUtilsSh = readScript('devtunnel-utils.sh');
+
+  it('shares dev tunnel helpers via devtunnel-utils.sh', () => {
+    expect(devTunnelUtilsSh).toContain('is_devtunnel_auth_error()');
+    expect(devTunnelUtilsSh).toContain('get_http_devtunnel_ports()');
+    expect(devTunnelUtilsSh).toContain('get_random_free_port()');
+    for (const script of [serveLoopSh, configDevTunnelSh]) {
+      expect(script).toContain('. "$SCRIPT_DIR/devtunnel-utils.sh"');
+    }
+  });
+
+  it('config-devtunnel.sh owns the tunnel-id to HTTP port binding without hosting', () => {
+    expect(configDevTunnelSh).toContain('port list "$TUNNEL_ID"');
+    expect(configDevTunnelSh).toContain('port create "$TUNNEL_ID" -p "$resolved_port" --protocol http');
+    expect(configDevTunnelSh).toContain('get_random_free_port');
+    expect(configDevTunnelSh).not.toContain('host "$TUNNEL_ID"');
+  });
+
+  it('coc-serve-loop.sh uses --tunnel-id as the only tunnel selector and rejects --port with it', () => {
+    expect(serveLoopSh).toContain('-t|--tunnel-id)');
+    expect(serveLoopSh).toContain(
+      '--port cannot be used with --tunnel-id. Configure the tunnel port with config-devtunnel.sh, then start the loop with only --tunnel-id.'
+    );
+    expect(serveLoopSh).toContain('resolve_configured_devtunnel_port');
+    expect(serveLoopSh).toContain('start_devtunnel_host');
+    expect(serveLoopSh).toContain('stop_devtunnel_host');
+    expect(serveLoopSh).toContain('trap stop_devtunnel_host EXIT');
+    expect(serveLoopSh).toContain("trap 'stop_devtunnel_host; exit 130' INT");
+    expect(serveLoopSh).toContain("trap 'stop_devtunnel_host; exit 143' TERM");
+  });
+
+  it('coc-serve-loop.sh resolves the configured port before building and stops the host after serving', () => {
+    expect(serveLoopSh.indexOf('resolve_configured_devtunnel_port "$TUNNEL_ID"')).toBeLessThan(
+      serveLoopSh.indexOf('while true; do')
+    );
+    expect(serveLoopSh).toContain('port list "$id"');
+    expect(serveLoopSh.indexOf('stop_devtunnel_host')).toBeGreaterThan(serveLoopSh.indexOf('coc serve --no-open'));
+    expect(serveLoopSh).not.toContain('port create');
+  });
+});
+
+describeBash('CoC service bash script behavior', () => {
+  it('passes bash syntax checks', () => {
+    for (const file of ['devtunnel-utils.sh', 'config-devtunnel.sh', 'coc-serve-loop.sh']) {
+      const result = spawnSync('bash', ['-n', resolve(scriptsRoot, file)], { encoding: 'utf-8' });
+      expect(result.status, `${file}: ${result.stderr}`).toBe(0);
+    }
+  });
+
+  it('rejects --port with --tunnel-id before building', () => {
+    const result = runBashFile('coc-serve-loop.sh', [
+      '--tunnel-id',
+      'my-remote-coc',
+      '--port',
+      '51234',
+      '--skip-initial-build',
+    ]);
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(result.status, output).toBe(2);
+    expect(output).toContain(
+      '--port cannot be used with --tunnel-id. Configure the tunnel port with config-devtunnel.sh, then start the loop with only --tunnel-id.'
+    );
+    expect(output).not.toContain('=== Installing dependencies ===');
+  });
+
+  it('fails tunnel mode with a clear error when no HTTP port is configured', () => {
+    const fake = createFakeDevTunnel('none');
+    try {
+      const result = runBashFile('coc-serve-loop.sh', ['--tunnel-id', 'missing-port-coc', '--skip-initial-build'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(2);
+      expect(output).toContain("Dev tunnel 'missing-port-coc' has no configured HTTP port.");
+      expect(output).not.toContain('=== Installing dependencies ===');
+
+      const log = readDevTunnelLog(fake.logPath);
+      expect(log).toContain('port\tlist\tmissing-port-coc');
+      expect(log.some((line) => line.startsWith('host\tmissing-port-coc'))).toBe(false);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('starts non-tunnel mode on the default port', () => {
+    const fake = createFakeDevTunnel('none');
+    try {
+      const result = runBashFile('coc-serve-loop.sh', ['--skip-initial-build'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(0);
+      expect(output).toContain('=== Starting coc serve (host 127.0.0.1, port 4000) ===');
+      expect(readLogLines(fake.cocLogPath)).toContain('serve\t--no-open\t--port\t4000\t--host\t127.0.0.1');
+      expect(readLogLines(fake.logPath)).toEqual([]);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('starts non-tunnel mode on an explicit port', () => {
+    const fake = createFakeDevTunnel('none');
+    try {
+      const result = runBashFile('coc-serve-loop.sh', ['--skip-initial-build', '--port', '51235'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(0);
+      expect(output).toContain('=== Starting coc serve (host 127.0.0.1, port 51235) ===');
+      expect(readLogLines(fake.cocLogPath)).toContain('serve\t--no-open\t--port\t51235\t--host\t127.0.0.1');
+      expect(readLogLines(fake.logPath)).toEqual([]);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('starts tunnel mode on the configured HTTP port and reports the URL', () => {
+    const fake = createFakeDevTunnel('one');
+    try {
+      const result = runBashFile('coc-serve-loop.sh', ['--tunnel-id', 'existing-coc', '--skip-initial-build'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(0);
+      expect(output).toContain("Using dev tunnel 'existing-coc' configured HTTP port 51234.");
+      expect(output).toContain('Dev tunnel URL: https://fake.devtunnels.ms');
+      expect(readLogLines(fake.cocLogPath)).toContain('serve\t--no-open\t--port\t51234\t--host\t127.0.0.1');
+      expect(readDevTunnelLog(fake.logPath)).toEqual(['port\tlist\texisting-coc', 'host\texisting-coc']);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('selects the dev tunnel URL matching the configured HTTP port', () => {
+    const fake = createFakeDevTunnel('host-wrong-first');
+    try {
+      const result = runBashFile('coc-serve-loop.sh', ['--tunnel-id', 'existing-coc', '--skip-initial-build'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(0);
+      expect(output).toContain("Using dev tunnel 'existing-coc' configured HTTP port 53910.");
+      expect(output).toContain('=== Starting coc serve (host 127.0.0.1, port 53910) ===');
+      expect(output).toContain('Dev tunnel URL: https://fake.devtunnels.ms:53910');
+      expect(output).not.toContain('Dev tunnel URL: https://fake.devtunnels.ms:4000');
+      expect(readLogLines(fake.cocLogPath)).toContain('serve\t--no-open\t--port\t53910\t--host\t127.0.0.1');
+      expect(readDevTunnelLog(fake.logPath)).toEqual(['port\tlist\texisting-coc', 'host\texisting-coc']);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('config-devtunnel.sh configures an explicit HTTP port when the tunnel has none', () => {
+    const fake = createFakeDevTunnel('none');
+    try {
+      const result = runBashFile('config-devtunnel.sh', ['--tunnel-id', 'my-remote-coc', '--port', '51234'], fake.env);
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).toContain("Dev tunnel 'my-remote-coc' is configured for HTTP port 51234.");
+
+      const log = readDevTunnelLog(fake.logPath);
+      expect(log).toContain('create\tmy-remote-coc');
+      expect(log).toContain('port\tlist\tmy-remote-coc');
+      expect(log).toContain('port\tcreate\tmy-remote-coc\t-p\t51234\t--protocol\thttp');
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('config-devtunnel.sh reuses an existing single HTTP port', () => {
+    const fake = createFakeDevTunnel('one');
+    try {
+      const result = runBashFile('config-devtunnel.sh', ['--tunnel-id', 'existing-coc', '--port', '4000'], fake.env);
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).toContain('already has HTTP port 51234; reusing it instead of requested port 4000');
+      expect(result.stdout).toContain("Dev tunnel 'existing-coc' is configured for HTTP port 51234.");
+      expect(readDevTunnelLog(fake.logPath)).not.toContain('port\tcreate\texisting-coc\t-p\t4000\t--protocol\thttp');
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('config-devtunnel.sh fails when multiple HTTP ports exist', () => {
+    const fake = createFakeDevTunnel('multi');
+    try {
+      const result = runBashFile('config-devtunnel.sh', ['--tunnel-id', 'ambiguous-coc'], fake.env);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status, output).toBe(2);
+      expect(output).toContain("Dev tunnel 'ambiguous-coc' has multiple HTTP ports (4000 51234).");
+      expect(readDevTunnelLog(fake.logPath).some((line) => line.startsWith('port\tcreate\tambiguous-coc'))).toBe(false);
     } finally {
       fake.cleanup();
     }

--- a/packages/coc/test/server/devtunnel-connector.test.ts
+++ b/packages/coc/test/server/devtunnel-connector.test.ts
@@ -258,6 +258,50 @@ describe('DevTunnelConnector', () => {
         expect(state.effectiveUrl).toBe('http://127.0.0.1:4000');
     });
 
+    it('tolerates slow remote health responses that exceed the poll interval', async () => {
+        // Regression: per-attempt health timeout was clamped to pollMs (~500ms), which aborted every
+        // request on high-latency (remote-node) tunnels. Each attempt must get its own generous budget.
+        const child = new FakeChild();
+        const connector = new DevTunnelConnector({
+            commandRunner: async () => ({ stdout: '4000 http coc', stderr: '' }),
+            processStarter: () => child,
+            healthChecker: (_url, signal) => new Promise((resolve, reject) => {
+                const timer = setTimeout(() => resolve(true), 40);
+                signal?.addEventListener('abort', () => {
+                    clearTimeout(timer);
+                    reject(new Error('aborted'));
+                });
+            }),
+            readinessPollMs: 1,
+            healthRequestTimeoutMs: 1_000,
+        });
+
+        const state = await connector.connect('t1');
+        expect(state.status).toBe('online');
+        expect(state.effectiveUrl).toBe('http://127.0.0.1:4000');
+    });
+
+    it('still times out when health never succeeds within the readiness window', async () => {
+        const child = new FakeChild();
+        const connector = new DevTunnelConnector({
+            commandRunner: async () => ({ stdout: '4000 http coc', stderr: '' }),
+            processStarter: () => child,
+            healthChecker: (_url, signal) => new Promise((_resolve, reject) => {
+                const timer = setTimeout(() => reject(new Error('boom')), 200);
+                signal?.addEventListener('abort', () => {
+                    clearTimeout(timer);
+                    reject(new Error('aborted'));
+                });
+            }),
+            readinessTimeoutMs: 30,
+            readinessPollMs: 1,
+            healthRequestTimeoutMs: 5,
+        });
+
+        await expect(connector.connect('t1')).rejects.toThrow(/health/i);
+        expect(connector.getState('t1').status).toBe('failed');
+    });
+
     it('parses the forwarded port from stderr output', async () => {
         const child = new FakeChild();
         child.stderr = new EventEmitter();
@@ -276,5 +320,20 @@ describe('DevTunnelConnector', () => {
         const state = await connectPromise;
         expect(state.effectiveUrl).toBe('http://127.0.0.1:52000');
         expect(state.port).toBe(52000);
+    });
+
+    it('stops child processes on dispose', async () => {
+        const child = new FakeChild();
+        const connector = new DevTunnelConnector({
+            commandRunner: async () => ({ stdout: '4000 http coc', stderr: '' }),
+            processStarter: () => child,
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+
+        await connector.connect('my-tunnel');
+        connector.dispose();
+        expect(child.killed).toBe(true);
+        expect(connector.getStates()).toEqual([]);
     });
 });

--- a/packages/coc/test/server/devtunnel-connector.test.ts
+++ b/packages/coc/test/server/devtunnel-connector.test.ts
@@ -4,6 +4,8 @@ import { DevTunnelConnector, type DevTunnelChildProcess } from '../../src/server
 
 class FakeChild extends EventEmitter implements DevTunnelChildProcess {
     killed = false;
+    stdout?: EventEmitter;
+    stderr?: EventEmitter;
     kill(): boolean {
         this.killed = true;
         return true;
@@ -217,18 +219,62 @@ describe('DevTunnelConnector', () => {
         expect(second.publicUrl).toBe('https://new-url.devtunnels.ms');
     });
 
-    it('stops child processes on dispose', async () => {
+    it('health-checks the forwarded local port parsed from devtunnel connect output', async () => {
         const child = new FakeChild();
+        child.stdout = new EventEmitter();
+        const connector = new DevTunnelConnector({
+            commandRunner: async () => ({ stdout: '46279 http coc', stderr: '' }),
+            processStarter: () => child,
+            healthChecker: async url => url === 'http://127.0.0.1:63770',
+            readinessPollMs: 1,
+            forwardReadyTimeoutMs: 1_000,
+        });
+
+        const connectPromise = connector.connect('db-west3-wsl');
+        // Allow connectInternal to spawn the child and attach the stdout listener.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        child.stdout.emit('data', 'SSH: Forwarding from 127.0.0.1:63770 to host port 46279.\n');
+
+        const state = await connectPromise;
+        expect(state.status).toBe('online');
+        expect(state.port).toBe(63770);
+        expect(state.effectiveUrl).toBe('http://127.0.0.1:63770');
+    });
+
+    it('falls back to the configured port when no forwarding line is emitted', async () => {
+        const child = new FakeChild();
+        child.stdout = new EventEmitter();
         const connector = new DevTunnelConnector({
             commandRunner: async () => ({ stdout: '4000 http coc', stderr: '' }),
             processStarter: () => child,
-            healthChecker: async () => true,
+            healthChecker: async url => url === 'http://127.0.0.1:4000',
             readinessPollMs: 1,
+            forwardReadyTimeoutMs: 5,
         });
 
-        await connector.connect('my-tunnel');
-        connector.dispose();
-        expect(child.killed).toBe(true);
-        expect(connector.getStates()).toEqual([]);
+        const state = await connector.connect('t1');
+        expect(state.status).toBe('online');
+        expect(state.port).toBe(4000);
+        expect(state.effectiveUrl).toBe('http://127.0.0.1:4000');
+    });
+
+    it('parses the forwarded port from stderr output', async () => {
+        const child = new FakeChild();
+        child.stderr = new EventEmitter();
+        const connector = new DevTunnelConnector({
+            commandRunner: async () => ({ stdout: '8080 http coc', stderr: '' }),
+            processStarter: () => child,
+            healthChecker: async url => url === 'http://127.0.0.1:52000',
+            readinessPollMs: 1,
+            forwardReadyTimeoutMs: 1_000,
+        });
+
+        const connectPromise = connector.connect('t1');
+        await new Promise(resolve => setTimeout(resolve, 0));
+        child.stderr.emit('data', 'Forwarding port 8080 to local port 52000.\n');
+
+        const state = await connectPromise;
+        expect(state.effectiveUrl).toBe('http://127.0.0.1:52000');
+        expect(state.port).toBe(52000);
     });
 });

--- a/packages/coc/test/server/devtunnel-port-parser.test.ts
+++ b/packages/coc/test/server/devtunnel-port-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DevTunnelPortParseError, parseDevTunnelHttpPort, parseDevTunnelHttpPortInfo } from '../../src/server/servers/devtunnel-port-parser';
+import { DevTunnelPortParseError, parseDevTunnelForwardedPort, parseDevTunnelHttpPort, parseDevTunnelHttpPortInfo } from '../../src/server/servers/devtunnel-port-parser';
 
 describe('parseDevTunnelHttpPort', () => {
     it('returns the single HTTP port from table output', () => {
@@ -121,5 +121,59 @@ describe('parseDevTunnelHttpPortInfo', () => {
 
     it('throws on multiple HTTP ports', () => {
         expect(() => parseDevTunnelHttpPortInfo('4000 http coc\n5000 http other')).toThrow(DevTunnelPortParseError);
+    });
+});
+
+describe('parseDevTunnelForwardedPort', () => {
+    it('parses the local port from a "Forwarding from <addr>:<local> to host port <host>" line', () => {
+        const output = 'SSH: Forwarding from 127.0.0.1:63770 to host port 46279.';
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBe(63770);
+    });
+
+    it('parses the local port from an IPv6 forwarding line', () => {
+        const output = 'SSH: Forwarding from [::1]:63770 to host port 46279.';
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBe(63770);
+    });
+
+    it('parses the local port from a "Forwarding port <host> to local port <local>" line', () => {
+        const output = 'Forwarding port 46279 to local port 50001.';
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBe(50001);
+    });
+
+    it('handles same-port forwarding (local === host)', () => {
+        const output = 'Forwarding from 127.0.0.1:46279 to host port 46279.';
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBe(46279);
+    });
+
+    it('picks the line matching the requested host port among several', () => {
+        const output = [
+            'Forwarding from 127.0.0.1:11111 to host port 22.',
+            'Forwarding from 127.0.0.1:63770 to host port 46279.',
+        ].join('\n');
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBe(63770);
+    });
+
+    it('parses real multi-line devtunnel connect output', () => {
+        const output = [
+            'Connected to tunnel: db-west3-wsl',
+            'SSH: Forwarding from 127.0.0.1:63770 to host port 46279.',
+            'SSH: Forwarding from [::1]:63770 to host port 46279.',
+            'SSH: PortForwardingService listening on 127.0.0.1:63770.',
+        ].join('\n');
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBe(63770);
+    });
+
+    it('returns undefined when no forwarding line matches the host port', () => {
+        const output = 'Forwarding from 127.0.0.1:63770 to host port 22.';
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBeUndefined();
+    });
+
+    it('returns undefined for empty output', () => {
+        expect(parseDevTunnelForwardedPort('', 46279)).toBeUndefined();
+    });
+
+    it('rejects out-of-range local ports', () => {
+        const output = 'Forwarding from 127.0.0.1:99999 to host port 46279.';
+        expect(parseDevTunnelForwardedPort(output, 46279)).toBeUndefined();
     });
 });

--- a/packages/coc/test/server/remote-server-routes.test.ts
+++ b/packages/coc/test/server/remote-server-routes.test.ts
@@ -188,6 +188,29 @@ describe('remote server routes', () => {
         });
     });
 
+    it('surfaces the underlying connector error when the tunnel cannot resolve an endpoint', async () => {
+        const connector = new DevTunnelConnector({
+            commandRunner: async () => {
+                throw Object.assign(new Error('devtunnel not found'), { code: 'ENOENT' });
+            },
+            processStarter: () => new FakeChild(),
+            healthChecker: async () => true,
+            readinessPollMs: 1,
+        });
+        const baseUrl = await startApi(connector);
+
+        const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'devtunnel', label: 'VM', tunnelId: 'my-remote-coc' });
+        const health = await request(baseUrl, 'GET', `/api/servers/${created.body.id}/health`);
+
+        expect(health.status).toBe(200);
+        expect(health.body).toMatchObject({
+            kind: 'devtunnel',
+            status: 'offline',
+            error: 'devtunnel CLI is not installed or not on PATH',
+        });
+        expect(health.body.error).not.toBe('No effective endpoint is available');
+    });
+
     it('rejects manual connect and disconnect for direct URL entries', async () => {
         const baseUrl = await startApi(new DevTunnelConnector());
         const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Lab', url: 'http://lab.example.com' });

--- a/packages/coc/test/server/schedule-concurrent.test.ts
+++ b/packages/coc/test/server/schedule-concurrent.test.ts
@@ -273,6 +273,13 @@ describe('Schedule Concurrency With Queue (Section 5)', () => {
     let server: ExecutionServer | undefined;
     let dataDir: string;
 
+    // These tests exercise the manual `/run` path against a live server whose
+    // ScheduleManager arms real cron timers. A frequent cron (e.g. '* * * * *')
+    // can auto-fire on a minute boundary mid-test and add an extra history
+    // record, making length assertions flaky. The cron value is irrelevant to
+    // what these tests assert, so use one that won't fire during the test.
+    const NON_FIRING_CRON = '0 0 1 1 *';
+
     beforeEach(() => {
         dataDir = createTempDir();
     });
@@ -301,14 +308,14 @@ describe('Schedule Concurrency With Queue (Section 5)', () => {
         const cr1 = await postJSON(schedulesUrl(), {
             name: 'Schedule A',
             target: 'pipelines/a.yaml',
-            cron: '* * * * *',
+            cron: NON_FIRING_CRON,
             params: {},
             onFailure: 'notify',
         });
         const cr2 = await postJSON(schedulesUrl(), {
             name: 'Schedule B',
             target: 'pipelines/b.yaml',
-            cron: '* * * * *',
+            cron: NON_FIRING_CRON,
             params: {},
             onFailure: 'notify',
         });
@@ -338,7 +345,7 @@ describe('Schedule Concurrency With Queue (Section 5)', () => {
         const cr = await postJSON(schedulesUrl(), {
             name: 'Queue Test Schedule',
             target: 'pipelines/test.yaml',
-            cron: '* * * * *',
+            cron: NON_FIRING_CRON,
             params: {},
             onFailure: 'notify',
         });

--- a/packages/forge/src/connectors/devtunnel-connector.ts
+++ b/packages/forge/src/connectors/devtunnel-connector.ts
@@ -1,7 +1,8 @@
-import { execFile } from 'child_process';
-import { parseDevTunnelHttpPortInfo } from './devtunnel-port-parser';
+import { execFile, spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { parseDevTunnelForwardedPort, parseDevTunnelHttpPortInfo } from './devtunnel-port-parser';
 import type { DevTunnelConnectionState, RemoteServer, ManagedChildProcess, ProcessStarter, HealthChecker } from './types';
-import { startProcess as defaultProcessStarter, defaultHealthChecker, waitForHealth } from './health';
+import { defaultHealthChecker, waitForHealth } from './health';
 
 export type DevTunnelCommandRunner = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
 
@@ -11,6 +12,8 @@ export interface DevTunnelConnectorOptions {
     healthChecker?: HealthChecker;
     readinessTimeoutMs?: number;
     readinessPollMs?: number;
+    forwardReadyTimeoutMs?: number;
+    healthRequestTimeoutMs?: number;
 }
 
 interface ManagedConnection {
@@ -18,6 +21,8 @@ interface ManagedConnection {
     child?: ManagedChildProcess;
     pending?: Promise<DevTunnelConnectionState>;
     intentionalStop?: boolean;
+    forwardedPort?: number;
+    forwardBuffer?: string;
 }
 
 function runCommand(command: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
@@ -30,6 +35,15 @@ function runCommand(command: string, args: string[]): Promise<{ stdout: string; 
             resolve({ stdout: stdout.toString(), stderr: stderr.toString() });
         });
     });
+}
+
+// `devtunnel connect` prints the forwarded local port to stdout, so pipe it (the shared
+// startProcess uses stdio:'ignore' and would discard that output).
+function startDevTunnelProcess(command: string, args: string[]): ManagedChildProcess {
+    return spawn(command, args, {
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    }) as ChildProcess as ManagedChildProcess;
 }
 
 function classifyCommandError(error: unknown): string {
@@ -51,13 +65,17 @@ export class DevTunnelConnector {
     private readonly healthChecker: HealthChecker;
     private readonly readinessTimeoutMs: number;
     private readonly readinessPollMs: number;
+    private readonly forwardReadyTimeoutMs: number;
+    private readonly healthRequestTimeoutMs: number;
 
     constructor(options: DevTunnelConnectorOptions = {}) {
         this.commandRunner = options.commandRunner ?? runCommand;
-        this.processStarter = options.processStarter ?? defaultProcessStarter;
+        this.processStarter = options.processStarter ?? startDevTunnelProcess;
         this.healthChecker = options.healthChecker ?? defaultHealthChecker;
-        this.readinessTimeoutMs = options.readinessTimeoutMs ?? 15_000;
+        this.readinessTimeoutMs = options.readinessTimeoutMs ?? 20_000;
         this.readinessPollMs = options.readinessPollMs ?? 500;
+        this.forwardReadyTimeoutMs = options.forwardReadyTimeoutMs ?? 10_000;
+        this.healthRequestTimeoutMs = options.healthRequestTimeoutMs ?? 5_000;
     }
 
     getState(tunnelId: string): DevTunnelConnectionState {
@@ -92,10 +110,8 @@ export class DevTunnelConnector {
         const entry = this.getConnection(tunnelId);
 
         entry.intentionalStop = true;
-        if (entry.child) {
-            entry.child.kill();
-            entry.child = undefined;
-        }
+        entry.child?.kill();
+        this.clearChild(entry);
 
         entry.pending = undefined;
 
@@ -114,10 +130,8 @@ export class DevTunnelConnector {
     disconnect(tunnelId: string): DevTunnelConnectionState {
         const entry = this.getConnection(tunnelId);
         entry.intentionalStop = true;
-        if (entry.child) {
-            entry.child.kill();
-            entry.child = undefined;
-        }
+        entry.child?.kill();
+        this.clearChild(entry);
         entry.state = {
             tunnelId,
             status: 'idle',
@@ -146,17 +160,18 @@ export class DevTunnelConnector {
         try {
             const { stdout, stderr } = await this.commandRunner('devtunnel', ['port', 'list', tunnelId]);
             const { port, publicUrl } = parseDevTunnelHttpPortInfo(`${stdout}\n${stderr}`);
-            const effectiveUrl = `http://127.0.0.1:${port}`;
 
             if (!entry.child) {
                 entry.intentionalStop = false;
+                this.clearChild(entry);
                 const child = this.processStarter('devtunnel', ['connect', tunnelId]);
                 entry.child = child;
+                this.attachForwardListener(entry, child, port);
                 child.once('exit', (code, signal) => {
                     if (entry.intentionalStop || entry.child !== child) {
                         return;
                     }
-                    entry.child = undefined;
+                    this.clearChild(entry);
                     entry.state = {
                         ...entry.state,
                         status: 'failed',
@@ -168,7 +183,7 @@ export class DevTunnelConnector {
                     if (entry.child !== child) {
                         return;
                     }
-                    entry.child = undefined;
+                    this.clearChild(entry);
                     entry.state = {
                         ...entry.state,
                         status: 'failed',
@@ -178,10 +193,15 @@ export class DevTunnelConnector {
                 });
             }
 
-            await waitForHealth(effectiveUrl, this.healthChecker, this.readinessTimeoutMs, this.readinessPollMs, 'DevTunnel');
+            // `devtunnel connect` forwards the remote HTTP port to a possibly-different local port,
+            // so health-check the actual forwarded local port (falling back to the configured port).
+            const localPort = await this.resolveForwardedPort(entry, port);
+            const effectiveUrl = `http://127.0.0.1:${localPort}`;
+
+            await waitForHealth(effectiveUrl, this.healthChecker, this.readinessTimeoutMs, this.readinessPollMs, 'DevTunnel', this.healthRequestTimeoutMs);
             entry.state = {
                 tunnelId,
-                port,
+                port: localPort,
                 effectiveUrl,
                 publicUrl,
                 status: 'online',
@@ -201,6 +221,40 @@ export class DevTunnelConnector {
             };
             throw new Error(entry.state.lastError);
         }
+    }
+
+    private clearChild(entry: ManagedConnection): void {
+        entry.child = undefined;
+        entry.forwardedPort = undefined;
+        entry.forwardBuffer = undefined;
+    }
+
+    private attachForwardListener(entry: ManagedConnection, child: ManagedChildProcess, hostPort: number): void {
+        const onData = (chunk: Buffer | string): void => {
+            if (entry.child !== child || entry.forwardedPort !== undefined) {
+                return; // stale child or already learned — keep draining the pipe, do nothing
+            }
+            entry.forwardBuffer = `${entry.forwardBuffer ?? ''}${chunk.toString()}`.slice(-65536);
+            const local = parseDevTunnelForwardedPort(entry.forwardBuffer, hostPort);
+            if (local !== undefined) {
+                entry.forwardedPort = local;
+                entry.forwardBuffer = undefined;
+            }
+        };
+        child.stdout?.on('data', onData);
+        child.stderr?.on('data', onData);
+    }
+
+    private async resolveForwardedPort(entry: ManagedConnection, configuredPort: number): Promise<number> {
+        const child = entry.child;
+        if (!child || (!child.stdout && !child.stderr)) {
+            return entry.forwardedPort ?? configuredPort;
+        }
+        const deadline = Date.now() + this.forwardReadyTimeoutMs;
+        while (entry.forwardedPort === undefined && entry.child === child && Date.now() < deadline) {
+            await new Promise(resolve => setTimeout(resolve, this.readinessPollMs));
+        }
+        return entry.forwardedPort ?? configuredPort;
     }
 
     private getConnection(tunnelId: string): ManagedConnection {

--- a/packages/forge/src/connectors/devtunnel-port-parser.ts
+++ b/packages/forge/src/connectors/devtunnel-port-parser.ts
@@ -133,3 +133,43 @@ export function parseDevTunnelHttpPortInfo(output: string): ParsedHttpPort {
 export function parseDevTunnelHttpPort(output: string): number {
     return parseDevTunnelHttpPortInfo(output).port;
 }
+
+function toValidPort(value: string): number | undefined {
+    const port = Number(value);
+    return Number.isInteger(port) && port > 0 && port <= 65535 ? port : undefined;
+}
+
+/**
+ * Parse the local forwarded port from `devtunnel connect` output for a given remote host port.
+ *
+ * `devtunnel connect` forwards the remote (host) port to a possibly-different local port and logs
+ * lines such as:
+ *   "Forwarding from 127.0.0.1:63770 to host port 46279."
+ *   "Forwarding from [::1]:63770 to host port 46279."
+ *   "Forwarding port 46279 to local port 63770."
+ * Returns the local port mapped to `hostPort`, or undefined if no mapping is present.
+ */
+export function parseDevTunnelForwardedPort(output: string, hostPort: number): number | undefined {
+    if (!output || !Number.isInteger(hostPort)) {
+        return undefined;
+    }
+    for (const line of output.split(/\r?\n/)) {
+        // "Forwarding from <addr>:<local> to host port <host>"
+        const fromMatch = line.match(/forwarding from .*?:(\d{1,5})\s+to host port\s+(\d{1,5})/i);
+        if (fromMatch && Number(fromMatch[2]) === hostPort) {
+            const local = toValidPort(fromMatch[1]);
+            if (local !== undefined) {
+                return local;
+            }
+        }
+        // "Forwarding port <host> to local port <local>"
+        const toMatch = line.match(/forwarding port\s+(\d{1,5})\s+to local port\s+(\d{1,5})/i);
+        if (toMatch && Number(toMatch[1]) === hostPort) {
+            const local = toValidPort(toMatch[2]);
+            if (local !== undefined) {
+                return local;
+            }
+        }
+    }
+    return undefined;
+}

--- a/packages/forge/src/connectors/health.ts
+++ b/packages/forge/src/connectors/health.ts
@@ -20,12 +20,17 @@ export async function waitForHealth(
     timeoutMs: number,
     pollMs: number,
     label: string = 'Tunnel',
+    requestTimeoutMs: number = 5_000,
 ): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     let lastError = '';
     while (Date.now() <= deadline) {
         const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), Math.min(pollMs, 2_000));
+        // Per-attempt timeout is independent of the poll interval: a single health request over a
+        // WAN tunnel relay can easily take longer than pollMs, so clamping to pollMs would abort
+        // every attempt on remote tunnels. Bound it by the remaining overall deadline.
+        const attemptBudget = Math.max(1, Math.min(requestTimeoutMs, deadline - Date.now()));
+        const timer = setTimeout(() => controller.abort(), attemptBudget);
         try {
             if (await checker(url, controller.signal)) {
                 clearTimeout(timer);
@@ -35,6 +40,9 @@ export async function waitForHealth(
             lastError = err instanceof Error ? err.message : String(err);
         } finally {
             clearTimeout(timer);
+        }
+        if (Date.now() >= deadline) {
+            break;
         }
         await new Promise(resolve => setTimeout(resolve, pollMs));
     }

--- a/packages/forge/src/connectors/index.ts
+++ b/packages/forge/src/connectors/index.ts
@@ -4,7 +4,7 @@ export type { SshConnectorOptions } from './ssh-connector';
 export { DevTunnelConnector } from './devtunnel-connector';
 export type { DevTunnelCommandRunner, DevTunnelConnectorOptions } from './devtunnel-connector';
 
-export { parseDevTunnelHttpPortInfo, parseDevTunnelHttpPort, DevTunnelPortParseError } from './devtunnel-port-parser';
+export { parseDevTunnelHttpPortInfo, parseDevTunnelHttpPort, parseDevTunnelForwardedPort, DevTunnelPortParseError } from './devtunnel-port-parser';
 export type { DevTunnelPortParseErrorCode, ParsedHttpPort } from './devtunnel-port-parser';
 
 export { startProcess, defaultHealthChecker, waitForHealth } from './health';

--- a/packages/forge/src/connectors/types.ts
+++ b/packages/forge/src/connectors/types.ts
@@ -91,8 +91,14 @@ export interface SshConnectionState {
     lastChecked?: number;
 }
 
+export interface ConnectorReadable {
+    on(event: 'data', listener: (chunk: Buffer | string) => void): unknown;
+}
+
 export interface ManagedChildProcess {
     pid?: number;
+    stdout?: ConnectorReadable | null;
+    stderr?: ConnectorReadable | null;
     kill(signal?: NodeJS.Signals | number): boolean;
     once(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
     once(event: 'error', listener: (error: Error) => void): this;

--- a/scripts/coc-serve-loop.ps1
+++ b/scripts/coc-serve-loop.ps1
@@ -51,6 +51,13 @@ param(
 $RESTART_EXIT_CODE = 75
 $LOG_MAX_BYTES     = 10MB
 
+# Seconds to wait for `devtunnel host` to publish a public URL before treating the
+# tunnel as failed. Override with COC_DEVTUNNEL_URL_TIMEOUT (positive integer).
+$DEVTUNNEL_URL_TIMEOUT = 30
+if ($env:COC_DEVTUNNEL_URL_TIMEOUT -match '^[1-9][0-9]*$') {
+    $DEVTUNNEL_URL_TIMEOUT = [int]$env:COC_DEVTUNNEL_URL_TIMEOUT
+}
+
 . (Join-Path $PSScriptRoot 'devtunnel-utils.ps1')
 
 $portWasProvided = $PSBoundParameters.ContainsKey('Port')
@@ -156,24 +163,49 @@ function Start-DevTunnel {
         return $null
     }
 
-    $stdoutPath = Join-Path ([IO.Path]::GetTempPath()) "coc-devtunnel-$TunnelId.out.log"
-    $stderrPath = Join-Path ([IO.Path]::GetTempPath()) "coc-devtunnel-$TunnelId.err.log"
+    $safeId = ($TunnelId -replace '[^A-Za-z0-9_.-]', '_')
+    $stdoutPath = Join-Path ([IO.Path]::GetTempPath()) "coc-devtunnel-$safeId.out.log"
+    $stderrPath = Join-Path ([IO.Path]::GetTempPath()) "coc-devtunnel-$safeId.err.log"
     Remove-Item $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
 
-    $proc = Start-Process $devTunnelCommand -ArgumentList @('host', $TunnelId) -PassThru -WindowStyle Hidden -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath
+    $startArgs = @{
+        FilePath               = $devTunnelCommand
+        ArgumentList           = @('host', $TunnelId)
+        PassThru               = $true
+        RedirectStandardOutput = $stdoutPath
+        RedirectStandardError  = $stderrPath
+        ErrorAction            = 'Stop'
+    }
+    # -WindowStyle is only supported by Start-Process on Windows editions of
+    # PowerShell; on PowerShell 7 for Linux/macOS it throws and would leave the
+    # process handle null. Apply it only when hosting on Windows.
+    $isWindowsHost = ($null -eq $IsWindows) -or $IsWindows
+    if ($isWindowsHost) { $startArgs['WindowStyle'] = 'Hidden' }
+
+    $proc = $null
+    $startError = $null
+    try {
+        $proc = Start-Process @startArgs
+    } catch {
+        $startError = $_.Exception.Message
+    }
+
     $url = $null
-    $deadline = (Get-Date).AddSeconds(30)
-    while ((Get-Date) -lt $deadline -and -not $proc.HasExited) {
-        $text = ''
-        if (Test-Path $stdoutPath) { $text += (Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) }
-        if (Test-Path $stderrPath) { $text += "`n" + (Get-Content $stderrPath -Raw -ErrorAction SilentlyContinue) }
-        $matchedUrl = Select-DevTunnelUrl -Text $text -Port $Port
-        if ($matchedUrl) {
-            $url = $matchedUrl
-            break
+    if ($proc) {
+        $deadline = (Get-Date).AddSeconds($DEVTUNNEL_URL_TIMEOUT)
+        while ((Get-Date) -lt $deadline) {
+            if ($proc.HasExited) { break }
+            $text = ''
+            if (Test-Path $stdoutPath) { $text += (Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) }
+            if (Test-Path $stderrPath) { $text += "`n" + (Get-Content $stderrPath -Raw -ErrorAction SilentlyContinue) }
+            $matchedUrl = Select-DevTunnelUrl -Text $text -Port $Port
+            if ($matchedUrl) {
+                $url = $matchedUrl
+                break
+            }
+            Start-Sleep -Milliseconds 500
+            $proc.Refresh()
         }
-        Start-Sleep -Milliseconds 500
-        $proc.Refresh()
     }
 
     [pscustomobject]@{
@@ -181,6 +213,7 @@ function Start-DevTunnel {
         Url        = $url
         StdoutPath = $stdoutPath
         StderrPath = $stderrPath
+        StartError = $startError
     }
 }
 
@@ -301,18 +334,37 @@ while ($true) {
     $first = $false
 
     # Serve step
-    Write-Log "=== Starting coc serve (host $BindAddress, port $Port) ===" -Color Cyan
-    Write-Log 'POST /api/admin/restart to rebuild and restart.'
-
     $tunnelSession = $null
     if ($tunnelEnabled) {
         $tunnelSession = Start-DevTunnel -TunnelId $TunnelId -Port $Port
-        if ($tunnelSession -and $tunnelSession.Url) {
-            Write-Log "Dev tunnel URL: $($tunnelSession.Url)" -Color Green
-        } elseif ($tunnelSession) {
-            Write-Log 'Dev tunnel started but no public URL was detected within 30 seconds. Continuing with local serving.' -Color Yellow
+        if (-not $tunnelSession -or -not $tunnelSession.Url) {
+            Write-Log "Failed to host dev tunnel '$TunnelId' within $DEVTUNNEL_URL_TIMEOUT seconds. Aborting startup instead of serving locally without a working tunnel." -Color Red
+            if (-not $tunnelSession) {
+                Write-Log 'devtunnel CLI not found. Run .\scripts\config-devtunnel.ps1 before starting the loop with -TunnelId.' -Color Red
+            } else {
+                if ($tunnelSession.StartError) {
+                    Write-Log "Could not start 'devtunnel host $TunnelId': $($tunnelSession.StartError)" -Color Red
+                }
+                $diag = ''
+                foreach ($logPath in @($tunnelSession.StdoutPath, $tunnelSession.StderrPath)) {
+                    if ($logPath -and (Test-Path $logPath)) {
+                        $content = Get-Content $logPath -Raw -ErrorAction SilentlyContinue
+                        if (-not [string]::IsNullOrWhiteSpace($content)) { $diag += $content }
+                    }
+                }
+                if (-not [string]::IsNullOrWhiteSpace($diag)) {
+                    Write-Log "devtunnel host output:`n$($diag.Trim())" -Color Red
+                }
+            }
+            Write-Log "Verify you are logged in as the tunnel owner ('devtunnel user login') and that 'devtunnel host $TunnelId' works, then retry. Set COC_DEVTUNNEL_URL_TIMEOUT to wait longer." -Color Yellow
+            Stop-DevTunnel -TunnelSession $tunnelSession
+            exit 1
         }
+        Write-Log "Dev tunnel URL: $($tunnelSession.Url)" -Color Green
     }
+
+    Write-Log "=== Starting coc serve (host $BindAddress, port $Port) ===" -Color Cyan
+    Write-Log 'POST /api/admin/restart to rebuild and restart.'
 
     try {
         if ($Script:LogFile) {

--- a/scripts/coc-serve-loop.ps1
+++ b/scripts/coc-serve-loop.ps1
@@ -231,6 +231,10 @@ function Resolve-ConfiguredDevTunnelPort {
         Write-Log "devtunnel is not authenticated. Run 'devtunnel user login', then rerun this script." -Color Red
         return $null
     }
+    if (Test-DevTunnelNotOwnedError $portList.Output) {
+        Write-Log "Dev tunnel '$TunnelId' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere. Log in as the owner with 'devtunnel user login', or pick a new tunnel ID." -Color Red
+        return $null
+    }
     if ($portList.ExitCode -ne 0) {
         Write-Log "Failed to list dev tunnel ports for '$TunnelId': $($portList.Output.Trim())" -Color Red
         return $null
@@ -251,6 +255,20 @@ function Resolve-ConfiguredDevTunnelPort {
 
 function Stop-ProcessTree {
     param([Parameter(Mandatory)][int]$ProcessId)
+
+    # Win32_Process (CIM/WMI) is Windows-only, so on PowerShell 7 for Linux/macOS it
+    # enumerates nothing and child `devtunnel` processes would leak. There, use .NET's
+    # Process.Kill($true) (available on .NET 5+, which pwsh 7 runs on) to kill the whole
+    # tree. On Windows (incl. Windows PowerShell 5.1) keep the portable CIM walk.
+    $isWindowsHost = ($null -eq $IsWindows) -or $IsWindows
+    if (-not $isWindowsHost) {
+        try {
+            (Get-Process -Id $ProcessId -ErrorAction Stop).Kill($true)
+        } catch {
+            # Process already exited or cannot be killed — best effort.
+        }
+        return
+    }
 
     Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
         Where-Object { $_.ParentProcessId -eq $ProcessId } |

--- a/scripts/coc-serve-loop.sh
+++ b/scripts/coc-serve-loop.sh
@@ -8,26 +8,39 @@
 # 3. When the server exits with code 75 (restart requested), loops back to step 1.
 # 4. Any other exit code (0 = clean shutdown, Ctrl+C, etc.) stops the loop.
 #
+# In tunnel mode (--tunnel-id), hosts the Microsoft Dev Tunnel configured by
+# config-devtunnel.sh and serves on its configured HTTP port. Run
+# `devtunnel host` is managed for you per serve iteration.
+#
 # Usage:
 #   ./scripts/coc-serve-loop.sh
 #   ./scripts/coc-serve-loop.sh -p 8080
 #   ./scripts/coc-serve-loop.sh --skip-initial-build
+#   ./scripts/config-devtunnel.sh --tunnel-id my-remote-coc
+#   ./scripts/coc-serve-loop.sh --tunnel-id my-remote-coc
 
 set -euo pipefail
 
 RESTART_EXIT_CODE=75
 PORT=4000
+PORT_PROVIDED=false
 HOST=127.0.0.1
 SKIP_INITIAL_BUILD=false
+TUNNEL_ID=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -p|--port)
             PORT="$2"
+            PORT_PROVIDED=true
             shift 2
             ;;
         -H|--host)
             HOST="$2"
+            shift 2
+            ;;
+        -t|--tunnel-id)
+            TUNNEL_ID="$2"
             shift 2
             ;;
         --skip-initial-build)
@@ -35,11 +48,15 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            echo "Usage: $0 [-p|--port PORT] [-H|--host ADDR] [--skip-initial-build]"
+            echo "Usage: $0 [-p|--port PORT] [-H|--host ADDR] [-t|--tunnel-id ID] [--skip-initial-build]"
             echo ""
             echo "Options:"
-            echo "  -p, --port PORT        Port to serve on (default: 4000)"
+            echo "  -p, --port PORT        Port to serve on (default: 4000). Cannot be used"
+            echo "                         with --tunnel-id; configure tunnel ports with"
+            echo "                         config-devtunnel.sh instead."
             echo "  -H, --host ADDR        Bind address (default: 127.0.0.1)"
+            echo "  -t, --tunnel-id ID     Host the Dev Tunnel with this ID and serve on its"
+            echo "                         configured HTTP port (see config-devtunnel.sh)."
             echo "  --skip-initial-build   Skip the first build"
             exit 0
             ;;
@@ -50,8 +67,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ -n "$TUNNEL_ID" ]] && $PORT_PROVIDED; then
+    echo "--port cannot be used with --tunnel-id. Configure the tunnel port with config-devtunnel.sh, then start the loop with only --tunnel-id." >&2
+    exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=scripts/devtunnel-utils.sh
+. "$SCRIPT_DIR/devtunnel-utils.sh"
 
 if [[ -d "$PWD/packages/coc" ]]; then
     REPO_ROOT="$PWD"
@@ -87,6 +112,161 @@ build_coc() {
     fi
 }
 
+# ── Dev Tunnel host process ──────────────────────────────────────────────────────
+
+DEVTUNNEL_HOST_PID=""
+DEVTUNNEL_HOST_OUT=""
+
+resolve_devtunnel_cmd() {
+    if command -v devtunnel >/dev/null 2>&1; then
+        command -v devtunnel
+        return 0
+    fi
+    local local_exe="$HOME/.coc/bin/devtunnel"
+    if [[ -x "$local_exe" ]]; then
+        echo "$local_exe"
+        return 0
+    fi
+    return 1
+}
+
+# Selects the public devtunnels.ms URL that matches the served port, falling
+# back to the first URL found. Mirrors Select-DevTunnelUrl.
+select_devtunnel_url() {
+    node -e '
+        const text = process.argv[1] || "";
+        const port = Number(process.argv[2]);
+        const m = text.match(/https:\/\/[^\s,]+devtunnels\.ms[^\s,]*/g);
+        if (!m) process.exit(0);
+        const urls = m.map((u) => u.replace(/[.;)\]]+$/, ""));
+        const matchesPort = (u) => {
+            try {
+                const x = new URL(u);
+                if (Number(x.port) === port) return true;
+                const esc = String(port).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                return new RegExp("(^|[-.])" + esc + "([-.]|$)").test(x.hostname);
+            } catch {
+                return false;
+            }
+        };
+        for (const u of urls) if (matchesPort(u)) { console.log(u); process.exit(0); }
+        console.log(urls[0]);
+    ' "$1" "$2"
+}
+
+# Reads the single configured HTTP port for the tunnel. Prints the port on
+# success; logs to stderr and returns non-zero otherwise.
+resolve_configured_devtunnel_port() {
+    local id="$1" cmd out rc=0
+    if ! cmd="$(resolve_devtunnel_cmd)"; then
+        echo -e "\033[31mdevtunnel CLI not found. Run ./scripts/config-devtunnel.sh before starting the loop with --tunnel-id.\033[0m" >&2
+        return 1
+    fi
+
+    out="$("$cmd" port list "$id" 2>&1)" || rc=$?
+    if is_devtunnel_auth_error "$out"; then
+        echo -e "\033[31mdevtunnel is not authenticated. Run '$cmd user login', then rerun this script.\033[0m" >&2
+        return 1
+    fi
+    if (( rc != 0 )); then
+        echo -e "\033[31mFailed to list dev tunnel ports for '$id': $out\033[0m" >&2
+        return 1
+    fi
+
+    local ports=()
+    local line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && ports+=("$line")
+    done < <(get_http_devtunnel_ports "$out" | grep -E '^[0-9]+$')
+    if (( ${#ports[@]} == 0 )); then
+        echo -e "\033[31mDev tunnel '$id' has no configured HTTP port. Run ./scripts/config-devtunnel.sh -t $id first.\033[0m" >&2
+        return 1
+    fi
+    if (( ${#ports[@]} > 1 )); then
+        echo -e "\033[31mDev tunnel '$id' has multiple HTTP ports (${ports[*]}). Remove the extra ports or recreate the tunnel, then rerun this script.\033[0m" >&2
+        return 1
+    fi
+    echo "${ports[0]}"
+}
+
+start_devtunnel_host() {
+    local id="$1" port="$2" cmd
+    if ! cmd="$(resolve_devtunnel_cmd)"; then
+        echo -e "\033[33mdevtunnel CLI not found. Run ./scripts/config-devtunnel.sh before starting the loop with --tunnel-id.\033[0m"
+        return 0
+    fi
+
+    DEVTUNNEL_HOST_OUT="$(mktemp "${TMPDIR:-/tmp}/coc-devtunnel-XXXXXX")"
+    "$cmd" host "$id" >"$DEVTUNNEL_HOST_OUT" 2>&1 &
+    DEVTUNNEL_HOST_PID=$!
+
+    local timeout="${COC_DEVTUNNEL_URL_TIMEOUT:-30}"
+    local deadline url=""
+    deadline=$(( $(date +%s) + timeout ))
+    while (( $(date +%s) < deadline )); do
+        if ! kill -0 "$DEVTUNNEL_HOST_PID" 2>/dev/null; then break; fi
+        url="$(select_devtunnel_url "$(cat "$DEVTUNNEL_HOST_OUT" 2>/dev/null)" "$port")"
+        [[ -n "$url" ]] && break
+        sleep 0.5
+    done
+
+    if [[ -n "$url" ]]; then
+        echo -e "\033[32mDev tunnel URL: $url\033[0m"
+    elif kill -0 "$DEVTUNNEL_HOST_PID" 2>/dev/null; then
+        echo -e "\033[33mDev tunnel started but no public URL was detected within ${timeout}s. Continuing with local serving.\033[0m"
+    else
+        echo -e "\033[33mDev tunnel host exited before a public URL was detected. Continuing with local serving.\033[0m"
+    fi
+}
+
+# Recursively terminates a process and its descendants (portable; no pkill).
+# Sends SIGTERM, then SIGKILL to any survivor after a short grace period.
+kill_process_tree() {
+    local pid="$1" child
+    local children
+    children="$(ps -ax -o pid=,ppid= 2>/dev/null | awk -v p="$pid" '$2==p{print $1}')"
+    for child in $children; do
+        kill_process_tree "$child"
+    done
+    kill "$pid" 2>/dev/null || true
+    local i
+    for i in 1 2 3 4 5 6; do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.25
+    done
+    kill -9 "$pid" 2>/dev/null || true
+}
+
+stop_devtunnel_host() {
+    if [[ -n "$DEVTUNNEL_HOST_PID" ]] && kill -0 "$DEVTUNNEL_HOST_PID" 2>/dev/null; then
+        echo -e "\033[33mStopping dev tunnel process $DEVTUNNEL_HOST_PID...\033[0m"
+        kill_process_tree "$DEVTUNNEL_HOST_PID"
+        # Reap the direct background child so it does not linger as a zombie.
+        wait "$DEVTUNNEL_HOST_PID" 2>/dev/null || true
+    fi
+    [[ -n "$DEVTUNNEL_HOST_OUT" ]] && rm -f "$DEVTUNNEL_HOST_OUT" 2>/dev/null || true
+    DEVTUNNEL_HOST_PID=""
+    DEVTUNNEL_HOST_OUT=""
+}
+
+trap stop_devtunnel_host EXIT
+trap 'stop_devtunnel_host; exit 130' INT
+trap 'stop_devtunnel_host; exit 143' TERM
+
+# ── Main loop ────────────────────────────────────────────────────────────────────
+
+tunnel_enabled=false
+if [[ -n "$TUNNEL_ID" ]]; then
+    tunnel_enabled=true
+    resolve_rc=0
+    resolved_port="$(resolve_configured_devtunnel_port "$TUNNEL_ID")" || resolve_rc=$?
+    if [[ $resolve_rc -ne 0 ]]; then
+        exit 2
+    fi
+    PORT="$resolved_port"
+    echo -e "\033[32mUsing dev tunnel '$TUNNEL_ID' configured HTTP port $PORT.\033[0m"
+fi
+
 first=true
 
 while true; do
@@ -110,10 +290,16 @@ while true; do
     echo -e "\033[90mPOST /api/admin/restart to rebuild & restart.\033[0m"
     echo ""
 
+    if $tunnel_enabled; then
+        start_devtunnel_host "$TUNNEL_ID" "$PORT"
+    fi
+
     set +e
     coc serve --no-open --port "$PORT" --host "$HOST"
     exit_code=$?
     set -e
+
+    stop_devtunnel_host
 
     if [[ $exit_code -eq $RESTART_EXIT_CODE ]]; then
         echo -e "\n\033[33mRestart requested (exit code $RESTART_EXIT_CODE). Rebuilding...\033[0m"

--- a/scripts/coc-serve-loop.sh
+++ b/scripts/coc-serve-loop.sh
@@ -192,8 +192,8 @@ resolve_configured_devtunnel_port() {
 start_devtunnel_host() {
     local id="$1" port="$2" cmd
     if ! cmd="$(resolve_devtunnel_cmd)"; then
-        echo -e "\033[33mdevtunnel CLI not found. Run ./scripts/config-devtunnel.sh before starting the loop with --tunnel-id.\033[0m"
-        return 0
+        echo -e "\033[33mdevtunnel CLI not found. Run ./scripts/config-devtunnel.sh before starting the loop with --tunnel-id.\033[0m" >&2
+        return 1
     fi
 
     DEVTUNNEL_HOST_OUT="$(mktemp "${TMPDIR:-/tmp}/coc-devtunnel-XXXXXX")"
@@ -201,6 +201,7 @@ start_devtunnel_host() {
     DEVTUNNEL_HOST_PID=$!
 
     local timeout="${COC_DEVTUNNEL_URL_TIMEOUT:-30}"
+    [[ "$timeout" =~ ^[1-9][0-9]*$ ]] || timeout=30
     local deadline url=""
     deadline=$(( $(date +%s) + timeout ))
     while (( $(date +%s) < deadline )); do
@@ -212,11 +213,9 @@ start_devtunnel_host() {
 
     if [[ -n "$url" ]]; then
         echo -e "\033[32mDev tunnel URL: $url\033[0m"
-    elif kill -0 "$DEVTUNNEL_HOST_PID" 2>/dev/null; then
-        echo -e "\033[33mDev tunnel started but no public URL was detected within ${timeout}s. Continuing with local serving.\033[0m"
-    else
-        echo -e "\033[33mDev tunnel host exited before a public URL was detected. Continuing with local serving.\033[0m"
+        return 0
     fi
+    return 1
 }
 
 # Recursively terminates a process and its descendants (portable; no pkill).
@@ -238,10 +237,13 @@ kill_process_tree() {
 }
 
 stop_devtunnel_host() {
-    if [[ -n "$DEVTUNNEL_HOST_PID" ]] && kill -0 "$DEVTUNNEL_HOST_PID" 2>/dev/null; then
-        echo -e "\033[33mStopping dev tunnel process $DEVTUNNEL_HOST_PID...\033[0m"
-        kill_process_tree "$DEVTUNNEL_HOST_PID"
-        # Reap the direct background child so it does not linger as a zombie.
+    if [[ -n "$DEVTUNNEL_HOST_PID" ]]; then
+        if kill -0 "$DEVTUNNEL_HOST_PID" 2>/dev/null; then
+            echo -e "\033[33mStopping dev tunnel process $DEVTUNNEL_HOST_PID...\033[0m"
+            kill_process_tree "$DEVTUNNEL_HOST_PID"
+        fi
+        # Reap the direct background child even if it already exited so it does
+        # not linger as a zombie.
         wait "$DEVTUNNEL_HOST_PID" 2>/dev/null || true
     fi
     [[ -n "$DEVTUNNEL_HOST_OUT" ]] && rm -f "$DEVTUNNEL_HOST_OUT" 2>/dev/null || true
@@ -285,14 +287,23 @@ while true; do
     fi
     first=false
 
+    if $tunnel_enabled; then
+        if ! start_devtunnel_host "$TUNNEL_ID" "$PORT"; then
+            echo -e "\033[31mFailed to host dev tunnel '$TUNNEL_ID'. Aborting startup instead of serving locally without a working tunnel.\033[0m" >&2
+            if [[ -n "$DEVTUNNEL_HOST_OUT" && -s "$DEVTUNNEL_HOST_OUT" ]]; then
+                echo -e "\033[31mdevtunnel host output:\033[0m" >&2
+                cat "$DEVTUNNEL_HOST_OUT" >&2
+            fi
+            echo -e "\033[33mVerify you are logged in as the tunnel owner ('devtunnel user login') and that 'devtunnel host $TUNNEL_ID' works, then retry. Set COC_DEVTUNNEL_URL_TIMEOUT to wait longer.\033[0m" >&2
+            stop_devtunnel_host
+            exit 1
+        fi
+    fi
+
     echo ""
     echo -e "\033[36m=== Starting coc serve (host $HOST, port $PORT) ===\033[0m"
     echo -e "\033[90mPOST /api/admin/restart to rebuild & restart.\033[0m"
     echo ""
-
-    if $tunnel_enabled; then
-        start_devtunnel_host "$TUNNEL_ID" "$PORT"
-    fi
 
     set +e
     coc serve --no-open --port "$PORT" --host "$HOST"

--- a/scripts/coc-serve-loop.sh
+++ b/scripts/coc-serve-loop.sh
@@ -168,6 +168,10 @@ resolve_configured_devtunnel_port() {
         echo -e "\033[31mdevtunnel is not authenticated. Run '$cmd user login', then rerun this script.\033[0m" >&2
         return 1
     fi
+    if is_devtunnel_not_owned_error "$out"; then
+        echo -e "\033[31mDev tunnel '$id' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere. Log in as the owner with '$cmd user login', or pick a new tunnel ID.\033[0m" >&2
+        return 1
+    fi
     if (( rc != 0 )); then
         echo -e "\033[31mFailed to list dev tunnel ports for '$id': $out\033[0m" >&2
         return 1

--- a/scripts/config-devtunnel.ps1
+++ b/scripts/config-devtunnel.ps1
@@ -101,16 +101,16 @@ function Invoke-EnsureTunnel {
     }
 
     $create = Invoke-DevTunnelCli -Arguments @('create', $TunnelId)
+    if (Test-DevTunnelNotOwnedError $create.Output) {
+        Write-Log "Dev tunnel '$TunnelId' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere." -Color Red
+        Write-Log "Log in as the tunnel's owner ('devtunnel user login'), or rerun with a different -TunnelId." -Color Yellow
+        return [pscustomobject]@{ Status = 'NotOwned'; Port = $null }
+    }
     if (Test-DevTunnelAuthError $create.Output) {
         Write-Log "devtunnel is not authenticated. Run 'devtunnel user login', then rerun this script." -Color Yellow
         return [pscustomobject]@{ Status = 'Unauthenticated'; Port = $null }
     }
     if ($create.ExitCode -ne 0 -and -not (Test-DevTunnelAlreadyConfigured $create.Output)) {
-        if (Test-DevTunnelNotOwnedError $create.Output) {
-            Write-Log "Dev tunnel '$TunnelId' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere." -Color Red
-            Write-Log "Log in as the tunnel's owner ('devtunnel user login'), or rerun with a different -TunnelId." -Color Yellow
-            return [pscustomobject]@{ Status = 'NotOwned'; Port = $null }
-        }
         Write-Log "Failed to create dev tunnel '$TunnelId': $($create.Output.Trim())" -Color Red
         return [pscustomobject]@{ Status = 'Unavailable'; Port = $null }
     }

--- a/scripts/config-devtunnel.ps1
+++ b/scripts/config-devtunnel.ps1
@@ -106,11 +106,21 @@ function Invoke-EnsureTunnel {
         return [pscustomobject]@{ Status = 'Unauthenticated'; Port = $null }
     }
     if ($create.ExitCode -ne 0 -and -not (Test-DevTunnelAlreadyConfigured $create.Output)) {
+        if (Test-DevTunnelNotOwnedError $create.Output) {
+            Write-Log "Dev tunnel '$TunnelId' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere." -Color Red
+            Write-Log "Log in as the tunnel's owner ('devtunnel user login'), or rerun with a different -TunnelId." -Color Yellow
+            return [pscustomobject]@{ Status = 'NotOwned'; Port = $null }
+        }
         Write-Log "Failed to create dev tunnel '$TunnelId': $($create.Output.Trim())" -Color Red
         return [pscustomobject]@{ Status = 'Unavailable'; Port = $null }
     }
 
     $portList = Invoke-DevTunnelCli -Arguments @('port', 'list', $TunnelId)
+    if (Test-DevTunnelNotOwnedError $portList.Output) {
+        Write-Log "Dev tunnel '$TunnelId' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere." -Color Red
+        Write-Log "Log in as the tunnel's owner ('devtunnel user login'), or rerun with a different -TunnelId." -Color Yellow
+        return [pscustomobject]@{ Status = 'NotOwned'; Port = $null }
+    }
     if (Test-DevTunnelAuthError $portList.Output) {
         Write-Log "devtunnel is not authenticated. Run 'devtunnel user login', then rerun this script." -Color Yellow
         return [pscustomobject]@{ Status = 'Unauthenticated'; Port = $null }
@@ -163,7 +173,7 @@ if ($status.Status -eq 'Ready') {
     Write-Log "Start CoC with: .\scripts\coc-serve-loop.ps1 -TunnelId $TunnelId" -Color Green
     exit 0
 }
-if ($status.Status -eq 'Unauthenticated' -or $status.Status -eq 'InvalidConfiguration') {
+if ($status.Status -eq 'Unauthenticated' -or $status.Status -eq 'InvalidConfiguration' -or $status.Status -eq 'NotOwned') {
     exit 2
 }
 exit 1

--- a/scripts/config-devtunnel.sh
+++ b/scripts/config-devtunnel.sh
@@ -150,12 +150,22 @@ if is_devtunnel_auth_error "$create_out"; then
     exit 2
 fi
 if (( create_rc != 0 )) && ! is_already_configured "$create_out"; then
+    if is_devtunnel_not_owned_error "$create_out"; then
+        log_error "Dev tunnel '$TUNNEL_ID' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere."
+        log_warn "Log in as the tunnel's owner ('$DEVTUNNEL user login'), or rerun with a different --tunnel-id."
+        exit 2
+    fi
     log_error "Failed to create dev tunnel '$TUNNEL_ID': $create_out"
     exit 1
 fi
 
 list_out="$("$DEVTUNNEL" port list "$TUNNEL_ID" 2>&1)"
 list_rc=$?
+if is_devtunnel_not_owned_error "$list_out"; then
+    log_error "Dev tunnel '$TUNNEL_ID' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere."
+    log_warn "Log in as the tunnel's owner ('$DEVTUNNEL user login'), or rerun with a different --tunnel-id."
+    exit 2
+fi
 if is_devtunnel_auth_error "$list_out"; then
     log_warn "devtunnel is not authenticated. Run '$DEVTUNNEL user login', then rerun this script."
     exit 2

--- a/scripts/config-devtunnel.sh
+++ b/scripts/config-devtunnel.sh
@@ -145,16 +145,16 @@ fi
 
 create_out="$("$DEVTUNNEL" create "$TUNNEL_ID" 2>&1)"
 create_rc=$?
+if is_devtunnel_not_owned_error "$create_out"; then
+    log_error "Dev tunnel '$TUNNEL_ID' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere."
+    log_warn "Log in as the tunnel's owner ('$DEVTUNNEL user login'), or rerun with a different --tunnel-id."
+    exit 2
+fi
 if is_devtunnel_auth_error "$create_out"; then
     log_warn "devtunnel is not authenticated. Run '$DEVTUNNEL user login', then rerun this script."
     exit 2
 fi
 if (( create_rc != 0 )) && ! is_already_configured "$create_out"; then
-    if is_devtunnel_not_owned_error "$create_out"; then
-        log_error "Dev tunnel '$TUNNEL_ID' is not accessible to the current account; the tunnel ID is owned by a different account or in use elsewhere."
-        log_warn "Log in as the tunnel's owner ('$DEVTUNNEL user login'), or rerun with a different --tunnel-id."
-        exit 2
-    fi
     log_error "Failed to create dev tunnel '$TUNNEL_ID': $create_out"
     exit 1
 fi

--- a/scripts/config-devtunnel.sh
+++ b/scripts/config-devtunnel.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# Installs and configures the Microsoft Dev Tunnel used by the CoC service (Linux/WSL).
+#
+# Linux/WSL counterpart of config-devtunnel.ps1. Ensures the devtunnel CLI is
+# available, creates or reuses the stable CoC tunnel ID, and owns the persistent
+# TunnelId -> HTTP port binding. It does NOT host the tunnel; once configured,
+# host it and start the server with:
+#
+#   devtunnel host <tunnel-id> &
+#   ./scripts/coc-serve-loop.sh --port <port>
+#
+# Usage:
+#   ./scripts/config-devtunnel.sh
+#   ./scripts/config-devtunnel.sh --tunnel-id my-remote-coc
+#   ./scripts/config-devtunnel.sh --tunnel-id my-remote-coc --port 51234
+#
+# Exit codes: 0 = ready, 1 = unavailable, 2 = unauthenticated / invalid config.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/devtunnel-utils.sh
+. "$SCRIPT_DIR/devtunnel-utils.sh"
+
+PORT=""
+PORT_PROVIDED=false
+TUNNEL_ID="$(hostname | tr '[:upper:]' '[:lower:]')-coc"
+LOCAL_BIN="$HOME/.coc/bin"
+LOCAL_EXE="$LOCAL_BIN/devtunnel"
+DEVTUNNEL=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--port)
+            PORT="$2"
+            PORT_PROVIDED=true
+            shift 2
+            ;;
+        -t|--tunnel-id)
+            TUNNEL_ID="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [-t|--tunnel-id ID] [-p|--port PORT]"
+            echo ""
+            echo "Options:"
+            echo "  -t, --tunnel-id ID   Dev Tunnel ID to configure (default: <hostname>-coc)"
+            echo "  -p, --port PORT      HTTP port to expose. If omitted, a random free"
+            echo "                       local port is selected and persisted on the tunnel."
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+log() {
+    local color="$1"; shift
+    echo -e "\033[${color}m[$(date '+%Y-%m-%d %H:%M:%S')] $*\033[0m"
+}
+log_info()  { log 37 "$*"; }
+log_cyan()  { log 36 "$*"; }
+log_green() { log 32 "$*"; }
+log_warn()  { log 33 "$*"; }
+log_error() { log 31 "$*"; }
+
+if $PORT_PROVIDED && { ! [[ "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1 || PORT > 65535 )); }; then
+    log_error "--port must be between 1 and 65535."
+    exit 2
+fi
+
+# ── devtunnel CLI resolution / install ──────────────────────────────────────────
+
+install_devtunnel_cli() {
+    if command -v devtunnel >/dev/null 2>&1; then
+        DEVTUNNEL="$(command -v devtunnel)"
+        return 0
+    fi
+
+    if [[ -x "$LOCAL_EXE" ]]; then
+        DEVTUNNEL="$LOCAL_EXE"
+        log_green "Using devtunnel CLI from $LOCAL_EXE"
+        return 0
+    fi
+
+    log_warn "devtunnel CLI not found. Downloading to $LOCAL_EXE..."
+    mkdir -p "$LOCAL_BIN"
+
+    local arch os url
+    arch="$(uname -m)"
+    os="$(uname -s)"
+    case "$os" in
+        Linux)
+            case "$arch" in
+                x86_64|amd64) url="https://aka.ms/TunnelsCliDownload/linux-x64" ;;
+                aarch64|arm64) url="https://aka.ms/TunnelsCliDownload/linux-arm64" ;;
+                *) url="" ;;
+            esac
+            ;;
+        Darwin)
+            case "$arch" in
+                x86_64|amd64) url="https://aka.ms/TunnelsCliDownload/osx-x64" ;;
+                arm64|aarch64) url="https://aka.ms/TunnelsCliDownload/osx-arm64" ;;
+                *) url="" ;;
+            esac
+            ;;
+        *) url="" ;;
+    esac
+    if [[ -z "$url" ]]; then
+        log_error "Unsupported platform '$os/$arch'. Install devtunnel manually from https://learn.microsoft.com/azure/developer/dev-tunnels/get-started."
+        return 1
+    fi
+
+    if curl -fsSL "$url" -o "$LOCAL_EXE"; then
+        chmod +x "$LOCAL_EXE"
+        if "$LOCAL_EXE" --version >/dev/null 2>&1; then
+            DEVTUNNEL="$LOCAL_EXE"
+            log_green "devtunnel CLI installed to $LOCAL_EXE."
+            return 0
+        fi
+    fi
+
+    log_error "Unable to install devtunnel CLI. Install it manually from https://learn.microsoft.com/azure/developer/dev-tunnels/get-started."
+    return 1
+}
+
+is_already_configured() {
+    grep -qiE 'already exists|conflict with existing entity' <<<"$1"
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────────
+
+if $PORT_PROVIDED; then
+    log_cyan "=== Configuring dev tunnel '$TUNNEL_ID' for requested port $PORT ==="
+else
+    log_cyan "=== Configuring dev tunnel '$TUNNEL_ID' for a persistent generated port ==="
+fi
+
+if ! install_devtunnel_cli; then
+    exit 1
+fi
+
+create_out="$("$DEVTUNNEL" create "$TUNNEL_ID" 2>&1)"
+create_rc=$?
+if is_devtunnel_auth_error "$create_out"; then
+    log_warn "devtunnel is not authenticated. Run '$DEVTUNNEL user login', then rerun this script."
+    exit 2
+fi
+if (( create_rc != 0 )) && ! is_already_configured "$create_out"; then
+    log_error "Failed to create dev tunnel '$TUNNEL_ID': $create_out"
+    exit 1
+fi
+
+list_out="$("$DEVTUNNEL" port list "$TUNNEL_ID" 2>&1)"
+list_rc=$?
+if is_devtunnel_auth_error "$list_out"; then
+    log_warn "devtunnel is not authenticated. Run '$DEVTUNNEL user login', then rerun this script."
+    exit 2
+fi
+if (( list_rc != 0 )); then
+    log_error "Failed to list dev tunnel ports for '$TUNNEL_ID': $list_out"
+    exit 1
+fi
+
+existing_ports=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && existing_ports+=("$line")
+done < <(get_http_devtunnel_ports "$list_out" | grep -E '^[0-9]+$')
+
+if (( ${#existing_ports[@]} > 1 )); then
+    log_error "Dev tunnel '$TUNNEL_ID' has multiple HTTP ports (${existing_ports[*]}). Remove the extra ports or recreate the tunnel, then rerun this script."
+    exit 2
+fi
+
+if (( ${#existing_ports[@]} == 1 )); then
+    resolved_port="${existing_ports[0]}"
+    if $PORT_PROVIDED && [[ "$PORT" != "$resolved_port" ]]; then
+        log_warn "Dev tunnel '$TUNNEL_ID' already has HTTP port $resolved_port; reusing it instead of requested port $PORT."
+    fi
+    log_green "Dev tunnel '$TUNNEL_ID' is configured for HTTP port $resolved_port."
+    log_green "Start CoC with: ./scripts/coc-serve-loop.sh --tunnel-id $TUNNEL_ID"
+    exit 0
+fi
+
+if $PORT_PROVIDED; then
+    resolved_port="$PORT"
+else
+    resolved_port="$(get_random_free_port)"
+    log_warn "No HTTP port is configured for '$TUNNEL_ID'. Selected free local port $resolved_port."
+fi
+
+port_out="$("$DEVTUNNEL" port create "$TUNNEL_ID" -p "$resolved_port" --protocol http 2>&1)"
+port_rc=$?
+if is_devtunnel_auth_error "$port_out"; then
+    log_warn "devtunnel is not authenticated. Run '$DEVTUNNEL user login', then rerun this script."
+    exit 2
+fi
+if (( port_rc != 0 )) && ! is_already_configured "$port_out"; then
+    log_error "Failed to create dev tunnel port $resolved_port for '$TUNNEL_ID': $port_out"
+    exit 1
+fi
+
+log_green "Dev tunnel '$TUNNEL_ID' is configured for HTTP port $resolved_port."
+log_green "Start CoC with: ./scripts/coc-serve-loop.sh --tunnel-id $TUNNEL_ID"
+exit 0

--- a/scripts/config-devtunnel.sh
+++ b/scripts/config-devtunnel.sh
@@ -4,11 +4,11 @@
 #
 # Linux/WSL counterpart of config-devtunnel.ps1. Ensures the devtunnel CLI is
 # available, creates or reuses the stable CoC tunnel ID, and owns the persistent
-# TunnelId -> HTTP port binding. It does NOT host the tunnel; once configured,
-# host it and start the server with:
+# TunnelId -> HTTP port binding. It does NOT host the tunnel; use
+# coc-serve-loop.sh --tunnel-id <id> to read the configured binding and start
+# devtunnel host together with the server:
 #
-#   devtunnel host <tunnel-id> &
-#   ./scripts/coc-serve-loop.sh --port <port>
+#   ./scripts/coc-serve-loop.sh --tunnel-id <tunnel-id>
 #
 # Usage:
 #   ./scripts/config-devtunnel.sh

--- a/scripts/devtunnel-utils.ps1
+++ b/scripts/devtunnel-utils.ps1
@@ -3,6 +3,14 @@ function Test-DevTunnelAuthError {
     return $Output -match '(?i)(not logged in|not authenticated|login required|log in|401|unauthorized)'
 }
 
+function Test-DevTunnelNotOwnedError {
+    param([string]$Output)
+    # Surfaces when listing/inspecting a tunnel the current account does not own
+    # (owned by a different identity or in use elsewhere). These signals never
+    # appear for a tunnel the current account owns, so they indicate ownership.
+    return $Output -match '(?i)(tunnel not found|request not permitted|unauthorized tunnel access)'
+}
+
 function Invoke-DevTunnelCli {
     param(
         [Parameter(Mandatory)][string[]]$Arguments,

--- a/scripts/devtunnel-utils.sh
+++ b/scripts/devtunnel-utils.sh
@@ -9,6 +9,14 @@ is_devtunnel_auth_error() {
     grep -qiE 'not logged in|not authenticated|login required|log in|\b401\b|unauthorized' <<<"${1:-}"
 }
 
+# Returns 0 when the devtunnel CLI output indicates the tunnel ID exists but is
+# not accessible to the current account: owned by a different identity or in use
+# elsewhere. These signals surface when listing/inspecting the tunnel, never for
+# a tunnel the current account owns, so they unambiguously indicate ownership.
+is_devtunnel_not_owned_error() {
+    grep -qiE 'tunnel not found|request not permitted|unauthorized tunnel access' <<<"${1:-}"
+}
+
 # Parses HTTP port numbers from `devtunnel port list` output. Handles JSON,
 # table, and key-value styles (mirrors Get-HttpDevTunnelPorts). Prints one
 # unique port per line.

--- a/scripts/devtunnel-utils.sh
+++ b/scripts/devtunnel-utils.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Shared Microsoft Dev Tunnel helpers for the CoC service scripts (Linux/WSL).
+# Linux/WSL counterpart of devtunnel-utils.ps1. Source this file; it only
+# defines functions and has no top-level side effects.
+
+# Returns 0 when the devtunnel CLI output indicates an authentication problem.
+is_devtunnel_auth_error() {
+    grep -qiE 'not logged in|not authenticated|login required|log in|\b401\b|unauthorized' <<<"${1:-}"
+}
+
+# Parses HTTP port numbers from `devtunnel port list` output. Handles JSON,
+# table, and key-value styles (mirrors Get-HttpDevTunnelPorts). Prints one
+# unique port per line.
+get_http_devtunnel_ports() {
+    node -e '
+        let raw = "";
+        process.stdin.on("data", (d) => (raw += d));
+        process.stdin.on("end", () => {
+            const ports = new Set();
+            const add = (value) => {
+                const n = Number(value);
+                if (Number.isInteger(n) && n >= 1 && n <= 65535) ports.add(n);
+            };
+
+            // 1. JSON output.
+            try {
+                const data = JSON.parse(raw.trim());
+                let items = [];
+                if (Array.isArray(data)) items = data;
+                else if (data && Array.isArray(data.ports)) items = data.ports;
+                else if (data && Array.isArray(data.items)) items = data.items;
+                else if (data) items = [data];
+                for (const it of items) {
+                    if (!it) continue;
+                    const proto = String(it.protocol ?? it.protocols ?? "").toLowerCase();
+                    const port = it.portNumber ?? it.port ?? it.port_number ?? it.number;
+                    if (/\bhttp\b/.test(proto) && /^\d+$/.test(String(port))) add(port);
+                }
+            } catch {
+                // devtunnel defaults to table output; fall through to text parsing.
+            }
+
+            // 2. Table / key-value output.
+            let pending = null;
+            for (const line of raw.split(/\r?\n/)) {
+                const t = line.trim();
+                if (!t) continue;
+                const km = t.match(/\bport(?:\s+number)?\b\s*[:=]\s*(\d{1,5})/i);
+                if (km) pending = Number(km[1]);
+                if (/\bprotocol\b\s*[:=]\s*http\b/i.test(t)) {
+                    if (pending !== null) {
+                        add(pending);
+                        pending = null;
+                    }
+                    continue;
+                }
+                if (/\bhttp\b/i.test(t)) {
+                    const nm = t.match(/(?<![\d.])([1-9]\d{0,4})(?![\d.])/);
+                    if (nm) add(nm[1]);
+                }
+            }
+
+            console.log([...ports].join("\n"));
+        });
+    ' <<<"${1:-}"
+}
+
+# Prints a free local TCP port chosen by the OS.
+get_random_free_port() {
+    node -e 'const n=require("net");const s=n.createServer();s.listen(0,"127.0.0.1",()=>{console.log(s.address().port);s.close()});'
+}


### PR DESCRIPTION
## Summary

Brings the Windows PowerShell DevTunnel workflow to Linux/WSL and improves DevTunnel diagnostics on both sides.

### Host-side bash scripts (parity with PowerShell)
- **`scripts/config-devtunnel.sh`** — Linux/WSL port of `config-devtunnel.ps1`. Installs the `devtunnel` CLI when missing, creates/reuses the tunnel ID, ensures exactly one HTTP port binding, and picks a stable free port. `--tunnel-id`/`-t` ↔ `-TunnelId`, `--port`/`-p` ↔ `-Port`.
- **`scripts/devtunnel-utils.sh`** — shared bash helpers (auth + ownership matchers).
- **`scripts/coc-serve-loop.sh`** — new `--tunnel-id` flag hosts the configured tunnel (reads the persisted HTTP port, runs `devtunnel host`, then `coc serve` on that port, and tears the tunnel host down on exit), matching `coc-serve-loop.ps1 -TunnelId`.

### Ownership-conflict diagnostics (bash + PowerShell)
When a tunnel ID is owned by a different account (devtunnel reports `Tunnel not found` / `request not permitted` / `unauthorized tunnel access`), both `config-devtunnel.sh` and `config-devtunnel.ps1` now print a clear "owned by a different account or in use elsewhere" hint and exit `2`, instead of a confusing not-found message. The ownership check runs **before** the auth check on both the create and port-list paths (the matchers overlap on "unauthorized").

### Surface real DevTunnel connect error
`remote-server-health.ts` / `remote-server-routes.ts`: the offline "No effective endpoint is available" message now surfaces the connector's actual `lastError` (auth failure, CLI missing, readiness timeout) so the dashboard explains *why* a DevTunnel server is unreachable.

### Docs
Updated `coc-knowledge` `remote-servers.md` with the Linux/WSL equivalents, the ownership-conflict failure mode, and the surfaced-error behavior.

## Testing
- `cd packages/coc && PATH="$HOME/.pwsh:$PATH" npx vitest run test/coc-service-scripts.test.ts` → **44 passed | 2 skipped** (bash + PowerShell static and behavior tests, including the new `not-owned` / `create-not-owned` fake modes).
- `remote-server-routes.test.ts` regression test asserts the connector error is surfaced.
- `packages/coc` build clean; changed files lint clean.

> Note: opening as a normal PR (no auto-merge) so it can be validated on a second WSL node before merge.
