### PR TITLE
feat(coc-agent-sdk): shared vitest-free ISDKService mock via ./testing subpath

### DIFF
--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -16,6 +16,7 @@ Location: `packages/coc-agent-sdk/src/`
 | `claude-sdk-service.ts` | `ClaudeSDKService` — optional Claude backend (`@anthropic-ai/claude-agent-sdk`) |
 | `sdk-service-interface.ts` | `ISDKService` provider-agnostic contract |
 | `sdk-service-registry.ts` | `SDKServiceRegistry` — named-provider registry |
+| `testing/` | Shared vitest-free `ISDKService` mock (`createMockSDKService` + presets); exposed via `./testing` subpath export |
 | `request-runner.ts` | `sendMessage`/`transform` execution: session creation, MCP wiring, permission handler, streaming routing |
 | `stream-error-guard.ts` | `StreamErrorGuard` + `isStreamDestroyedError()`/`isConnectionDisposedError()` helpers |
 | `session-manager.ts` | Active session tracking and cancellation |
@@ -286,7 +287,9 @@ Without a call to `initSDKLogger`, all internal SDK log statements are silently 
 
 ## Testing Notes
 
-- Mock helpers in `packages/coc-agent-sdk/test/helpers/mock-sdk.ts`
-- 306 tests in `packages/coc-agent-sdk/test/`
+- **Shared ISDKService mock** in `packages/coc-agent-sdk/src/testing/` — vitest-free, exposed via `@plusplusoneplusplus/coc-agent-sdk/testing` subpath export. Factories: `createMockSDKService`, `createUnavailableMock`, `createStreamingMock`, `createFailingMock`, `createMockBridge`, `createExpiredSessionBridge`. Accepts an injectable mock-fn factory (`fn` parameter); consumers pass `vi.fn` for vitest spy assertions.
+- `packages/coc/test/helpers/mock-sdk-service.ts` is a thin wrapper that binds `vi.fn` and re-exports from the shared mock.
+- Lower-level mock helpers in `packages/coc-agent-sdk/test/helpers/mock-sdk.ts` (MockCopilotClient — different layer, not migrated).
+- 539+ tests in `packages/coc-agent-sdk/test/`
 - Set `serviceAny.sdkModule` and `serviceAny.availabilityCache` to bypass real SDK
 - Unit tests cover: session-manager, streaming-session, sdk-loader, sdk-client-factory, stream-error-guard, request-runner, logger, codex-sdk-service

--- a/packages/coc-agent-sdk/package.json
+++ b/packages/coc-agent-sdk/package.json
@@ -4,6 +4,16 @@
   "description": "Provider-agnostic AI agent SDK for CoC — supports Copilot and Codex",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/coc-agent-sdk/src/testing/index.ts
+++ b/packages/coc-agent-sdk/src/testing/index.ts
@@ -1,0 +1,13 @@
+export type { MockFnHandle, MockFnFactory } from './mock-fn';
+export { createDefaultMockFn } from './mock-fn';
+
+export type { MockSDKServiceOptions, MockSDKService, MockSDKServiceResult } from './mock-sdk-service';
+export {
+    createMockSDKService,
+    createUnavailableMock,
+    createStreamingMock,
+    createFailingMock,
+} from './mock-sdk-service';
+
+export type { MockBridge } from './mock-bridge';
+export { createMockBridge, createExpiredSessionBridge } from './mock-bridge';

--- a/packages/coc-agent-sdk/src/testing/mock-bridge.ts
+++ b/packages/coc-agent-sdk/src/testing/mock-bridge.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared mock for QueueExecutorBridge — vitest-free.
+ *
+ * The bridge type is defined in coc, not here. We use a structural type that
+ * matches the QueueExecutorBridge interface so consumers can cast to their
+ * local import.
+ */
+
+import type { MockFnHandle, MockFnFactory } from './mock-fn';
+import { createDefaultMockFn } from './mock-fn';
+
+export interface MockBridge {
+    executeFollowUp: MockFnHandle;
+    isSessionAlive: MockFnHandle;
+    enqueue: MockFnHandle;
+    cancelProcess: MockFnHandle;
+    steerProcess: MockFnHandle;
+    getTask: MockFnHandle;
+}
+
+export function createMockBridge(
+    overrides?: Partial<Record<keyof MockBridge, unknown>>,
+    fn: MockFnFactory = createDefaultMockFn,
+): MockBridge {
+    return {
+        executeFollowUp: (overrides?.executeFollowUp ?? fn(() => Promise.resolve(undefined))) as MockFnHandle,
+        isSessionAlive: (overrides?.isSessionAlive ?? fn(() => Promise.resolve(true))) as MockFnHandle,
+        enqueue: (overrides?.enqueue ?? fn(() => Promise.resolve('mock-task-id'))) as MockFnHandle,
+        cancelProcess: (overrides?.cancelProcess ?? fn(() => Promise.resolve(undefined))) as MockFnHandle,
+        steerProcess: (overrides?.steerProcess ?? fn(() => Promise.resolve(true))) as MockFnHandle,
+        getTask: (overrides?.getTask ?? fn(() => undefined)) as MockFnHandle,
+    };
+}
+
+/** Bridge where isSessionAlive resolves to false. Used for 410 test cases. */
+export function createExpiredSessionBridge(
+    fn: MockFnFactory = createDefaultMockFn,
+): MockBridge {
+    return createMockBridge(
+        { isSessionAlive: fn(() => Promise.resolve(false)) },
+        fn,
+    );
+}

--- a/packages/coc-agent-sdk/src/testing/mock-fn.ts
+++ b/packages/coc-agent-sdk/src/testing/mock-fn.ts
@@ -1,0 +1,64 @@
+/**
+ * Lightweight mock-function utility — vitest-free.
+ *
+ * Modelled on the e2e `MockFn` pattern from `packages/coc/test/e2e/fixtures/mock-ai.ts`.
+ * Consumers inject `vi.fn` (or any other spy factory) via the `fn` parameter of
+ * `createMockSDKService`; the default shim here keeps the package usable standalone.
+ */
+
+export interface MockFnHandle<TReturn = unknown> {
+    (...args: unknown[]): TReturn;
+    calls: unknown[][];
+    mockResolvedValue(value: unknown): MockFnHandle<TReturn>;
+    mockResolvedValueOnce(value: unknown): MockFnHandle<TReturn>;
+    mockImplementation(fn: (...args: unknown[]) => unknown): MockFnHandle<TReturn>;
+    mockImplementationOnce(fn: (...args: unknown[]) => unknown): MockFnHandle<TReturn>;
+    mockReset(): MockFnHandle<TReturn>;
+}
+
+export type MockFnFactory = (impl?: (...args: any[]) => any) => MockFnHandle;
+
+export function createDefaultMockFn(defaultImpl?: (...args: any[]) => any): MockFnHandle {
+    const initialImpl = defaultImpl ?? (() => undefined);
+    let currentImpl: (...args: unknown[]) => unknown = initialImpl;
+    const onceQueue: Array<(...args: unknown[]) => unknown> = [];
+
+    const fn = ((...args: unknown[]) => {
+        fn.calls.push(args);
+        if (onceQueue.length > 0) {
+            return onceQueue.shift()!(...args);
+        }
+        return currentImpl(...args);
+    }) as MockFnHandle;
+
+    fn.calls = [];
+
+    fn.mockResolvedValue = (value: unknown) => {
+        currentImpl = () => Promise.resolve(value);
+        return fn;
+    };
+
+    fn.mockResolvedValueOnce = (value: unknown) => {
+        onceQueue.push(() => Promise.resolve(value));
+        return fn;
+    };
+
+    fn.mockImplementation = (impl: (...args: unknown[]) => unknown) => {
+        currentImpl = impl;
+        return fn;
+    };
+
+    fn.mockImplementationOnce = (impl: (...args: unknown[]) => unknown) => {
+        onceQueue.push(impl);
+        return fn;
+    };
+
+    fn.mockReset = () => {
+        fn.calls = [];
+        onceQueue.length = 0;
+        currentImpl = initialImpl;
+        return fn;
+    };
+
+    return fn;
+}

