### PR TITLE
Upgrade @github/copilot-sdk to ^1.0.0

### DIFF
--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -24,7 +24,7 @@ Location: `packages/coc-agent-sdk/src/`
 | `streaming-state-machine.ts` | Pure state machine: `Idle → Streaming → Settled \| Cancelled` |
 | `session-timer-manager.ts` | Timer management: overall timeout, idle timeout, turn-end grace |
 | `session-telemetry.ts` | Token usage accumulation, tool-call tracking |
-| `sdk-client-factory.ts` | Per-request `CopilotClient` spawning: cwd validation, folder trust |
+| `sdk-client-factory.ts` | Per-request `CopilotClient` spawning: working-directory validation, folder trust |
 | `sdk-loader.ts` | SDK binary discovery + ESM import workaround |
 | `sdk-esm-loader.ts` | Dynamic ESM import helper (webpack-safe `new Function` indirection) |
 | `types.ts` | Shared types: `SendMessageOptions`, MCP configs, permissions, tools, token usage |
@@ -200,7 +200,7 @@ Claude tool-call capture treats assistant `tool_use` blocks as start events and 
 8. sessionManager.track(session)
 9. Route: streaming (timeoutMs>120s or onStreamingChunk) vs sendAndWait
 10. Empty-response handling (turnCount>0 = success)
