### PR TITLE
Fix root npm install peer dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
       options: --ipc=host
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/glob": "^8.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.1",
-        "@types/node": "16.x",
+        "@types/node": "^20.0.0",
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -4976,8 +4976,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "license": "MIT"
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -15645,7 +15650,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -17620,14 +17624,6 @@
         "node": ">=12"
       }
     },
-    "packages/coc-agent-sdk/node_modules/@types/node": {
-      "version": "20.19.41",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "packages/coc-agent-sdk/node_modules/assertion-error": {
       "version": "1.1.0",
       "dev": true,
@@ -18251,14 +18247,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/coc-client/node_modules/@types/node": {
-      "version": "20.19.41",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "packages/coc-client/node_modules/assertion-error": {
@@ -18892,14 +18880,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/coc-memory/node_modules/@types/node": {
-      "version": "20.19.41",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "packages/coc-memory/node_modules/@vitest/coverage-v8": {
@@ -19574,16 +19554,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/coc-workflow/node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "packages/coc-workflow/node_modules/@vitest/coverage-v8": {
@@ -20438,14 +20408,6 @@
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "packages/coc/node_modules/@types/node": {
-      "version": "20.19.33",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "packages/coc/node_modules/@vitest/coverage-v8": {
       "version": "1.6.1",
       "dev": true,
@@ -21139,14 +21101,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/coccontainer/node_modules/@types/node": {
-      "version": "20.19.41",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
     },
     "packages/coccontainer/node_modules/@vitest/coverage-v8": {
       "version": "4.1.6",
@@ -21931,14 +21885,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/deep-wiki/node_modules/@types/node": {
-      "version": "20.19.32",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "packages/deep-wiki/node_modules/@vitest/coverage-v8": {
@@ -22736,14 +22682,6 @@
         "node": ">=12"
       }
     },
-    "packages/forge/node_modules/@types/node": {
-      "version": "20.19.37",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "packages/forge/node_modules/@vitest/coverage-v8": {
       "version": "1.6.1",
       "dev": true,
@@ -23037,14 +22975,6 @@
       },
       "engines": {
         "node": ">=24"
-      }
-    },
-    "packages/teams-bot/node_modules/@types/node": {
-      "version": "20.19.41",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "packages/teams-bot/node_modules/@vitest/coverage-v8": {
@@ -23381,14 +23311,6 @@
       },
       "engines": {
         "node": ">=24"
-      }
-    },
-    "packages/whatsapp-bot/node_modules/@types/node": {
-      "version": "20.19.41",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "packages/whatsapp-bot/node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -3815,7 +3815,7 @@
     "@types/glob": "^8.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.1",
-    "@types/node": "16.x",
+    "@types/node": "^20.0.0",
     "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",


### PR DESCRIPTION
Align the root @types/node dependency with Vitest 4 peer requirements so the CoC serve loop can complete its npm install step.