### PR TITLE
pr/6622c34c7 fixcoc prevent empty state content from

### DIFF
--- a/packages/coc/specs/usage-stats-tab.spec.md
+++ b/packages/coc/specs/usage-stats-tab.spec.md
@@ -3,7 +3,7 @@
 **Document type:** Formal UX Specification  
 **Scope:** CoC Dashboard → Usage & Costs (embedded in Admin Shell · Operations Group)  
 **Purpose:** Authoritative reference for validating any future UI/UX changes to the Usage & Costs tab.  
-**Version:** 2.0.0
+**Version:** 3.0.0
 
 ---
 
@@ -11,7 +11,7 @@
 
 The **Usage & Costs route** displays AI token usage and estimated cost statistics aggregated across all processes. It is reached at the top-level URL `#stats` but is rendered embedded inside the Admin shell's left sidebar **Operations** group — `UsageStatsView` is mounted in the right pane while the admin sidebar stays visible.
 
-The view shows a per-day table with one column per model and a Total column. Each cell breaks input tokens into `total / cached / new`, output tokens, cache-write tokens, and (in the Total column) estimated USD cost. Hover tooltips reveal the full numeric breakdown plus per-model pricing source. Data is computed server-side by aggregating all process records.
+The view shows a three-column table (Date / Model / Tokens) with models stacked as rows within each date group rather than spread horizontally as columns. Each date group starts with an "All models" summary row followed by per-model rows. Each cell breaks input tokens into `total / cached / new`, output tokens, cache-write tokens, and (in summary rows) estimated USD cost. Hover tooltips reveal the full numeric breakdown plus per-model pricing source. Data is computed server-side by aggregating all process records. This row-based layout fits the viewport regardless of how many models are in use.
 
 ### 1.1 Tab Identity
 
@@ -42,8 +42,8 @@ The view shows a per-day table with one column per model and a Total column. Eac
 
 - **Given** the Usage & Costs tab is open
 - **When** usage data is loaded via `useTokenUsageStats(days)` (`GET /api/stats/token-usage?days=<n>`)
-- **Then** the table shows one row per `entry.date` (`YYYY-MM-DD`) with one column per `data.models[]` plus a final Total column
-- **And** each cell shows `↓<input> total · <cached> cached · <new> new` and `↑<output> out · <cacheWrite> cache write` (with optional `est $X` cost in the Total column)
+- **Then** the table has 3 fixed columns (Date / Model / Tokens); each date group shows an "All models" summary row followed by one row per model that has data for that day
+- **And** each cell shows `↓<input> total · <cached> cached · <new> new` and `↑<output> out · <cacheWrite> cache write` (with optional `est $X` cost in summary rows)
 
 ---
 
@@ -88,10 +88,10 @@ The view shows a per-day table with one column per model and a Total column. Eac
 ---
 
 **US-05 — View per-model and grand totals**
-> As an administrator, I want to see a per-model column total plus a single grand total.
+> As an administrator, I want to see a per-model total plus a single grand total.
 
 - **Given** the usage table is displayed with at least one entry
-- **Then** a `<tfoot>` row labeled "Total" sums the per-model columns (using `sumByModel`) and the rightmost cell shows the grand total cell (`UsageCell` with `showCostDetails`)
+- **Then** a `<tfoot>` section labeled "Total" shows an "All models" grand total row (with `showCostDetails`) followed by one row per model (using `sumByModel`)
 
 ---
 
@@ -117,19 +117,19 @@ The view shows a per-day table with one column per model and a Total column. Eac
 
 | Feature | Acceptance Criteria |
 |---|---|
-| Sticky header | `<thead>` is `sticky top-0` |
-| Date column | Monospace; one row per `entry.date` |
-| Model columns | One per `data.models[]`; header truncated to 18 chars + `…` when ID longer than 20 chars; full ID in `title` |
-| Total column | Per-row grand total via `entry.dayTotal`, rendered with `showCostDetails` |
-| Empty model cell | `—` |
+| Sticky header | `<thead>` is `sticky top-0` with 3 columns: Date / Model / Tokens |
+| Date groups | Each date uses `rowSpan` on the Date cell; first row is "All models" summary, followed by per-model rows (only models with data for that day) |
+| Model names | Full model name in cell text and `title` attribute; truncated via CSS `max-w-[200px] truncate` |
+| Summary row | "All models" row per date shows `entry.dayTotal` with `showCostDetails` |
 | Cell input row | `↓<inputTotal> total · <cachedInput> cached · <newInput> new` |
 | Cell output row | `↑<outputTotal> out · <cacheWrite> cache write[ · est $<usd>]` (cost only when `showCostDetails`) |
 | Premium units row | `Premium units: <units>` (only when `usage.cost` is present and `showCostDetails`) |
 | Token formatting | `fmt(n)` — `k` for ≥1000, `M` for ≥1_000_000, otherwise integer |
 | Cost formatting | `fmtUsdCost`: `$X.XX` for ≥$0.01; up to 6 decimals (trailing zeros stripped) for smaller |
-| Zebra striping | Odd rows (`i % 2 === 1`) use `vscode-list-hoverBackground` |
-| Footer total row | `<tfoot>` "Total" with per-model sums and grand total |
+| Zebra striping | Alternating date groups use `vscode-list-hoverBackground` |
+| Footer total section | `<tfoot>` "Total" with "All models" grand total row (with `showCostDetails`) + per-model rows; `—` for models with no data |
 | Tooltip | Multi-line `title` per US-04 |
+| Fixed width | 3 columns fit within the viewport regardless of model count |
 
 ### 4.3 Hooks / Data Aggregation
 
@@ -148,9 +148,9 @@ The view shows a per-day table with one column per model and a Total column. Eac
 | INV-01 | The Usage & Costs route renders inside the Admin shell's right pane (Operations group); the admin sidebar stays mounted |
 | INV-02 | Time range change triggers a server refetch via `useTokenUsageStats`, not client-side filtering |
 | INV-03 | "All time" is sent as no `days` param (the server treats missing/invalid `days` as all-time) |
-| INV-04 | The table footer Total row is only rendered when `data.entries.length > 0` |
-| INV-05 | Model column headers are truncated at 20 characters with the full ID available in the `title` attribute |
-| INV-06 | Cost details (`est $X`, premium units, breakdown lines) are only rendered when `showCostDetails` is true — currently only on the Total column and grand total |
+| INV-04 | The table footer Total section is only rendered when `data.entries.length > 0` |
+| INV-05 | Model names are shown in full within each row; CSS `truncate` with `max-w-[200px]` handles overflow; full ID is available in the `title` attribute |
+| INV-06 | Cost details (`est $X`, premium units, breakdown lines) are only rendered when `showCostDetails` is true — on "All models" summary rows (per-date and grand total) |
 | INV-07 | When `costBreakdown` is missing on an `entry.byModel[m]` cell, that cell still aggregates without breakdown; the Total column may still show breakdown if at least one source provided it |
 | INV-08 | Tooltip text is rendered via the native `title` attribute (no custom popover) |
 