-11. FINALLY: remove abort listener, untrack + session.destroy + client.stop
+11. FINALLY: remove abort listener, untrack + session.disconnect + client.stop
 ```
 
 ## Streaming Internals
@@ -250,7 +250,11 @@ provider SDK — keeping the runtime + bridge free of any compile-time dependenc
 `@github/copilot-sdk`. `defineTool()` is a local pure data-merge. A compile-time
 guard in `types.ts` asserts the native contract stays structurally interchangeable
 with the Copilot SDK's, since the Copilot path assigns the same bundle to the SDK's
-`SessionConfig.tools` (`request-runner.ts`).
+`SessionConfig.tools` (`request-runner.ts`). Matching the SDK (>= 1.0.0),
+`Tool.handler` is optional (declaration-only tools); every CoC-authored tool
+supplies one, and `CocToolRuntime.callTool` returns an error result for a
+handler-less tool instead of throwing. CoC's local `defineTool()` still requires
+a handler.
 
 Pipeline (all in `coc-agent-sdk/src/llm-tools/`):
 1. `CocToolRuntime` wraps the per-invocation `Tool<any>[]` → `listTools()` (JSON-schema
@@ -321,6 +325,6 @@ Without a call to `initSDKLogger`, all internal SDK log statements are silently 
 - **Shared ISDKService mock** in `packages/coc-agent-sdk/src/testing/` — vitest-free, exposed via `@plusplusoneplusplus/coc-agent-sdk/testing` subpath export. Factories: `createMockSDKService`, `createUnavailableMock`, `createStreamingMock`, `createFailingMock`, `createMockBridge`, `createExpiredSessionBridge`. Accepts an injectable mock-fn factory (`fn` parameter); consumers pass `vi.fn` for vitest spy assertions.
 - `packages/coc/test/helpers/mock-sdk-service.ts` is a thin wrapper that binds `vi.fn` and re-exports from the shared mock.
 - Lower-level mock helpers in `packages/coc-agent-sdk/test/helpers/mock-sdk.ts` (MockCopilotClient — different layer, not migrated).
-- 539+ tests in `packages/coc-agent-sdk/test/`
+- 580+ tests in `packages/coc-agent-sdk/test/`
 - Set `serviceAny.sdkModule` and `serviceAny.availabilityCache` to bypass real SDK
 - Unit tests cover: session-manager, streaming-session, sdk-loader, sdk-client-factory, stream-error-guard, request-runner, logger, codex-sdk-service

--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -198,7 +198,7 @@ Claude tool-call capture treats assistant `tool_use` blocks as start events and 
 6. onSessionCreated callback fires
 7. Attach AbortSignal listener for cancellation
 8. sessionManager.track(session)
-9. Route: streaming (timeoutMs>120s or onStreamingChunk) vs sendAndWait
+9. Route: streaming (timeoutMs>120s or onStreamingChunk) vs race-safe non-streaming send+idle wait (not the SDK's `sendAndWait`, whose `session.error` handler can reject its internal promise before a catch is attached — an unhandled rejection on slow hosts; falls back to `sendAndWait` only for sessions lacking `on`/`send`)
 10. Empty-response handling (turnCount>0 = success)
 11. FINALLY: remove abort listener, untrack + session.disconnect + client.stop
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packages/teams-bot"
       ],
       "dependencies": {
-        "@github/copilot-sdk": "^0.3.0",
+        "@github/copilot-sdk": "^1.0.0",
         "@plusplusoneplusplus/forge": "file:packages/forge",
         "diff": "^5.2.0",
         "esbuild": "0.28.0",
@@ -1837,24 +1837,31 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.36",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.61.tgz",
+      "integrity": "sha512-E4f7YXTL2uUZY/ypnfsUruAeSgrHx3AGYEbm5N0DrpzPqoNAZqV6kHEWM4vu+W/nGvydIfPxmOTqaMEhM8r0Uw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.36",
-        "@github/copilot-darwin-x64": "1.0.36",
-        "@github/copilot-linux-arm64": "1.0.36",
-        "@github/copilot-linux-x64": "1.0.36",
-        "@github/copilot-win32-arm64": "1.0.36",
-        "@github/copilot-win32-x64": "1.0.36"
+        "@github/copilot-darwin-arm64": "1.0.61",
+        "@github/copilot-darwin-x64": "1.0.61",
+        "@github/copilot-linux-arm64": "1.0.61",
+        "@github/copilot-linux-x64": "1.0.61",
+        "@github/copilot-linuxmusl-arm64": "1.0.61",
+        "@github/copilot-linuxmusl-x64": "1.0.61",
+        "@github/copilot-win32-arm64": "1.0.61",
+        "@github/copilot-win32-x64": "1.0.61"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.36.tgz",
-      "integrity": "sha512-5qkb7frTS4K/LdTDLrzKo78VR4aw/EZ6JzLz4KfmaW4UYyPiNirExDFXa/By22X0o8YMfOp4MCA2KSCAxKdgTg==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.61.tgz",
+      "integrity": "sha512-10prvjHRXB0SD28NsIpzdNDgLquQYUwaH5Ev9KVdIWdBPAvlQsHmQ4JSCyD/UILc/nrrr02CKUgum+mZRKUKIg==",
       "cpu": [
         "arm64"
       ],
@@ -1868,9 +1875,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.36.tgz",
-      "integrity": "sha512-AdsM8QtM5QSzMLpavLREh8HALO5G+VWzGNQqIHu4f0YQC/s1cGoiwo3wsgkpxRcLGBykFc+bDX3yK3MDQ8XvSw==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.61.tgz",
+      "integrity": "sha512-NXUjageJ3mxDfHtXGYu//XhJ+dhJFYObT4R3jeWgIHhd+4lX7FlC754nwlBP/ZuVhJ3ND22JK9sua9d2F3Cbwg==",
       "cpu": [
         "x64"
       ],
@@ -1884,11 +1891,14 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.36.tgz",
-      "integrity": "sha512-n7K1I6r0ggOJ4A9uAMS11USTvn6BKtAwvrOkzEaeRK89VNUJzpTe6p0mE13ItzRe5eot9WLBQOxvXLtL9f6E+g==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.61.tgz",
+      "integrity": "sha512-dwB2+QSMr622JkePeK56M7YWXsTT/DQzKfpDq8Lk2kmGU052RZAarRmt8gcNm4anofN7pMSrqc3YHj1TM84MFw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1900,11 +1910,14 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.36.tgz",
-      "integrity": "sha512-wBtCdR3ITZcq07BJbkwHfwI6ayiwbH5pF1ex+Ycl4UI+Lf1vP9eQD6wJppPgsrjwFcdeWRThaYTPCRTkSGHv5g==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.61.tgz",
+      "integrity": "sha512-q6n8R8oybvuCmmkP+43w809Wpud/wwRi/fFSZEYJagiNGmYJ00SDkrfJxHbZsAFMpaJC+oTswqzJHjRoZbO74w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1915,11 +1928,51 @@
         "copilot-linux-x64": "copilot"
       }
     },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.61.tgz",
+      "integrity": "sha512-yWo7JXnZS11eJpm68E1RWKMR47EwzPKj3V7GX0EMTd8Fw0T2Aurk9wt9p3c9w0v02nTO1DqJhi68KVWJPdVqvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.61.tgz",
+      "integrity": "sha512-nHzx27Ac4B0fpD9CcmvyrGOBEMJ01CPRgVRP0yAl4wpU4cM2I6+9TPyfYThlWDqZqiUKGXC1ZRQ+B8cJREVGmA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.3.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.0.tgz",
+      "integrity": "sha512-OKjmJMDM+GB2uHr8UA6O0FNs1Gfw/tkoE5vUNlYmKbydc9Yjf6pvuBdseGjAVvzc6f9HIbB5eZKLUrxbOTw+yA==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.36-0",
+        "@github/copilot": "^1.0.57",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1928,9 +1981,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.36.tgz",
-      "integrity": "sha512-0GzZUZQn07alI8BgbzK0NlR5+ta/Rd0sWmd8kbRCns7oybAIkSALy6BKVwJmVHtXUi6h4iUE8oiFhkn0spymvw==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.61.tgz",
+      "integrity": "sha512-k6knzI+K5HlZeJDS/yeJAfoYD4xcURWfuqunpTCyk1pDbIFxmrLSqR/TDi7KNlpsf883n5WqpnB06K5kysdHHQ==",
       "cpu": [
         "arm64"
       ],
@@ -1944,7 +1997,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.36",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.61.tgz",
+      "integrity": "sha512-L6NZ6o73VZFHd7OoRaztV3Prh1PbW9HXqYsAx+XywNALQvE1u489WBUC1ggfYBW5MTBCf8mxSkYQdb3Am2omsw==",
       "cpu": [
         "x64"
       ],
@@ -17065,7 +17120,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.162",
         "@excalidraw/excalidraw": "^0.18.1",
-        "@github/copilot-sdk": "^0.3.0",
+        "@github/copilot-sdk": "^1.0.0",
         "@monaco-editor/react": "^4.7.0",
         "@octokit/rest": "^22.0.1",
         "@openai/codex-sdk": "^0.133.0",
@@ -17164,7 +17219,7 @@
       },
       "peerDependencies": {
         "@anthropic-ai/claude-agent-sdk": ">=0.3.0",
-        "@github/copilot-sdk": "^0.3.0",
+        "@github/copilot-sdk": "^1.0.0",
         "@openai/codex-sdk": ">=0.1.0"
       },
       "peerDependenciesMeta": {
@@ -21456,7 +21511,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot-sdk": "^0.3.0",
+        "@github/copilot-sdk": "^1.0.0",
         "@octokit/rest": "^22.0.1",
         "@plusplusoneplusplus/coc-agent-sdk": "*",
         "@plusplusoneplusplus/coc-workflow": "^0.1.0",
@@ -22254,7 +22309,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot-sdk": "^0.3.0",
+        "@github/copilot-sdk": "^1.0.0",
         "@octokit/rest": "^22.0.1",
         "@plusplusoneplusplus/coc-agent-sdk": "*",
         "@plusplusoneplusplus/coc-workflow": "*",

--- a/package.json
+++ b/package.json
@@ -3831,7 +3831,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.0",
     "@plusplusoneplusplus/forge": "file:packages/forge",
     "diff": "^5.2.0",
     "esbuild": "0.28.0",

--- a/packages/coc-agent-sdk/package.json
+++ b/packages/coc-agent-sdk/package.json
@@ -27,7 +27,7 @@
     "test:run": "vitest run"
   },
   "peerDependencies": {
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.0",
     "@openai/codex-sdk": ">=0.1.0",
     "@anthropic-ai/claude-agent-sdk": ">=0.3.0"
   },

--- a/packages/coc-agent-sdk/src/copilot-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/copilot-sdk-service.ts
@@ -151,7 +151,7 @@ export class CopilotSDKService implements ISDKService {
 
     public async createClient(cwd?: string): Promise<CopilotClient> {
         if (this.disposed) throw new Error('CopilotSDKService has been disposed');
-        return createSdkClient({ cwd });
+        return createSdkClient({ workingDirectory: cwd });
     }
 
     /**

--- a/packages/coc-agent-sdk/src/llm-tools/coc-tool-runtime.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/coc-tool-runtime.ts
@@ -146,6 +146,11 @@ export class CocToolRuntime {
         if (!tool) {
             return errorResult(`Unknown tool: ${name}`);
         }
+        // Declaration-only tools (no handler) cannot be executed by the runtime.
+        const handler = tool.handler;
+        if (typeof handler !== 'function') {
+            return errorResult(`Tool "${name}" has no handler and cannot be executed`);
+        }
 
         const invocation: ToolInvocation = {
             sessionId: this.context.sessionId ?? '',
@@ -155,7 +160,7 @@ export class CocToolRuntime {
         };
 
         try {
-            const raw = await tool.handler(args as never, invocation);
+            const raw = await handler(args as never, invocation);
             return normalizeToolResult(raw);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);

--- a/packages/coc-agent-sdk/src/request-runner.ts
+++ b/packages/coc-agent-sdk/src/request-runner.ts
@@ -8,7 +8,7 @@
  * independently of CopilotSDKService.
  */
 
-import type { CopilotClient, CopilotSession, SessionConfig, AssistantMessageEvent } from '@github/copilot-sdk';
+import type { CopilotClient, CopilotSession, SessionConfig, AssistantMessageEvent, SessionEvent } from '@github/copilot-sdk';
 import { ToolCall } from './tool-call';
 import { getAIServiceLogger, createSessionLogger } from './logger';
 import { loadEffectiveMcpConfig } from './mcp-config-loader';
@@ -525,13 +525,58 @@ export class RequestRunner {
         });
     }
 
-    /** Send a message without streaming (non-streaming path). */
-    private sendWithTimeout(
+    /**
+     * Send a message without streaming (non-streaming path).
+     *
+     * Deliberately does NOT use the SDK's `sendAndWait()`: that helper rejects
+     * its internal idle promise from a `session.error` handler, but only
+     * attaches rejection handling after `await send()` resolves. When the
+     * error event outraces the send acknowledgment (observed on slow CI hosts
+     * with an unauthenticated CLI), the rejection has no handler attached and
+     * surfaces as an unhandled rejection in the host process. This
+     * re-implementation attaches all handlers before issuing `send()`.
+     */
+    private async sendWithTimeout(
         session: CopilotSession,
         prompt: string,
         timeoutMs: number,
         attachments?: Attachment[],
     ): Promise<AssistantMessageEvent | undefined> {
-        return session.sendAndWait({ prompt, attachments }, timeoutMs);
+        if (typeof session.on !== 'function' || typeof session.send !== 'function') {
+            return session.sendAndWait({ prompt, attachments }, timeoutMs);
+        }
+
+        let lastAssistantMessage: AssistantMessageEvent | undefined;
+        let unsubscribe: (() => void) | undefined;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        try {
+            const settled = new Promise<AssistantMessageEvent | undefined>((resolve, reject) => {
+                unsubscribe = session.on((event: SessionEvent) => {
+                    if (event.type === 'assistant.message') {
+                        lastAssistantMessage = event as AssistantMessageEvent;
+                    } else if (event.type === 'session.idle') {
+                        resolve(lastAssistantMessage);
+                    } else if (event.type === 'session.error') {
+                        const data = (event as { data?: { message?: string; stack?: string } }).data;
+                        const error = new Error(data?.message ?? 'Unknown session error');
+                        if (data?.stack) error.stack = data.stack;
+                        reject(error);
+                    }
+                });
+                timeoutId = setTimeout(
+                    () => reject(new Error(`Timeout after ${timeoutMs}ms waiting for session.idle`)),
+                    timeoutMs,
+                );
+            });
+            // Mark `settled` handled before send() is issued so a session.error
+            // arriving mid-send can never become an unhandled rejection; the
+            // real consumer is the `await settled` below.
+            settled.catch(() => { /* consumed below */ });
+            await session.send({ prompt, attachments });
+            return await settled;
+        } finally {
+            if (timeoutId !== undefined) clearTimeout(timeoutId);
+            unsubscribe?.();
+        }
     }
 }

--- a/packages/coc-agent-sdk/src/request-runner.ts
+++ b/packages/coc-agent-sdk/src/request-runner.ts
@@ -322,11 +322,11 @@ export class RequestRunner {
             }
 
             const abortSession = () => {
-                sessionLog.debug('Abort signal received — destroying session');
-                const destroy = () => session?.destroy().catch(() => {});
+                sessionLog.debug('Abort signal received — disconnecting session');
+                const disconnect = () => session?.disconnect().catch(() => {});
                 const abort = typeof (session as { abort?: () => Promise<void> }).abort === 'function'
-                    ? (session as { abort: () => Promise<void> }).abort().catch(() => undefined).then(destroy)
-                    : destroy();
+                    ? (session as { abort: () => Promise<void> }).abort().catch(() => undefined).then(disconnect)
+                    : disconnect();
                 Promise.resolve(abort).catch(() => {});
             };
             options.signal?.addEventListener('abort', abortSession, { once: true });
@@ -404,10 +404,10 @@ export class RequestRunner {
                 this.sessionManager.untrack(session.sessionId);
                 const finalSessionLog = createSessionLogger(session.sessionId);
                 try {
-                    await session.destroy();
-                    finalSessionLog.debug('Session destroyed');
-                } catch (destroyError) {
-                    finalSessionLog.debug({ err: destroyError }, 'Warning: Error destroying session');
+                    await session.disconnect();
+                    finalSessionLog.debug('Session disconnected');
+                } catch (disconnectError) {
+                    finalSessionLog.debug({ err: disconnectError }, 'Warning: Error disconnecting session');
                 }
                 if (client && clientOwned) {
                     try { await client.stop(); } catch { /* ignore */ }

--- a/packages/coc-agent-sdk/src/sdk-client-factory.ts
+++ b/packages/coc-agent-sdk/src/sdk-client-factory.ts
@@ -25,44 +25,44 @@ import {
  *
  * Requires the SDK to have been loaded via `loadCopilotSdk()` before calling.
  *
- * @param options - Client creation options (e.g. `cwd`).
+ * @param options - Client creation options (e.g. `workingDirectory`).
  * @returns The newly created SDK client instance.
  */
 export function createSdkClient(options: CopilotClientOptions = {}): CopilotClient {
-    const { cwd } = options;
+    const { workingDirectory } = options;
     const aiLog = getAIServiceLogger();
     const clientOptions: CopilotClientOptions = { ...options };
 
-    if (cwd) {
-        const executionContext = resolveWorkspaceExecutionContext(cwd);
+    if (workingDirectory) {
+        const executionContext = resolveWorkspaceExecutionContext(workingDirectory);
         if (executionContext.kind === 'wsl') {
-            const hostWorkingDirectory = translatePathForHostFilesystem(cwd, executionContext);
+            const hostWorkingDirectory = translatePathForHostFilesystem(workingDirectory, executionContext);
             if (!fs.existsSync(hostWorkingDirectory)) {
                 aiLog.warn(
-                    { cwd, hostWorkingDirectory },
+                    { workingDirectory, hostWorkingDirectory },
                     'Translated WSL working directory does not exist on the host filesystem. ' +
                     'The SDK will fail with ERR_STREAM_DESTROYED because child_process.spawn ' +
                     'requires an existing cwd. Ensure the caller passes a valid directory.',
                 );
             }
-            clientOptions.cwd = hostWorkingDirectory;
+            clientOptions.workingDirectory = hostWorkingDirectory;
             try {
                 ensureFolderTrusted(hostWorkingDirectory);
             } catch {
                 // Non-fatal: trust dialog will appear if this fails
             }
         } else {
-            if (!fs.existsSync(cwd)) {
+            if (!fs.existsSync(workingDirectory)) {
                 aiLog.warn(
-                    { cwd },
+                    { workingDirectory },
                     'Working directory does not exist. ' +
                     'The SDK will fail with ERR_STREAM_DESTROYED because child_process.spawn ' +
                     'requires an existing cwd. Ensure the caller passes a valid directory.',
                 );
             }
-            clientOptions.cwd = cwd;
+            clientOptions.workingDirectory = workingDirectory;
             try {
-                ensureFolderTrusted(cwd);
+                ensureFolderTrusted(workingDirectory);
             } catch {
                 // Non-fatal: trust dialog will appear if this fails
             }

--- a/packages/coc-agent-sdk/src/session-manager.ts
+++ b/packages/coc-agent-sdk/src/session-manager.ts
@@ -16,7 +16,7 @@ import type { IStreamableSession } from './streaming-session';
  */
 export interface IAbortableSession {
     sessionId: string;
-    destroy(): Promise<void>;
+    disconnect(): Promise<void>;
 }
 
 /**
@@ -56,11 +56,11 @@ export class SessionManager {
 
     /**
      * Soft-abort an active session by calling the SDK's abort() method.
-     * This signals the CLI to stop in-flight work without destroying the session.
+     * This signals the CLI to stop in-flight work without disconnecting the session.
      * The streaming promise settles with a partial result; the request-runner
-     * finally block handles destroy() and untrack().
+     * finally block handles disconnect() and untrack().
      *
-     * Falls back to hard destroy if abort() is unavailable or fails.
+     * Falls back to hard disconnect if abort() is unavailable or fails.
      *
      * @returns `true` if the session was found and soft-aborted, `false` otherwise.
      */
@@ -81,17 +81,17 @@ export class SessionManager {
                 sessionLog.debug('Session soft-aborted successfully');
                 return true;
             }
-            // No abort method — fall back to hard destroy
-            sessionLog.debug('Session has no abort() — falling back to hard destroy');
-            await session.destroy();
+            // No abort method — fall back to hard disconnect
+            sessionLog.debug('Session has no abort() — falling back to hard disconnect');
+            await session.disconnect();
             this.activeSessions.delete(sessionId);
             return true;
         } catch (error) {
             sessionLog.error(
                 { err: error instanceof Error ? error : undefined },
-                'Error soft-aborting session — falling back to hard destroy',
+                'Error soft-aborting session — falling back to hard disconnect',
             );
-            try { await session.destroy(); } catch { /* best effort */ }
+            try { await session.disconnect(); } catch { /* best effort */ }
             this.activeSessions.delete(sessionId);
             return false;
         }
@@ -99,7 +99,7 @@ export class SessionManager {
 
     /**
      * Abort an active session by its ID.
-     * Destroys the session and removes it from tracking.
+     * Disconnects the session and removes it from tracking.
      *
      * @returns `true` if the session was found and aborted, `false` otherwise.
      */
@@ -115,7 +115,7 @@ export class SessionManager {
         sessionLog.debug('Aborting session');
 
         try {
-            await session.destroy();
+            await session.disconnect();
             this.activeSessions.delete(sessionId);
             sessionLog.debug('Session aborted successfully');
             return true;
@@ -124,7 +124,7 @@ export class SessionManager {
                 { err: error instanceof Error ? error : undefined },
                 'Error aborting session',
             );
-            // Still remove from tracking even if destroy failed
+            // Still remove from tracking even if disconnect failed
             this.activeSessions.delete(sessionId);
             return false;
         }

--- a/packages/coc-agent-sdk/src/streaming-session.ts
+++ b/packages/coc-agent-sdk/src/streaming-session.ts
@@ -55,9 +55,9 @@ export interface IStreamableSession {
         attachments?: Attachment[];
         mode?: DeliveryMode;
     }) => Promise<string | void>;
-    /** Soft-abort: signals the SDK to stop in-flight work without destroying the session. */
+    /** Soft-abort: signals the SDK to stop in-flight work without disconnecting the session. */
     abort?(): Promise<void>;
-    destroy(): Promise<void>;
+    disconnect(): Promise<void>;
 }
 
 /** SDK event fired by the streaming session. */
@@ -211,9 +211,9 @@ export class StreamingSession {
                     }
                     this.sessionLog.error(
                         { elapsedMs: this.options.timeoutMs, activeTools: [...this.telemetry.activeToolCalls.keys()] },
-                        'Force-destroying session due to timeout',
+                        'Force-disconnecting session due to timeout',
                     );
-                    this.session.destroy().catch(() => {});
+                    this.session.disconnect().catch(() => {});
                     this.settleError(new Error(`Request timed out after ${this.options.timeoutMs}ms`));
                 },
                 onIdleTimeout: () => {
@@ -237,9 +237,9 @@ export class StreamingSession {
                     }
                     this.sessionLog.error(
                         { elapsedMs: effectiveIdleMs },
-                        'Force-destroying session due to idle timeout',
+                        'Force-disconnecting session due to idle timeout',
                     );
-                    this.session.destroy().catch(() => {});
+                    this.session.disconnect().catch(() => {});
                     this.settleError(new Error(`Request idle-timed out after ${effectiveIdleMs}ms with no activity`));
                 },
                 onTurnEndGrace: () => {

--- a/packages/coc-agent-sdk/src/types.ts
+++ b/packages/coc-agent-sdk/src/types.ts
@@ -15,7 +15,7 @@ export interface AIInvocationResult { success: boolean; response?: string; error
 // The CoC tool contract is owned here rather than aliased from a specific
 // provider's SDK. This keeps the provider-neutral tool runtime + MCP bridge
 // (see ./llm-tools) free of any compile-time dependency on @github/copilot-sdk
-// and insulates every CoC tool from churn in that pre-1.0 package. The Copilot
+// and insulates every CoC tool from churn in that package. The Copilot
 // provider path still hands the same `Tool[]` bundle straight to the SDK, so a
 // compile-time drift guard (below) asserts these stay structurally
 // interchangeable with the Copilot SDK's contract.
@@ -40,9 +40,15 @@ export type ToolResultType = 'success' | 'failure' | 'rejected' | 'denied' | 'ti
 export interface ToolBinaryResult {
     data: string;
     mimeType: string;
-    type: string;
+    type: 'image' | 'resource';
     description?: string;
 }
+
+/**
+ * Per-tool telemetry payload attached to a structured tool result.
+ * Matches the Copilot SDK's `ToolTelemetry`.
+ */
+export type ToolTelemetry = Record<string, Record<string, unknown> | undefined>;
 
 /**
  * Structured tool-handler result. Structurally identical to the Copilot SDK's
@@ -54,7 +60,7 @@ export interface ToolResultObject {
     resultType: ToolResultType;
     error?: string;
     sessionLog?: string;
-    toolTelemetry?: Record<string, unknown>;
+    toolTelemetry?: ToolTelemetry;
 }
 
 /**
@@ -87,12 +93,17 @@ export interface ZodSchema<T = unknown> {
 /**
  * Tool definition. `parameters` may be a Zod-like schema (enabling handler-arg
  * inference), a raw JSON Schema object, or omitted.
+ *
+ * `handler` is optional to stay structurally interchangeable with the Copilot
+ * SDK's `Tool` (which supports declaration-only tools resolved via external
+ * tool-request events). Every CoC-authored tool supplies a handler; the CoC
+ * tool runtime fails the call with an error result when one is absent.
  */
 export interface Tool<TArgs = unknown> {
     name: string;
     description?: string;
     parameters?: ZodSchema<TArgs> | Record<string, unknown>;
-    handler: ToolHandler<TArgs>;
+    handler?: ToolHandler<TArgs>;
     /**
      * When true, explicitly indicates this tool is intended to override a
      * built-in tool of the same name. If unset and the name clashes with a
@@ -435,7 +446,7 @@ export interface SendMessageOptions {
      * a new child process, and will **not** call `client.stop()` in the finally
      * block (the caller owns the client's lifecycle).
      *
-     * Session `destroy()` is still called per-request to release in-memory
+     * Session `disconnect()` is still called per-request to release in-memory
      * resources, but the underlying CLI process stays alive for future calls.
      */
     client?: import('@github/copilot-sdk').CopilotClient;
@@ -731,7 +742,7 @@ export const denyAllPermissions: import('@github/copilot-sdk').PermissionHandler
 
 /**
  * Check whether a permission result represents an approval.
- * v0.3.0 of the SDK has three approval kinds: approve-once, approve-for-session, approve-for-location.
+ * The SDK has three approval kinds: approve-once, approve-for-session, approve-for-location.
  */
 export function isPermissionApproved(result: { kind: string }): boolean {
     return result.kind === 'approve-once' || result.kind === 'approve-for-session' || result.kind === 'approve-for-location';

--- a/packages/coc-agent-sdk/test/ai/coc-tool-runtime.test.ts
+++ b/packages/coc-agent-sdk/test/ai/coc-tool-runtime.test.ts
@@ -97,6 +97,17 @@ describe('CocToolRuntime', () => {
             expect(result.content[0].text).toContain('Unknown tool: nope');
         });
 
+        it('returns an error result for a declaration-only tool (no handler) without throwing', async () => {
+            // SDK >= 1.0.0 allows handler-less tool declarations; the runtime
+            // only executes in-process closures, so such a tool must fail the
+            // call gracefully instead of crashing the bridge.
+            const runtime = new CocToolRuntime([tool('declared_only', { handler: undefined })]);
+            expect(runtime.hasTool('declared_only')).toBe(true);
+            const result = await runtime.callTool('declared_only', {});
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('has no handler');
+        });
+
         it('captures handler exceptions as an error result', async () => {
             const runtime = new CocToolRuntime([
                 tool('boom', { handler: async () => { throw new Error('kaboom'); } }),

--- a/packages/coc-agent-sdk/test/ai/copilot-sdk-delivery-mode.test.ts
+++ b/packages/coc-agent-sdk/test/ai/copilot-sdk-delivery-mode.test.ts
@@ -252,7 +252,7 @@ describe('CopilotSDKService - Delivery Mode', () => {
         const mockSession = {
             sessionId: 'non-streaming-session',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
         };
 
         const capturedOptions: any[] = [];

--- a/packages/coc-agent-sdk/test/ai/copilot-sdk-service-skills.test.ts
+++ b/packages/coc-agent-sdk/test/ai/copilot-sdk-service-skills.test.ts
@@ -67,7 +67,7 @@ describe('CopilotSDKService - Skills Passthrough', () => {
         const mockSession = {
             sessionId: 'skills-dir-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn(),
             send: vi.fn(),
         };
@@ -98,7 +98,7 @@ describe('CopilotSDKService - Skills Passthrough', () => {
         const mockSession = {
             sessionId: 'disabled-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn(),
             send: vi.fn(),
         };
@@ -129,7 +129,7 @@ describe('CopilotSDKService - Skills Passthrough', () => {
         const mockSession = {
             sessionId: 'both-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn(),
             send: vi.fn(),
         };
@@ -162,7 +162,7 @@ describe('CopilotSDKService - Skills Passthrough', () => {
         const mockSession = {
             sessionId: 'no-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn(),
             send: vi.fn(),
         };
@@ -193,7 +193,7 @@ describe('CopilotSDKService - Skills Passthrough', () => {
         const mockSession = {
             sessionId: 'empty-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn(),
             send: vi.fn(),
         };

--- a/packages/coc-agent-sdk/test/ai/copilot-sdk-service-skills.test.ts
+++ b/packages/coc-agent-sdk/test/ai/copilot-sdk-service-skills.test.ts
@@ -68,8 +68,6 @@ describe('CopilotSDKService - Skills Passthrough', () => {
             sessionId: 'skills-dir-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
             disconnect: vi.fn().mockResolvedValue(undefined),
-            on: vi.fn(),
-            send: vi.fn(),
         };
 
         const { MockCopilotClient, mockClient } = createMockSDKModule(mockSession);
@@ -99,8 +97,6 @@ describe('CopilotSDKService - Skills Passthrough', () => {
             sessionId: 'disabled-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
             disconnect: vi.fn().mockResolvedValue(undefined),
-            on: vi.fn(),
-            send: vi.fn(),
         };
 
         const { MockCopilotClient, mockClient } = createMockSDKModule(mockSession);
@@ -130,8 +126,6 @@ describe('CopilotSDKService - Skills Passthrough', () => {
             sessionId: 'both-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
             disconnect: vi.fn().mockResolvedValue(undefined),
-            on: vi.fn(),
-            send: vi.fn(),
         };
 
         const { MockCopilotClient, mockClient } = createMockSDKModule(mockSession);
@@ -163,8 +157,6 @@ describe('CopilotSDKService - Skills Passthrough', () => {
             sessionId: 'no-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
             disconnect: vi.fn().mockResolvedValue(undefined),
-            on: vi.fn(),
-            send: vi.fn(),
         };
 
         const { MockCopilotClient, mockClient } = createMockSDKModule(mockSession);
@@ -194,8 +186,6 @@ describe('CopilotSDKService - Skills Passthrough', () => {
             sessionId: 'empty-skills-test',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
             disconnect: vi.fn().mockResolvedValue(undefined),
-            on: vi.fn(),
-            send: vi.fn(),
         };
 
         const { MockCopilotClient, mockClient } = createMockSDKModule(mockSession);

--- a/packages/coc-agent-sdk/test/ai/copilot-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/ai/copilot-sdk-service.test.ts
@@ -1466,13 +1466,26 @@ describe('CopilotSDKService - Non-streaming (sendAndWait)', () => {
         resetCopilotSDKService();
     });
 
-    it('should use sendAndWait when timeout <= 120000 and streaming is not set', async () => {
+    it('should use the race-safe send + idle wait when timeout <= 120000 and streaming is not set', async () => {
+        const handlers: Array<(event: any) => void> = [];
         const mockSession = {
             sessionId: 'non-streaming-session',
-            sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'Non-streaming response' } }),
+            sendAndWait: vi.fn(),
             disconnect: vi.fn().mockResolvedValue(undefined),
-            on: vi.fn(),
-            send: vi.fn(),
+            on: vi.fn().mockImplementation((handler: (event: any) => void) => {
+                handlers.push(handler);
+                return () => {
+                    const idx = handlers.indexOf(handler);
+                    if (idx >= 0) handlers.splice(idx, 1);
+                };
+            }),
+            send: vi.fn().mockImplementation(async () => {
+                setTimeout(() => {
+                    for (const h of [...handlers]) h({ type: 'assistant.message', data: { content: 'Non-streaming response' } });
+                    for (const h of [...handlers]) h({ type: 'session.idle', data: {} });
+                }, 5);
+                return 'message-id';
+            }),
         };
 
         const capturedOptions: any[] = [];
@@ -1495,14 +1508,77 @@ describe('CopilotSDKService - Non-streaming (sendAndWait)', () => {
         const result = await service.sendMessage({
             prompt: 'Test',
             workingDirectory: '/test',
-            timeoutMs: 60000, // <= 120000, should use sendAndWait
+            timeoutMs: 60000, // <= 120000 → non-streaming path
             loadDefaultMcpConfig: false,
         });
 
         expect(result.success).toBe(true);
         expect(result.response).toBe('Non-streaming response');
-        expect(mockSession.sendAndWait).toHaveBeenCalledWith({ prompt: 'Test' }, 60000);
-        expect(mockSession.send).not.toHaveBeenCalled();
+        expect(mockSession.send).toHaveBeenCalledWith({ prompt: 'Test', attachments: undefined });
+        // The SDK's sendAndWait must NOT be used — its session.error handler can
+        // reject an internal promise before any catch is attached (unhandled rejection).
+        expect(mockSession.sendAndWait).not.toHaveBeenCalled();
+    });
+
+    it('does not produce an unhandled rejection when session.error outraces the send acknowledgment', async () => {
+        const handlers: Array<(event: any) => void> = [];
+        const mockSession = {
+            sessionId: 'racy-error-session',
+            sendAndWait: vi.fn(),
+            disconnect: vi.fn().mockResolvedValue(undefined),
+            on: vi.fn().mockImplementation((handler: (event: any) => void) => {
+                handlers.push(handler);
+                return () => {
+                    const idx = handlers.indexOf(handler);
+                    if (idx >= 0) handlers.splice(idx, 1);
+                };
+            }),
+            send: vi.fn().mockImplementation(() => {
+                // Emit the failure synchronously — before the send promise
+                // resolves — mimicking a slow host where the CLI's session.error
+                // event wins the race against the send acknowledgment.
+                for (const h of [...handlers]) {
+                    h({ type: 'session.error', data: { message: 'Execution failed: Error: Session was not created with authentication info or custom provider' } });
+                }
+                return new Promise<string>(resolve => setTimeout(() => resolve('message-id'), 10));
+            }),
+        };
+
+        const mockClient = {
+            createSession: vi.fn().mockResolvedValue(mockSession),
+            stop: vi.fn().mockResolvedValue(undefined),
+        };
+
+        class MockCopilotClient {
+            constructor() {
+                Object.assign(this, mockClient);
+            }
+        }
+
+        const serviceAny = service as any;
+        createSdkClientMock.mockImplementation((opts: any) => new MockCopilotClient(opts));
+        serviceAny.availabilityCache = { available: true, sdkPath: '/fake/sdk' };
+
+        const unhandled: unknown[] = [];
+        const listener = (reason: unknown) => { unhandled.push(reason); };
+        process.on('unhandledRejection', listener);
+        try {
+            const result = await service.sendMessage({
+                prompt: 'Test',
+                workingDirectory: '/test',
+                timeoutMs: 60000,
+                loadDefaultMcpConfig: false,
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Session was not created with authentication info');
+
+            // Flush micro/macrotasks so any unhandled rejection would have fired.
+            await new Promise(resolve => setTimeout(resolve, 20));
+            expect(unhandled).toHaveLength(0);
+        } finally {
+            process.removeListener('unhandledRejection', listener);
+        }
     });
 
     it('should fall back to sendAndWait when session lacks on/send methods', async () => {

--- a/packages/coc-agent-sdk/test/ai/copilot-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/ai/copilot-sdk-service.test.ts
@@ -56,7 +56,7 @@ describe('CopilotSDKService - Client Initialization', () => {
         resetCopilotSDKService();
     });
 
-    it('should pass cwd to createSdkClient when working directory is specified', async () => {
+    it('should pass workingDirectory to createSdkClient when working directory is specified', async () => {
         const { MockCopilotClient } = createMockSDKModule();
 
         const serviceAny = service as any;
@@ -65,7 +65,7 @@ describe('CopilotSDKService - Client Initialization', () => {
 
         await service.createClient('/some/project/path');
 
-        expect(createSdkClientMock).toHaveBeenCalledWith({ cwd: '/some/project/path' });
+        expect(createSdkClientMock).toHaveBeenCalledWith({ workingDirectory: '/some/project/path' });
     });
 
     it('should not call ensureFolderTrusted when no working directory is given', async () => {
@@ -80,7 +80,7 @@ describe('CopilotSDKService - Client Initialization', () => {
         expect(trustedFolder.ensureFolderTrusted).not.toHaveBeenCalled();
     });
 
-    it('should pass each cwd to createSdkClient when clients are created', async () => {
+    it('should pass each workingDirectory to createSdkClient when clients are created', async () => {
         const { MockCopilotClient } = createMockSDKModule();
 
         const serviceAny = service as any;
@@ -91,8 +91,8 @@ describe('CopilotSDKService - Client Initialization', () => {
         await service.createClient('/second/path');
 
         expect(createSdkClientMock).toHaveBeenCalledTimes(2);
-        expect(createSdkClientMock).toHaveBeenCalledWith({ cwd: '/first/path' });
-        expect(createSdkClientMock).toHaveBeenCalledWith({ cwd: '/second/path' });
+        expect(createSdkClientMock).toHaveBeenCalledWith({ workingDirectory: '/first/path' });
+        expect(createSdkClientMock).toHaveBeenCalledWith({ workingDirectory: '/second/path' });
     });
 
     it('should still create client successfully even if ensureFolderTrusted throws', async () => {
@@ -109,7 +109,7 @@ describe('CopilotSDKService - Client Initialization', () => {
         await service.createClient('/some/path');
 
         expect(capturedOptions).toHaveLength(1);
-        expect(capturedOptions[0].cwd).toBe('/some/path');
+        expect(capturedOptions[0].workingDirectory).toBe('/some/path');
     });
 });
 
@@ -214,7 +214,7 @@ describe('CopilotSDKService - onSessionCreated callback', () => {
         const mockSession = {
             sessionId: 'non-streaming-early',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
         };
         const { MockCopilotClient } = createMockSDKModule(mockSession);
         const serviceAny = service as any;
@@ -268,7 +268,7 @@ describe('CopilotSDKService - onSessionCreated callback', () => {
         const mockSession = {
             sessionId: 'no-callback-session',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
         };
         const { MockCopilotClient } = createMockSDKModule(mockSession);
         const serviceAny = service as any;
@@ -430,8 +430,8 @@ describe('CopilotSDKService - Streaming (sendWithStreaming)', () => {
         // Wait for the timeout to fire — don't dispatch any events
         await expect(streamingPromise).rejects.toThrow('Request timed out after 50ms');
 
-        // Session must be force-destroyed on timeout
-        expect(session.destroy).toHaveBeenCalled();
+        // Session must be force-disconnected on timeout
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('should unsubscribe event handler after session.idle resolves', async () => {
@@ -1015,7 +1015,7 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
         expect(result.success).toBe(false);
         expect(result.error).toContain('idle-timed out');
         expect(result.error).toContain('50ms');
-        expect(sessions[0].session.destroy).toHaveBeenCalled();
+        expect(sessions[0].session.disconnect).toHaveBeenCalled();
     });
 
     it('should reset idle timer on message_delta events', async () => {
@@ -1039,8 +1039,8 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
         const result = await promise;
         expect(result.response).toContain('chunk0');
         expect(result.response).toContain('chunk2');
-        // Session should NOT have been destroyed by idle timeout
-        expect(session.destroy).not.toHaveBeenCalled();
+        // Session should NOT have been disconnected by idle timeout
+        expect(session.disconnect).not.toHaveBeenCalled();
     });
 
     it('should reset idle timer on tool execution events', async () => {
@@ -1064,7 +1064,7 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
 
         const result = await promise;
         expect(result.response).toBe('Done');
-        expect(session.destroy).not.toHaveBeenCalled();
+        expect(session.disconnect).not.toHaveBeenCalled();
     });
 
     it('should fire idle timeout independently of total timeout', async () => {
@@ -1078,7 +1078,7 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
 
         // Wait for idle timeout to fire (no activity)
         await expect(promise).rejects.toThrow('idle-timed out after 50ms');
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('should clear idle timer on successful completion', async () => {
@@ -1098,7 +1098,7 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
 
         // Wait past the idle timeout to ensure the timer was cleared and doesn't cause issues
         await new Promise(r => setTimeout(r, 150));
-        // If the idle timer wasn't cleared, it would try to destroy/reject after settle — no crash means pass
+        // If the idle timer was not cleared, it would try to disconnect/reject after settle — no crash means pass
     });
 
     it('should not activate idle timer when idleTimeoutMs is 0', async () => {
@@ -1119,7 +1119,7 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
 
         const result = await promise;
         expect(result.response).toBe('response');
-        expect(session.destroy).not.toHaveBeenCalled();
+        expect(session.disconnect).not.toHaveBeenCalled();
     });
 
     it('should reset idle timer on fallback onStreamingChunk (assistant.message without deltas)', async () => {
@@ -1147,7 +1147,7 @@ describe('CopilotSDKService - Idle Timeout (sendWithStreaming)', () => {
         const result = await promise;
         expect(result.response).toBe('Fallback message');
         expect(chunks).toContain('Fallback message');
-        expect(session.destroy).not.toHaveBeenCalled();
+        expect(session.disconnect).not.toHaveBeenCalled();
     });
 });
 
@@ -1470,7 +1470,7 @@ describe('CopilotSDKService - Non-streaming (sendAndWait)', () => {
         const mockSession = {
             sessionId: 'non-streaming-session',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'Non-streaming response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn(),
             send: vi.fn(),
         };
@@ -1509,7 +1509,7 @@ describe('CopilotSDKService - Non-streaming (sendAndWait)', () => {
         const mockSession = {
             sessionId: 'basic-session',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'Basic response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             // No on() or send() methods — streaming not supported
         };
 
@@ -1727,7 +1727,7 @@ describe('CopilotSDKService - Token Usage Tracking', () => {
         const mockSession = {
             sessionId: 'non-streaming-session',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'Basic response' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
         };
 
         const mockClient = {
@@ -2665,7 +2665,7 @@ describe('CopilotSDKService - Client Invalidation on Stream Error', () => {
         const mockSession = {
             sessionId: 'fresh-session',
             sendAndWait: vi.fn().mockResolvedValue({ data: { content: 'success!' } }),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
         };
         const mockClient2 = {
             createSession: vi.fn().mockResolvedValue(mockSession),

--- a/packages/coc-agent-sdk/test/ai/copilot-sdk-session-resume.test.ts
+++ b/packages/coc-agent-sdk/test/ai/copilot-sdk-session-resume.test.ts
@@ -218,7 +218,7 @@ describe('CopilotSDKService - Session Resume', () => {
         const streamingSession = {
             sessionId: 'stream-resumed-sess',
             sendAndWait: vi.fn(),
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             on: vi.fn().mockImplementation((handler: (event: any) => void) => {
                 streamingHandlers.push(handler);
                 return () => {};

--- a/packages/coc-agent-sdk/test/copilot-sdk-wrapper/request-runner.test.ts
+++ b/packages/coc-agent-sdk/test/copilot-sdk-wrapper/request-runner.test.ts
@@ -135,7 +135,7 @@ describe('RequestRunner.send() — non-streaming path', () => {
         expect(result.error).toContain('No response received');
     });
 
-    it('destroys the active session when the abort signal fires', async () => {
+    it('disconnects the active session when the abort signal fires', async () => {
         const controller = new AbortController();
         let rejectSend: ((error: Error) => void) | undefined;
         const mockSession = {
@@ -144,7 +144,7 @@ describe('RequestRunner.send() — non-streaming path', () => {
                 rejectSend = reject;
             })),
             abort: vi.fn().mockResolvedValue(undefined),
-            destroy: vi.fn().mockImplementation(() => {
+            disconnect: vi.fn().mockImplementation(() => {
                 rejectSend?.(new Error('destroyed'));
                 return Promise.resolve();
             }),
@@ -168,7 +168,7 @@ describe('RequestRunner.send() — non-streaming path', () => {
         expect(result.success).toBe(false);
         expect(result.error).toContain('destroyed');
         expect(mockSession.abort).toHaveBeenCalledTimes(1);
-        expect(mockSession.destroy).toHaveBeenCalled();
+        expect(mockSession.disconnect).toHaveBeenCalled();
     });
 
     it('translates WSL attachment paths before sending', async () => {
@@ -577,7 +577,7 @@ describe('RequestRunner.send() — external client (keepalive)', () => {
         expect(externalClient.stop).not.toHaveBeenCalled();
     });
 
-    it('still calls session.destroy() even when client is externally provided', async () => {
+    it('still calls session.disconnect() even when client is externally provided', async () => {
         const mockSession = createMockSession({ sendAndWaitResponse: { data: { content: 'hello' } } });
         const externalClient = {
             createSession: vi.fn().mockResolvedValue(mockSession),
@@ -592,7 +592,7 @@ describe('RequestRunner.send() — external client (keepalive)', () => {
             loadDefaultMcpConfig: false,
         });
 
-        expect(mockSession.destroy).toHaveBeenCalled();
+        expect(mockSession.disconnect).toHaveBeenCalled();
     });
 
     it('DOES call client.stop() when client is internally created', async () => {

--- a/packages/coc-agent-sdk/test/copilot-sdk-wrapper/sdk-client-factory.test.ts
+++ b/packages/coc-agent-sdk/test/copilot-sdk-wrapper/sdk-client-factory.test.ts
@@ -72,35 +72,35 @@ describe('createSdkClient', () => {
         vi.mocked(fs.existsSync).mockReturnValue(true);
     });
 
-    it('creates a client with no cwd when called without options', () => {
+    it('creates a client with no workingDirectory when called without options', () => {
         createSdkClient();
 
         expect(capturedOptions).toHaveLength(1);
-        expect(capturedOptions[0].cwd).toBeUndefined();
+        expect(capturedOptions[0].workingDirectory).toBeUndefined();
     });
 
-    it('creates a client with no cwd when cwd is undefined', () => {
-        createSdkClient({ cwd: undefined });
+    it('creates a client with no workingDirectory when workingDirectory is undefined', () => {
+        createSdkClient({ workingDirectory: undefined });
 
         expect(capturedOptions).toHaveLength(1);
-        expect(capturedOptions[0].cwd).toBeUndefined();
+        expect(capturedOptions[0].workingDirectory).toBeUndefined();
     });
 
-    it('passes cwd to the CopilotClient constructor when cwd is provided', () => {
-        createSdkClient({ cwd: '/some/project' });
+    it('passes workingDirectory to the CopilotClient constructor when provided', () => {
+        createSdkClient({ workingDirectory: '/some/project' });
 
         expect(capturedOptions).toHaveLength(1);
-        expect(capturedOptions[0].cwd).toBe('/some/project');
+        expect(capturedOptions[0].workingDirectory).toBe('/some/project');
     });
 
-    it('calls ensureFolderTrusted with cwd when cwd is provided', () => {
-        createSdkClient({ cwd: '/my/repo' });
+    it('calls ensureFolderTrusted with workingDirectory when provided', () => {
+        createSdkClient({ workingDirectory: '/my/repo' });
 
         expect(trustedFolder.ensureFolderTrusted).toHaveBeenCalledOnce();
         expect(trustedFolder.ensureFolderTrusted).toHaveBeenCalledWith('/my/repo');
     });
 
-    it('does NOT call ensureFolderTrusted when no cwd is given', () => {
+    it('does NOT call ensureFolderTrusted when no workingDirectory is given', () => {
         createSdkClient();
 
         expect(trustedFolder.ensureFolderTrusted).not.toHaveBeenCalled();
@@ -111,65 +111,64 @@ describe('createSdkClient', () => {
             throw new Error('Permission denied');
         });
 
-        const client = createSdkClient({ cwd: '/protected/path' });
+        const client = createSdkClient({ workingDirectory: '/protected/path' });
 
         expect(client).toBeDefined();
         expect(capturedOptions).toHaveLength(1);
-        expect(capturedOptions[0].cwd).toBe('/protected/path');
+        expect(capturedOptions[0].workingDirectory).toBe('/protected/path');
     });
 
     it('returns the created client instance', () => {
-        const client = createSdkClient({ cwd: '/project' });
+        const client = createSdkClient({ workingDirectory: '/project' });
 
         expect(typeof (client as any).start).toBe('function');
         expect(typeof (client as any).stop).toBe('function');
     });
 
-    it('does NOT warn when cwd exists', () => {
+    it('does NOT warn when workingDirectory exists', () => {
         vi.mocked(fs.existsSync).mockReturnValue(true);
 
-        createSdkClient({ cwd: '/existing/dir' });
+        createSdkClient({ workingDirectory: '/existing/dir' });
 
         expect(fs.existsSync).toHaveBeenCalledWith('/existing/dir');
     });
 
-    it('checks existsSync when cwd is provided', () => {
+    it('checks existsSync when workingDirectory is provided', () => {
         vi.mocked(fs.existsSync).mockReturnValue(false);
 
-        const client = createSdkClient({ cwd: '/nonexistent/dir' });
+        const client = createSdkClient({ workingDirectory: '/nonexistent/dir' });
 
         expect(client).toBeDefined();
         expect(fs.existsSync).toHaveBeenCalledWith('/nonexistent/dir');
     });
 
-    it('does NOT call existsSync when cwd is absent', () => {
+    it('does NOT call existsSync when workingDirectory is absent', () => {
         createSdkClient();
 
         expect(fs.existsSync).not.toHaveBeenCalled();
     });
 
     it('routes WSL working directories to the host filesystem for the Windows Copilot CLI', () => {
-        const cwd = String.raw`\\wsl$\Ubuntu\home\tester\repo`;
-        createSdkClient({ cwd });
+        const workingDirectory = String.raw`\\wsl$\Ubuntu\home\tester\repo`;
+        createSdkClient({ workingDirectory });
 
-        expect(workspaceExecution.resolveWorkspaceExecutionContext).toHaveBeenCalledWith(cwd);
+        expect(workspaceExecution.resolveWorkspaceExecutionContext).toHaveBeenCalledWith(workingDirectory);
         expect(workspaceExecution.translatePathForHostFilesystem).toHaveBeenCalledWith(
-            cwd,
+            workingDirectory,
             expect.objectContaining({
                 kind: 'wsl',
                 linuxWorkingDirectory: '/home/tester/repo',
             }),
         );
-        expect(capturedOptions[0].cwd).toBe(cwd);
-        expect(capturedOptions[0].cliPath).toBeUndefined();
-        expect(capturedOptions[0].cliArgs).toBeUndefined();
+        expect(capturedOptions[0].workingDirectory).toBe(workingDirectory);
+        expect(capturedOptions[0].connection).toBeUndefined();
         expect(capturedOptions[0].env).toBeUndefined();
-        expect(trustedFolder.ensureFolderTrusted).toHaveBeenCalledWith(cwd);
-        expect(fs.existsSync).toHaveBeenCalledWith(cwd);
+        expect(trustedFolder.ensureFolderTrusted).toHaveBeenCalledWith(workingDirectory);
+        expect(fs.existsSync).toHaveBeenCalledWith(workingDirectory);
     });
 
     it('translates Linux-style WSL working directories to host UNC paths', () => {
-        createSdkClient({ cwd: '/home/tester/repo' });
+        createSdkClient({ workingDirectory: '/home/tester/repo' });
 
         expect(workspaceExecution.translatePathForHostFilesystem).toHaveBeenCalledWith(
             '/home/tester/repo',
@@ -178,7 +177,7 @@ describe('createSdkClient', () => {
                 linuxWorkingDirectory: '/home/tester/repo',
             }),
         );
-        expect(capturedOptions[0].cwd).toBe(String.raw`\\wsl$\Ubuntu\home\tester\repo`);
+        expect(capturedOptions[0].workingDirectory).toBe(String.raw`\\wsl$\Ubuntu\home\tester\repo`);
         expect(trustedFolder.ensureFolderTrusted).toHaveBeenCalledWith(String.raw`\\wsl$\Ubuntu\home\tester\repo`);
         expect(fs.existsSync).toHaveBeenCalledWith(String.raw`\\wsl$\Ubuntu\home\tester\repo`);
     });

--- a/packages/coc-agent-sdk/test/copilot-sdk-wrapper/streaming-session.test.ts
+++ b/packages/coc-agent-sdk/test/copilot-sdk-wrapper/streaming-session.test.ts
@@ -33,7 +33,7 @@ function makeMockSession(sessionId = 'test-session') {
             return () => { handler = undefined; };
         }),
         send: vi.fn(() => Promise.resolve()),
-        destroy: vi.fn(() => Promise.resolve()),
+        disconnect: vi.fn(() => Promise.resolve()),
     };
 
     const emit = (event: ISessionEvent) => {
@@ -145,7 +145,7 @@ describe('StreamingSession — cancellation', () => {
 
         await expect(promise).rejects.toThrow('timed out after 1000ms');
         expect((ss as any).state).toBe(StreamingState.Cancelled);
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('idle timeout: Streaming → Cancelled when no activity arrives', async () => {
@@ -160,7 +160,7 @@ describe('StreamingSession — cancellation', () => {
 
         await expect(promise).rejects.toThrow('idle-timed out after 500ms');
         expect((ss as any).state).toBe(StreamingState.Cancelled);
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('idle timeout is suppressed while a tool call is in flight (regression: ask_user widget)', async () => {
@@ -181,7 +181,7 @@ describe('StreamingSession — cancellation', () => {
         // the agent is blocked on a human reply, not idle.
         vi.advanceTimersByTime(5000);
         expect((ss as any).state).toBe(StreamingState.Streaming);
-        expect(session.destroy).not.toHaveBeenCalled();
+        expect(session.disconnect).not.toHaveBeenCalled();
 
         // Tool completes; session then settles normally.
         emit({
@@ -213,7 +213,7 @@ describe('StreamingSession — cancellation', () => {
 
         await expect(promise).rejects.toThrow('timed out after 1000ms');
         expect((ss as any).state).toBe(StreamingState.Cancelled);
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('idle timeout fires after the tool completes if then no activity arrives', async () => {

--- a/packages/coc-agent-sdk/test/helpers/mock-sdk.ts
+++ b/packages/coc-agent-sdk/test/helpers/mock-sdk.ts
@@ -18,7 +18,7 @@ import type { CopilotSDKService } from '../../src/copilot-sdk-service';
 export interface MockSession {
     sessionId: string;
     sendAndWait: ReturnType<typeof vi.fn>;
-    destroy: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
     setModel: ReturnType<typeof vi.fn>;
 }
 
@@ -76,7 +76,7 @@ export function createMockSession(overrides?: Partial<{
             : vi.fn().mockResolvedValue(
                 overrides?.sendAndWaitResponse ?? { data: { content: 'mock response' } }
             ),
-        destroy: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
         setModel: vi.fn().mockResolvedValue(undefined),
     };
 }
@@ -93,7 +93,7 @@ export function createStreamingMockSession(sessionId?: string): StreamingMockSes
     const session: MockStreamingSession = {
         sessionId: sid,
         sendAndWait: vi.fn(),
-        destroy: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
         setModel: vi.fn().mockResolvedValue(undefined),
         on: vi.fn().mockImplementation((handler: (event: any) => void) => {
             handlers.push(handler);
@@ -130,7 +130,7 @@ export function createMockSDKModule(sessionOrFactory?: any): MockSDKModule {
             ? vi.fn().mockResolvedValue({
                 sessionId: 'test-session',
                 sendAndWait: vi.fn().mockResolvedValue('response'),
-                destroy: vi.fn().mockResolvedValue(undefined),
+                disconnect: vi.fn().mockResolvedValue(undefined),
                 setModel: vi.fn().mockResolvedValue(undefined),
             })
             : typeof sessionOrFactory === 'function'

--- a/packages/coc/package.json
+++ b/packages/coc/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.162",
     "@excalidraw/excalidraw": "^0.18.1",
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@octokit/rest": "^22.0.1",
     "@openai/codex-sdk": "^0.133.0",

--- a/packages/coc/src/server/mcp-oauth/mcp-oauth-initiator.ts
+++ b/packages/coc/src/server/mcp-oauth/mcp-oauth-initiator.ts
@@ -70,7 +70,7 @@ interface RpcShape {
 interface SessionShape {
     sessionId: string;
     on?: (event: string, handler: (event: unknown) => void) => void;
-    destroy?: () => Promise<void>;
+    disconnect?: () => Promise<void>;
 }
 
 interface ClientShape {
@@ -180,7 +180,7 @@ export async function initiateMcpOAuth(opts: InitiateMcpOAuthOptions): Promise<I
                 LogCategory.MCP,
                 `[McpOAuthInitiator] Server "${serverName}" already authenticated — no flow required`,
             );
-            await safeDestroy(session);
+            await safeDisconnect(session);
             return { requestId: '', alreadyAuthenticated: true };
         }
 
@@ -205,7 +205,7 @@ export async function initiateMcpOAuth(opts: InitiateMcpOAuthOptions): Promise<I
         return { requestId: entry.id, authorizationUrl, alreadyAuthenticated: false };
     } catch (err) {
         // Best-effort cleanup on failure paths
-        if (session) await safeDestroy(session);
+        if (session) await safeDisconnect(session);
         throw err;
     }
 }
@@ -235,7 +235,7 @@ function scheduleSessionRelease(
                 );
                 manager.resolve(requestId, 'completed');
                 clearInterval(interval);
-                void safeDestroy(session);
+                void safeDisconnect(session);
                 return;
             }
         }
@@ -252,7 +252,7 @@ function scheduleSessionRelease(
                     resolved ? entry?.status : missing ? 'manager-evicted' : 'timeout'
                 }`,
             );
