### PR TITLE
fix: coccontainer-serve-loop missing dependency builds + CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,10 @@ jobs:
       - name: Build packages
         run: npm run build:packages
 
+      - name: Build whatsapp-bot package
+        run: npm run build
+        working-directory: packages/whatsapp-bot
+
       - name: Build coccontainer package
         run: npm run build
         working-directory: packages/coccontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,9 +485,65 @@ jobs:
           kill $SERVER_PID 2>/dev/null || true
           exit 1
 
+  coccontainer-serve-smoke:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Build coccontainer package
+        run: npm run build
+        working-directory: packages/coccontainer
+
+      - name: Start coccontainer serve and verify health
+        shell: bash
+        run: |
+          sleep 120 | node packages/coccontainer/dist/index.js serve --no-open --port 4222 &
+          SERVER_PID=$!
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:4222/api/container/agents > /dev/null 2>&1; then
+              echo "✓ CoCContainer healthy after ${i}s"
+              kill $SERVER_PID 2>/dev/null || true
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "✗ CoCContainer failed to respond within 60s"
+          kill $SERVER_PID 2>/dev/null || true
+          exit 1
+
   ci:
     runs-on: ubuntu-latest
-    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, extension-test, e2e, coc-serve-smoke]
+    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, extension-test, e2e, coc-serve-smoke, coccontainer-serve-smoke]
     if: always()
     steps:
       - name: Verify all required jobs succeeded
@@ -501,6 +557,7 @@ jobs:
             [extension-test]="${{ needs.extension-test.result }}"
             [e2e]="${{ needs.e2e.result }}"
             [coc-serve-smoke]="${{ needs.coc-serve-smoke.result }}"
+            [coccontainer-serve-smoke]="${{ needs.coccontainer-serve-smoke.result }}"
           )
           failed=0
           for job in "${!results[@]}"; do

--- a/packages/coc/src/server/work-items/work-item-sync-github-repo.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-github-repo.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'child_process';
 export interface WorkItemSyncGithubPreference {
     owner?: string;
     repo?: string;
+    [key: string]: unknown;
 }
 
 export interface WorkItemSyncRepoPreferences {
@@ -11,6 +12,7 @@ export interface WorkItemSyncRepoPreferences {
             github?: WorkItemSyncGithubPreference;
         };
     };
+    [key: string]: unknown;
 }
 
 export interface WorkItemSyncWorkspaceInfo {

--- a/scripts/coccontainer-serve-loop.sh
+++ b/scripts/coccontainer-serve-loop.sh
@@ -58,14 +58,23 @@ build_coccontainer() {
     cd "$REPO_ROOT"
     npm install || { echo -e "\033[31mnpm install failed\033[0m"; return 1; }
 
-    echo -e "\n\033[36m=== Building all packages (coc-memory → forge → teams-bot → whatsapp-bot → coc → coccontainer) ===\033[0m"
+    echo -e "\n\033[36m=== Building all packages (coc-memory → coc-agent-sdk → forge → coc-client → coc-workflow → teams-bot → whatsapp-bot → coc → coccontainer) ===\033[0m"
 
     cd "$REPO_ROOT/packages/coc-memory"
     npm run build || { echo -e "\033[31mcoc-memory build failed\033[0m"; return 1; }
 
+    cd "$REPO_ROOT/packages/coc-agent-sdk"
+    npm run build || { echo -e "\033[31mcoc-agent-sdk build failed\033[0m"; return 1; }
+
     cd "$REPO_ROOT/packages/forge"
     npm run build || { echo -e "\033[31mforge build failed\033[0m"; return 1; }
     npm link
+
+    cd "$REPO_ROOT/packages/coc-client"
+    npm run build || { echo -e "\033[31mcoc-client build failed\033[0m"; return 1; }
+
+    cd "$REPO_ROOT/packages/coc-workflow"
+    npm run build || { echo -e "\033[31mcoc-workflow build failed\033[0m"; return 1; }
 
     cd "$REPO_ROOT/packages/teams-bot"
     npm run build || { echo -e "\033[31mteams-bot build failed\033[0m"; return 1; }


### PR DESCRIPTION
## Summary

- **Fix `coccontainer-serve-loop.sh` build chain**: Add missing `coc-agent-sdk`, `coc-client`, and `coc-workflow` package builds before the `coc` build step. The `coc` package imports types from `@plusplusoneplusplus/coc-client` (e.g., `WorkItemSyncProvider`, `WorkItemSyncProviderStatus`, `RuntimeDashboardConfig`) and these must be compiled to `dist/` before `coc` can build.
- **Fix `WorkItemSyncRepoPreferences` type compatibility**: Add index signatures to `WorkItemSyncRepoPreferences` and `WorkItemSyncGithubPreference` so that `PerRepoPreferences` (from `coc-client`, which has extra fields like `pollingEnabled`, `pollIntervalMinutes`) is structurally assignable.
- **Add `coccontainer-serve-smoke` CI job**: New CI job that builds all packages + coccontainer, starts `coccontainer serve`, and verifies the `/api/container/agents` endpoint responds within 60s. Runs on ubuntu-latest and windows-latest. Added to the CI gate job.

## Test plan

- [x] `coc-client` builds successfully
- [x] `coc` builds successfully (no more TS errors)
- [x] `coccontainer` builds successfully
- [x] work-item-sync tests pass (14/14)
- [x] runtime-config-handler tests pass (27/27)
- [x] coccontainer tests pass (233/233)
- [ ] CI `coccontainer-serve-smoke` job passes on ubuntu and windows


Made with [Cursor](https://cursor.com)