@@ -165,13 +165,16 @@ The view shows a per-day table with one column per model and a Total column. Eac
 │ │  📊 Usage*   │  │ ─────────────────────────────────────────────  │ │
 │ │  📋 Logs     │  │ [Last 30 days ▾] [↻ Refresh]   Generated at:…  │ │
 │ │  ⌗ Server    │  │ ─────────────────────────────────────────────  │ │
-│ │  ▦ Backup…   │  │ DATE | gpt-4o          | claude-…   | TOTAL    │ │
-│ │              │  │ 26-05-29 ↓20k total · 8k cached · 12k new      │ │
-│ │              │  │            ↑6k out · 0 cache write             │ │
-│ │              │  │          | …            | …          | est $0.18│ │
-│ │              │  │ …                                              │ │
-│ │              │  │ ──────┼─────────────────┼──────────┼────────── │ │
-│ │              │  │ Total | …               | …        | est $0.50 │ │
+│ │  ▦ Backup…   │  │ DATE     | MODEL       | TOKENS                │ │
+│ │              │  │ 26-05-29 | All models  | ↓20k total …  est $0.18│
+│ │              │  │          | gpt-4o      | ↓12k total …           │ │
+│ │              │  │          | claude-…    | ↓8k total …            │ │
+│ │              │  │ 26-05-28 | All models  | ↓15k total …  est $0.12│
+│ │              │  │          | gpt-4o      | ↓15k total …           │ │
+│ │              │  │ ─────────┼─────────────┼──────────────────────  │ │
+│ │              │  │ Total    | All models  | ↓35k total …  est $0.30│
+│ │              │  │          | gpt-4o      | ↓27k total …           │ │
+│ │              │  │          | claude-…    | ↓8k total …            │ │
 │ └──────────────┘  └────────────────────────────────────────────────┘ │
 └──────────────────────────────────────────────────────────────────────┘
 ```
@@ -214,3 +217,4 @@ The response shape is `ClientTokenUsageStatsResponse` with `entries[]` (date / b
 |---|---|---|
 | 1.0.0 | 2026-03-25 | Initial specification (top-level Usage tab; flat input/output cell + simple cost) |
 | 2.0.0 | 2026-05-29 | Embedded inside Admin shell's Operations group; sidebar label changed to "Usage & Costs"; cell layout now shows `↓<input> total · <cached> · <new>` and `↑<output> · <cacheWrite>`; cost details (`costBreakdown`, `estimatedUsdCost`, premium units, pricing source / unavailable) surfaced via tooltip and Total column. |
+| 3.0.0 | 2026-06-05 | Redesigned from column-per-model table to 3-column row-based layout (Date / Model / Tokens). Models are stacked as rows within each date group, keeping the table width fixed regardless of model count. |

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -1201,40 +1201,44 @@ export function AdminPanel() {
             <div id="admin-page-content" className="ar-shell">
                 {/* ── Sidebar ── */}
                 <aside className="ar-sidebar" aria-label="Admin sections">
-                    <div className="ar-brand">
-                        <div className="ar-brand-logo" aria-hidden="true" />
-                        <div className="ar-brand-text">
-                            <span className="ar-brand-name">CoC Admin</span>
-                            <span className="ar-brand-sub">{versionInfo?.version ? `v${versionInfo.version}` : 'Local server'}</span>
+                    <div className="ar-sidebar-head">
+                        <div className="ar-brand">
+                            <div className="ar-brand-logo" aria-hidden="true" />
+                            <div className="ar-brand-text">
+                                <span className="ar-brand-name">CoC Admin</span>
+                                <span className="ar-brand-sub">{versionInfo?.version ? `v${versionInfo.version}` : 'Local server'}</span>
+                            </div>
                         </div>
                     </div>
 
-                    {navGroups.map(group => (
-                        <nav key={group.label} className="ar-nav-group" aria-label={group.label}>
-                            <div className="ar-nav-group-label">{group.label}</div>
-                            {group.items.map(item => {
-                                const isActive = activeNavKey === item.key;
-                                const isTool = item.action.kind === 'tool';
-                                return (
-                                    <button
-                                        key={item.key}
-                                        id={isTool ? item.testId : undefined}
-                                        type="button"
-                                        className={`ar-nav-item${isActive ? ' is-active' : ''}`}
-                                        onClick={() => handleNavItemClick(item)}
-                                        data-testid={item.testId}
-                                        data-tab={isTool ? item.action.tab : undefined}
-                                        aria-label={item.label}
-                                        aria-current={isActive ? 'page' : undefined}
-                                        title={item.label}
-                                    >
-                                        <span className="ar-nav-icon" aria-hidden="true">{item.icon}</span>
-                                        <span className="ar-nav-label">{item.label}</span>
-                                    </button>
-                                );
-                            })}
-                        </nav>
-                    ))}
+                    <div className="ar-sidebar-nav">
+                        {navGroups.map(group => (
+                            <nav key={group.label} className="ar-nav-group" aria-label={group.label}>
+                                <div className="ar-nav-group-label">{group.label}</div>
+                                {group.items.map(item => {
+                                    const isActive = activeNavKey === item.key;
+                                    const isTool = item.action.kind === 'tool';
+                                    return (
+                                        <button
+                                            key={item.key}
+                                            id={isTool ? item.testId : undefined}
+                                            type="button"
+                                            className={`ar-nav-item${isActive ? ' is-active' : ''}`}
+                                            onClick={() => handleNavItemClick(item)}
+                                            data-testid={item.testId}
+                                            data-tab={isTool ? item.action.tab : undefined}
+                                            aria-label={item.label}
+                                            aria-current={isActive ? 'page' : undefined}
+                                            title={item.label}
+                                        >
+                                            <span className="ar-nav-icon" aria-hidden="true">{item.icon}</span>
+                                            <span className="ar-nav-label">{item.label}</span>
+                                        </button>
+                                    );
+                                })}
+                            </nav>
+                        ))}
+                    </div>
 
                     <div className="ar-sidebar-foot">
                         <div className="ar-stats-block">
@@ -1268,6 +1272,16 @@ export function AdminPanel() {
                                 </>
                             )}
                         </div>
+                        <button
+                            type="button"
+                            className="ar-sidebar-restart"
+                            onClick={handleRestart}
+                            disabled={restarting}
+                            data-testid="sidebar-restart-btn"
+                            title={restarting ? restartStatus : 'Rebuild & restart the CoC server'}
+                        >
+                            {restarting ? <><Spinner size="sm" /> Restarting…</> : '↻ Restart Server'}
+                        </button>
                     </div>
                 </aside>
 

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -1241,37 +1241,6 @@ export function AdminPanel() {
                     </div>
 
                     <div className="ar-sidebar-foot">
-                        <div className="ar-stats-block">
-                            <div className="ar-stats-head">
-                                <span>Usage</span>
-                                <button
-                                    id="admin-refresh-stats"
-                                    type="button"
-                                    onClick={loadStats}
-                                    title="Refresh stats"
-                                    className="ar-stats-refresh"
-                                    aria-label="Refresh stats"
-                                >↻</button>
-                            </div>
-                            {statsLoading ? (
-                                <Spinner size="sm" />
-                            ) : (
-                                <>
-                                    <div className="ar-stat-row" data-testid="stat-processes">
-                                        <span className="ar-stat-label">Processes</span>
-                                        <span className="ar-stat-value">{stats?.processCount ?? '—'}</span>
-                                    </div>
-                                    <div className="ar-stat-row" data-testid="stat-wikis">
-                                        <span className="ar-stat-label">Wikis</span>
-                                        <span className="ar-stat-value">{stats?.wikiCount ?? '—'}</span>
-                                    </div>
-                                    <div className="ar-stat-row" data-testid="stat-disk">
-                                        <span className="ar-stat-label">Disk</span>
-                                        <span className="ar-stat-value">{stats?.totalBytes != null ? formatBytes(stats.totalBytes) : '—'}</span>
-                                    </div>
-                                </>
-                            )}
-                        </div>
                         <button
                             type="button"
                             className="ar-sidebar-restart"

--- a/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
+++ b/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
@@ -132,19 +132,31 @@
   background: var(--ar-bg);
 }
 
-/* Sidebar — fills the grid row, scrolls internally only if its own
-   content is too tall for the viewport. */
+/* Sidebar — three-zone layout: fixed brand header, scrollable nav
+   groups, fixed footer.  The sidebar never scrolls as a whole; only
+   the middle nav zone scrolls when its content overflows. */
 .admin-redesign .ar-sidebar {
   background: var(--ar-bg-1);
   border-right: 1px solid var(--ar-border);
-  padding: 18px 14px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+.admin-redesign .ar-sidebar-head {
+  padding: 18px 14px 4px;
+  flex-shrink: 0;
+}
+.admin-redesign .ar-sidebar-nav {
+  flex: 1;
   min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 .admin-redesign .ar-brand {
   display: flex;
@@ -261,8 +273,8 @@
 }
 
 .admin-redesign .ar-sidebar-foot {
-  margin-top: auto;
-  padding-top: 12px;
+  flex-shrink: 0;
+  padding: 12px 14px 14px;
   border-top: 1px solid var(--ar-border);
   display: flex;
   flex-direction: column;
@@ -320,6 +332,34 @@
   color: var(--ar-text);
   background: var(--ar-bg-3);
   border-color: var(--ar-border);
+}
+
+.admin-redesign .ar-sidebar-restart {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  height: 30px;
+  border-radius: var(--ar-radius-sm);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  border: 1px solid var(--ar-border-strong);
+  background: var(--ar-bg-2);
+  color: var(--ar-text-2);
+  transition: background .12s, border-color .12s, color .12s;
+  white-space: nowrap;
+}
+.admin-redesign .ar-sidebar-restart:hover {
+  background: var(--ar-bg-3);
+  border-color: var(--ar-border-focus);
+  color: var(--ar-text);
+}
+.admin-redesign .ar-sidebar-restart[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 /* Mobile-only tab select shown when the sidebar collapses */

--- a/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
+++ b/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
@@ -280,60 +280,6 @@
   flex-direction: column;
   gap: 10px;
 }
-.admin-redesign .ar-stats-block {
-  display: grid;
-  gap: 8px;
-  padding: 10px 10px;
-  background: var(--ar-bg-2);
-  border-radius: var(--ar-radius);
-  border: 1px solid var(--ar-border);
-}
-.admin-redesign .ar-stats-block .ar-stats-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--ar-text-dim);
-}
-.admin-redesign .ar-stats-block .ar-stat-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  font-size: 11.5px;
-}
-.admin-redesign .ar-stats-block .ar-stat-row .ar-stat-label {
-  color: var(--ar-text-mute);
-}
-.admin-redesign .ar-stats-block .ar-stat-row .ar-stat-value {
-  color: var(--ar-text);
-  font-family: var(--ar-font-mono);
-  font-size: 12px;
-  font-weight: 500;
-}
-.admin-redesign .ar-stats-block .ar-stats-refresh {
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--ar-text-mute);
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-}
-.admin-redesign .ar-stats-block .ar-stats-refresh:hover {
-  color: var(--ar-text);
-  background: var(--ar-bg-3);
-  border-color: var(--ar-border);
-}
-
 .admin-redesign .ar-sidebar-restart {
   display: flex;
   align-items: center;

--- a/packages/coc/src/server/spa/client/react/features/stats/UsageStatsView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/stats/UsageStatsView.tsx
@@ -72,21 +72,12 @@ function sumByModel(entries: ClientTokenUsageStatsEntry[], model: string): Clien
     );
 }
 
-function UsageCell({
-    usage,
-    showCostDetails = false,
-}: {
-    usage: ClientTokenUsage;
-    showCostDetails?: boolean;
-}) {
-    const premiumUnits = showCostDetails ? fmtPremiumUnits(usage.cost) : null;
-    const estimatedCost = showCostDetails && usage.estimatedUsdCost !== undefined
-        ? fmtUsdCost(usage.estimatedUsdCost)
-        : null;
+function buildTooltip(usage: ClientTokenUsage, showCostDetails: boolean): string {
     const cachedInputTokens = usage.cacheReadTokens;
     const newInputTokens = Math.max(usage.inputTokens - cachedInputTokens - usage.cacheWriteTokens, 0);
+    const premiumUnits = showCostDetails ? fmtPremiumUnits(usage.cost) : null;
 
-    const tooltip = [
+    return [
         `Input total:   ${usage.inputTokens.toLocaleString()}`,
         `Input cached/read: ${cachedInputTokens.toLocaleString()}`,
         `Input non-cached:  ${newInputTokens.toLocaleString()}`,
@@ -104,6 +95,22 @@ function UsageCell({
         ...(showCostDetails && premiumUnits ? [`Premium units: ${premiumUnits}`] : []),
         ...(showCostDetails && usage.pricingSource ? [`Pricing source: ${usage.pricingSource}`] : []),
     ].join('\n');
+}
+
+function UsageCell({
+    usage,
+    showCostDetails = false,
+}: {
+    usage: ClientTokenUsage;
+    showCostDetails?: boolean;
+}) {
+    const premiumUnits = showCostDetails ? fmtPremiumUnits(usage.cost) : null;
+    const estimatedCost = showCostDetails && usage.estimatedUsdCost !== undefined
+        ? fmtUsdCost(usage.estimatedUsdCost)
+        : null;
+    const cachedInputTokens = usage.cacheReadTokens;
+    const newInputTokens = Math.max(usage.inputTokens - cachedInputTokens - usage.cacheWriteTokens, 0);
+    const tooltip = buildTooltip(usage, showCostDetails);
 
     return (
         <span title={tooltip} className="cursor-default inline-flex flex-col gap-0.5 leading-snug">
@@ -130,8 +137,48 @@ const thClass =
     'px-3 py-2 text-left font-semibold text-xs text-[var(--vscode-descriptionForeground)] ' +
     'uppercase border-b border-[var(--vscode-panel-border)] whitespace-nowrap';
 
-const tdClass = 'px-3 py-1.5 align-top whitespace-nowrap';
-const tdDateClass = 'px-3 py-1.5 align-top font-mono text-[var(--vscode-foreground)] whitespace-nowrap';
+const tdClass = 'px-3 py-1.5 align-top';
+
+function DateGroupRow({
+    entry,
+    models,
+    isEven,
+}: {
+    entry: ClientTokenUsageStatsEntry;
+    models: string[];
+    isEven: boolean;
+}) {
+    const modelsWithUsage = models.filter(m => entry.byModel[m]);
+    const bgClass = isEven ? '' : 'bg-[var(--vscode-list-hoverBackground)]';
+
+    return (
+        <>
+            {/* Day total summary row */}
+            <tr className={`border-b border-[var(--vscode-panel-border)] ${bgClass}`}>
+                <td className="px-3 py-1.5 align-top font-mono text-[var(--vscode-foreground)] whitespace-nowrap" rowSpan={modelsWithUsage.length + 1}>
+                    {entry.date}
+                </td>
+                <td className={`${tdClass} font-semibold text-[var(--vscode-foreground)]`}>
+                    All models
+                </td>
+                <td className={tdClass}>
+                    <UsageCell usage={entry.dayTotal} showCostDetails />
+                </td>
+            </tr>
+            {/* Per-model rows */}
+            {modelsWithUsage.map(model => (
+                <tr key={model} className={`border-b border-[var(--vscode-panel-border)] ${bgClass}`}>
+                    <td className={`${tdClass} text-[var(--vscode-descriptionForeground)] truncate max-w-[200px]`} title={model}>
+                        {model}
+                    </td>
+                    <td className={tdClass}>
+                        <UsageCell usage={entry.byModel[model]} />
+                    </td>
+                </tr>
+            ))}
+        </>
+    );
+}
 
 export function UsageStatsView() {
     const [days, setDays] = useState<number | undefined>(30);
@@ -197,64 +244,51 @@ export function UsageStatsView() {
                     <table className="w-full text-xs border-collapse">
                         <thead className="sticky top-0 bg-[var(--vscode-editor-background)] z-10">
                             <tr>
-                                <th className={thClass}>Date</th>
-                                {data.models.map(m => (
-                                    <th key={m} className={thClass} title={m}>
-                                        {m.length > 20 ? m.slice(0, 18) + '…' : m}
-                                    </th>
-                                ))}
-                                <th className={thClass}>Total</th>
+                                <th className={thClass} style={{ width: '110px' }}>Date</th>
+                                <th className={thClass} style={{ width: '200px' }}>Model</th>
+                                <th className={thClass}>Tokens</th>
                             </tr>
                         </thead>
                         <tbody>
                             {data.entries.map((entry, i) => (
-                                <tr
+                                <DateGroupRow
                                     key={entry.date}
-                                    className={
-                                        'border-b border-[var(--vscode-panel-border)] ' +
-                                        (i % 2 === 1 ? 'bg-[var(--vscode-list-hoverBackground)]' : '')
-                                    }
-                                >
-                                    <td className={tdDateClass}>{entry.date}</td>
-
-                                    {data.models.map(model => {
-                                        const usage = entry.byModel[model];
-                                        return (
-                                            <td key={model} className={tdClass}>
-                                                {usage ? (
-                                                    <UsageCell usage={usage} />
-                                                ) : (
-                                                    <span className="text-[var(--vscode-descriptionForeground)]">—</span>
-                                                )}
-                                            </td>
-                                        );
-                                    })}
-
-                                    <td className={tdClass}>
-                                        <UsageCell usage={entry.dayTotal} showCostDetails />
-                                    </td>
-                                </tr>
+                                    entry={entry}
+                                    models={data.models}
+                                    isEven={i % 2 === 0}
+                                />
                             ))}
                         </tbody>
                         <tfoot>
+                            {/* Grand total row */}
                             <tr className="border-t-2 border-[var(--vscode-panel-border)] font-semibold bg-[var(--vscode-editor-background)]">
-                                <td className={tdDateClass}>Total</td>
-                                {data.models.map(model => {
-                                    const total = sumByModel(data.entries, model);
-                                    return (
-                                        <td key={model} className={tdClass}>
+                                <td className="px-3 py-1.5 align-top font-mono text-[var(--vscode-foreground)] whitespace-nowrap" rowSpan={data.models.length + 1}>
+                                    Total
+                                </td>
+                                <td className={`${tdClass} font-semibold text-[var(--vscode-foreground)]`}>
+                                    All models
+                                </td>
+                                <td className={tdClass}>
+                                    <UsageCell usage={grandTotal} showCostDetails />
+                                </td>
+                            </tr>
+                            {data.models.map(model => {
+                                const total = sumByModel(data.entries, model);
+                                return (
+                                    <tr key={model} className="border-b border-[var(--vscode-panel-border)] font-semibold bg-[var(--vscode-editor-background)]">
+                                        <td className={`${tdClass} text-[var(--vscode-descriptionForeground)] truncate max-w-[200px]`} title={model}>
+                                            {model}
+                                        </td>
+                                        <td className={tdClass}>
                                             {total ? (
                                                 <UsageCell usage={total} />
                                             ) : (
                                                 <span className="text-[var(--vscode-descriptionForeground)]">—</span>
                                             )}
                                         </td>
-                                    );
-                                })}
-                                <td className={tdClass}>
-                                    <UsageCell usage={grandTotal} showCostDetails />
-                                </td>
-                            </tr>
+                                    </tr>
+                                );
+                            })}
                         </tfoot>
                     </table>
                 )}

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
@@ -800,9 +800,18 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                             Plan v{item.plan.version}
                         </span>
                     )}
-                    <span className="inline-flex items-center rounded-full h-6 px-2 border border-[#d0d7de] dark:border-[#555] bg-[#f6f8fa] dark:bg-transparent text-[11px] text-[#656d76] dark:text-[#999] whitespace-nowrap">
-                        {d.priority}
-                    </span>
+                    <select
+                        value={d.priority}
+                        onChange={e => updateDraft('priority', e.target.value as 'high' | 'normal' | 'low')}
+                        className="h-[24px] rounded-full border border-[#d0d7de] dark:border-[#555] bg-[#f6f8fa] dark:bg-transparent px-2 text-[11px] text-[#656d76] dark:text-[#999] cursor-pointer appearance-none outline-none whitespace-nowrap"
+                        disabled={saving}
+                        data-testid="wi-priority-select"
+                        aria-label="Priority"
+                    >
+                        <option value="high">High</option>
+                        <option value="normal">Normal</option>
+                        <option value="low">Low</option>
+                    </select>
                     <span className="text-[11px] leading-[1.35] text-[#656d76] dark:text-[#999] truncate min-w-0 flex-1">
                         Updated {formatRelativeTime(item.updatedAt)}
                     </span>
@@ -1094,22 +1103,6 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                                 <span className="text-[#656d76] dark:text-[#999] font-mono">{item.parentId.slice(0, 8)}…</span>
                             </span>
                         ) : null}
-                        {/* Priority */}
-                        <span className="flex items-center gap-1" data-testid="wi-edit-fields">
-                            <strong className="text-[#1f2328] dark:text-[#cccccc]">Pri</strong>
-                            <select
-                                className="text-[11px] px-0.5 py-0 rounded border border-[#d0d7de] dark:border-[#555] bg-white dark:bg-[#1e1e1e] text-[#1f2328] dark:text-[#cccccc] outline-none"
-                                value={d.priority}
-                                onChange={e => updateDraft('priority', e.target.value as 'high' | 'normal' | 'low')}
-                                disabled={saving}
-                                data-testid="wi-priority-select"
-                                aria-label="Priority"
-                            >
-                                <option value="high">High</option>
-                                <option value="normal">Normal</option>
-                                <option value="low">Low</option>
-                            </select>
-                        </span>
                         {/* Tags */}
                         <span className="flex items-center gap-1 min-w-0">
                             <strong className="text-[#1f2328] dark:text-[#cccccc] shrink-0">Tags</strong>
@@ -1158,19 +1151,6 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                     </div>
                 </article>
 
-                {/* Remote mirror section */}
-                {(item.githubMirror || item.azureBoardsMirror) && (
-                    <section className="text-[12px]" data-testid={item.githubMirror ? 'work-item-github-mirror' : 'work-item-azure-boards-mirror'}>
-                        <div className="flex flex-wrap gap-2">
-                            <WorkItemRemoteMirrorBadge
-                                githubMirror={item.githubMirror}
-                                azureBoardsMirror={item.azureBoardsMirror}
-                                asLink
-                                data-testid={item.githubMirror ? 'work-item-github-mirror-link' : 'work-item-azure-boards-mirror-link'}
-                            />
-                        </div>
-                    </section>
-                )}
 
                 {/* AI Review section (aiDone only) */}
                 {isAiDone && (

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
@@ -532,7 +532,7 @@ export function WorkItemHierarchyTree({
 
     // ── Render ────────────────────────────────────────────────────────────────
     return (
-        <div className="flex flex-col h-full" data-testid="work-item-hierarchy-tree">
+        <div className="flex flex-col flex-1 min-h-0" data-testid="work-item-hierarchy-tree">
             {/* ── Rail top: search + actions + filters ── */}
             <div className="border-b border-[#d0d7de] dark:border-[#474749] bg-white dark:bg-[#1e1e1e] px-2 py-2 shrink-0 grid gap-1.5">
                 {/* Command line: search + New + Import + more */}

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
@@ -718,7 +718,7 @@ export function WorkItemHierarchyTree({
                         <Button variant="ghost" size="sm" onClick={fetchTree}>Retry</Button>
                     </div>
                 ) : treeData.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center h-24 gap-3 px-4 text-center" data-testid="hierarchy-empty">
+                    <div className="flex flex-col items-center justify-center min-h-24 gap-3 px-4 py-4 text-center" data-testid="hierarchy-empty">
                         <div className="text-3xl">🗂️</div>
                         <p className="text-xs text-[#848484]">
                             {searchQuery ? 'No results found.' : trackerCopy.empty}

--- a/packages/coc/test/e2e/admin.spec.ts
+++ b/packages/coc/test/e2e/admin.spec.ts
@@ -125,44 +125,16 @@ test.describe('Admin Panel (008)', () => {
     });
 
     // ----------------------------------------------------------------
-    // TC2: Admin Page Shows Storage Stats
+    // TC2: Sidebar stats block is removed
     // ----------------------------------------------------------------
 
-    test('8.3 admin page renders stat cards', async ({ page, serverUrl }) => {
+    test('8.3 admin sidebar does not render the stats block', async ({ page, serverUrl }) => {
         await navigateToAdmin(page, serverUrl);
 
-        // Stat cards should be visible and rendered
-        await expect(page.locator('[data-testid="stat-processes"]')).toBeVisible();
-        await expect(page.locator('[data-testid="stat-wikis"]')).toBeVisible();
-        await expect(page.locator('[data-testid="stat-disk"]')).toBeVisible();
-
-        // Stats should have loaded (no longer showing the loading indicator "…")
-        await expect(page.locator('[data-testid="stat-processes"]')).not.toHaveText('…', { timeout: 5000 });
-    });
-
-    // ----------------------------------------------------------------
-    // TC3: Refresh Stats
-    // ----------------------------------------------------------------
-
-    test('8.4 refresh button triggers stats API call', async ({ page, serverUrl }) => {
-        await navigateToAdmin(page, serverUrl);
-
-        // Wait for initial stats load
-        await expect(page.locator('[data-testid="stat-processes"]')).not.toHaveText('…', { timeout: 5000 });
-
-        // Intercept the next stats request to prove refresh triggers a new fetch
-        const statsPromise = page.waitForRequest(req =>
-            req.url().includes('/admin/data/stats'),
-        );
-
-        // Click refresh
-        await page.click('#admin-refresh-stats');
-
-        // Should trigger a stats API call
-        await statsPromise;
-
-        // After refresh, stats should finish loading again
-        await expect(page.locator('[data-testid="stat-processes"]')).not.toHaveText('…', { timeout: 5000 });
+        await expect(page.locator('[data-testid="stat-processes"]')).toHaveCount(0);
+        await expect(page.locator('[data-testid="stat-wikis"]')).toHaveCount(0);
+        await expect(page.locator('[data-testid="stat-disk"]')).toHaveCount(0);
+        await expect(page.locator('#admin-refresh-stats')).toHaveCount(0);
     });
 
     // ----------------------------------------------------------------
@@ -224,7 +196,7 @@ test.describe('Admin Panel (008)', () => {
 
         await navigateToAdmin(page, serverUrl);
         await page.click('[data-testid="admin-tab-data"]');
-        await expect(page.locator('[data-testid="stat-processes"]')).not.toHaveText('…', { timeout: 5000 });
+        await expect(page.locator('#admin-wipe-btn')).toBeVisible({ timeout: 5000 });
 
         // Click "Wipe Data" to get token (two-step flow)
         await page.click('#admin-wipe-btn');
@@ -302,7 +274,7 @@ test.describe('Admin Panel (008)', () => {
     // TC8: Stats Show Error on API Failure
     // ----------------------------------------------------------------
 
-    test('8.10 stats show dash when API fails', async ({ page, serverUrl }) => {
+    test('8.10 admin page renders without sidebar stats block even when API fails', async ({ page, serverUrl }) => {
         await page.goto(serverUrl);
 
         // Intercept stats API to return error
@@ -319,10 +291,8 @@ test.describe('Admin Panel (008)', () => {
         await expect(page.locator('#view-admin')).toBeVisible({ timeout: 5000 });
         await expect(page.locator('#admin-page-content')).not.toBeEmpty({ timeout: 5000 });
 
-        // Stats should show "—" (dash) when API fails (counts are suffixed: "— processes", "— wikis")
-        await expect(page.locator('[data-testid="stat-processes"]')).toContainText('—', { timeout: 5000 });
-        await expect(page.locator('[data-testid="stat-wikis"]')).toContainText('—');
-        await expect(page.locator('[data-testid="stat-disk"]')).toContainText('—');
+        // Sidebar stats block no longer exists
+        await expect(page.locator('[data-testid="stat-processes"]')).toHaveCount(0);
     });
 
     // ----------------------------------------------------------------
@@ -614,8 +584,8 @@ test.describe('Admin Panel (008)', () => {
         await navigateToAdmin(page, serverUrl);
         await page.click('[data-testid="admin-tab-data"]');
 
-        // Wait for initial stat load to finish (not loading indicator "…")
-        await expect(page.locator('[data-testid="stat-processes"]')).not.toHaveText('…', { timeout: 5000 });
+        // Wait for wipe button to be ready
+        await expect(page.locator('#admin-wipe-btn')).toBeVisible({ timeout: 5000 });
 
         // Perform wipe
         await page.click('#admin-wipe-btn');

--- a/packages/coc/test/e2e/error-handling.spec.ts
+++ b/packages/coc/test/e2e/error-handling.spec.ts
@@ -357,7 +357,7 @@ test.describe('Error Handling (008)', () => {
         // First visit to admin
         await page.click('#admin-toggle');
         await expect(page.locator('#view-admin')).toBeVisible({ timeout: 5000 });
-        await expect(page.locator('[data-testid="stat-processes"]')).not.toHaveText('…', { timeout: 5000 });
+        await expect(page.locator('#admin-page-content')).not.toBeEmpty({ timeout: 5000 });
 
         // Switch to repos (navigate away from admin)
         await page.click('[data-tab="repos"]');

--- a/packages/coc/test/e2e/mobile-responsive/desktop-regression.spec.ts
+++ b/packages/coc/test/e2e/mobile-responsive/desktop-regression.spec.ts
@@ -157,22 +157,14 @@ test.describe('Desktop Regression', () => {
         await expect(page.locator('#view-skills')).toBeVisible({ timeout: 10000 });
     });
 
-    test('desktop: admin panel renders', async ({ page, serverUrl }) => {
+    test('desktop: admin panel renders with restart button in sidebar footer', async ({ page, serverUrl }) => {
         await page.goto(serverUrl);
         await page.click('#admin-toggle');
 
         await expect(page.locator('#view-admin')).toBeVisible({ timeout: 5000 });
-        await expect(page.locator('[data-testid="stat-processes"]')).toBeVisible();
-        await expect(page.locator('[data-testid="stat-wikis"]')).toBeVisible();
-        await expect(page.locator('[data-testid="stat-disk"]')).toBeVisible();
 
-        // Sidebar usage block stacks the stats vertically (Linear-inspired admin
-        // redesign). Each subsequent stat must sit below the previous one.
-        const procBox = await page.locator('[data-testid="stat-processes"]').boundingBox();
-        const wikiBox = await page.locator('[data-testid="stat-wikis"]').boundingBox();
-        const diskBox = await page.locator('[data-testid="stat-disk"]').boundingBox();
-        expect(procBox && wikiBox && diskBox).toBeTruthy();
-        expect(wikiBox!.y).toBeGreaterThanOrEqual(procBox!.y);
-        expect(diskBox!.y).toBeGreaterThanOrEqual(wikiBox!.y);
+        // Sidebar stats block is removed; restart button is in the footer
+        await expect(page.locator('[data-testid="stat-processes"]')).toHaveCount(0);
+        await expect(page.locator('[data-testid="sidebar-restart-btn"]')).toBeVisible();
     });
 });

--- a/packages/coc/test/e2e/mobile-responsive/mobile-navigation.spec.ts
+++ b/packages/coc/test/e2e/mobile-responsive/mobile-navigation.spec.ts
@@ -141,13 +141,11 @@ test.describe('Mobile Navigation', () => {
         await page.goto(`${serverUrl}/#admin`);
         await expect(page.locator('#view-admin')).toBeVisible({ timeout: 10000 });
 
