### PR TITLE
feat(coc): label remote scope by provider (ADO/GitHub) and drop Clone label

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -30,6 +30,7 @@ import { computeVisibleSubTabs, type SubTabDef } from '../repo-detail/repoSubTab
 import { groupReposByRemote, truncatePath } from '../../repos/repoGrouping';
 import {
     partitionShellTabs, computeCloneStatusMap, cloneStatusColor, summarizeRemote, computeVisibleTabKeys,
+    remoteProviderLabel,
 } from './shellModel';
 import { useShellNavigation } from './useShellNavigation';
 import type { RepoData } from '../../repos/repoGrouping';
@@ -89,6 +90,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
     );
     const remoteColor = (clones[0]?.workspace.color as string) || '#848484';
     const remoteLabel = group ? summarizeRemote(group, cloneStatus, {}).name : ws.name;
+    const providerLabel = remoteProviderLabel(group?.normalizedUrl);
     const branch = repo.gitInfo?.branch || null;
 
     const [cloneOpen, setCloneOpen] = useState(false);
@@ -220,14 +222,13 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
             </div>
 
             {/* ── Remote scope ── */}
-            {remoteTabs.length > 0 && <span className={scopeLabelClass} data-testid="scope-label-remote">Remote</span>}
+            {remoteTabs.length > 0 && <span className={scopeLabelClass} data-testid="scope-label-remote">{providerLabel}</span>}
             {remoteTabs.map(t => renderTab(t, 'remote-scope-tab'))}
 
             {/* divider */}
             <span className="w-px h-[22px] bg-[#d8dee4] dark:bg-[#3c3c3c] mx-2 flex-shrink-0" aria-hidden />
 
             {/* ── Clone scope ── */}
-            <span className={scopeLabelClass} data-testid="scope-label-clone">Clone</span>
             <div className="relative flex-shrink-0" ref={cloneRef}>
                 <button
                     data-testid="clone-switch"

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/shellModel.ts
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/shellModel.ts
@@ -153,3 +153,19 @@ export function summarizeRemote(
     const name = label.includes('/') ? label.split('/').slice(-1)[0] : label;
     return { status, unseen, cloneCount: group.repos.length, color, name };
 }
+
+/**
+ * Derive the hosting-provider label ("ADO" or "GitHub") from a normalized
+ * remote URL (`host/user/repo`). Falls back to "Remote" for unknown hosts.
+ */
+export function remoteProviderLabel(normalizedUrl: string | null | undefined): string {
+    if (!normalizedUrl) return 'Remote';
+    const host = normalizedUrl.split('/')[0]?.toLowerCase() ?? '';
+    if (host === 'dev.azure.com' || host.endsWith('.visualstudio.com') || host.includes('azure.com')) {
+        return 'ADO';
+    }
+    if (host === 'github.com' || host.endsWith('.github.com') || host.includes('github')) {
+        return 'GitHub';
+    }
+    return 'Remote';
+}

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -65,6 +65,24 @@ describe('RemoteSubBar', () => {
         expect(remoteTabs).toEqual(['work-items', 'pull-requests']);
     });
 
+    it('labels the remote scope by provider (GitHub) and drops the Clone scope label', () => {
+        renderBar();
+        const label = screen.getByTestId('scope-label-remote');
+        expect(label.textContent).toBe('GitHub');
+        expect(screen.queryByTestId('scope-label-clone')).toBeNull();
+    });
+
+    it('labels the remote scope ADO for Azure DevOps remotes', () => {
+        const ado = 'https://dev.azure.com/org/project/_git/repo';
+        const adoRepo = (id: string, name: string) => ({
+            workspace: { id, name, color: '#0078d4', remoteUrl: ado, rootPath: `/r/${id}` },
+            gitInfo: { isGitRepo: true, branch: 'main', dirty: false, remoteUrl: ado },
+        });
+        const repos = [adoRepo('a', 'repo'), adoRepo('b', 'repo-2')];
+        render(<RemoteSubBar repo={repos[0] as any} repos={repos as any} />);
+        expect(screen.getByTestId('scope-label-remote').textContent).toBe('ADO');
+    });
+
     it('shows every non-remote tab in the clone scope, inline, when width is unconstrained', () => {
         renderBar();
         const cloneTabs = screen.getAllByTestId('clone-scope-tab').map(el => el.getAttribute('data-subtab'));

--- a/packages/coc/test/spa/react/remote-shell/shellModel.test.ts
+++ b/packages/coc/test/spa/react/remote-shell/shellModel.test.ts
@@ -8,6 +8,7 @@ import {
     computeCloneStatusMap,
     cloneStatusColor,
     summarizeRemote,
+    remoteProviderLabel,
     REMOTE_SCOPE_KEYS,
 } from '../../../../src/server/spa/client/react/features/remote-shell/shellModel';
 import type { SubTabDef } from '../../../../src/server/spa/client/react/features/repo-detail/repoSubTabs';
@@ -129,5 +130,24 @@ describe('summarizeRemote', () => {
     it('uses the whole label as the name when there is no owner/ prefix', () => {
         const g: RepoGroup = { normalizedUrl: null, label: 'my-repo', repos: [repo('a')], expanded: true };
         expect(summarizeRemote(g, {}, {}).name).toBe('my-repo');
+    });
+});
+
+describe('remoteProviderLabel', () => {
+    it('returns ADO for Azure DevOps remotes', () => {
+        expect(remoteProviderLabel('dev.azure.com/org/project/repo')).toBe('ADO');
+        expect(remoteProviderLabel('acme.visualstudio.com/project/repo')).toBe('ADO');
+    });
+
+    it('returns GitHub for GitHub remotes', () => {
+        expect(remoteProviderLabel('github.com/acme/shortcuts')).toBe('GitHub');
+        expect(remoteProviderLabel('ghe.github.com/acme/repo')).toBe('GitHub');
+    });
+
+    it('falls back to Remote for unknown or empty hosts', () => {
+        expect(remoteProviderLabel('gitlab.com/acme/repo')).toBe('Remote');
+        expect(remoteProviderLabel(null)).toBe('Remote');
+        expect(remoteProviderLabel(undefined)).toBe('Remote');
+        expect(remoteProviderLabel('')).toBe('Remote');
     });
 });


### PR DESCRIPTION
Replace the static 'Remote' scope label in RemoteSubBar with a provider
label derived from the remote URL (ADO for Azure DevOps, GitHub for
GitHub, Remote otherwise), and remove the redundant 'Clone' scope label.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