--- a/packages/coc-agent-sdk/src/testing/mock-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/testing/mock-sdk-service.ts
@@ -1,0 +1,225 @@
+/**
+ * Shared vitest-free mock of ISDKService.
+ *
+ * Implements all 13 interface methods plus the off-interface `createClient`.
+ * The mock-function factory is injectable so consumers can bind `vi.fn` for
+ * full spy assertions while the package itself imports nothing from vitest.
+ */
+
+import type { ISDKService, IAvailabilityResult, IInvocationResult, IModelInfo } from '../sdk-service-interface';
+import type { SendMessageOptions } from '../types';
+import type { MockFnHandle, MockFnFactory } from './mock-fn';
+import { createDefaultMockFn } from './mock-fn';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MockSDKServiceOptions {
+    /** Availability result. Default: `{ available: true }` */
+    available?: boolean | IAvailabilityResult;
+    /** Default sendMessage response */
+    sendMessageResponse?: IInvocationResult;
+    /** Default transform result. Default: `'Generated Title'` */
+    transformResult?: unknown;
+    /** Default listModels result. Default: `[]` */
+    listModelsResult?: IModelInfo[];
+    /** Arbitrary method overrides applied after defaults */
+    overrides?: Partial<ISDKService>;
+}
+
+export type MockSDKService = ISDKService & { createClient: (...args: unknown[]) => unknown };
+
+export interface MockSDKServiceResult {
+    service: MockSDKService;
+    mockSendMessage: MockFnHandle;
+    mockTitleSendMessage: MockFnHandle;
+    mockIsAvailable: MockFnHandle;
+    mockCreateClient: MockFnHandle;
+    mockTransform: MockFnHandle;
+    mockAbortSession: MockFnHandle;
+    mockSoftAbortSession: MockFnHandle;
+    mockSteerSession: MockFnHandle;
+    mockListModels: MockFnHandle;
+    mockForkSession: MockFnHandle;
+    mockClearAvailabilityCache: MockFnHandle;
+    mockHasActiveSession: MockFnHandle;
+    mockGetActiveSessionCount: MockFnHandle;
+    mockCleanup: MockFnHandle;
+    mockDispose: MockFnHandle;
+    resetAll: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createMockSDKService(
+    options?: MockSDKServiceOptions,
+    fn: MockFnFactory = createDefaultMockFn,
+): MockSDKServiceResult {
+    const availableResult: IAvailabilityResult =
+        typeof options?.available === 'object'
+            ? options.available
+            : { available: options?.available ?? true };
+
+    const sendMessageResponse: IInvocationResult = options?.sendMessageResponse ?? {
+        success: true,
+        response: 'AI response text',
+        sessionId: 'session-123',
+    };
+
+    const transformResult = options?.transformResult ?? 'Generated Title';
+    const listModelsResult = options?.listModelsResult ?? [];
+
+    // Individual mock handles
+    const mockSendMessage = fn(() => Promise.resolve(sendMessageResponse));
+    const mockTitleSendMessage = fn(() =>
+        Promise.resolve({ success: true, response: 'Generated Title', sessionId: 'title-session' }),
+    );
+
+    const sendMessageRouter = fn((...args: unknown[]) => {
+        const messageOptions = args[0] as SendMessageOptions | undefined;
+        if (
+            typeof messageOptions?.prompt === 'string' &&
+            messageOptions.prompt.startsWith('Summarise the following conversation')
+        ) {
+            return mockTitleSendMessage(messageOptions);
+        }
+        return mockSendMessage(messageOptions);
+    });
+
+    const mockIsAvailable = fn(() => Promise.resolve(availableResult));
+    const mockCreateClient = fn(() => Promise.resolve({ __mockClient: true }));
+    const mockTransform = fn(() => Promise.resolve(transformResult));
+    const mockAbortSession = fn(() => Promise.resolve(true));
+    const mockSoftAbortSession = fn(() => Promise.resolve(true));
+    const mockSteerSession = fn(() => Promise.resolve(true));
+    const mockListModels = fn(() => Promise.resolve(listModelsResult));
+    const mockForkSession = fn((...args: unknown[]) => Promise.resolve(`${String(args[0])}-forked`));
+    const mockClearAvailabilityCache = fn(() => undefined);
+    const mockHasActiveSession = fn(() => true);
+    const mockGetActiveSessionCount = fn(() => 0);
+    const mockCleanup = fn(() => Promise.resolve());
+    const mockDispose = fn(() => undefined);
+
+    const baseService: MockSDKService = {
+        sendMessage: sendMessageRouter as unknown as ISDKService['sendMessage'],
+        isAvailable: mockIsAvailable as unknown as ISDKService['isAvailable'],
+        createClient: mockCreateClient,
+        transform: mockTransform as unknown as ISDKService['transform'],
+        abortSession: mockAbortSession as unknown as ISDKService['abortSession'],
+        softAbortSession: mockSoftAbortSession as unknown as ISDKService['softAbortSession'],
+        steerSession: mockSteerSession as unknown as ISDKService['steerSession'],
+        listModels: mockListModels as unknown as ISDKService['listModels'],
+        forkSession: mockForkSession as unknown as ISDKService['forkSession'],
+        clearAvailabilityCache: mockClearAvailabilityCache as unknown as ISDKService['clearAvailabilityCache'],
+        hasActiveSession: mockHasActiveSession as unknown as ISDKService['hasActiveSession'],
+        getActiveSessionCount: mockGetActiveSessionCount as unknown as ISDKService['getActiveSessionCount'],
+        cleanup: mockCleanup as unknown as ISDKService['cleanup'],
+        dispose: mockDispose as unknown as ISDKService['dispose'],
+    };
+
+    if (options?.overrides) {
+        Object.assign(baseService, options.overrides);
+    }
+
+    const resetAll = () => {
+        mockSendMessage.mockReset().mockResolvedValue(sendMessageResponse);
+        mockTitleSendMessage.mockReset().mockResolvedValue({
+            success: true,
+            response: 'Generated Title',
+            sessionId: 'title-session',
+        });
+        sendMessageRouter.mockReset().mockImplementation((...args: unknown[]) => {
+            const messageOptions = args[0] as SendMessageOptions | undefined;
+            if (
+                typeof messageOptions?.prompt === 'string' &&
+                messageOptions.prompt.startsWith('Summarise the following conversation')
+            ) {
+                return mockTitleSendMessage(messageOptions);
+            }
+            return mockSendMessage(messageOptions);
+        });
+        mockIsAvailable.mockReset().mockResolvedValue(availableResult);
+        mockCreateClient.mockReset().mockResolvedValue({ __mockClient: true });
+        mockTransform.mockReset().mockResolvedValue(transformResult);
+        mockAbortSession.mockReset().mockResolvedValue(true);
+        mockSoftAbortSession.mockReset().mockResolvedValue(true);
+        mockSteerSession.mockReset().mockResolvedValue(true);
+        mockListModels.mockReset().mockResolvedValue(listModelsResult);
+        mockForkSession.mockReset().mockImplementation((...args: unknown[]) => Promise.resolve(`${String(args[0])}-forked`));
+        mockClearAvailabilityCache.mockReset();
+        mockHasActiveSession.mockReset().mockImplementation(() => true);
+        mockGetActiveSessionCount.mockReset().mockImplementation(() => 0);
+        mockCleanup.mockReset().mockResolvedValue(undefined);
+        mockDispose.mockReset();
+    };
+
+    return {
+        service: baseService,
+        mockSendMessage,
+        mockTitleSendMessage,
+        mockIsAvailable,
+        mockCreateClient,
+        mockTransform,
+        mockAbortSession,
+        mockSoftAbortSession,
+        mockSteerSession,
+        mockListModels,
+        mockForkSession,
+        mockClearAvailabilityCache,
+        mockHasActiveSession,
+        mockGetActiveSessionCount,
+        mockCleanup,
+        mockDispose,
+        resetAll,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Preset factories
+// ---------------------------------------------------------------------------
+
+/** Mock where isAvailable returns `{ available: false }`. */
+export function createUnavailableMock(
+    fn?: MockFnFactory,
+): MockSDKServiceResult {
+    return createMockSDKService({ available: false }, fn);
+}
+
+/**
+ * Mock where sendMessage invokes `onStreamingChunk` for each chunk
+ * before resolving. The final response is the concatenation of all chunks.
+ */
+export function createStreamingMock(
+    chunks: string[],
+    fn?: MockFnFactory,
+): MockSDKServiceResult {
+    const result = createMockSDKService(undefined, fn);
+    const fullResponse = chunks.join('');
+
+    const streamingImpl = async (...args: unknown[]) => {
+        const options = args[1] as { onStreamingChunk?: (chunk: string) => void } | undefined;
+        if (options?.onStreamingChunk) {
+            for (const chunk of chunks) {
+                options.onStreamingChunk(chunk);
+            }
+        }
+        return { success: true, response: fullResponse, sessionId: 'session-streaming' };
+    };
+
+    result.mockSendMessage.mockImplementation(streamingImpl);
+    return result;
+}
+
+/** Mock where sendMessage resolves with `{ success: false, error }`. */
+export function createFailingMock(
+    error: string,
+    fn?: MockFnFactory,
+): MockSDKServiceResult {
+    return createMockSDKService(
+        { sendMessageResponse: { success: false, error } },
+        fn,
+    );
+}

--- a/packages/coc-agent-sdk/test/testing/mock-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/testing/mock-sdk-service.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ISDKService } from '../../src/sdk-service-interface';
+import {
+    createMockSDKService,
+    createUnavailableMock,
+    createStreamingMock,
+    createFailingMock,
+    createMockBridge,
+    createExpiredSessionBridge,
+    createDefaultMockFn,
+} from '../../src/testing/index';
+import type { MockFnFactory } from '../../src/testing/index';
+
+// ---------------------------------------------------------------------------
+// Default shim tests (no vitest spy injection)
+// ---------------------------------------------------------------------------
+
+describe('createMockSDKService (default shim)', () => {
+    it('returns a service with all 13 ISDKService methods + createClient', () => {
+        const { service } = createMockSDKService();
+        const s: ISDKService = service;
+        expect(typeof s.isAvailable).toBe('function');
+        expect(typeof s.clearAvailabilityCache).toBe('function');
+        expect(typeof s.listModels).toBe('function');
+        expect(typeof s.sendMessage).toBe('function');
+        expect(typeof s.transform).toBe('function');
+        expect(typeof s.forkSession).toBe('function');
+        expect(typeof s.abortSession).toBe('function');
+        expect(typeof s.softAbortSession).toBe('function');
+        expect(typeof s.steerSession).toBe('function');
+        expect(typeof s.hasActiveSession).toBe('function');
+        expect(typeof s.getActiveSessionCount).toBe('function');
+        expect(typeof s.cleanup).toBe('function');
+        expect(typeof s.dispose).toBe('function');
+        expect(typeof service.createClient).toBe('function');
+    });
+
+    it('default sendMessage returns success response', async () => {
+        const { service } = createMockSDKService();
+        const result = await service.sendMessage({ prompt: 'hello' } as any);
+        expect(result).toEqual({
+            success: true,
+            response: 'AI response text',
+            sessionId: 'session-123',
+        });
+    });
+
+    it('title-router routes summarise prompts to mockTitleSendMessage', async () => {
+        const { service, mockTitleSendMessage } = createMockSDKService();
+        await service.sendMessage({
+            prompt: 'Summarise the following conversation as a short title',
+        } as any);
+        expect(mockTitleSendMessage.calls.length).toBe(1);
+    });
+
+    it('default isAvailable returns { available: true }', async () => {
+        const { service } = createMockSDKService();
+        expect(await service.isAvailable()).toEqual({ available: true });
+    });
+
+    it('default transform returns Generated Title', async () => {
+        const { service } = createMockSDKService();
+        expect(await service.transform('prompt')).toBe('Generated Title');
+    });
+
+    it('default forkSession returns id-forked', async () => {
+        const { service } = createMockSDKService();
+        expect(await service.forkSession('sess-1')).toBe('sess-1-forked');
+    });
+
+    it('default session methods return expected values', async () => {
+        const { service } = createMockSDKService();
+        expect(await service.abortSession('s')).toBe(true);
+        expect(await service.softAbortSession('s')).toBe(true);
+        expect(await service.steerSession('s', 'msg')).toBe(true);
+        expect(service.hasActiveSession('s')).toBe(true);
+        expect(service.getActiveSessionCount()).toBe(0);
+    });
+
+    it('default lifecycle methods work', async () => {
+        const { service } = createMockSDKService();
+        await expect(service.cleanup()).resolves.toBeUndefined();
+        expect(() => service.dispose()).not.toThrow();
+    });
+
+    it('default createClient returns mock client', async () => {
+        const { service } = createMockSDKService();
+        expect(await service.createClient()).toEqual({ __mockClient: true });
+    });
+
+    it('default shim records calls', async () => {
+        const { mockSendMessage, service } = createMockSDKService();
+        await service.sendMessage({ prompt: 'test' } as any);
+        expect(mockSendMessage.calls.length).toBe(1);
+    });
+
+    it('resetAll restores defaults', async () => {
+        const { service, mockSendMessage, resetAll } = createMockSDKService();
+        mockSendMessage.mockResolvedValue({ success: false, error: 'fail' });
+        const badResult = await service.sendMessage({ prompt: 'x' } as any);
+        expect(badResult).toEqual({ success: false, error: 'fail' });
+
+        resetAll();
+        const goodResult = await service.sendMessage({ prompt: 'y' } as any);
+        expect(goodResult).toEqual({
+            success: true,
+            response: 'AI response text',
+            sessionId: 'session-123',
+        });
+    });
+});
+
+describe('createMockSDKService options', () => {
+    it('accepts boolean available', async () => {
+        const { service } = createMockSDKService({ available: false });
+        expect(await service.isAvailable()).toEqual({ available: false });
+    });
+
+    it('accepts full IAvailabilityResult', async () => {
+        const { service } = createMockSDKService({
+            available: { available: false, error: 'not installed' },
+        });
+        expect(await service.isAvailable()).toEqual({ available: false, error: 'not installed' });
+    });
+
+    it('accepts custom sendMessageResponse', async () => {
+        const custom = { success: false, error: 'boom' };
+        const { service } = createMockSDKService({ sendMessageResponse: custom });
+        expect(await service.sendMessage({ prompt: 'x' } as any)).toEqual(custom);
+    });
+
+    it('accepts custom transformResult', async () => {
+        const { service } = createMockSDKService({ transformResult: 'custom title' });
+        expect(await service.transform('p')).toBe('custom title');
+    });
+
+    it('accepts custom listModelsResult', async () => {
+        const models = [{ id: 'gpt-5', name: 'GPT-5' }];
+        const { service } = createMockSDKService({ listModelsResult: models });
+        expect(await service.listModels()).toEqual(models);
+    });
+
+    it('accepts method overrides', async () => {
+        const { service } = createMockSDKService({
+            overrides: {
+                isAvailable: async () => ({ available: false, error: 'override' }),
+            },
+        });
+        expect(await service.isAvailable()).toEqual({ available: false, error: 'override' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Injected vi.fn factory
+// ---------------------------------------------------------------------------
+
+describe('createMockSDKService with injected vi.fn', () => {
+    const viFnFactory: MockFnFactory = (impl) => {
+        const mock = impl ? vi.fn(impl) : vi.fn();
+        (mock as any).calls = [];
+        (mock as any).mockResolvedValue = mock.mockResolvedValue.bind(mock);
+        (mock as any).mockResolvedValueOnce = mock.mockResolvedValueOnce.bind(mock);
+        (mock as any).mockImplementation = mock.mockImplementation.bind(mock);
+        (mock as any).mockImplementationOnce = mock.mockImplementationOnce.bind(mock);
+        const origReset = mock.mockReset.bind(mock);
+        (mock as any).mockReset = () => { origReset(); return mock as any; };
+        return mock as any;
+    };
+
+    it('injected factory is honored', async () => {
+        const { mockSendMessage, service } = createMockSDKService(undefined, viFnFactory);
+        await service.sendMessage({ prompt: 'hello' } as any);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('vitest assertions work on mock handles', async () => {
+        const { mockIsAvailable, service } = createMockSDKService(undefined, viFnFactory);
+        await service.isAvailable();
+        expect(mockIsAvailable).toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Preset factories
+// ---------------------------------------------------------------------------
+
+describe('createUnavailableMock', () => {
+    it('returns unavailable service', async () => {
+        const { service } = createUnavailableMock();
+        expect(await service.isAvailable()).toEqual({ available: false });
+    });
+});
+
+describe('createStreamingMock', () => {
+    it('invokes onStreamingChunk for each chunk', async () => {
+        const chunks = ['Hello', ' ', 'World'];
+        const { mockSendMessage } = createStreamingMock(chunks);
+        const received: string[] = [];
+        await mockSendMessage('test', { onStreamingChunk: (c: string) => received.push(c) });
+        expect(received).toEqual(chunks);
+    });
+});
+
+describe('createFailingMock', () => {
+    it('returns failure response', async () => {
+        const { service } = createFailingMock('oops');
+        const result = await service.sendMessage({ prompt: 'x' } as any);
+        expect(result).toEqual({ success: false, error: 'oops' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Default MockFn shim
+// ---------------------------------------------------------------------------
+
+describe('createDefaultMockFn', () => {
+    it('tracks calls', () => {
+        const fn = createDefaultMockFn(() => 42);
+        fn('a', 'b');
+        fn('c');
+        expect(fn.calls).toEqual([['a', 'b'], ['c']]);
+    });
+
+    it('mockResolvedValue overrides return', async () => {
+        const fn = createDefaultMockFn(() => Promise.resolve(1));
+        fn.mockResolvedValue(99);
+        expect(await fn()).toBe(99);
+    });
+
+    it('mockResolvedValueOnce is consumed once', async () => {
+        const fn = createDefaultMockFn(() => Promise.resolve('default'));
+        fn.mockResolvedValueOnce('once');
+        expect(await fn()).toBe('once');
+        expect(await fn()).toBe('default');
+    });
+
+    it('mockImplementation replaces default', () => {
+        const fn = createDefaultMockFn(() => 'a');
+        fn.mockImplementation(() => 'b');
+        expect(fn()).toBe('b');
+    });
+
+    it('mockImplementationOnce is consumed once', () => {
+        const fn = createDefaultMockFn(() => 'default');
+        fn.mockImplementationOnce(() => 'once');
+        expect(fn()).toBe('once');
+        expect(fn()).toBe('default');
+    });
+
+    it('mockReset restores initial impl and clears calls', () => {
+        const fn = createDefaultMockFn(() => 'initial');
+        fn.mockImplementation(() => 'replaced');
+        fn('call1');
+        fn.mockReset();
+        expect(fn()).toBe('initial');
+        expect(fn.calls).toEqual([[]]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bridge mocks
+// ---------------------------------------------------------------------------
+
+describe('createMockBridge', () => {
+    it('returns all bridge methods', async () => {
+        const bridge = createMockBridge();
+        expect(typeof bridge.executeFollowUp).toBe('function');
+        expect(typeof bridge.isSessionAlive).toBe('function');
+        expect(typeof bridge.enqueue).toBe('function');
+        expect(typeof bridge.cancelProcess).toBe('function');
+        expect(typeof bridge.steerProcess).toBe('function');
+        expect(typeof bridge.getTask).toBe('function');
+    });
+
+    it('default isSessionAlive returns true', async () => {
+        const bridge = createMockBridge();
+        expect(await bridge.isSessionAlive()).toBe(true);
+    });
+
+    it('accepts overrides', async () => {
+        const customFn = createDefaultMockFn(() => Promise.resolve(false));
+        const bridge = createMockBridge({ isSessionAlive: customFn });
+        expect(await bridge.isSessionAlive()).toBe(false);
+    });
+});
+
+describe('createExpiredSessionBridge', () => {
+    it('returns bridge where isSessionAlive is false', async () => {
+        const bridge = createExpiredSessionBridge();
+        expect(await bridge.isSessionAlive()).toBe(false);
+    });
+});

--- a/packages/coc/test/helpers/mock-sdk-service.ts
+++ b/packages/coc/test/helpers/mock-sdk-service.ts
@@ -1,197 +1,98 @@
 /**
- * Shared mock factories for CopilotSDKService (as exposed via sdkServiceRegistry.getOrThrow())
- * and QueueExecutorBridge.
+ * Thin wrapper around the shared `@plusplusoneplusplus/coc-agent-sdk/testing`
+ * mock, binding `vi.fn` so all mock handles are real vitest spies.
  *
- * Consolidates duplicated mock setup from:
- *   - test/server/queue-executor-bridge.test.ts
- *   - test/server/executor-session-tracking.test.ts
- *   - test/server/follow-up-api.test.ts
+ * The import path (`../helpers/mock-sdk-service`) is preserved — no callers
+ * need updating.
  */
 
 import { vi } from 'vitest';
+import {
+    createMockSDKService as _createMockSDKService,
+    createUnavailableMock as _createUnavailableMock,
+    createStreamingMock as _createStreamingMock,
+    createFailingMock as _createFailingMock,
+    createMockBridge as _createMockBridge,
+    createExpiredSessionBridge as _createExpiredSessionBridge,
+} from '@plusplusoneplusplus/coc-agent-sdk/testing';
+import type {
+    MockSDKServiceOptions,
+    MockSDKServiceResult,
+    MockSDKService,
+    MockFnFactory,
+} from '@plusplusoneplusplus/coc-agent-sdk/testing';
 import type { QueueExecutorBridge } from '../../src/server/queue/queue-executor-bridge';
 
 // ---------------------------------------------------------------------------
-// Interfaces
+// vitest-backed mock-fn factory
 // ---------------------------------------------------------------------------
 
-/** Shape of the mock SDK service returned by sdkServiceRegistry.getOrThrow() */
-export interface MockCopilotSDKService {
-    sendMessage: ReturnType<typeof vi.fn>;
-    isAvailable: ReturnType<typeof vi.fn>;
-    createClient: ReturnType<typeof vi.fn>;
-    transform: ReturnType<typeof vi.fn>;
-    abortSession: ReturnType<typeof vi.fn>;
-    steerSession: ReturnType<typeof vi.fn>;
-    listModels: ReturnType<typeof vi.fn>;
-}
+const viFnFactory: MockFnFactory = (impl) => {
+    const spy = impl ? vi.fn(impl) : vi.fn();
+    // Attach the MockFnHandle API on top of vitest's Mock so the shared mock
+    // can drive it without importing vitest.
+    const handle = spy as any;
+    handle.calls = spy.mock.calls;
 
-/** Configuration for SDK service mock behavior */
-export interface MockSDKServiceOptions {
-    /** Default availability result. Default: { available: true } */
-    available?: boolean;
-    /** Default sendMessage response */
-    sendMessageResponse?: {
-        success: boolean;
-        response?: string;
-        error?: string;
-        sessionId?: string;
+    const origMRV = spy.mockResolvedValue.bind(spy);
+    handle.mockResolvedValue = (v: unknown) => { origMRV(v); return handle; };
+
+    const origMRVO = spy.mockResolvedValueOnce.bind(spy);
+    handle.mockResolvedValueOnce = (v: unknown) => { origMRVO(v); return handle; };
+
+    const origMI = spy.mockImplementation.bind(spy);
+    handle.mockImplementation = (fn: (...a: unknown[]) => unknown) => { origMI(fn); return handle; };
+
+    const origMIO = spy.mockImplementationOnce.bind(spy);
+    handle.mockImplementationOnce = (fn: (...a: unknown[]) => unknown) => { origMIO(fn); return handle; };
+
+    const origReset = spy.mockReset.bind(spy);
+    handle.mockReset = () => {
+        origReset();
+        handle.calls = spy.mock.calls;
+        return handle;
     };
-}
 
-/** Return type from createMockSDKService() with reset helper */
-export interface MockSDKServiceResult {
-    service: MockCopilotSDKService;
-    mockSendMessage: ReturnType<typeof vi.fn>;
-    mockTitleSendMessage: ReturnType<typeof vi.fn>;
-    mockIsAvailable: ReturnType<typeof vi.fn>;
-    mockCreateClient: ReturnType<typeof vi.fn>;
-    mockTransform: ReturnType<typeof vi.fn>;
-    mockAbortSession: ReturnType<typeof vi.fn>;
-    mockSteerSession: ReturnType<typeof vi.fn>;
-    mockListModels: ReturnType<typeof vi.fn>;
-    /** Reset all mocks to their initial configured state */
-    resetAll: () => void;
-}
+    return handle;
+};
 
 // ---------------------------------------------------------------------------
-// Factory Functions
+// Re-export types for backward compat
 // ---------------------------------------------------------------------------
 
-/**
- * Creates a mock CopilotSDKService with configurable default behaviors.
- *
- * Default behavior (no options):
- * - isAvailable → { available: true }
- * - sendMessage → { success: true, response: 'AI response text', sessionId: 'session-123' }
- * - sendFollowUp → { success: true, response: 'Follow-up response', sessionId: 'sess-follow' }
- * - hasKeptAliveSession → true
- * - canResumeSession → true
- */
+/** @deprecated Use `MockSDKService` from `@plusplusoneplusplus/coc-agent-sdk/testing` */
+export type MockCopilotSDKService = MockSDKService;
+
+export type { MockSDKServiceOptions, MockSDKServiceResult };
+
+// ---------------------------------------------------------------------------
+// Factory wrappers (inject vi.fn)
+// ---------------------------------------------------------------------------
+
 export function createMockSDKService(options?: MockSDKServiceOptions): MockSDKServiceResult {
-    const availableResult = { available: options?.available ?? true };
-    const sendMessageResponse = options?.sendMessageResponse ?? {
-        success: true,
-        response: 'AI response text',
-        sessionId: 'session-123',
-    };
-
-    const mockSendMessage = vi.fn().mockResolvedValue(sendMessageResponse);
-    const mockTitleSendMessage = vi.fn().mockResolvedValue({ success: true, response: 'Generated Title', sessionId: 'title-session' });
-    const sendMessageRouter = vi.fn((messageOptions: any) => {
-        if (typeof messageOptions?.prompt === 'string' && messageOptions.prompt.startsWith('Summarise the following conversation')) {
-            return mockTitleSendMessage(messageOptions);
-        }
-        return mockSendMessage(messageOptions);
-    });
-    const mockIsAvailable = vi.fn().mockResolvedValue(availableResult);
-    const mockCreateClient = vi.fn().mockResolvedValue({ __mockClient: true });
-    const mockTransform = vi.fn().mockResolvedValue('Generated Title');
-    const mockAbortSession = vi.fn().mockResolvedValue(true);
-    const mockSteerSession = vi.fn().mockResolvedValue(true);
-    const mockListModels = vi.fn().mockResolvedValue([]);
-
-    const service: MockCopilotSDKService = {
-        sendMessage: sendMessageRouter,
-        isAvailable: mockIsAvailable,
-        createClient: mockCreateClient,
-        transform: mockTransform,
-        abortSession: mockAbortSession,
-        steerSession: mockSteerSession,
-        listModels: mockListModels,
-    };
-
-    const resetAll = () => {
-        mockSendMessage.mockReset().mockResolvedValue(sendMessageResponse);
-        mockTitleSendMessage.mockReset().mockResolvedValue({ success: true, response: 'Generated Title', sessionId: 'title-session' });
-        sendMessageRouter.mockReset().mockImplementation((messageOptions: any) => {
-            if (typeof messageOptions?.prompt === 'string' && messageOptions.prompt.startsWith('Summarise the following conversation')) {
-                return mockTitleSendMessage(messageOptions);
-            }
-            return mockSendMessage(messageOptions);
-        });
-        mockIsAvailable.mockReset().mockResolvedValue(availableResult);
-        mockCreateClient.mockReset().mockResolvedValue({ __mockClient: true });
-        mockTransform.mockReset().mockResolvedValue('Generated Title');
-        mockAbortSession.mockReset().mockResolvedValue(true);
-        mockSteerSession.mockReset().mockResolvedValue(true);
-        mockListModels.mockReset().mockResolvedValue([]);
-    };
-
-    return {
-        service,
-        mockSendMessage,
-        mockTitleSendMessage,
-        mockIsAvailable,
-        mockCreateClient,
-        mockTransform,
-        mockAbortSession,
-        mockSteerSession,
-        mockListModels,
-        resetAll,
-    };
+    return _createMockSDKService(options, viFnFactory);
 }
 
-/**
- * Creates a mock QueueExecutorBridge with default implementations.
- * - executeFollowUp → vi.fn().mockResolvedValue(undefined)
- * - isSessionAlive → vi.fn().mockResolvedValue(true)
- * - enqueue → vi.fn().mockResolvedValue('mock-task-id')
- * - requeueForFollowUp → vi.fn().mockResolvedValue(undefined)
- * - cancelProcess → vi.fn().mockResolvedValue(undefined)
- */
-export function createMockBridge(overrides?: Partial<QueueExecutorBridge>): QueueExecutorBridge {
-    return {
-        executeFollowUp: overrides?.executeFollowUp ?? vi.fn().mockResolvedValue(undefined),
-        isSessionAlive: overrides?.isSessionAlive ?? vi.fn().mockResolvedValue(true),
-        enqueue: overrides?.enqueue ?? vi.fn().mockResolvedValue('mock-task-id'),
-        cancelProcess: overrides?.cancelProcess ?? vi.fn().mockResolvedValue(undefined),
-        steerProcess: overrides?.steerProcess ?? vi.fn().mockResolvedValue(true),
-        getTask: overrides?.getTask ?? vi.fn().mockReturnValue(undefined),
-    };
-}
-
-// ---------------------------------------------------------------------------
-// Preset Factory Functions
-// ---------------------------------------------------------------------------
-
-/** Mock where isAvailable returns { available: false }. Useful for SDK unavailability paths. */
 export function createUnavailableMock(): MockSDKServiceResult {
-    return createMockSDKService({ available: false });
+    return _createUnavailableMock(viFnFactory);
 }
 
-/**
- * Mock where sendMessage and sendFollowUp invoke onStreamingChunk for each chunk
- * before resolving. The final response is the concatenation of all chunks.
- */
 export function createStreamingMock(chunks: string[]): MockSDKServiceResult {
-    const result = createMockSDKService();
-    const fullResponse = chunks.join('');
-
-    const streamingImpl = async (_prompt: string, options?: any) => {
-        if (options?.onStreamingChunk) {
-            for (const chunk of chunks) {
-                options.onStreamingChunk(chunk);
-            }
-        }
-        return { success: true, response: fullResponse, sessionId: 'session-streaming' };
-    };
-
-    result.mockSendMessage.mockImplementation(streamingImpl);
-
-    return result;
+    return _createStreamingMock(chunks, viFnFactory);
 }
 
-/** Mock where sendMessage resolves with { success: false, error }. */
 export function createFailingMock(error: string): MockSDKServiceResult {
-    return createMockSDKService({
-        sendMessageResponse: { success: false, error },
-    });
+    return _createFailingMock(error, viFnFactory);
 }
 
-/** Bridge where isSessionAlive resolves to false. Used for 410 test cases. */
+// ---------------------------------------------------------------------------
+// Bridge helpers
+// ---------------------------------------------------------------------------
+
+export function createMockBridge(overrides?: Partial<QueueExecutorBridge>): QueueExecutorBridge {
+    return _createMockBridge(overrides as any, viFnFactory) as unknown as QueueExecutorBridge;
+}
+
 export function createExpiredSessionBridge(): QueueExecutorBridge {
-    return createMockBridge({
-        isSessionAlive: vi.fn().mockResolvedValue(false),
-    });
+    return _createExpiredSessionBridge(viFnFactory) as unknown as QueueExecutorBridge;
 }

--- a/packages/coc/test/server/admin-handler.test.ts
+++ b/packages/coc/test/server/admin-handler.test.ts
@@ -17,8 +17,9 @@ import type { ExecutionServer } from '@plusplusoneplusplus/coc-server';
 import { registerAdminRoutes } from '../../src/server/admin/admin-handler';
 import { createRouter } from '../../src/server/shared/router';
 import type { Route } from '../../src/server/types';
-import type { ISDKService, IAvailabilityResult } from '@plusplusoneplusplus/forge';
+import type { IAvailabilityResult } from '@plusplusoneplusplus/forge';
 import { SDKServiceRegistry } from '@plusplusoneplusplus/forge';
+import { createMockSDKService } from '../helpers/mock-sdk-service';
 
 // ============================================================================
 // Helpers
@@ -1927,16 +1928,10 @@ describe('Admin Handler', () => {
 // GET /api/admin/codex/availability — unit tests (direct route registration)
 // ============================================================================
 
-function makeMockSdkService(result: IAvailabilityResult): ISDKService {
-    return {
-        isAvailable: async () => result,
-    } as unknown as ISDKService;
-}
-
 function makeRegistryWith(services: Record<string, IAvailabilityResult>): SDKServiceRegistry {
     const registry = new SDKServiceRegistry();
     for (const [name, avail] of Object.entries(services)) {
-        registry.register(name, makeMockSdkService(avail));
+        registry.register(name, createMockSDKService({ available: avail }).service);
     }
     return registry;
 }

--- a/packages/coc/test/server/agent-provider-effort-tiers-routes.test.ts
+++ b/packages/coc/test/server/agent-provider-effort-tiers-routes.test.ts
@@ -13,7 +13,8 @@ import type { AgentProvidersRouteContext } from '../../src/server/agent-provider
 import { RuntimeConfigService } from '../../src/config/runtime-config-service';
 import type { Route } from '../../src/server/types';
 import type { CLIConfig } from '../../src/config';
-import type { ModelInfo, ISDKService } from '@plusplusoneplusplus/forge';
+import type { ModelInfo } from '@plusplusoneplusplus/forge';
+import { createMockSDKService } from '../helpers/mock-sdk-service';
 
 // Mock modelMetadataStore from forge
 const mockGetAll = vi.fn<() => ModelInfo[]>().mockReturnValue([]);
@@ -79,25 +80,6 @@ function makeConfigFunctions(initialConfig?: CLIConfig): {
         getConfigFilePath: () => '/fake/config.yaml',
     };
     return result;
-}
-
-function makeAiService(overrides?: Partial<ISDKService>): ISDKService {
-    return {
-        isAvailable: async () => ({ available: true }),
-        clearAvailabilityCache: () => undefined,
-        listModels: async () => [],
-        sendMessage: async () => ({ success: true, response: 'ok', sessionId: 'sess-1' }),
-        transform: async () => '',
-        forkSession: async () => 'forked',
-        abortSession: async () => false,
-        softAbortSession: async () => false,
-        steerSession: async () => false,
-        hasActiveSession: () => false,
-        getActiveSessionCount: () => 0,
-        cleanup: async () => undefined,
-        dispose: () => undefined,
-        ...overrides,
-    };
 }
 
 function makeCtx(overrides?: Partial<AgentProvidersRouteContext>): AgentProvidersRouteContext {
@@ -528,9 +510,9 @@ describe('PUT /api/agent-providers/:provider/effort-tiers — per-provider isola
 
     it('writes to codex without touching copilot tiers', async () => {
         mockGetAll.mockReturnValue([]);
-        const codexService = makeAiService({
-            listModels: async () => [makeModelInfo('gpt-5.5', 'GPT-5.5')] as unknown as any[],
-        });
+        const codexService = createMockSDKService({
+            overrides: { listModels: async () => [makeModelInfo('gpt-5.5', 'GPT-5.5')] as unknown as any[] },
+        }).service;
         const cfgFns = makeConfigFunctions({
             models: { providers: { copilot: { effortTiers: { low: { model: 'copilot-low' } } } } },
         });

--- a/packages/coc/test/server/agent-provider-model-routes.test.ts
+++ b/packages/coc/test/server/agent-provider-model-routes.test.ts
@@ -13,7 +13,8 @@ import type { AgentProvidersRouteContext } from '../../src/server/agent-provider
 import { RuntimeConfigService } from '../../src/config/runtime-config-service';
 import type { Route } from '../../src/server/types';
 import type { CLIConfig } from '../../src/config';
-import type { ModelInfo, ISDKService } from '@plusplusoneplusplus/forge';
+import type { ModelInfo } from '@plusplusoneplusplus/forge';
+import { createMockSDKService } from '../helpers/mock-sdk-service';
 
 // Mock modelMetadataStore from forge
 const mockGetAll = vi.fn<() => ModelInfo[]>().mockReturnValue([]);
@@ -74,25 +75,6 @@ function makeConfigFunctions(initialConfig?: CLIConfig): {
         getConfigFilePath: () => '/fake/config.yaml',
     };
     return result;
-}
-
-function makeAiService(overrides?: Partial<ISDKService>): ISDKService {
-    return {
-        isAvailable: async () => ({ available: true }),
-        clearAvailabilityCache: () => undefined,
-        listModels: async () => [],
-        sendMessage: async () => ({ success: true, response: 'test response', sessionId: 'sess-1' }),
-        transform: async () => '',
-        forkSession: async () => 'forked',
-        abortSession: async () => false,
-        softAbortSession: async () => false,
-        steerSession: async () => false,
-        hasActiveSession: () => false,
-        getActiveSessionCount: () => 0,
-        cleanup: async () => undefined,
-        dispose: () => undefined,
-        ...overrides,
-    };
 }
 
 function makeCtx(overrides?: Partial<AgentProvidersRouteContext>): AgentProvidersRouteContext {
@@ -236,9 +218,9 @@ describe('GET /api/agent-providers/:provider/models', () => {
             supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
             defaultReasoningEffort: 'medium',
         };
-        const codexService = makeAiService({
-            listModels: async () => [gpt55] as unknown as any[],
-        });
+        const codexService = createMockSDKService({
+            overrides: { listModels: async () => [gpt55] as unknown as any[] },
+        }).service;
         const ctx = makeCtx({
             getCodexSdkService: () => codexService as unknown as any,
         });
@@ -257,9 +239,9 @@ describe('GET /api/agent-providers/:provider/models', () => {
     });
 
     it('returns empty models for codex when SDK service listModels throws', async () => {
-        const codexService = makeAiService({
-            listModels: async () => { throw new Error('catalog unavailable'); },
-        });
+        const codexService = createMockSDKService({
+            overrides: { listModels: async () => { throw new Error('catalog unavailable'); } },
+        }).service;
         const ctx = makeCtx({
             getCodexSdkService: () => codexService as unknown as any,
         });
@@ -467,13 +449,15 @@ describe('POST /api/agent-providers/:provider/models/query', () => {
     });
 
     it('queries the SDK service for copilot', async () => {
-        const aiService = makeAiService({
-            sendMessage: async () => ({
-                success: true,
-                response: 'hello world',
-                sessionId: 'sess-42',
-            }),
-        });
+        const aiService = createMockSDKService({
+            overrides: {
+                sendMessage: async () => ({
+                    success: true,
+                    response: 'hello world',
+                    sessionId: 'sess-42',
+                }),
+            },
+        }).service;
         const ctx = makeCtx({
             getCopilotSdkService: () => aiService as any,
         });
@@ -491,7 +475,7 @@ describe('POST /api/agent-providers/:provider/models/query', () => {
     });
 
     it('returns 400 for missing prompt', async () => {
-        const aiService = makeAiService();
+        const aiService = createMockSDKService().service;
         const ctx = makeCtx({
             getCopilotSdkService: () => aiService as any,
         });

--- a/packages/coc/test/server/work-items/work-item-ai-generator.test.ts
+++ b/packages/coc/test/server/work-items/work-item-ai-generator.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../src/server/work-items/work-item-ai-generator';
 import type { NewItemDraftContext, ImproveItemDraftContext } from '../../../src/server/routes/work-item-ai-routes';
 import { MAX_CLARIFICATION_ROUNDS } from '../../../src/server/routes/work-item-ai-routes';
-import type { ISDKService } from '@plusplusoneplusplus/forge';
+import { createMockSDKService, createFailingMock } from '../../helpers/mock-sdk-service';
 
 // ============================================================================
 // parseAiDraftResponse
@@ -331,30 +331,6 @@ describe('buildImproveItemPrompt', () => {
 // ============================================================================
 
 describe('createWorkItemAiGenerators', () => {
-    /**
-     * Build a minimal mock ISDKService that returns a fixed AI response.
-     */
-    function makeMockService(response: object): ISDKService {
-        return {
-            sendMessage: async () => ({
-                success: true,
-                response: JSON.stringify(response),
-            }),
-            isAvailable: async () => ({ available: true }),
-        } as unknown as ISDKService;
-    }
-
-    function makeMockServiceError(errorMsg: string): ISDKService {
-        return {
-            sendMessage: async () => ({
-                success: false,
-                response: '',
-                error: errorMsg,
-            }),
-            isAvailable: async () => ({ available: true }),
-        } as unknown as ISDKService;
-    }
-
     const newCtx: NewItemDraftContext = {
         workspaceId: 'ws-test',
         prompt: 'Build a search feature',
@@ -381,7 +357,9 @@ describe('createWorkItemAiGenerators', () => {
             workItem: { title: 'Search Feature', priority: 'normal' },
             goal: '## Objective\nBuild search.',
         };
-        const service = makeMockService(mockDraft);
+        const service = createMockSDKService({
+            sendMessageResponse: { success: true, response: JSON.stringify(mockDraft) },
+        }).service;
         const { generateNewItemDraft } = createWorkItemAiGenerators({ aiService: service });
 
         const result = await generateNewItemDraft(newCtx);
@@ -398,7 +376,9 @@ describe('createWorkItemAiGenerators', () => {
             questions: ['What types of content to search?'],
             clarificationCount: 0,
         };
-        const service = makeMockService(mockClarification);
+        const service = createMockSDKService({
+            sendMessageResponse: { success: true, response: JSON.stringify(mockClarification) },
+        }).service;
         const { generateNewItemDraft } = createWorkItemAiGenerators({ aiService: service });
 
         const result = await generateNewItemDraft(newCtx);
@@ -413,7 +393,9 @@ describe('createWorkItemAiGenerators', () => {
             kind: 'draft',
             workItem: { title: 'Improved Search', description: 'Better description' },
         };
-        const service = makeMockService(mockDraft);
+        const service = createMockSDKService({
+            sendMessageResponse: { success: true, response: JSON.stringify(mockDraft) },
+        }).service;
         const { generateImproveItemDraft } = createWorkItemAiGenerators({ aiService: service });
 
         const result = await generateImproveItemDraft(improveCtx);
@@ -424,17 +406,16 @@ describe('createWorkItemAiGenerators', () => {
     });
 
     it('generateNewItemDraft throws when AI service reports failure', async () => {
-        const service = makeMockServiceError('LLM unavailable');
+        const service = createFailingMock('LLM unavailable').service;
         const { generateNewItemDraft } = createWorkItemAiGenerators({ aiService: service });
 
         await expect(generateNewItemDraft(newCtx)).rejects.toThrow(/LLM unavailable/i);
     });
 
     it('generateImproveItemDraft throws when AI returns non-JSON', async () => {
-        const service = {
-            sendMessage: async () => ({ success: true, response: 'Here is a nice plan for you!' }),
-            isAvailable: async () => ({ available: true }),
-        } as unknown as ISDKService;
+        const service = createMockSDKService({
+            sendMessageResponse: { success: true, response: 'Here is a nice plan for you!' },
+        }).service;
         const { generateImproveItemDraft } = createWorkItemAiGenerators({ aiService: service });
 
         await expect(generateImproveItemDraft(improveCtx)).rejects.toThrow(/non-JSON/i);
@@ -449,7 +430,9 @@ describe('createWorkItemAiGenerators', () => {
                 { title: 'Logout endpoint', type: 'work-item' },
             ],
         };
-        const service = makeMockService(mockDraft);
+        const service = createMockSDKService({
+            sendMessageResponse: { success: true, response: JSON.stringify(mockDraft) },
+        }).service;
         const { generateNewItemDraft } = createWorkItemAiGenerators({ aiService: service });
 
         const result = await generateNewItemDraft({ ...newCtx, hierarchyEnabled: true });

--- a/packages/forge/test/copilot-sdk-wrapper/sdk-service-registry.test.ts
+++ b/packages/forge/test/copilot-sdk-wrapper/sdk-service-registry.test.ts
@@ -10,29 +10,23 @@ import {
     SDK_PROVIDER_COPILOT,
 } from '@plusplusoneplusplus/coc-agent-sdk';
 import type { ISDKService } from '@plusplusoneplusplus/coc-agent-sdk';
+import { createMockSDKService } from '@plusplusoneplusplus/coc-agent-sdk/testing';
 
 // ---------------------------------------------------------------------------
-// Minimal stub that satisfies ISDKService structurally
+// Shared factory wrapper with parameterized id
 // ---------------------------------------------------------------------------
 function makeMockProvider(id = 'mock'): ISDKService {
-    return {
-        isAvailable: async () => ({ available: true }),
-        clearAvailabilityCache: () => {},
-        listModels: async () => [{ id, name: `Model ${id}` }],
-        sendMessage: async () => ({ success: true, response: 'ok' }),
-        transform: async <T = string>(prompt: string, parse?: (raw: string) => T) => {
-            const raw = `transformed: ${prompt}`;
-            return (parse ? parse(raw) : raw) as T;
+    return createMockSDKService({
+        listModelsResult: [{ id, name: `Model ${id}` }],
+        overrides: {
+            hasActiveSession: () => false,
+            transform: (async <T = string>(prompt: string, parse?: (raw: string) => T) => {
+                const raw = `transformed: ${prompt}`;
+                return (parse ? parse(raw) : raw) as T;
+            }) as ISDKService['transform'],
+            forkSession: async (sid: string) => `${sid}-fork`,
         },
-        forkSession: async (sid: string) => `${sid}-fork`,
-        abortSession: async () => true,
-        softAbortSession: async () => true,
-        steerSession: async () => true,
-        hasActiveSession: () => false,
-        getActiveSessionCount: () => 0,
-        cleanup: async () => {},
-        dispose: () => {},
-    };
+    }).service;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/forge/test/review/ai-reviewer.test.ts
+++ b/packages/forge/test/review/ai-reviewer.test.ts
@@ -7,6 +7,7 @@ import type { DiffSource, CommitDiffSource, RangeDiffSource, WorkingTreeDiffSour
 import type { ReviewComment, ReviewOptions } from '../../src/review/types';
 import { AIReviewer, AIReviewerConfig, parseReviewFindings, extractJsonFromResponse } from '../../src/review/ai-reviewer';
 import type { SDKInvocationResult } from '@plusplusoneplusplus/coc-agent-sdk';
+import { createMockSDKService } from '@plusplusoneplusplus/coc-agent-sdk/testing';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -37,14 +38,30 @@ function makeWorkingTreeSource(): WorkingTreeDiffSource {
     };
 }
 
+const viFactory = (impl?: (...args: any[]) => any): any => {
+    const spy = impl ? vi.fn(impl) : vi.fn();
+    const h = spy as any;
+    h.calls = spy.mock.calls;
+    const origMRV = spy.mockResolvedValue.bind(spy);
+    const origMRVO = spy.mockResolvedValueOnce.bind(spy);
+    const origMI = spy.mockImplementation.bind(spy);
+    const origMIO = spy.mockImplementationOnce.bind(spy);
+    const origReset = spy.mockReset.bind(spy);
+    h.mockResolvedValue = (v: unknown) => { origMRV(v); return h; };
+    h.mockResolvedValueOnce = (v: unknown) => { origMRVO(v); return h; };
+    h.mockImplementation = (fn: (...a: unknown[]) => unknown) => { origMI(fn); return h; };
+    h.mockImplementationOnce = (fn: (...a: unknown[]) => unknown) => { origMIO(fn); return h; };
+    h.mockReset = () => { origReset(); h.calls = spy.mock.calls; return h; };
+    return h;
+};
+
 function makeMockSdkService(response?: Partial<SDKInvocationResult>) {
-    return {
-        sendMessage: vi.fn().mockResolvedValue({
-            success: true,
-            response: '[]',
-            ...response,
-        }),
-    } as unknown as AIReviewerConfig['sdkService'];
+    const merged = { success: true, response: '[]', ...response };
+    const { service } = createMockSDKService(
+        { sendMessageResponse: merged },
+        viFactory,
+    );
+    return service as unknown as AIReviewerConfig['sdkService'];
 }
 
 function makeConfig(overrides?: Partial<AIReviewerConfig>): AIReviewerConfig {


### PR DESCRIPTION
Create a shared mock factory in coc-agent-sdk/src/testing that genuinely
implements all 13 ISDKService methods plus createClient. The mock accepts
an injectable mock-fn factory so consumers bind vi.fn for spy assertions
while the package itself imports nothing from vitest.

- AC-01: New testing module with createMockSDKService, createUnavailableMock,
  createStreamingMock, createFailingMock, createMockBridge,
  createExpiredSessionBridge. Exposed via "./testing" subpath export.
  32 focused tests added.

- AC-02: coc's mock-sdk-service.ts is now a thin wrapper that binds vi.fn
  and re-exports from the shared mock. Inline stubs deleted from
  admin-handler, agent-provider-model-routes, effort-tiers-routes, and
  work-item-ai-generator test files. Zero assertion rewrites.

- AC-03: forge's ai-reviewer and sdk-service-registry tests consume the
  shared factory. Structural-contract literals preserved.

Co-authored-by: Cursor <cursoragent@cursor.com>