-        // The Linear-inspired admin redesign hides the entire sidebar (which carries
-        // the usage stats) under the 600px breakpoint and surfaces a mobile select
-        // for the top-level tabs instead. The mobile-tab fallback control should be
-        // visible while the desktop-only stat rows must be hidden.
+        // The Linear-inspired admin redesign hides the entire sidebar under
+        // the 600px breakpoint and surfaces a mobile select for the top-level
+        // tabs instead.
         await expect(page.locator('#view-admin .ar-mobile-tab-select')).toBeVisible({ timeout: 10000 });
         await expect(page.locator('#view-admin .ar-sidebar')).toBeHidden();
-        await expect(page.locator('[data-testid="stat-processes"]')).toBeHidden();
     });
 
     test('mobile: bottom nav hides when a repo is selected', async ({ page, serverUrl }) => {

--- a/packages/coc/test/server/spa/client/admin/AdminPanel-scratchpad.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/AdminPanel-scratchpad.test.tsx
@@ -147,7 +147,7 @@ describe('AdminPanel — Scratchpad toggle', () => {
         });
     });
 
-    it('renders admin stats from the typed admin client', async () => {
+    it('does not render sidebar stats block but still calls the stats API', async () => {
         mockFetch.mockImplementation((url: string) => {
             if (url.includes('/admin/data/stats')) return Promise.resolve(mockStatsResponse({ processCount: 7, wikiCount: 2, totalBytes: 1536 }));
             if (url.includes('/admin/config')) return Promise.resolve(mockConfigResponse());
@@ -158,13 +158,11 @@ describe('AdminPanel — Scratchpad toggle', () => {
         render(<AdminPanel />);
 
         await waitFor(() => {
-            // The sidebar stats block renders the count and label in separate
-            // spans, so the row's combined text content is "Processes7".
-            expect(screen.getByTestId('stat-processes').textContent).toMatch(/Processes.*7/);
+            expect(mockFetch.mock.calls.some(([url]) => String(url).includes('/admin/data/stats?includeWikis=true'))).toBe(true);
         });
-        expect(screen.getByTestId('stat-wikis').textContent).toMatch(/Wikis.*2/);
-        expect(screen.getByTestId('stat-disk').textContent).toMatch(/Disk.*1\.5 KB/);
-        expect(mockFetch.mock.calls.some(([url]) => String(url).includes('/admin/data/stats?includeWikis=true'))).toBe(true);
+        expect(screen.queryByTestId('stat-processes')).toBeNull();
+        expect(screen.queryByTestId('stat-wikis')).toBeNull();
+        expect(screen.queryByTestId('stat-disk')).toBeNull();
     });
 
     /**

--- a/packages/coc/test/spa/react/AdminPanel.test.tsx
+++ b/packages/coc/test/spa/react/AdminPanel.test.tsx
@@ -51,7 +51,7 @@ describe('AdminPanel', () => {
         expect(screen.queryByRole('heading', { name: 'Admin' })).toBeNull();
     });
 
-    it('renders storage stats section', async () => {
+    it('does not render the sidebar usage stats block', async () => {
         mockFetch.mockImplementation((url: string) => {
             if (url.includes('/admin/data/stats')) {
                 return Promise.resolve({
@@ -66,11 +66,9 @@ describe('AdminPanel', () => {
             renderWithProviders();
         });
 
-        await waitFor(() => {
-            expect(screen.getByTestId('stat-processes').textContent).toContain('42');
-            expect(screen.getByTestId('stat-wikis').textContent).toContain('5');
-            expect(screen.getByTestId('stat-disk').textContent).toContain('1.0 MB');
-        });
+        expect(screen.queryByTestId('stat-processes')).toBeNull();
+        expect(screen.queryByTestId('stat-wikis')).toBeNull();
+        expect(screen.queryByTestId('stat-disk')).toBeNull();
     });
 
     it('renders configuration section with editable fields', async () => {

--- a/packages/coc/test/spa/react/admin/AdminPanel-fit-viewport.test.ts
+++ b/packages/coc/test/spa/react/admin/AdminPanel-fit-viewport.test.ts
@@ -68,17 +68,20 @@ describe('AdminPanel — fit-to-viewport layout invariants', () => {
         expect(shell).not.toMatch(/min-height:\s*100%/);
     });
 
-    it('.ar-sidebar fills the grid row, scrolls only its own overflow, and is NOT sticky', () => {
+    it('.ar-sidebar fills the grid row with three fixed zones and does NOT scroll as a whole', () => {
         const sidebar = block('.ar-sidebar');
         expect(sidebar).toMatch(/height:\s*100%/);
         expect(sidebar).toMatch(/min-height:\s*0/);
-        expect(sidebar).toMatch(/overflow-y:\s*auto/);
-        // The previous design used sticky + 100vh to keep the sidebar in view
-        // while the whole page scrolled. With fit-to-viewport, both are
-        // unnecessary and would be wrong (100vh != container height in a
-        // dialog or nested pane).
+        expect(sidebar).toMatch(/overflow:\s*hidden/);
         expect(sidebar).not.toMatch(/position:\s*sticky/);
         expect(sidebar).not.toMatch(/height:\s*100vh/);
+    });
+
+    it('.ar-sidebar-nav is the scrollable zone inside the sidebar', () => {
+        const nav = block('.ar-sidebar-nav');
+        expect(nav).toMatch(/flex:\s*1/);
+        expect(nav).toMatch(/min-height:\s*0/);
+        expect(nav).toMatch(/overflow-y:\s*auto/);
     });
 
     it('.ar-main is the single internal scroller', () => {

--- a/packages/coc/test/spa/react/admin/AdminPanel-tools-sidebar.test.tsx
+++ b/packages/coc/test/spa/react/admin/AdminPanel-tools-sidebar.test.tsx
@@ -55,6 +55,65 @@ function renderAdmin() {
 
 // ── AdminPanel grouped sidebar navigation ─────────────────────
 
+describe('AdminPanel — sidebar layout zones', () => {
+    it('renders the sidebar with fixed header, scrollable nav, and fixed footer zones', async () => {
+        await act(async () => { renderAdmin(); });
+        await waitFor(() => {
+            const sidebar = document.querySelector('.ar-sidebar');
+            expect(sidebar).toBeTruthy();
+            expect(sidebar!.querySelector('.ar-sidebar-head')).toBeTruthy();
+            expect(sidebar!.querySelector('.ar-sidebar-nav')).toBeTruthy();
+            expect(sidebar!.querySelector('.ar-sidebar-foot')).toBeTruthy();
+        });
+    });
+
+    it('renders brand/title inside the fixed header zone', async () => {
+        await act(async () => { renderAdmin(); });
+        await waitFor(() => {
+            const head = document.querySelector('.ar-sidebar-head');
+            expect(head).toBeTruthy();
+            expect(head!.querySelector('.ar-brand')).toBeTruthy();
+            expect(head!.textContent).toContain('CoC Admin');
+        });
+    });
+
+    it('renders nav groups inside the scrollable middle zone', async () => {
+        await act(async () => { renderAdmin(); });
+        await waitFor(() => {
+            const nav = document.querySelector('.ar-sidebar-nav');
+            expect(nav).toBeTruthy();
+            const labels = Array.from(nav!.querySelectorAll('.ar-nav-group-label')).map(el => el.textContent);
+            expect(labels).toEqual(['Configure', 'Knowledge', 'Operations', 'Developer / Internals']);
+        });
+    });
+
+    it('renders restart button in the fixed footer zone', async () => {
+        await act(async () => { renderAdmin(); });
+        await waitFor(() => {
+            const foot = document.querySelector('.ar-sidebar-foot');
+            expect(foot).toBeTruthy();
+            const restartBtn = foot!.querySelector('[data-testid="sidebar-restart-btn"]') as HTMLButtonElement;
+            expect(restartBtn).toBeTruthy();
+            expect(restartBtn.textContent).toContain('Restart Server');
+            expect(restartBtn.disabled).toBe(false);
+        });
+    });
+
+    it('sidebar restart button triggers the restart handler', async () => {
+        await act(async () => { renderAdmin(); });
+        await waitFor(() => expect(document.querySelector('[data-testid="sidebar-restart-btn"]')).toBeTruthy());
+
+        await act(async () => {
+            fireEvent.click(document.querySelector('[data-testid="sidebar-restart-btn"]')!);
+        });
+
+        const restartCall = mockFetch.mock.calls.find(
+            (call: any[]) => typeof call[0] === 'string' && call[0].includes('/api/admin/restart')
+        );
+        expect(restartCall).toBeTruthy();
+    });
+});
+
 describe('AdminPanel — grouped sidebar navigation', () => {
     it('renders user-intent nav groups in the sidebar', async () => {
         await act(async () => { renderAdmin(); });

--- a/packages/coc/test/spa/react/features/stats/UsageStatsView.test.tsx
+++ b/packages/coc/test/spa/react/features/stats/UsageStatsView.test.tsx
@@ -96,7 +96,7 @@ describe('UsageStatsView', () => {
         expect(mockReload).toHaveBeenCalledTimes(1);
     });
 
-    it('renders table with date and model header when data is present', () => {
+    it('renders table with date, model column, and "All models" summary row', () => {
         (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
             makeHookResult({
                 data: {
@@ -109,16 +109,56 @@ describe('UsageStatsView', () => {
         );
         render(<UsageStatsView />);
         expect(screen.getByText('2025-07-10')).toBeTruthy();
-        expect(screen.getByText('gpt-4o')).toBeTruthy();
+        expect(screen.getAllByText('gpt-4o').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('All models').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Total').length).toBeGreaterThan(0);
     });
 
-    it('renders — for missing model data in a row', () => {
+    it('renders per-model rows under each date group', () => {
+        (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
+            makeHookResult({
+                data: {
+                    entries: [{
+                        date: '2025-07-10',
+                        byModel: {
+                            'gpt-4o': makeUsage({ inputTokens: 500 }),
+                            'claude-3': makeUsage({ inputTokens: 800 }),
+                        },
+                        dayTotal: makeUsage({ inputTokens: 1300 }),
+                    }],
+                    models: ['gpt-4o', 'claude-3'],
+                    generatedAt: '2025-07-10T12:00:00Z',
+                    totalDays: 1,
+                },
+            })
+        );
+        render(<UsageStatsView />);
+        expect(screen.getAllByText('gpt-4o').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('claude-3').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('only shows models that have data for a given date', () => {
         (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
             makeHookResult({
                 data: {
                     entries: [makeEntry('2025-07-10', 'gpt-4o')],
                     models: ['gpt-4o', 'claude-3'],
+                    generatedAt: '2025-07-10T12:00:00Z',
+                    totalDays: 1,
+                },
+            })
+        );
+        render(<UsageStatsView />);
+        const gpt4oCells = screen.getAllByText('gpt-4o');
+        expect(gpt4oCells.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows — for models with no usage in the grand total', () => {
+        (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
+            makeHookResult({
+                data: {
+                    entries: [makeEntry('2025-07-10', 'gpt-4o')],
+                    models: ['gpt-4o', 'never-used-model'],
                     generatedAt: '2025-07-10T12:00:00Z',
                     totalDays: 1,
                 },
@@ -153,7 +193,7 @@ describe('UsageStatsView', () => {
         expect(screen.getByText(/Generated at:/)).toBeTruthy();
     });
 
-    it('shows premium units only in rightmost total cells', () => {
+    it('shows premium units only in cost-details cells (All models summary)', () => {
         (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
             makeHookResult({
                 data: {
@@ -176,16 +216,10 @@ describe('UsageStatsView', () => {
 
         render(<UsageStatsView />);
 
-        expect(screen.getAllByText('↓14.1M total').length).toBe(4);
-        expect(screen.getAllByText('· 9.5M cached').length).toBe(4);
-        expect(screen.getAllByText('· 4.6M new').length).toBe(4);
-        expect(screen.getAllByText('↑125.4k out').length).toBe(4);
-        expect(screen.getAllByText('· 18.2k cache write').length).toBe(4);
         expect(screen.getAllByText('Premium units: 416.38').length).toBe(2);
-        expect(screen.queryByText(/416\.38 units/)).toBeNull();
     });
 
-    it('renders estimated token cost only in rightmost total cells', () => {
+    it('renders estimated token cost only in cost-details cells', () => {
         (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
             makeHookResult({
                 data: {
@@ -240,5 +274,58 @@ describe('UsageStatsView', () => {
 
         expect(screen.getAllByText('Premium units: 12.50').length).toBe(2);
         expect(document.body.textContent).not.toContain('$12.50');
+    });
+
+    it('fits within a fixed number of columns regardless of model count', () => {
+        const manyModels = Array.from({ length: 20 }, (_, i) => `model-${i}`);
+        const byModel: Record<string, ClientTokenUsage> = {};
+        for (const m of manyModels) {
+            byModel[m] = makeUsage({ inputTokens: 100 * (manyModels.indexOf(m) + 1) });
+        }
+        const dayTotal = makeUsage({ inputTokens: 2000, outputTokens: 1000 });
+
+        (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
+            makeHookResult({
+                data: {
+                    entries: [{ date: '2025-07-10', byModel, dayTotal }],
+                    models: manyModels,
+                    generatedAt: '2025-07-10T12:00:00Z',
+                    totalDays: 1,
+                },
+            })
+        );
+
+        render(<UsageStatsView />);
+
+        const headers = screen.getAllByRole('columnheader');
+        expect(headers).toHaveLength(3);
+        expect(headers[0].textContent).toBe('Date');
+        expect(headers[1].textContent).toBe('Model');
+        expect(headers[2].textContent).toBe('Tokens');
+
+        for (const m of manyModels) {
+            expect(screen.getAllByText(m).length).toBeGreaterThanOrEqual(1);
+        }
+    });
+
+    it('shows grand total in footer with per-model breakdowns', () => {
+        (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
+            makeHookResult({
+                data: {
+                    entries: [
+                        makeEntry('2025-07-10', 'gpt-4o', { inputTokens: 2000, outputTokens: 1000 }),
+                        makeEntry('2025-07-11', 'gpt-4o', { inputTokens: 3000, outputTokens: 1500 }),
+                    ],
+                    models: ['gpt-4o'],
+                    generatedAt: '2025-07-11T12:00:00Z',
+                    totalDays: 2,
+                },
+            })
+        );
+
+        render(<UsageStatsView />);
+
+        expect(screen.getByText('Total')).toBeTruthy();
+        expect(screen.getAllByText('All models').length).toBe(3);
     });
 });


### PR DESCRIPTION
- **fix(coc): prevent empty-state content from overlapping stats bar in work item tree**
- **fix(coc): prevent empty-state content from overlapping stats bar in work item tree**
- **fix(coc): remove duplicate priority and mirror badge from work item detail**
- **redesign Usage & Costs page to row-based layout that fits within viewport**
- **fix(coc): admin sidebar fixed header/footer with restart button**
- **fix(coc): remove sidebar usage stats block from admin page**
