### PR TITLE
fix(coc): detect compact commit outputs in chat

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -114,8 +114,9 @@ tool/tool-group. This keeps a rich answer visible even when a hidden
 Chat commit strips are detected from real shell output on `powershell`, `shell`,
 and `bash` tool calls. The detector only treats commit-creating commands
 (`git commit`, `git merge`, `git cherry-pick`, `git revert`) with native git
-output such as `[branch abc1234] subject` as commits; assistant prose and
-read-only git command output are ignored.
+output such as `[branch abc1234] subject`, or compact verification output such
+as `abc1234 subject` from the same commit-creating command, as commits;
+assistant prose and read-only git command output are ignored.
 
 Completed `ask_user` tool calls render as read-only historical question cards via
 `AskUserHistoryCard` inside `ConversationTurnBubble`. Live unanswered questions

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/commitDetection.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/commitDetection.ts
@@ -39,6 +39,13 @@ const AGENT_TOOL_NAMES = new Set(['task', 'general-purpose']);
 const GIT_COMMIT_RE = /\[(\S+?)(?:\s+\(root-commit\))?\s+([0-9a-f]{7,12})\]\s+(.+)/;
 
 /**
+ * Compact one-line commit output, usually emitted by `git log --oneline -1`
+ * after a commit command has already succeeded:
+ *   shortHash subject line
+ */
+const GIT_ONELINE_COMMIT_RE = /^([0-9a-f]{7,40})\s+(.+)$/;
+
+/**
  * Diffstat line pattern:
  *   N file(s) changed, M insertion(s)(+), K deletion(s)(-)
  * Any of the three parts may be absent.
@@ -86,6 +93,13 @@ function isReadOnlyGitCommand(command: string): boolean {
     return READ_ONLY_GIT_PATTERNS.some(re => re.test(command));
 }
 
+function normalizeCommitHash(hash: string): Pick<DetectedCommit, 'shortHash' | 'fullHash'> {
+    if (hash.length === 40) {
+        return { shortHash: hash.slice(0, 12), fullHash: hash };
+    }
+    return { shortHash: hash };
+}
+
 /**
  * Scans tool calls in a tool group for git commit output and returns
  * structured commit metadata for each detected commit.
@@ -108,24 +122,42 @@ export function detectCommitsInToolGroup(toolCalls: ToolCallLike[]): DetectedCom
 
         if (!isShell && !isAgent) continue;
 
+        let allowCompactOneline = false;
         if (isShell) {
             const command = getCommandString(tc.args);
+            const createsCommit = isCommitCreatingCommand(command);
 
-            // Skip read-only git commands even if their output happens to match
-            if (isReadOnlyGitCommand(command)) continue;
+            // Skip read-only-only git commands even if their output happens to match.
+            // Commit commands often chain read-only verification such as
+            // `git log --oneline -1`, so those are still eligible.
+            if (isReadOnlyGitCommand(command) && !createsCommit) continue;
 
             // Only scan results from commit-creating commands, or when
             // we can't determine the command (e.g. missing args)
-            if (command && !isCommitCreatingCommand(command)) continue;
+            if (command && !createsCommit) continue;
+
+            allowCompactOneline = createsCommit;
         }
         // Agent tools: scan result directly — no command to inspect
 
         const lines = tc.result.split(/\r?\n/);
         for (let i = 0; i < lines.length; i++) {
             const match = GIT_COMMIT_RE.exec(lines[i]);
-            if (!match) continue;
 
-            const [, branch, shortHash, subject] = match;
+            let branch: string | undefined;
+            let hash: string;
+            let subject: string;
+            if (match) {
+                [, branch, hash, subject] = match;
+            } else if (allowCompactOneline) {
+                const onelineMatch = GIT_ONELINE_COMMIT_RE.exec(lines[i].trim());
+                if (!onelineMatch) continue;
+                [, hash, subject] = onelineMatch;
+            } else {
+                continue;
+            }
+
+            const { shortHash, fullHash } = normalizeCommitHash(hash);
             if (seenHashes.has(shortHash)) continue;
             seenHashes.add(shortHash);
 
@@ -135,10 +167,11 @@ export function detectCommitsInToolGroup(toolCalls: ToolCallLike[]): DetectedCom
             const commit: DetectedCommit = {
                 shortHash,
                 subject: trimmedSubject,
-                branch,
                 toolCallId: tc.id,
                 isFixup,
             };
+            if (branch) commit.branch = branch;
+            if (fullHash) commit.fullHash = fullHash;
 
             // Look for diffstat on subsequent lines
             for (let j = i + 1; j < Math.min(i + 4, lines.length); j++) {

--- a/packages/coc/test/spa/processes/commitDetection.test.ts
+++ b/packages/coc/test/spa/processes/commitDetection.test.ts
@@ -302,6 +302,34 @@ describe('detectCommitsInToolGroup', () => {
             expect(commits[0].isFixup).toBe(false);
         });
 
+        it('detects compact oneline output emitted after a commit-creating bash command', () => {
+            const toolCalls = [
+                {
+                    id: 't1',
+                    toolName: 'bash',
+                    args: {
+                        command: [
+                            'git add packages/coc/src/server/work-items/work-item-sync-conflict.ts',
+                            'git commit --quiet -m "feat(work-items): shared typed per-field stale-save conflict (AC-02 server)"',
+                            'git log --oneline -1',
+                        ].join(' && '),
+                        description: 'Commit source changes',
+                    },
+                    result: '33bd35b38 feat(work-items): shared typed per-field stale-save conflict (AC-02 server)',
+                    status: 'completed',
+                },
+            ];
+
+            const commits = detectCommitsInToolGroup(toolCalls);
+            expect(commits).toHaveLength(1);
+            expect(commits[0]).toEqual<DetectedCommit>({
+                shortHash: '33bd35b38',
+                subject: 'feat(work-items): shared typed per-field stale-save conflict (AC-02 server)',
+                toolCallId: 't1',
+                isFixup: false,
+            });
+        });
+
         it('bash tool: ignores read-only git commands', () => {
             const toolCalls = [
                 { id: 't1', toolName: 'bash', args: { command: 'git log --oneline' }, result: '[main abc1234] Some old commit', status: 'completed' },


### PR DESCRIPTION
Handle commit-creating shell commands that verify with compact git oneline output so dashboard commit strips appear for commits like Ralph iteration commits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