-            void safeDestroy(session);
+            void safeDisconnect(session);
         }
     }, SESSION_HOLD_POLL_INTERVAL_MS);
 
@@ -260,9 +260,9 @@ function scheduleSessionRelease(
     if (typeof interval.unref === 'function') interval.unref();
 }
 
-async function safeDestroy(session: SessionShape): Promise<void> {
+async function safeDisconnect(session: SessionShape): Promise<void> {
     try {
-        await session.destroy?.();
+        await session.disconnect?.();
     } catch {
         // Non-fatal — best-effort cleanup.
     }

--- a/packages/coc/test/server/mcp-oauth/mcp-oauth-initiator.test.ts
+++ b/packages/coc/test/server/mcp-oauth/mcp-oauth-initiator.test.ts
@@ -32,7 +32,7 @@ interface FakeSession {
         };
     };
     on: ReturnType<typeof vi.fn>;
-    destroy: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
 }
 
 function makeFakeAiService(opts: {
@@ -56,7 +56,7 @@ function makeFakeAiService(opts: {
                   },
               },
         on: vi.fn(),
-        destroy: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
     };
 
     const client = {
@@ -121,7 +121,7 @@ describe('initiateMcpOAuth', () => {
             aiService: service,
             manager,
         })).rejects.toThrow(/mcp\.oauth\.login RPC/);
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('reports alreadyAuthenticated when login returns no URL', async () => {
@@ -135,7 +135,7 @@ describe('initiateMcpOAuth', () => {
         expect(result.alreadyAuthenticated).toBe(true);
         expect(result.requestId).toBe('');
         // Session is released eagerly when no flow is needed
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
         expect(manager.listPending()).toHaveLength(0);
     });
 
@@ -169,7 +169,7 @@ describe('initiateMcpOAuth', () => {
             aiService: service,
             manager,
         })).rejects.toThrow(/OAuth login request failed: network down/);
-        expect(session.destroy).toHaveBeenCalled();
+        expect(session.disconnect).toHaveBeenCalled();
     });
 
     it('passes the server config through to createSession with tools defaulted', async () => {
@@ -226,9 +226,9 @@ describe('initiateMcpOAuth', () => {
             // Advance past the poll interval so the session-release watcher fires.
             await vi.advanceTimersByTimeAsync(2_000);
 
-            // Entry should now be resolved and the session destroyed.
+            // Entry should now be resolved and the session disconnected.
             expect(manager.getPending(result.requestId)?.status).toBe('completed');
-            expect(session.destroy).toHaveBeenCalled();
+            expect(session.disconnect).toHaveBeenCalled();
 
             vi.useRealTimers();
         });
@@ -248,7 +248,7 @@ describe('initiateMcpOAuth', () => {
             await vi.advanceTimersByTimeAsync(4_000);
 
             expect(manager.getPending(result.requestId)?.status).toBe('pending');
-            expect(session.destroy).not.toHaveBeenCalled();
+            expect(session.disconnect).not.toHaveBeenCalled();
 
             vi.useRealTimers();
         });

--- a/packages/deep-wiki/package.json
+++ b/packages/deep-wiki/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.0",
     "@octokit/rest": "^22.0.1",
     "@plusplusoneplusplus/coc-agent-sdk": "*",
     "@plusplusoneplusplus/coc-workflow": "^0.1.0",

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@plusplusoneplusplus/coc-workflow": "*",
     "@plusplusoneplusplus/coc-agent-sdk": "*",
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.0",
     "@octokit/rest": "^22.0.1",
     "azure-devops-node-api": "^14.1.0",
     "better-sqlite3": "^11.9.1",

--- a/packages/forge/test/copilot-sdk-wrapper/session-manager.test.ts
+++ b/packages/forge/test/copilot-sdk-wrapper/session-manager.test.ts
@@ -13,11 +13,11 @@ setLogger(nullLogger);
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-function makeSession(id: string, destroyError?: Error): IAbortableSession {
+function makeSession(id: string, disconnectError?: Error): IAbortableSession {
     return {
         sessionId: id,
-        destroy: destroyError
-            ? vi.fn().mockRejectedValue(destroyError)
+        disconnect: disconnectError
+            ? vi.fn().mockRejectedValue(disconnectError)
             : vi.fn().mockResolvedValue(undefined),
     };
 }
@@ -83,18 +83,18 @@ describe('SessionManager', () => {
         expect(result).toBe(false);
     });
 
-    it('abort destroys the session and untracks it', async () => {
+    it('abort disconnects the session and untracks it', async () => {
         const s = makeSession('s2');
         manager.track(s);
         const result = await manager.abort('s2');
         expect(result).toBe(true);
-        expect(s.destroy).toHaveBeenCalledOnce();
+        expect(s.disconnect).toHaveBeenCalledOnce();
         expect(manager.has('s2')).toBe(false);
         expect(manager.count()).toBe(0);
     });
 
-    it('abort returns false and untracks when destroy throws', async () => {
-        const s = makeSession('err', new Error('destroy failed'));
+    it('abort returns false and untracks when disconnect throws', async () => {
+        const s = makeSession('err', new Error('disconnect failed'));
         manager.track(s);
         const result = await manager.abort('err');
         expect(result).toBe(false);
@@ -111,14 +111,14 @@ describe('SessionManager', () => {
 
     // ── abortAll ──────────────────────────────────────────────────────────────
 
-    it('abortAll destroys all sessions and clears the map', async () => {
+    it('abortAll disconnects all sessions and clears the map', async () => {
         const sessions = ['a', 'b', 'c'].map(id => makeSession(id));
         sessions.forEach(s => manager.track(s));
 
         await manager.abortAll();
 
         for (const s of sessions) {
-            expect(s.destroy).toHaveBeenCalledOnce();
+            expect(s.disconnect).toHaveBeenCalledOnce();
         }
         expect(manager.count()).toBe(0);
     });
@@ -128,28 +128,28 @@ describe('SessionManager', () => {
         expect(manager.count()).toBe(0);
     });
 
-    it('abortAll completes even when some sessions throw on destroy', async () => {
+    it('abortAll completes even when some sessions throw on disconnect', async () => {
         manager.track(makeSession('ok'));
         manager.track(makeSession('bad', new Error('boom')));
         await expect(manager.abortAll()).resolves.not.toThrow();
         expect(manager.count()).toBe(0);
     });
 
-    it('abortAll calls destroy on every session even when one throws', async () => {
+    it('abortAll calls disconnect on every session even when one throws', async () => {
         const good = makeSession('good');
-        const bad = makeSession('bad', new Error('destroy failed'));
+        const bad = makeSession('bad', new Error('disconnect failed'));
         manager.track(bad);
         manager.track(good);
         await manager.abortAll();
-        expect(good.destroy).toHaveBeenCalledOnce();
-        expect(bad.destroy).toHaveBeenCalledOnce();
+        expect(good.disconnect).toHaveBeenCalledOnce();
+        expect(bad.disconnect).toHaveBeenCalledOnce();
     });
 
-    it('abortAll initiates all destroys concurrently via allSettled', async () => {
+    it('abortAll initiates all disconnects concurrently via allSettled', async () => {
         const order: string[] = [];
         const slow = {
             sessionId: 'slow',
-            destroy: vi.fn(async () => {
+            disconnect: vi.fn(async () => {
                 order.push('slow-start');
                 await new Promise(r => setTimeout(r, 20));
                 order.push('slow-end');
@@ -157,7 +157,7 @@ describe('SessionManager', () => {
         };
         const fast = {
             sessionId: 'fast',
-            destroy: vi.fn(async () => {
+            disconnect: vi.fn(async () => {
                 order.push('fast-start');
                 order.push('fast-end');
             }),
@@ -194,7 +194,7 @@ describe('SessionManager', () => {
         manager.track(s);
         expect(await manager.abort('once')).toBe(true);
         expect(await manager.abort('once')).toBe(false);
-        expect(s.destroy).toHaveBeenCalledOnce();
+        expect(s.disconnect).toHaveBeenCalledOnce();
     });
 
     // ── untrack after abort ──────────────────────────────────────────────────
@@ -232,45 +232,45 @@ describe('SessionManager', () => {
         const abortFn = vi.fn().mockResolvedValue(undefined);
         const s = {
             sessionId: 'soft1',
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             abort: abortFn,
         };
         manager.track(s);
         const result = await manager.softAbort('soft1');
         expect(result).toBe(true);
         expect(abortFn).toHaveBeenCalledOnce();
-        // Does NOT call destroy — request-runner finally block handles that
-        expect(s.destroy).not.toHaveBeenCalled();
+        // Does NOT call disconnect — request-runner finally block handles that
+        expect(s.disconnect).not.toHaveBeenCalled();
         // Does NOT untrack — request-runner finally block handles that
         expect(manager.has('soft1')).toBe(true);
     });
 
-    it('softAbort falls back to destroy when abort() is not available', async () => {
+    it('softAbort falls back to disconnect when abort() is not available', async () => {
         const s = makeSession('no-abort');
         manager.track(s);
         const result = await manager.softAbort('no-abort');
         expect(result).toBe(true);
-        expect(s.destroy).toHaveBeenCalledOnce();
+        expect(s.disconnect).toHaveBeenCalledOnce();
         expect(manager.has('no-abort')).toBe(false);
     });
 
-    it('softAbort falls back to destroy when abort() throws', async () => {
+    it('softAbort falls back to disconnect when abort() throws', async () => {
         const s = {
             sessionId: 'bad-abort',
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             abort: vi.fn().mockRejectedValue(new Error('abort failed')),
         };
         manager.track(s);
         const result = await manager.softAbort('bad-abort');
         expect(result).toBe(false);
-        expect(s.destroy).toHaveBeenCalledOnce();
+        expect(s.disconnect).toHaveBeenCalledOnce();
         expect(manager.has('bad-abort')).toBe(false);
     });
 
-    it('softAbort handles both abort() and destroy() failing', async () => {
+    it('softAbort handles both abort() and disconnect() failing', async () => {
         const s = {
             sessionId: 'double-fail',
-            destroy: vi.fn().mockRejectedValue(new Error('destroy failed')),
+            disconnect: vi.fn().mockRejectedValue(new Error('disconnect failed')),
             abort: vi.fn().mockRejectedValue(new Error('abort failed')),
         };
         manager.track(s);
@@ -279,22 +279,22 @@ describe('SessionManager', () => {
         expect(manager.has('double-fail')).toBe(false);
     });
 
-    // ── stale session (destroy already resolved) ─────────────────────────────
+    // ── stale session (disconnect already resolved) ─────────────────────────────
 
-    it('abortAll handles a session whose destroy was already resolved gracefully', async () => {
-        // Simulate a "stale" session whose destroy resolves immediately
+    it('abortAll handles a session whose disconnect was already resolved gracefully', async () => {
+        // Simulate a "stale" session whose disconnect resolves immediately
         const stale = makeSession('stale');
         const fresh = makeSession('fresh');
         manager.track(stale);
         manager.track(fresh);
 
-        // Manually call destroy to simulate staleness (session already done)
-        await stale.destroy();
+        // Manually call disconnect to simulate staleness (session already done)
+        await stale.disconnect();
 
         await expect(manager.abortAll()).resolves.not.toThrow();
-        // destroy called twice on stale (once manually, once by abortAll)
-        expect(stale.destroy).toHaveBeenCalledTimes(2);
-        expect(fresh.destroy).toHaveBeenCalledOnce();
+        // disconnect called twice on stale (once manually, once by abortAll)
+        expect(stale.disconnect).toHaveBeenCalledTimes(2);
+        expect(fresh.disconnect).toHaveBeenCalledOnce();
         expect(manager.count()).toBe(0);
     });
 
@@ -313,7 +313,7 @@ describe('SessionManager', () => {
     it('getSession returns the session when it has a send() method', () => {
         const s = {
             sessionId: 'streamable',
-            destroy: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
             send: vi.fn().mockResolvedValue(undefined),
         };
         manager.track(s);

--- a/packages/vscode-extension/src/test/suite/permission-handler.test.ts
+++ b/packages/vscode-extension/src/test/suite/permission-handler.test.ts
@@ -10,14 +10,24 @@ import {
     PermissionHandler
 } from '@plusplusoneplusplus/forge';
 
+/**
+ * Build a minimal synthetic PermissionRequest. The SDK's PermissionRequest is
+ * a union of kind-specific shapes with required tool-specific payload fields;
+ * the handlers under test only read `kind` (and optionally `toolCallId`), so
+ * tests cast minimal objects instead of fabricating full SDK payloads.
+ */
+function makeRequest(kind: PermissionRequest['kind'], extra?: { toolCallId?: string }): PermissionRequest {
+    return { kind, ...extra } as PermissionRequest;
+}
+
 suite('Permission Handler Tests', () => {
     test('approveAllPermissions should approve all request types', async () => {
         const requests: PermissionRequest[] = [
-            { kind: 'read' },
-            { kind: 'write' },
-            { kind: 'shell' },
-            { kind: 'mcp' },
-            { kind: 'url' }
+            makeRequest('read'),
+            makeRequest('write'),
+            makeRequest('shell'),
+            makeRequest('mcp'),
+            makeRequest('url')
         ];
 
         for (const request of requests) {
@@ -28,11 +38,11 @@ suite('Permission Handler Tests', () => {
 
     test('denyAllPermissions should deny all request types', async () => {
         const requests: PermissionRequest[] = [
-            { kind: 'read' },
-            { kind: 'write' },
-            { kind: 'shell' },
-            { kind: 'mcp' },
-            { kind: 'url' }
+            makeRequest('read'),
+            makeRequest('write'),
+            makeRequest('shell'),
+            makeRequest('mcp'),
+            makeRequest('url')
         ];
 
         for (const request of requests) {
@@ -50,8 +60,8 @@ suite('Permission Handler Tests', () => {
             return { kind: 'reject' };
         };
 
-        const readRequest: PermissionRequest = { kind: 'read' };
-        const writeRequest: PermissionRequest = { kind: 'write' };
+        const readRequest: PermissionRequest = makeRequest('read');
+        const writeRequest: PermissionRequest = makeRequest('write');
 
         const readResult = await Promise.resolve(selectiveHandler(readRequest, { sessionId: 'test' }));
         const writeResult = await Promise.resolve(selectiveHandler(writeRequest, { sessionId: 'test' }));
@@ -67,7 +77,7 @@ suite('Permission Handler Tests', () => {
             return { kind: 'approve-once' };
         };
 
-        const request: PermissionRequest = { kind: 'shell' };
+        const request: PermissionRequest = makeRequest('shell');
         const result = await asyncHandler(request, { sessionId: 'test' });
 
         assert.strictEqual(result.kind, 'approve-once');
@@ -79,15 +89,12 @@ suite('Permission Handler Tests', () => {
             return { kind: 'approve-once' };
         };
 
-        const request: PermissionRequest = { kind: 'read' };
+        const request: PermissionRequest = makeRequest('read');
         handler(request, { sessionId: 'my-session-123' });
     });
 
     test('Permission request can include toolCallId metadata', () => {
-        const request: PermissionRequest = {
-            kind: 'write',
-            toolCallId: 'tool-123',
-        };
+        const request: PermissionRequest = makeRequest('write', { toolCallId: 'tool-123' });
 
         // Handler can access all fields
         const handler: PermissionHandler = (req) => {


### PR DESCRIPTION
## What

Bumps `@github/copilot-sdk` from `^0.3.0` to `^1.0.0` in all 5 package.json files (root, coc-agent-sdk, forge, coc, deep-wiki) and adapts the wrapper layer to the 1.0.0 breaking changes.

## Breaking changes adapted

- **`CopilotClientOptions.cwd` removed** → pass `workingDirectory` instead (`sdk-client-factory.ts` incl. the WSL path-translation branch, `CopilotSDKService.createClient`).
- **`CopilotSession.destroy()` removed** — it was a deprecated alias of `disconnect()` in 0.3.0 with identical semantics (session state on disk stays resumable). Renamed in `request-runner.ts`, `session-manager.ts`, `streaming-session.ts`, and the `IAbortableSession`/`IStreamableSession` structural interfaces.
- **Native tool contract drift** (caught by the compile-time guard in `types.ts`): `Tool.handler` is now optional (declaration-only tools), `ToolBinaryResult.type` narrowed to `'image' | 'resource'`, `toolTelemetry` uses the SDK's `ToolTelemetry` shape. `CocToolRuntime.callTool` now returns an error result for a handler-less tool instead of throwing (new regression test).

## Reviewer notes

- One bug the compiler could **not** catch: `coc/src/server/mcp-oauth/mcp-oauth-initiator.ts` typed the session loosely as `destroy?: () => Promise<void>` and called `session.destroy?.()` — under 1.0.0 that silently becomes a no-op and leaks the OAuth holder session for up to 10 minutes. Switched to `disconnect?.()`.
- Verified unchanged in 1.0.0 (no action needed): all session event names, `SessionConfig` fields, permission decision kinds, `sessions.fork` / `account.getQuota` / `mcp.oauth.login` RPCs, `ModelInfo`, `MessageOptions`, `ReasoningEffort`.
- Test changes are mechanical `destroy` → `disconnect` mock renames plus `cwd` → `workingDirectory` assertion updates (obsolete `cliPath`/`cliArgs` assertions replaced with the 1.0.0 `connection` equivalent).

## Verification

- coc-agent-sdk: build + **581 tests** pass (baseline 580; +1 new regression test)
- forge: build + 118 copilot-sdk-wrapper tests pass
- deep-wiki: build + 43 bundle tests pass
- coc: full build + typecheck + 93 mcp-oauth tests pass
- Root aggregate: `npm run compile` (all packages + extension webpack) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)