### PR TITLE
fix(forge): stabilize ssh-connector reconnect-failure test on Windows

### DIFF
--- a/packages/forge/test/connectors/ssh-connector.test.ts
+++ b/packages/forge/test/connectors/ssh-connector.test.ts
@@ -323,13 +323,16 @@ describe('SshConnector', () => {
         child1.emit('exit', 1, null);
         expect(connector.getState('srv-1')?.status).toBe('failed');
 
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await vi.waitFor(() => {
+            expect(errorSpy).toHaveBeenCalledWith(
+                loggerModule.LogCategory.GENERAL,
+                expect.stringContaining('SSH reconnect failed for srv-1'),
+            );
+        }, { timeout: 500, interval: 20 });
 
-        expect(errorSpy).toHaveBeenCalledWith(
-            loggerModule.LogCategory.GENERAL,
-            expect.stringContaining('SSH reconnect failed for srv-1'),
-        );
-        expect(connector.getState('srv-1')?.status).toBe('failed');
+        await vi.waitFor(() => {
+            expect(connector.getState('srv-1')?.status).toBe('failed');
+        }, { timeout: 500, interval: 20 });
 
         connector.dispose();
     });


### PR DESCRIPTION
## Summary

- Fixes flaky `forge-test (windows-latest)` CI failure in `ssh-connector.test.ts > auto-reconnect failure logs error and reschedules instead of crashing`
- Root cause: the test used a fixed `100ms` sleep to wait for the reconnect cycle, but on Windows CI the `10ms` backoff + `15ms` health timeout wasn't always complete within that window — the assertion caught the state as `'connecting'` instead of `'failed'`
- Fix: replace the fixed sleep with `vi.waitFor()` polling (matching the pattern already used by the recovery test below it), giving the reconnect cycle up to 500ms to settle

## Test plan

- [x] `ssh-connector.test.ts` — all 17 tests pass locally
- [x] Full forge test suite — 194 files, 4687 tests pass
- [ ] CI `forge-test (windows-latest)` passes


Made with [Cursor](https://cursor.com)