### PR TITLE
feat(coc): SSH/devtunnel remote clones in the CLONE dropdown with remote-routed tabs

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -627,6 +627,26 @@ unreachable servers contribute their last-known list from a two-layer
 OFF, `aggregateRemoteWorkspaces()` returns empty and performs no remote fetch, so
 the classic flow is unchanged.
 
+**Per-clone request routing**: a remote clone's REST + WS can be routed to its
+server's `baseUrl` via opt-in primitives — there is NO global "active baseUrl";
+the default `getSpaCocClient()` singleton and the repos-list/git-info aggregation
+stay on the page origin. `getCocClientFor(baseUrl?)` (`api/cocClient.ts`) returns
+the default singleton when `baseUrl` is omitted, else a per-`baseUrl`-cached
+`CocClient` whose REST (`/api` base) and `events` WebSocket target that origin.
+`resolveCloneBaseUrl(ref, repos)` (`repos/cloneRouting.ts`) maps a workspace
+object or id to its remote `baseUrl` (or `undefined` when local) using the AC-01
+remote markers; the hooks `useResolveCloneBaseUrl()`, `useCocClient(ref?)`, and
+`useCloneWsUrl(ref?)` bind it to the live `ReposContext` repo list. WS URL
+construction goes through `cloneWsUrl(path, baseUrl?)` (`api/wsUrl.ts`): with a
+`baseUrl` it derives `ws(s)://{host:port}{path}` (http→ws, https→wss) keeping the
+path+query verbatim; without one it reproduces the legacy `window.location`
+behavior. The central WS call sites (the `/ws` comment subscriptions in
+`useTaskComments` + the `git/hooks/use*Comments` family, and the `/ws/terminal`
+socket in `useTerminalWebSocket`) route through `cloneWsUrl` so they are
+baseUrl-capable; wiring a clone's baseUrl into each tab is deferred to AC-07. The
+shared `/ws` process-event stream (`useWebSocket` → `getSpaCocClient().events`)
+is already baseUrl-aware through the SDK's `buildWebSocketUrl`.
+
 The sub-tab taxonomy and feature-flag/git/layout gating live in
 `features/repo-detail/repoSubTabs.ts` (`SUB_TABS`, `VISIBLE_SUB_TABS`,
 `TAB_GROUP_INDEX`, `computeVisibleSubTabs`), shared by both `RepoDetail` and the

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -622,7 +622,15 @@ model built on `features/remote-shell/`:
   `connecting`/`idle` (not yet online) → connecting (blue `#3b82f6`, distinct from
   queued orange), else the remote `queue` state (mirroring local running/queued/
   paused/idle). The computed status is exposed on each row as
-  `data-clone-status`. Clone tabs use **responsive overflow**: a hidden
+  `data-clone-status`. A remote clone whose status resolves to `offline`
+  (server offline/failed) renders the row greyed (`opacity-50 grayscale`),
+  non-interactive (`disabled` + `aria-disabled`, `data-offline="true"`, click
+  guarded so `selectClone` is a no-op — its live tabs never open while offline),
+  and adds an `offline` badge (`clone-offline-badge`) next to the server-label
+  badge; it flips back to interactive automatically when the marker reports the
+  server online again (next `aggregateRemoteWorkspaces` run). Local clones and
+  online/connecting remote clones are never greyed. Clone tabs use **responsive
+  overflow**: a hidden
   measurement mirror plus a `ResizeObserver` feed `computeVisibleTabKeys`, which
   shows every tab that fits and collapses the tail into a `…` menu (always keeping
   the active tab visible).

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -594,20 +594,31 @@ When on, the desktop top nav switches from per-clone repo tabs to a remote-first
 model built on `features/remote-shell/`:
 - **Row 1 `RemoteTopBar`** replaces `RepoTabStrip` inside `TopBar`. It renders one
   tab per remote (origin) via `groupReposByRemote`, with a color dot, clone-count
-  chip, aggregate running pulse, and summed unseen badge. Selecting a remote picks
-  its last-used clone (else the first). Aggregation comes from `summarizeRemote` /
-  `computeCloneStatusMap` in `shellModel.ts`. A trailing `+` button
-  (`remote-add-btn`) opens an add menu — Add workspace folder (`AddFolderDialog`),
-  Add specific repository (`AddRepoDialog`), Clone repository (`CloneRepoDialog`) —
-  the single top-level add action (not duplicated per-origin).
+  chip, aggregate running pulse, and summed unseen badge. Aggregated remote
+  checkouts fold into the matching local origin's tab (by normalized git URL); a
+  remote-only repo (no local counterpart) gets its own tab. Selecting a remote
+  picks its last-used clone (else the first) — and because each group's clones are
+  sorted **local-first** by `groupReposByRemote`, the first clone is a local
+  checkout when one exists (a remote-only group selects its sole remote clone).
+  Aggregation comes from `summarizeRemote` / `computeCloneStatusMap` in
+  `shellModel.ts`. A trailing `+` button (`remote-add-btn`) opens an add menu — Add
+  workspace folder (`AddFolderDialog`), Add specific repository (`AddRepoDialog`),
+  Clone repository (`CloneRepoDialog`) — the single top-level add action (not
+  duplicated per-origin).
 - **Row 2 `RemoteSubBar`** renders above a `chromeless` `RepoDetail` in `ReposView`
   and replaces RepoDetail's own header. `partitionShellTabs` splits tabs into
   remote-scoped (Work Items, Pull Requests — always shown left) and clone-scoped
   (everything else). A clone-switcher popover (lists the remote's clones only) sits
   between them, then the clone tabs, then compact Ask/Queue targeting the active
-  clone. Clone tabs use **responsive overflow**: a hidden measurement mirror plus a
-  `ResizeObserver` feed `computeVisibleTabKeys`, which shows every tab that fits and
-  collapses the tail into a `…` menu (always keeping the active tab visible).
+  clone. The popover lists local and folded remote clones together; each remote
+  clone row is badged (`clone-remote-badge`) with its `remote.serverLabel` so it's
+  visually distinct, and the PRIMARY marker is anchored on the first **local**
+  clone (a remote clone never displaces it; a remote-only group marks its first
+  remote clone primary). `isRemoteRepo(repo)` (`repos/repoGrouping.ts`) is the
+  pure guard that distinguishes folded remote rows. Clone tabs use **responsive
+  overflow**: a hidden measurement mirror plus a `ResizeObserver` feed
+  `computeVisibleTabKeys`, which shows every tab that fits and collapses the tail
+  into a `…` menu (always keeping the active tab visible).
 
 **Remote workspace aggregation** (gated by `features.remoteShell`): when the flag
 is ON, `ReposContext.fetchRepos` also calls `aggregateRemoteWorkspaces()`

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -615,26 +615,40 @@ model built on `features/remote-shell/`:
   visually distinct, and the PRIMARY marker is anchored on the first **local**
   clone (a remote clone never displaces it; a remote-only group marks its first
   remote clone primary). `isRemoteRepo(repo)` (`repos/repoGrouping.ts`) is the
-  pure guard that distinguishes folded remote rows. Clone tabs use **responsive
-  overflow**: a hidden measurement mirror plus a `ResizeObserver` feed
-  `computeVisibleTabKeys`, which shows every tab that fits and collapses the tail
-  into a `…` menu (always keeping the active tab visible).
+  pure guard that distinguishes folded remote rows. Each clone row's **status
+  dot** comes from `cloneStatusColor(computeCloneStatusMap(...)[id])`: local
+  clones stay queue-derived; remote clones blend connection-first via
+  `blendRemoteCloneStatus` — `offline`/`failed` → offline (dim grey `#8c959f`),
+  `connecting`/`idle` (not yet online) → connecting (blue `#3b82f6`, distinct from
+  queued orange), else the remote `queue` state (mirroring local running/queued/
+  paused/idle). The computed status is exposed on each row as
+  `data-clone-status`. Clone tabs use **responsive overflow**: a hidden
+  measurement mirror plus a `ResizeObserver` feed `computeVisibleTabKeys`, which
+  shows every tab that fits and collapses the tail into a `…` menu (always keeping
+  the active tab visible).
 
 **Remote workspace aggregation** (gated by `features.remoteShell`): when the flag
 is ON, `ReposContext.fetchRepos` also calls `aggregateRemoteWorkspaces()`
 (`repos/remoteWorkspaceAggregation.ts`) in parallel with the local
 `listWorkspaces()` + git-info batch. For each registry server (`/api/servers`)
-that is `online`, it fetches `/api/workspaces` + the git-info batch DIRECTLY at
-the server's `effectiveUrl` via a self-contained `CocClient` (it does NOT reuse
-`getSpaCocClient` routing). Each remote workspace is tagged with a `remote`
-marker `{ baseUrl, serverId, serverLabel, offline }` plus a top-level `baseUrl`
-(the routing key — no composite IDs, no serverId namespace); local workspaces
-carry neither, so `isRemoteWorkspace()` distinguishes them. Remote rows are
-merged into the same `RepoData[]` as local ones (git-info pre-resolved from the
-per-server batch) and are skipped by the local Phase-2 git-info update. Offline /
-unreachable servers contribute their last-known list from a two-layer
-(in-memory + `localStorage['coc-remote-workspace-cache']`) per-server cache
-(`repos/remoteWorkspaceCache.ts`), each entry flagged `offline`. When the flag is
+that is `online`, it fetches `/api/workspaces` + the git-info batch + the queue
+(`queue.repos()`) DIRECTLY at the server's `effectiveUrl` via a self-contained
+`CocClient` (it does NOT reuse `getSpaCocClient` routing). Each remote workspace
+is tagged with a `remote` marker `{ baseUrl, serverId, serverLabel, offline,
+connection, queue }` plus a top-level `baseUrl` (the routing key — no composite
+IDs, no serverId namespace); local workspaces carry neither, so
+`isRemoteWorkspace()` distinguishes them. `connection` mirrors the registry's
+runtime status (`online`/`connecting`/`offline`/`failed`/`idle`) so the status
+dot can tell connecting from offline; `queue` is this workspace's remote queue
+state (`running`/`queued`/`paused`/`idle`, from `remoteQueueStatusFromRepo` keyed
+by `repoId` = workspace id), `'idle'` when offline or the resilient queue fetch
+fails (a queue failure never drops the server). Remote rows are merged into the
+same `RepoData[]` as local ones (git-info pre-resolved from the per-server batch)
+and are skipped by the local Phase-2 git-info update. Offline / unreachable
+servers contribute their last-known list from a two-layer (in-memory +
+`localStorage['coc-remote-workspace-cache']`) per-server cache
+(`repos/remoteWorkspaceCache.ts`), each entry flagged `offline` (with the real
+`connection` preserved). When the flag is
 OFF, `aggregateRemoteWorkspaces()` returns empty and performs no remote fetch, so
 the classic flow is unchanged.
 

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -609,6 +609,24 @@ model built on `features/remote-shell/`:
   `ResizeObserver` feed `computeVisibleTabKeys`, which shows every tab that fits and
   collapses the tail into a `…` menu (always keeping the active tab visible).
 
+**Remote workspace aggregation** (gated by `features.remoteShell`): when the flag
+is ON, `ReposContext.fetchRepos` also calls `aggregateRemoteWorkspaces()`
+(`repos/remoteWorkspaceAggregation.ts`) in parallel with the local
+`listWorkspaces()` + git-info batch. For each registry server (`/api/servers`)
+that is `online`, it fetches `/api/workspaces` + the git-info batch DIRECTLY at
+the server's `effectiveUrl` via a self-contained `CocClient` (it does NOT reuse
+`getSpaCocClient` routing). Each remote workspace is tagged with a `remote`
+marker `{ baseUrl, serverId, serverLabel, offline }` plus a top-level `baseUrl`
+(the routing key — no composite IDs, no serverId namespace); local workspaces
+carry neither, so `isRemoteWorkspace()` distinguishes them. Remote rows are
+merged into the same `RepoData[]` as local ones (git-info pre-resolved from the
+per-server batch) and are skipped by the local Phase-2 git-info update. Offline /
+unreachable servers contribute their last-known list from a two-layer
+(in-memory + `localStorage['coc-remote-workspace-cache']`) per-server cache
+(`repos/remoteWorkspaceCache.ts`), each entry flagged `offline`. When the flag is
+OFF, `aggregateRemoteWorkspaces()` returns empty and performs no remote fetch, so
+the classic flow is unchanged.
+
 The sub-tab taxonomy and feature-flag/git/layout gating live in
 `features/repo-detail/repoSubTabs.ts` (`SUB_TABS`, `VISIBLE_SUB_TABS`,
 `TAB_GROUP_INDEX`, `computeVisibleSubTabs`), shared by both `RepoDetail` and the

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -686,8 +686,12 @@ registry is unavailable). It exposes `lookupCloneBaseUrl(workspaceId)`,
 `getCocClientForWorkspace(workspaceId)` (= `getCocClientFor(lookupCloneBaseUrl(id))`,
 falling back to `getSpaCocClient()` for a local/unknown id so local behavior is
 byte-for-byte unchanged), `cloneApiBase(workspaceId)` (absolute remote REST base
-for hand-built URLs like the `EventSource` process stream), and
-`cloneWsUrlForWorkspace(path, workspaceId)`. The routing hooks
+for hand-built URLs like the `EventSource` process stream),
+`cloneWsUrlForWorkspace(path, workspaceId)`, and `requestForWorkspace(workspaceId,
+url, options?)` (clone-routed analog of `requestSpaApi` that fetches a RELATIVE
+api path against the clone — same `toSpaCocRequestOptions`/error-translation as
+`requestSpaApi`, used by the git diff-viewing layer which builds a bare path and
+then fetches it). The routing hooks
 (`useResolveCloneBaseUrl()`, `useCocClient(ref?)`, `useCloneWsUrl(ref?)`) resolve a
 bare workspace id through this registry (no `ReposContext` dependency, so they are
 safe in deep per-tab components and unit tests) and a workspace **object** from its
@@ -711,6 +715,21 @@ the input:
   from the registry and passes it into `cloneWsUrl`, so a remote clone's terminal
   targets its server. The `/ws` comment subscriptions (`useTaskComments` +
   `git/hooks/use*Comments`) already route through `cloneWsUrl`.
+- The Git diff-viewing layer is routed too: `WorkingTree` /
+  `WorkingTreeFileDiff` / `WorkingTreeAllComments` and the comment hooks
+  (`useDiffComments`, `useAllCommitComments`, `useFileCommentCounts`,
+  `useCommitCommentTotals`) use `useCocClient(workspaceId)` for their REST git
+  calls (their `/ws` subscriptions stay on `cloneWsUrl` unchanged);
+  `useClassification` / `useCommitClassificationStatus` route the
+  `/api/repos/:id/classify-diff*` calls through `useCocClient(workspaceId)`. The
+  `DiffSource` factories (`createCommitDiffSource`/`createBranchRangeDiffSource`/
+  `createPrDiffSource` in `git/diff/diffSource.ts`) resolve their path-builder
+  client via `getCocClientForWorkspace(id)`, and `fetchDiffFromSource(workspaceId,
+  url)` + `useCachedDiff` fetch the relative diff url via
+  `requestForWorkspace(workspaceId, url)`. `useFileDiff(url, fullUrl?, workspaceId?)`
+  threads the id from `FileDiffPanel`. Non-React `diffCommentApi`
+  (`patchDiffComment`/`deleteDiffCommentById`) routes via
+  `getCocClientForWorkspace(wsId)`.
 
 No-local-fallthrough guarantee: a remote clone's id always resolves to its
 `baseUrl`, so its clone-scoped REST/WS never hit the default local client; an

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -668,17 +668,55 @@ the default singleton when `baseUrl` is omitted, else a per-`baseUrl`-cached
 `CocClient` whose REST (`/api` base) and `events` WebSocket target that origin.
 `resolveCloneBaseUrl(ref, repos)` (`repos/cloneRouting.ts`) maps a workspace
 object or id to its remote `baseUrl` (or `undefined` when local) using the AC-01
-remote markers; the hooks `useResolveCloneBaseUrl()`, `useCocClient(ref?)`, and
-`useCloneWsUrl(ref?)` bind it to the live `ReposContext` repo list. WS URL
-construction goes through `cloneWsUrl(path, baseUrl?)` (`api/wsUrl.ts`): with a
-`baseUrl` it derives `ws(s)://{host:port}{path}` (http→ws, https→wss) keeping the
-path+query verbatim; without one it reproduces the legacy `window.location`
-behavior. The central WS call sites (the `/ws` comment subscriptions in
-`useTaskComments` + the `git/hooks/use*Comments` family, and the `/ws/terminal`
-socket in `useTerminalWebSocket`) route through `cloneWsUrl` so they are
-baseUrl-capable; wiring a clone's baseUrl into each tab is deferred to AC-07. The
-shared `/ws` process-event stream (`useWebSocket` → `getSpaCocClient().events`)
-is already baseUrl-aware through the SDK's `buildWebSocketUrl`.
+remote markers. WS URL construction goes through `cloneWsUrl(path, baseUrl?)`
+(`api/wsUrl.ts`): with a `baseUrl` it derives `ws(s)://{host:port}{path}`
+(http→ws, https→wss) keeping the path+query verbatim; without one it reproduces
+the legacy `window.location` behavior. The shared `/ws` process-event stream
+(`useWebSocket` → `getSpaCocClient().events`) is already baseUrl-aware through the
+SDK's `buildWebSocketUrl`.
+
+**Clone→baseUrl lookup registry + per-tab wiring (AC-07)**: every in-scope tab
+(Activity/Chats, Git, Terminal, Explorer, Schedules, Pull Requests, Work Items,
+Notes) loads and writes against a selected remote clone's own server, never the
+local one. The seam is `repos/cloneRegistry.ts` — a module-level
+`workspaceId → baseUrl` map (remote workspaces only) that `aggregateRemoteWorkspaces`
+populates on every repo refresh via `registerCloneBaseUrls` (full replace,
+covering online AND cached/offline rows; cleared when the flag is OFF or the
+registry is unavailable). It exposes `lookupCloneBaseUrl(workspaceId)`,
+`getCocClientForWorkspace(workspaceId)` (= `getCocClientFor(lookupCloneBaseUrl(id))`,
+falling back to `getSpaCocClient()` for a local/unknown id so local behavior is
+byte-for-byte unchanged), `cloneApiBase(workspaceId)` (absolute remote REST base
+for hand-built URLs like the `EventSource` process stream), and
+`cloneWsUrlForWorkspace(path, workspaceId)`. The routing hooks
+(`useResolveCloneBaseUrl()`, `useCocClient(ref?)`, `useCloneWsUrl(ref?)`) resolve a
+bare workspace id through this registry (no `ReposContext` dependency, so they are
+safe in deep per-tab components and unit tests) and a workspace **object** from its
+own marker.
+
+Wiring is at the per-feature HOOK/SERVICE seam where a `workspaceId` is already
+the input:
+- React components/hooks call `useCocClient(workspaceId)` and use the returned
+  client for all clone-scoped REST: `useGitInfo`, `TerminalView` (terminal
+  list/pin), `ChatDetail` (every `processes`/`queue`/`notes`/`canvases`/`skills`
+  call), `RepoSchedulesTab` (schedule CRUD + notes-git status),
+  `WorkItemSection` + `WorkItemHierarchyTree` (list/tree/mutations), and
+  `PullRequestsTab` (list/suggestions/roster/classification).
+- Non-React services that take a `workspaceId` resolve via
+  `getCocClientForWorkspace(workspaceId)`: `explorerApi.*` and `notesApi.*`.
+- The Activity WRITE path `useSendMessage` routes `processes.sendMessage` /
+  `promoteToRalph` through `getCocClientForWorkspace(workspaceId)`; the
+  Activity events stream `useChatSSE` opens its `EventSource` at
+  `cloneApiBase(workspaceId)`.
+- The terminal PTY socket (`useTerminalWebSocket`) resolves the clone baseUrl
+  from the registry and passes it into `cloneWsUrl`, so a remote clone's terminal
+  targets its server. The `/ws` comment subscriptions (`useTaskComments` +
+  `git/hooks/use*Comments`) already route through `cloneWsUrl`.
+
+No-local-fallthrough guarantee: a remote clone's id always resolves to its
+`baseUrl`, so its clone-scoped REST/WS never hit the default local client; an
+OFFLINE-selected clone still resolves to its last-known `baseUrl` (degrades to
+empty/cached UI, never a silent local call) because cached/offline rows are
+registered too.
 
 The sub-tab taxonomy and feature-flag/git/layout gating live in
 `features/repo-detail/repoSubTabs.ts` (`SUB_TABS`, `VISIBLE_SUB_TABS`,

--- a/.github/skills/coc-knowledge/references/remote-servers.md
+++ b/.github/skills/coc-knowledge/references/remote-servers.md
@@ -114,6 +114,8 @@ Health checks call:
 
 If no effective local endpoint is available, health is reported as offline.
 
+Direct URL servers have no managed connector, so their runtime `status` is the last health-probe result against the configured `url`, cached per server id by the routes layer: `online` when reachable, `offline` when not, and `idle` before the first probe. The probe runs on create, edit, and `GET /api/servers/:id/health`; `GET /api/servers` additionally refreshes URL reachability in the background (serve-stale-revalidate) so a reachable direct-URL server converges to `online` on subsequent polls and contributes its clones to the dashboard.
+
 ## API routes
 
 The dashboard and client package use these server routes:

--- a/.github/skills/coc-knowledge/references/streaming-architecture.md
+++ b/.github/skills/coc-knowledge/references/streaming-architecture.md
@@ -34,6 +34,15 @@ CoC uses three communication channels between server and browser, plus a WebSock
 - WebSocket = lightweight notifications, global (all events to all clients)
 - If everything went through WebSocket, every browser tab would receive token-by-token output from ALL running processes
 
+### Cross-Origin Policy (REST + WS) — loopback only
+
+The dashboard SPA may talk directly to a *different* CoC server forwarded at `http://127.0.0.1:{localPort}` (a cross-origin call: same host, different port). Both the REST CORS layer and the WS upgrade path therefore allow cross-origin access **from loopback origins only**:
+
+- `isLoopbackOrigin(origin)` (`packages/coc/src/server/shared/cors.ts`) is the single shared predicate. Loopback = hostname `localhost`, `127.0.0.1`, or `::1`, scheme `http`/`https`, any port. Everything else (other hostnames, non-http(s) schemes, look-alikes like `attacker.localhost.evil.com`, private LAN IPs) is rejected.
+- REST: `applyCorsHeaders()` reflects the request `Origin` only when allowed and **never emits `Access-Control-Allow-Origin: *`**. Non-loopback origins get no ACAO header (browser blocks the read). Same-origin / no-`Origin` requests are unaffected.
+- WS: `attachWebSocketUpgradeHandler()` (`streaming/websocket.ts`) calls `isWebSocketOriginAllowed()` before dispatching `/ws` or `/ws/terminal`. A non-loopback `Origin` upgrade is answered `403 Forbidden` and the socket destroyed; a missing `Origin` (non-browser client) is allowed.
+- This is always-on for loopback origins (not gated by `features.remoteShell`, which is a client-side UI flag).
+
 ## Internal Architecture (Single Node.js Process)
 
 Everything runs in one Node.js process. LLM API calls are async network I/O (not CPU-bound).

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -737,12 +737,16 @@ export { sendJson, send404, send400, send500, sendError, readJsonBody } from './
 export { createRequestHandler } from './router';
 export type { RouterOptions } from './router';
 
+// CORS / cross-origin policy (loopback-only allowance for REST + WS)
+export { applyCorsHeaders, getDefaultCorsPolicy, isLoopbackOrigin } from './shared/cors';
+export type { CorsPolicy } from './shared/cors';
+
 // Deprecated compat wrapper — use sendJson(res, data, statusCode) instead
 export { sendJSON, parseBody, parseQueryParams, stripExcludedFields } from './core/api-handler';
 export { detectRemoteUrl, normalizeRemoteUrl } from './core/api-handler';
 
 // WebSocket
-export { ProcessWebSocketServer, toProcessSummary, toCommentSummary, attachWebSocketUpgradeHandler } from './streaming/websocket';
+export { ProcessWebSocketServer, toProcessSummary, toCommentSummary, attachWebSocketUpgradeHandler, isWebSocketOriginAllowed } from './streaming/websocket';
 export type { WSClient, ProcessSummary, MarkdownCommentSummary, QueueTaskSummary, ServerMessage, ClientMessage, QueueSnapshot } from './streaming/websocket';
 
 // Terminal

--- a/packages/coc/src/server/servers/remote-server-routes.ts
+++ b/packages/coc/src/server/servers/remote-server-routes.ts
@@ -16,7 +16,9 @@ import type {
     DevTunnelRemoteServer,
     RemoteServer,
     RemoteServerCreateInput,
+    RemoteServerHealth,
     RemoteServerRuntime,
+    RemoteServerRuntimeStatus,
     RemoteServerWithRuntime,
     SshRemoteServer,
 } from './remote-server-types';
@@ -31,6 +33,26 @@ export interface RegisterRemoteServerRoutesOptions {
 }
 
 const LOCAL_SERVER_METADATA: GitOpServerMetadata = { id: 'local', label: 'Current CoC' };
+
+/**
+ * Cached reachability for `url`-kind servers, keyed by server id.
+ *
+ * `url`-kind remotes have no persistent connector (unlike ssh/devtunnel, whose
+ * connectors keep live runtime state). Their runtime status is instead the last
+ * health-probe result against the configured `url`: every `healthForServer` call
+ * (the `/health` endpoint, plus create/update) records it here, and the
+ * synchronous list/decorate path reads it back. A server stays `idle` until its
+ * first probe — matching the pre-existing baseline and the ssh/devtunnel
+ * "not yet connected" state — and only an actually reachable url reports
+ * `online`; an unreachable one reports `offline`.
+ */
+type UrlHealthCache = Map<string, RemoteServerHealth>;
+
+/** Map a cached url health probe onto the runtime status vocabulary. */
+function urlRuntimeStatus(health: RemoteServerHealth | undefined): RemoteServerRuntimeStatus {
+    if (!health) return 'idle';
+    return health.status === 'online' ? 'online' : 'offline';
+}
 
 interface ParsedTransferEndpoint {
     serverId?: string;
@@ -56,13 +78,21 @@ class TransferHttpError extends Error {
     }
 }
 
-function toRuntime(server: RemoteServer, connector: DevTunnelConnector, sshConnector?: SshConnector): RemoteServerRuntime {
+function toRuntime(
+    server: RemoteServer,
+    connector: DevTunnelConnector,
+    sshConnector?: SshConnector,
+    urlHealthCache?: UrlHealthCache,
+): RemoteServerRuntime {
     if (server.kind === 'url') {
+        const health = urlHealthCache?.get(server.id);
         return {
             serverId: server.id,
             kind: 'url',
             effectiveUrl: server.url,
-            status: 'idle',
+            status: urlRuntimeStatus(health),
+            lastChecked: health?.lastChecked,
+            lastError: health?.status === 'online' ? undefined : health?.error,
         };
     }
     if (server.kind === 'ssh') {
@@ -91,8 +121,13 @@ function toRuntime(server: RemoteServer, connector: DevTunnelConnector, sshConne
     };
 }
 
-function decorate(server: RemoteServer, connector: DevTunnelConnector, sshConnector?: SshConnector): RemoteServerWithRuntime {
-    const runtime = toRuntime(server, connector, sshConnector);
+function decorate(
+    server: RemoteServer,
+    connector: DevTunnelConnector,
+    sshConnector?: SshConnector,
+    urlHealthCache?: UrlHealthCache,
+): RemoteServerWithRuntime {
+    const runtime = toRuntime(server, connector, sshConnector, urlHealthCache);
     return {
         ...server,
         effectiveUrl: runtime.effectiveUrl,
@@ -189,6 +224,7 @@ async function callEndpoint<T>(
 async function resolveTransferEndpoint(
     ref: ParsedTransferEndpoint,
     options: RegisterRemoteServerRoutesOptions,
+    urlHealthCache: UrlHealthCache,
 ): Promise<ResolvedTransferEndpoint> {
     const timeoutMs = options.requestTimeoutMs ?? 30_000;
     if (!ref.serverId) {
@@ -210,7 +246,7 @@ async function resolveTransferEndpoint(
     if (!server) {
         transferError(404, { error: `Remote server not found: ${ref.serverId}` });
     }
-    const health = await healthForServer(server, options.connector, options.sshConnector);
+    const health = await healthForServer(server, options.connector, options.sshConnector, urlHealthCache);
     const metadata: GitOpServerMetadata = { id: server.id, label: server.label };
     if (health.status !== 'online' || !health.effectiveUrl) {
         transferError(503, {
@@ -229,9 +265,10 @@ async function resolveTransferEndpoint(
 async function runCherryPickTransfer(
     request: ParsedTransferRequest,
     options: RegisterRemoteServerRoutesOptions,
+    urlHealthCache: UrlHealthCache,
 ): Promise<CherryPickTransferResponse> {
-    const sourceEndpoint = await resolveTransferEndpoint(request.source, options);
-    const targetEndpoint = await resolveTransferEndpoint(request.target, options);
+    const sourceEndpoint = await resolveTransferEndpoint(request.source, options, urlHealthCache);
+    const targetEndpoint = await resolveTransferEndpoint(request.target, options, urlHealthCache);
 
     const exported = await callEndpoint<GitPatchExportResponse>(
         sourceEndpoint,
@@ -307,16 +344,21 @@ function disconnectIfUnusedTunnel(tunnelId: string, store: RemoteServerStore, co
     }
 }
 
-async function healthForServer(server: RemoteServer, connector: DevTunnelConnector, sshConnector?: SshConnector) {
+async function healthForServer(
+    server: RemoteServer,
+    connector: DevTunnelConnector,
+    sshConnector?: SshConnector,
+    urlHealthCache?: UrlHealthCache,
+): Promise<RemoteServerHealth> {
     if (server.kind === 'devtunnel') {
         await connectIfDevTunnel(server, connector);
     }
     if (server.kind === 'ssh') {
         await connectIfSsh(server, sshConnector);
     }
-    const runtime = toRuntime(server, connector, sshConnector);
+    const runtime = toRuntime(server, connector, sshConnector, urlHealthCache);
     const baseUrl = server.kind === 'url' ? server.url : runtime.effectiveUrl;
-    return checkRemoteServerHealth({
+    const health = await checkRemoteServerHealth({
         serverId: server.id,
         kind: server.kind,
         baseUrl,
@@ -325,6 +367,13 @@ async function healthForServer(server: RemoteServer, connector: DevTunnelConnect
         publicUrl: runtime.publicUrl,
         lastError: runtime.lastError,
     });
+    // `url`-kind has no connector to hold runtime state, so the probe result IS
+    // the runtime status. Record it (keyed by the real server id) so the
+    // synchronous list/decorate path reflects actual reachability.
+    if (server.kind === 'url' && urlHealthCache) {
+        urlHealthCache.set(server.id, health);
+    }
+    return health;
 }
 
 export function registerRemoteServerRoutes(
@@ -333,12 +382,46 @@ export function registerRemoteServerRoutes(
 ): void {
     const { store, connector, sshConnector } = options;
 
+    // Last-known reachability for url-kind servers (see UrlHealthCache). Lives for
+    // the life of the route registration, the same lifetime as the ssh/devtunnel
+    // connectors whose runtime state it mirrors for the connector-less url kind.
+    const urlHealthCache: UrlHealthCache = new Map();
+    // In-flight url health probes, so concurrent list requests share one probe per
+    // server instead of stampeding the remote.
+    const urlHealthInFlight = new Set<string>();
+
+    /**
+     * Serve-stale-revalidate: refresh url-kind reachability in the background so
+     * the next list reflects the current state, without blocking this response.
+     * Equivalent to how ssh/devtunnel connectors keep their state warm out of band.
+     */
+    function refreshUrlHealth(servers: RemoteServer[]): void {
+        for (const server of servers) {
+            if (server.kind !== 'url' || urlHealthInFlight.has(server.id)) {
+                continue;
+            }
+            urlHealthInFlight.add(server.id);
+            void healthForServer(server, connector, sshConnector, urlHealthCache)
+                .catch(() => {
+                    // checkRemoteServerHealth never rejects; this is defensive only.
+                })
+                .finally(() => {
+                    urlHealthInFlight.delete(server.id);
+                });
+        }
+    }
+
     routes.push({
         method: 'GET',
         pattern: '/api/servers',
         handler: (_req, res) => {
             try {
-                sendJson(res, store.list().map(server => decorate(server, connector, sshConnector)));
+                const servers = store.list();
+                sendJson(res, servers.map(server => decorate(server, connector, sshConnector, urlHealthCache)));
+                // Kick off a background reachability refresh for url-kind remotes so a
+                // reachable one converges to `online` (and an unreachable one to
+                // `offline`) on subsequent polls, without delaying this response.
+                refreshUrlHealth(servers);
             } catch (error) {
                 send500(res, error instanceof Error ? error.message : String(error));
             }
@@ -353,7 +436,12 @@ export function registerRemoteServerRoutes(
                 const server = store.create(await readJsonBody(req));
                 await connectIfDevTunnel(server, connector);
                 await connectIfSsh(server, sshConnector);
-                sendJson(res, decorate(server, connector, sshConnector), 201);
+                // Probe a new url-kind remote up front so the create response (and the
+                // next list) reflects whether it is actually reachable.
+                if (server.kind === 'url') {
+                    await healthForServer(server, connector, sshConnector, urlHealthCache);
+                }
+                sendJson(res, decorate(server, connector, sshConnector, urlHealthCache), 201);
             } catch (error) {
                 send400(res, error instanceof Error ? error.message : String(error));
             }
@@ -378,9 +466,16 @@ export function registerRemoteServerRoutes(
                 if (before.kind === 'ssh' && updated.kind !== 'ssh') {
                     sshConnector?.disconnect(before.id);
                 }
+                if (before.kind === 'url' && updated.kind !== 'url') {
+                    urlHealthCache.delete(before.id);
+                }
                 await connectIfDevTunnel(updated, connector);
                 await connectIfSsh(updated, sshConnector);
-                sendJson(res, decorate(updated, connector, sshConnector));
+                // The url may have changed; re-probe so the response reflects the new target.
+                if (updated.kind === 'url') {
+                    await healthForServer(updated, connector, sshConnector, urlHealthCache);
+                }
+                sendJson(res, decorate(updated, connector, sshConnector, urlHealthCache));
             } catch (error) {
                 send400(res, error instanceof Error ? error.message : String(error));
             }
@@ -402,6 +497,9 @@ export function registerRemoteServerRoutes(
             }
             if (removed.kind === 'ssh') {
                 sshConnector?.disconnect(removed.id);
+            }
+            if (removed.kind === 'url') {
+                urlHealthCache.delete(removed.id);
             }
             sendJson(res, { ok: true });
         },
@@ -430,7 +528,7 @@ export function registerRemoteServerRoutes(
                         addedAt: Date.now(),
                         updatedAt: Date.now(),
                     };
-                    sendJson(res, await healthForServer(server, connector, sshConnector));
+                    sendJson(res, await healthForServer(server, connector, sshConnector, urlHealthCache));
                     return;
                 }
                 // ssh kind: health check against the local forwarded port (no spawn at test time)
@@ -443,7 +541,7 @@ export function registerRemoteServerRoutes(
                     addedAt: Date.now(),
                     updatedAt: Date.now(),
                 };
-                sendJson(res, await healthForServer(server, connector, sshConnector));
+                sendJson(res, await healthForServer(server, connector, sshConnector, urlHealthCache));
             } catch (error) {
                 send400(res, error instanceof Error ? error.message : String(error));
             }
@@ -456,7 +554,7 @@ export function registerRemoteServerRoutes(
         handler: async (req, res) => {
             try {
                 const body = await readJsonBody<CherryPickTransferRequest>(req);
-                sendJson(res, await runCherryPickTransfer(parseTransferRequest(body), options));
+                sendJson(res, await runCherryPickTransfer(parseTransferRequest(body), options, urlHealthCache));
             } catch (error) {
                 sendTransferFailure(res, error);
             }
@@ -479,11 +577,11 @@ export function registerRemoteServerRoutes(
             }
             if (server.kind === 'ssh') {
                 await connectIfSsh(server, sshConnector);
-                sendJson(res, toRuntime(server, connector, sshConnector));
+                sendJson(res, toRuntime(server, connector, sshConnector, urlHealthCache));
                 return;
             }
             await connectIfDevTunnel(server, connector);
-            sendJson(res, toRuntime(server, connector, sshConnector));
+            sendJson(res, toRuntime(server, connector, sshConnector, urlHealthCache));
         },
     });
 
@@ -536,7 +634,7 @@ export function registerRemoteServerRoutes(
                         // Failed state is stored on the connector.
                     }
                 }
-                sendJson(res, toRuntime(server, connector, sshConnector));
+                sendJson(res, toRuntime(server, connector, sshConnector, urlHealthCache));
                 return;
             }
             try {
@@ -544,7 +642,7 @@ export function registerRemoteServerRoutes(
             } catch {
                 // The failed state is stored on the connector and returned below.
             }
-            sendJson(res, toRuntime(server, connector, sshConnector));
+            sendJson(res, toRuntime(server, connector, sshConnector, urlHealthCache));
         },
     });
 
@@ -558,7 +656,7 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            sendJson(res, await healthForServer(server, connector, sshConnector));
+            sendJson(res, await healthForServer(server, connector, sshConnector, urlHealthCache));
         },
     });
 
@@ -572,7 +670,7 @@ export function registerRemoteServerRoutes(
                 send404(res, `Remote server not found: ${id}`);
                 return;
             }
-            sendJson(res, toRuntime(server, connector, sshConnector));
+            sendJson(res, toRuntime(server, connector, sshConnector, urlHealthCache));
         },
     });
 }

--- a/packages/coc/src/server/shared/cors.ts
+++ b/packages/coc/src/server/shared/cors.ts
@@ -2,8 +2,11 @@
  * Shared CORS Utilities
  *
  * Single source of truth for CORS header logic.
- * Reflects the request Origin when it matches the allowlist (localhost variants
- * or explicitly configured origins). Falls back to `*` for unknown origins.
+ * Reflects the request Origin only when it is a loopback origin (or explicitly
+ * configured in the policy). Non-loopback cross-origin requests receive NO
+ * `Access-Control-Allow-Origin` header, so browsers block them; `*` is never
+ * emitted. Same-origin and no-Origin requests are unaffected (browsers do not
+ * require the header for those).
  *
  * Cross-platform compatible (Linux/Mac/Windows).
  */
@@ -16,7 +19,7 @@ import * as http from 'http';
 
 export interface CorsPolicy {
     /**
-     * Origins to allow in addition to localhost variants.
+     * Origins to allow in addition to loopback origins.
      * Use `'*'` to reflect any origin (permissive — avoid on public endpoints).
      */
     allowedOrigins: string[] | '*';
@@ -30,7 +33,14 @@ export interface CorsPolicy {
 // Constants
 // ============================================================================
 
-const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
+/**
+ * Loopback hostnames. A loopback origin can never reach another machine, so
+ * reflecting it for cross-origin requests is safe (the dashboard SPA and a
+ * forwarded remote CoC differ only by port, both on loopback). Note this set
+ * deliberately excludes `0.0.0.0` — it is a bind/wildcard address, not a
+ * hostname a browser ever sends as an Origin.
+ */
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
 
 const DEFAULT_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 const DEFAULT_HEADERS = ['Authorization', 'Content-Type'];
@@ -40,13 +50,36 @@ const DEFAULT_HEADERS = ['Authorization', 'Content-Type'];
 // ============================================================================
 
 /**
- * Returns true if `origin` is an HTTP origin on a well-known localhost hostname.
- * Any port is accepted.
+ * Returns true if `origin` is an `http:`/`https:` origin on a loopback
+ * hostname (`localhost`, `127.0.0.1`, or `::1`). Any port is accepted.
+ *
+ * Shared by the REST CORS layer and the WebSocket upgrade/verify path so both
+ * make the identical allow/reject decision. Everything else (other hostnames,
+ * other schemes, malformed values) is rejected.
+ *
+ * Examples:
+ *   isLoopbackOrigin('http://127.0.0.1:4000')        → true
+ *   isLoopbackOrigin('https://localhost:5000')       → true
+ *   isLoopbackOrigin('http://[::1]:4000')            → true
+ *   isLoopbackOrigin('http://evil.com')              → false
+ *   isLoopbackOrigin('http://192.168.1.10')          → false
+ *   isLoopbackOrigin('http://attacker.localhost.evil.com') → false
  */
-function isLocalhostOrigin(origin: string): boolean {
+export function isLoopbackOrigin(origin: string | undefined | null): boolean {
+    if (!origin) {
+        return false;
+    }
     try {
         const { protocol, hostname } = new URL(origin);
-        return protocol === 'http:' && LOCALHOST_HOSTNAMES.has(hostname);
+        if (protocol !== 'http:' && protocol !== 'https:') {
+            return false;
+        }
+        // URL() normalizes an IPv6 host to bracketed form (e.g. "[::1]");
+        // strip the brackets before matching the hostname set.
+        const host = hostname.startsWith('[') && hostname.endsWith(']')
+            ? hostname.slice(1, -1)
+            : hostname;
+        return LOOPBACK_HOSTNAMES.has(host);
     } catch {
         return false;
     }
@@ -58,8 +91,8 @@ function isLocalhostOrigin(origin: string): boolean {
 
 /**
  * Returns the default CORS policy:
- * - Localhost variants are always allowed (any port).
- * - No additional explicitly-listed origins beyond localhost.
+ * - Loopback origins are always allowed (any port, http or https).
+ * - No additional explicitly-listed origins beyond loopback.
  * - Credentials allowed for reflected origins.
  * - All standard HTTP methods including PUT/PATCH.
  * - `Authorization` and `Content-Type` in allowed headers.
@@ -74,13 +107,36 @@ export function getDefaultCorsPolicy(): CorsPolicy {
 }
 
 /**
+ * Returns true if a request carrying `origin` is allowed to make a cross-origin
+ * request under `policy`. Loopback origins are always allowed; otherwise the
+ * origin must be `'*'`-policy or explicitly listed. A missing Origin (e.g.
+ * same-origin or non-browser callers) is not a cross-origin request and is
+ * reported as not-reflected here — callers handle it as "no CORS header needed".
+ */
+function isOriginAllowed(origin: string | undefined, policy: CorsPolicy): boolean {
+    if (origin === undefined) {
+        return false;
+    }
+    return (
+        policy.allowedOrigins === '*' ||
+        isLoopbackOrigin(origin) ||
+        (Array.isArray(policy.allowedOrigins) && policy.allowedOrigins.includes(origin))
+    );
+}
+
+/**
  * Apply CORS headers to `res` according to `policy`.
  *
- * - If the request carries an `Origin` that is a localhost variant, explicitly
- *   listed in `policy.allowedOrigins`, or if `policy.allowedOrigins === '*'`,
- *   the origin is reflected back and (optionally) credentials are enabled.
- * - All other requests receive `Access-Control-Allow-Origin: *` with no
- *   credentials header, which is safe for unknown / unauthenticated callers.
+ * - If the request carries an `Origin` that is a loopback origin, is explicitly
+ *   listed in `policy.allowedOrigins`, or `policy.allowedOrigins === '*'`, the
+ *   origin is reflected back and (optionally) credentials are enabled.
+ * - All other requests receive NO `Access-Control-Allow-Origin` header. The
+ *   wildcard `*` is never sent, and a non-loopback Origin is never reflected,
+ *   so browsers block such cross-origin reads. Same-origin and no-Origin
+ *   requests are unaffected — browsers do not require the header for those.
+ *
+ * `Access-Control-Allow-Methods`/`-Headers` are always advertised so a
+ * preflight from an allowed origin sees the permitted methods/headers.
  */
 export function applyCorsHeaders(
     req: http.IncomingMessage,
@@ -89,21 +145,14 @@ export function applyCorsHeaders(
 ): void {
     const origin = req.headers['origin'] as string | undefined;
 
-    const shouldReflect =
-        origin !== undefined &&
-        (
-            policy.allowedOrigins === '*' ||
-            isLocalhostOrigin(origin) ||
-            (Array.isArray(policy.allowedOrigins) && policy.allowedOrigins.includes(origin))
-        );
-
-    if (shouldReflect && origin) {
+    if (isOriginAllowed(origin, policy) && origin) {
         res.setHeader('Access-Control-Allow-Origin', origin);
+        // Vary on Origin so shared caches do not serve one origin's reflected
+        // header to another.
+        res.setHeader('Vary', 'Origin');
         if (policy.credentials) {
             res.setHeader('Access-Control-Allow-Credentials', 'true');
         }
-    } else {
-        res.setHeader('Access-Control-Allow-Origin', '*');
     }
 
     res.setHeader('Access-Control-Allow-Methods', policy.methods.join(', '));

--- a/packages/coc/src/server/spa/client/react/App.tsx
+++ b/packages/coc/src/server/spa/client/react/App.tsx
@@ -24,6 +24,7 @@ import { FloatingChatManager } from './layout/FloatingChatManager';
 import { useWebSocket } from './hooks/useWebSocket';
 import { fetchApi } from './hooks/useApi';
 import { getSpaCocClient } from './api/cocClient';
+import { getCocClientForWorkspace } from './repos/cloneRegistry';
 import { ToastContainer, useToast } from './ui';
 import { toForwardSlashes } from '@plusplusoneplusplus/forge/utils/path-utils';
 import { MarkdownReviewDialog } from './processes/MarkdownReviewDialog';
@@ -335,7 +336,10 @@ function AppInner() {
             : null;
 
         const report = () => {
-            getSpaCocClient().workspaces.reportActiveWorkspace({ clientId, workspaceId }).catch(() => {});
+            // Route to the selected clone's server (AC-07): a remote clone's
+            // active-workspace report must reach the server that owns the workspace,
+            // else the local server 404s an unknown remote id. null/local → default.
+            getCocClientForWorkspace(workspaceId).workspaces.reportActiveWorkspace({ clientId, workspaceId }).catch(() => {});
         };
 
         report();

--- a/packages/coc/src/server/spa/client/react/api/cocClient.ts
+++ b/packages/coc/src/server/spa/client/react/api/cocClient.ts
@@ -33,6 +33,10 @@ function toLegacyFetchInit(init?: RequestInit): RequestInit {
     return next;
 }
 
+function spaFetch(): typeof fetch {
+    return ((input, init) => fetch(input, toLegacyFetchInit(init))) as typeof fetch;
+}
+
 export function getSpaCocClient(): CocClient {
     const apiBasePath = getApiBase();
     const wsPath = (globalThis as any).window?.__DASHBOARD_CONFIG__?.wsPath ?? '/ws';
@@ -43,13 +47,51 @@ export function getSpaCocClient(): CocClient {
             baseUrl: '',
             apiBasePath,
             wsPath,
-            fetch: ((input, init) => fetch(input, toLegacyFetchInit(init))) as typeof fetch,
+            fetch: spaFetch(),
         });
         cachedKey = key;
         cachedFetch = fetch;
     }
 
     return cachedClient;
+}
+
+/** Per-baseUrl client cache. Keyed by the normalized remote baseUrl. */
+const remoteClientCache = new Map<string, { client: CocClient; fetchRef: typeof fetch }>();
+
+function normalizeBaseUrlKey(baseUrl: string): string {
+    return baseUrl.replace(/\/+$/, '');
+}
+
+/**
+ * Return a CocClient routed to a specific clone's `baseUrl` (AC-03).
+ *
+ * - `baseUrl` undefined/empty → the EXISTING default `getSpaCocClient()`
+ *   singleton (current origin). Local clones and the repos-list/git-info
+ *   aggregation in ReposContext keep using this — there is NO global mutable
+ *   "active baseUrl"; remote routing is strictly per-call/opt-in.
+ * - `baseUrl` present → a cached CocClient whose REST calls and `events`
+ *   WebSocket target that origin (e.g. `http://127.0.0.1:4000`). Uses the
+ *   default `/api` base + `/ws` path, matching the remote CoC server layout
+ *   (remote servers are never in container mode, so no agent prefix applies).
+ */
+export function getCocClientFor(baseUrl?: string): CocClient {
+    if (!baseUrl) {
+        return getSpaCocClient();
+    }
+    const key = normalizeBaseUrlKey(baseUrl);
+    const cached = remoteClientCache.get(key);
+    if (cached && cached.fetchRef === fetch) {
+        return cached.client;
+    }
+    const wsPath = (globalThis as any).window?.__DASHBOARD_CONFIG__?.wsPath ?? '/ws';
+    const client = new CocClient({
+        baseUrl: key,
+        wsPath,
+        fetch: spaFetch(),
+    });
+    remoteClientCache.set(key, { client, fetchRef: fetch });
+    return client;
 }
 
 export function toSpaCocRequestOptions(options?: RequestInit): CocRequestOptions {
@@ -113,4 +155,5 @@ export function resetSpaCocClientForTests(): void {
     cachedClient = undefined;
     cachedKey = '';
     cachedFetch = undefined;
+    remoteClientCache.clear();
 }

--- a/packages/coc/src/server/spa/client/react/api/wsUrl.ts
+++ b/packages/coc/src/server/spa/client/react/api/wsUrl.ts
@@ -1,0 +1,49 @@
+/**
+ * WebSocket URL construction that honors a per-clone `baseUrl` (AC-03).
+ *
+ * The SPA opens WebSockets to the CoC server for the process-event stream
+ * (`/ws`), terminal PTYs (`/ws/terminal?…`), and comment subscriptions (`/ws`).
+ * Historically every call site derived the URL from `window.location`. To make a
+ * remote clone's sockets reach that clone's server, route the construction
+ * through `cloneWsUrl(path, baseUrl?)`:
+ *
+ *   • `baseUrl` omitted/empty → reproduce the legacy `window.location` behavior
+ *     EXACTLY (`ws(s)://{location.host}{path}`), so local clones are unchanged.
+ *   • `baseUrl` present → swap in that origin's host + port and map the scheme
+ *     (http→ws, https→wss), keeping `{path}` (incl. any query string) verbatim.
+ *
+ * `baseUrl` is the remote routing key (the server's effectiveUrl, e.g.
+ * `http://127.0.0.1:4000`) carried by AC-01's `RemoteWorkspaceMarker`. No
+ * composite IDs, no serverId namespace.
+ */
+
+/** Map an http(s) protocol to its ws(s) equivalent. Defaults to `ws:`. */
+function toWsProtocol(httpProtocol: string): 'ws:' | 'wss:' {
+    return httpProtocol === 'https:' ? 'wss:' : 'ws:';
+}
+
+/**
+ * Build a WebSocket URL for `path` (which may include a leading `/` and an
+ * embedded query string). When `baseUrl` is given the socket targets that
+ * origin; otherwise it targets the current page origin (legacy behavior).
+ */
+export function cloneWsUrl(path: string, baseUrl?: string): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+    if (baseUrl) {
+        // Parse only the origin from baseUrl; keep `path` (and its query) verbatim
+        // so terminal query strings like `?workspaceId=…` are not URL-mangled.
+        const origin = new URL(baseUrl);
+        const protocol = toWsProtocol(origin.protocol);
+        return `${protocol}//${origin.host}${normalizedPath}`;
+    }
+
+    const locationLike = (globalThis as { location?: Location }).location;
+    if (!locationLike) {
+        // Non-browser (SSR/tests without jsdom): return a relative URL, matching
+        // coc-client's buildWebSocketUrl fallback.
+        return normalizedPath;
+    }
+    const protocol = toWsProtocol(locationLike.protocol);
+    return `${protocol}//${locationLike.host}${normalizedPath}`;
+}

--- a/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
@@ -30,6 +30,12 @@ import {
     listWorkspaces,
 } from '../repos/repositoryService';
 import { aggregateRemoteWorkspaces, isRemoteWorkspace } from '../repos/remoteWorkspaceAggregation';
+import {
+    clearPersistedRemoteSelection,
+    loadPersistedRemoteSelection,
+    persistRemoteSelection,
+    resolvePersistedRemoteSelection,
+} from '../repos/remoteSelectionPersistence';
 
 import type { RepoData } from '../repos/repoGrouping';
 import type { AggregatedRemoteWorkspaces } from '../repos/remoteWorkspaceAggregation';
@@ -207,6 +213,29 @@ export function ReposProvider({ children }: { children: ReactNode }) {
                 dispatch({ type: 'SET_SELECTED_REPO', id: null });
             }
 
+            // Restore a persisted REMOTE-clone selection across reload (AC-08).
+            // The remote workspace only appears after aggregation resolves, so we
+            // re-apply the selection here, matching the persisted stable
+            // { serverId, workspaceId } pair against the freshly-aggregated remote
+            // workspaces. Resolution is via serverId (not baseUrl), so a clone whose
+            // devtunnel port/baseUrl changed still resolves. We never hijack an
+            // unrelated active selection: restore only when nothing is selected (or
+            // the missing selection was just cleared above) or the current selection
+            // already equals the resolved id. Local selection is untouched — the
+            // persisted pair only ever covers remote clones.
+            const resolvedRemoteId = resolvePersistedRemoteSelection(
+                loadPersistedRemoteSelection(),
+                remoteRepos.map(r => r.workspace),
+            );
+            if (resolvedRemoteId) {
+                const current = selectionStillPresent ? selectedRepoIdRef.current : null;
+                if (current === null || current === resolvedRemoteId) {
+                    if (selectedRepoIdRef.current !== resolvedRemoteId) {
+                        dispatch({ type: 'SET_SELECTED_REPO', id: resolvedRemoteId });
+                    }
+                }
+            }
+
             // Phase 2: Fetch git-info for all workspaces in a single batch request
             gitInfoAbortRef.current?.abort();
             const abortController = new AbortController();
@@ -328,6 +357,31 @@ export function ReposProvider({ children }: { children: ReactNode }) {
             }
         };
     }, []);
+
+    // Persist / clear the remote-clone selection as it changes (AC-08).
+    // - Remote selection → persist the stable { serverId, workspaceId } pair.
+    // - Known-LOCAL selection → clear any persisted remote pair so it can't fight
+    //   the hash-restored local selection on the next reload.
+    // - No selection yet, or an id not in the list yet (the cold-load window before
+    //   aggregation) → do NOTHING, so the persisted pair survives for the restore
+    //   step in fetchRepos. (Clearing on a null selection here would race the
+    //   restore and wipe the pair before it can be read.)
+    // Local behavior is otherwise unchanged: locals never write a remote pair; the
+    // only extra action for a known-local selection is dropping a stale REMOTE key.
+    useEffect(() => {
+        const selectedId = appState.selectedRepoId;
+        if (!selectedId) return;
+        const selected = repos.find(r => r.workspace.id === selectedId);
+        if (!selected) return;
+        if (isRemoteWorkspace(selected.workspace)) {
+            persistRemoteSelection({
+                serverId: selected.workspace.remote.serverId,
+                workspaceId: selected.workspace.id,
+            });
+        } else {
+            clearPersistedRemoteSelection();
+        }
+    }, [appState.selectedRepoId, repos]);
 
     const value = useMemo<ReposContextValue>(
         () => ({ repos, loading, fetchRepos, unseenCounts, refreshUnseenCounts }),

--- a/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
@@ -29,8 +29,10 @@ import {
     listQueueRepos,
     listWorkspaces,
 } from '../repos/repositoryService';
+import { aggregateRemoteWorkspaces, isRemoteWorkspace } from '../repos/remoteWorkspaceAggregation';
 
 import type { RepoData } from '../repos/repoGrouping';
+import type { AggregatedRemoteWorkspaces } from '../repos/remoteWorkspaceAggregation';
 
 // ── Context shape ──────────────────────────────────────────────────────
 
@@ -43,6 +45,27 @@ export interface ReposContextValue {
 }
 
 const ReposContext = createContext<ReposContextValue | null>(null);
+
+/**
+ * Build RepoData entries for aggregated remote workspaces. git-info comes from
+ * the per-server batch already fetched by the aggregator (online sources); offline
+ * (cached) sources have no git-info, so those rows fall back to the workspace's
+ * own isGitRepo flag. Remote rows are never re-sent to the local git-info batch.
+ */
+function buildRemoteRepoData(aggregate: AggregatedRemoteWorkspaces): RepoData[] {
+    return aggregate.workspaces.map((ws): RepoData => {
+        const git = aggregate.gitInfo[ws.id];
+        return {
+            workspace: ws,
+            gitInfo: git ?? { isGitRepo: !!ws.isGitRepo, branch: null, dirty: false },
+            // Offline (cached) rows never resolve git-info; online rows already have it.
+            gitInfoLoading: false,
+            workflows: [],
+            stats: { success: 0, failed: 0, running: 0 },
+            taskCount: 0,
+        };
+    });
+}
 
 // ── Provider ──────────────────────────────────────────────────────────
 
@@ -106,10 +129,14 @@ export function ReposProvider({ children }: { children: ReactNode }) {
 
     const fetchRepos = useCallback(async () => {
         try {
-            // Fetch workspaces and all process summaries in parallel
-            const [workspaces, processRes] = await Promise.all([
+            // Fetch workspaces, process summaries, and (when features.remoteShell
+            // is ON) remote-server workspaces in parallel. aggregateRemoteWorkspaces
+            // returns an empty result when the flag is OFF, so the classic flow is
+            // unchanged and incurs no remote fetch.
+            const [workspaces, processRes, remoteAggregate] = await Promise.all([
                 listWorkspaces(),
                 listProcessSummaries(5000).catch(() => null),
+                aggregateRemoteWorkspaces().catch(() => null),
             ]);
             if (!Array.isArray(workspaces)) {
                 setRepos([]);
@@ -152,20 +179,31 @@ export function ReposProvider({ children }: { children: ReactNode }) {
                 })
             );
 
-            // Render cards immediately (git-info still loading)
-            setRepos(enriched);
+            // Merge in remote-server workspaces (features.remoteShell only; empty
+            // otherwise). Remote rows already carry git-info from the per-server
+            // batch, so they render fully resolved alongside the local cards.
+            const remoteRepos = remoteAggregate ? buildRemoteRepoData(remoteAggregate) : [];
+            const combined = remoteRepos.length > 0 ? [...enriched, ...remoteRepos] : enriched;
+
+            // Render cards immediately (local git-info still loading; remote resolved)
+            setRepos(combined);
             setLoading(false);
 
             // Seed per-repo queue stats for card badges
-            seedRepoQueueStats(enriched);
+            seedRepoQueueStats(combined);
 
             // Fetch per-repo unseen counts from server
-            refreshUnseenCounts(enriched.map(r => r.workspace.id));
+            refreshUnseenCounts(combined.map(r => r.workspace.id));
 
             // Clear selection if repo was removed.
             // Check against the full workspaces list (not enriched) so virtual
             // workspaces like My Work / My Life don't get deselected on refresh.
-            if (selectedRepoIdRef.current && !workspaces.find((ws: any) => ws.id === selectedRepoIdRef.current)) {
+            // Remote workspaces are included so a selected remote clone survives a refresh.
+            const selectionStillPresent = selectedRepoIdRef.current
+                ? workspaces.some((ws: any) => ws.id === selectedRepoIdRef.current)
+                    || remoteRepos.some(r => r.workspace.id === selectedRepoIdRef.current)
+                : true;
+            if (!selectionStillPresent) {
                 dispatch({ type: 'SET_SELECTED_REPO', id: null });
             }
 
@@ -198,12 +236,15 @@ export function ReposProvider({ children }: { children: ReactNode }) {
                     if (abortController.signal.aborted) return;
                     const merged: Record<string, any> = {};
                     for (const data of responses) Object.assign(merged, data?.results || {});
-                    setRepos(prev => prev.map(r => ({
-                        ...r,
-                        // Preserve Phase 1 gitInfo (has isGitRepo) when batch result is absent
-                        gitInfo: merged[r.workspace.id] || r.gitInfo || undefined,
-                        gitInfoLoading: false,
-                    })));
+                    setRepos(prev => prev.map(r => (
+                        // Remote rows are resolved by the per-server batch; leave them untouched.
+                        isRemoteWorkspace(r.workspace) ? r : {
+                            ...r,
+                            // Preserve Phase 1 gitInfo (has isGitRepo) when batch result is absent
+                            gitInfo: merged[r.workspace.id] || r.gitInfo || undefined,
+                            gitInfoLoading: false,
+                        }
+                    )));
                 }).catch((err: unknown) => {
                     if (err instanceof Error && err.name === 'AbortError') return;
                     setRepos(prev => prev.map(r => ({ ...r, gitInfoLoading: false })));
@@ -212,11 +253,14 @@ export function ReposProvider({ children }: { children: ReactNode }) {
             getWorkspaceGitInfoBatch(wsIds, abortController.signal).then((data: any) => {
                 if (abortController.signal.aborted) return;
                 const results = data?.results || {};
-                setRepos(prev => prev.map(r => ({
-                    ...r,
-                    gitInfo: results[r.workspace.id] || undefined,
-                    gitInfoLoading: false,
-                })));
+                setRepos(prev => prev.map(r => (
+                    // Remote rows are resolved by the per-server batch; leave them untouched.
+                    isRemoteWorkspace(r.workspace) ? r : {
+                        ...r,
+                        gitInfo: results[r.workspace.id] || undefined,
+                        gitInfoLoading: false,
+                    }
+                )));
             }).catch((err: unknown) => {
                 if (err instanceof Error && err.name === 'AbortError') return;
                 setRepos(prev => prev.map(r => ({ ...r, gitInfoLoading: false })));

--- a/packages/coc/src/server/spa/client/react/features/canvas/CanvasPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/canvas/CanvasPanel.tsx
@@ -31,7 +31,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { CocApiError } from '@plusplusoneplusplus/coc-client';
 import type { Canvas, CanvasComment, CanvasVersion, CanvasVersionMeta } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { useMarkdownPreview } from '../../hooks/ui/useMarkdownPreview';
 import { MonacoFileEditor, getMonacoLanguage } from '../repo-detail/explorer/MonacoFileEditor';
 import { ExtensionCanvasView } from './ExtensionCanvasView';
@@ -136,6 +136,8 @@ function fenceCode(content: string, language: string | undefined): string {
 }
 
 export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi, onSendToAi, onFullscreenChange, onPopOut, reloadNonce }: CanvasPanelProps) {
+    // AC-07: canvas get/save/versions/comments + save-to-notes target the clone.
+    const cloneClient = useCocClient(workspaceId);
     const [canvas, setCanvas] = useState<Canvas | null>(null);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
@@ -188,7 +190,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
 
     const loadCanvas = useCallback(async () => {
         try {
-            const client = getSpaCocClient();
+            const client = cloneClient;
             const loaded = await client.canvases.get(workspaceId, canvasId);
             setCanvas(loaded);
             setDraft(loaded.content);
@@ -253,7 +255,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
             if (!current) return;
             const savedDraft = draft;
             setSaveState('saving');
-            getSpaCocClient().canvases
+            cloneClient.canvases
                 .save(workspaceId, canvasId, { content: savedDraft, expectedRevision: current.revision })
                 .then(saved => {
                     setCanvas({ ...saved, content: savedDraft });
@@ -289,7 +291,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
             setViewingVersion(null);
             return;
         }
-        getSpaCocClient().canvases.getVersion(workspaceId, canvasId, meta.revision)
+        cloneClient.canvases.getVersion(workspaceId, canvasId, meta.revision)
             .then(setViewingVersion)
             .catch(() => { /* keep current view on fetch failure */ });
     }, [workspaceId, canvasId, canvas]);
@@ -299,7 +301,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
         if (!current || !viewingVersion || restoring) return;
         setRestoring(true);
         try {
-            const saved = await getSpaCocClient().canvases.save(workspaceId, canvasId, {
+            const saved = await cloneClient.canvases.save(workspaceId, canvasId, {
                 content: viewingVersion.content,
                 expectedRevision: current.revision,
             });
@@ -308,7 +310,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
             setDirty(false);
             setSaveState('saved');
             setViewingVersion(null);
-            getSpaCocClient().canvases.listVersions(workspaceId, canvasId)
+            cloneClient.canvases.listVersions(workspaceId, canvasId)
                 .then(setVersions)
                 .catch(() => { /* best-effort */ });
         } catch (err) {
@@ -349,7 +351,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
     const handleSubmitComment = useCallback(async () => {
         if (!commentAnchor || !commentDraft.trim()) return;
         try {
-            const comment = await getSpaCocClient().canvases.addComment(workspaceId, canvasId, {
+            const comment = await cloneClient.canvases.addComment(workspaceId, canvasId, {
                 anchorText: commentAnchor,
                 body: commentDraft.trim(),
             });
@@ -361,7 +363,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
 
     const handleDeleteComment = useCallback(async (commentId: string) => {
         try {
-            await getSpaCocClient().canvases.deleteComment(workspaceId, canvasId, commentId);
+            await cloneClient.canvases.deleteComment(workspaceId, canvasId, commentId);
             setComments(prev => prev.filter(c => c.id !== commentId));
         } catch { /* keep the comment on failure */ }
     }, [workspaceId, canvasId]);
@@ -375,7 +377,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
         try {
             await onSendToAi(buildCommentsMessage(current, openComments));
             const updates = await Promise.all(openComments.map(c =>
-                getSpaCocClient().canvases.setCommentStatus(workspaceId, canvasId, c.id, 'sent').catch(() => null),
+                cloneClient.canvases.setCommentStatus(workspaceId, canvasId, c.id, 'sent').catch(() => null),
             ));
             setComments(prev => prev.map(c => updates.find(u => u?.id === c.id) ?? c));
         } catch { /* comments stay open if the send failed */ } finally {
@@ -428,7 +430,7 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
         if (!current || current.type !== 'markdown') return;
         try {
             const slug = current.id.replace(/-[0-9a-f]{6}$/, '') || current.id;
-            await getSpaCocClient().notes.saveContent(workspaceId, `canvases/${slug}.md`, current.content);
+            await cloneClient.notes.saveContent(workspaceId, `canvases/${slug}.md`, current.content);
             flashExportStatus('Saved to Notes');
         } catch {
             flashExportStatus('Save to Notes failed');

--- a/packages/coc/src/server/spa/client/react/features/chat/AskUserInline.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/AskUserInline.tsx
@@ -6,7 +6,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AskUserResponseRequest } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import type { AskUserBatch, AskUserQuestion } from './hooks/useChatSSE';
 import { AskUserMarkdown } from './AskUserMarkdown';
 import {
@@ -23,6 +23,8 @@ export interface AskUserInlineProps {
     batch: AskUserBatch;
     processId: string;
     onAnswered: () => void;
+    /** Owning workspace, so the ask_user reply routes to the chat's clone (AC-07). */
+    workspaceId?: string;
 }
 
 type AnswerValue = AskUserDraftValue;
@@ -222,7 +224,8 @@ function QuestionProvenance({ question }: { question: AskUserQuestion }) {
     );
 }
 
-export function AskUserInline({ batch, processId, onAnswered }: AskUserInlineProps) {
+export function AskUserInline({ batch, processId, onAnswered, workspaceId }: AskUserInlineProps) {
+    const cloneClient = useCocClient(workspaceId);
     const responseAcceptedRef = useRef(false);
     const [answers, setAnswers] = useState<Record<string, QuestionState>>(() => initialAnswers(batch, processId));
     const [submitting, setSubmitting] = useState(false);
@@ -249,7 +252,7 @@ export function AskUserInline({ batch, processId, onAnswered }: AskUserInlinePro
     const submitAll = useCallback(async (skipAll = false) => {
         setSubmitting(true);
         try {
-            await getSpaCocClient().processes.askUserResponse(processId, {
+            await cloneClient.processes.askUserResponse(processId, {
                 batchId: batch.batchId,
                 answers: batch.questions.map(question => {
                     const state = answers[question.questionId];
@@ -267,7 +270,7 @@ export function AskUserInline({ batch, processId, onAnswered }: AskUserInlinePro
         } finally {
             setSubmitting(false);
         }
-    }, [answers, batch.batchId, batch.questions, onAnswered, processId]);
+    }, [answers, batch.batchId, batch.questions, onAnswered, processId, cloneClient]);
 
     return (
         <div className="mx-2 my-3 rounded-lg border border-[#0078d4]/30 bg-[#f0f6ff] dark:bg-[#1a2332] p-4 shadow-sm" data-testid="ask-user-inline">

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -8,7 +8,8 @@
  */
 
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { getConversationTurns } from './conversation/chatConversationUtils';
 import { getSessionIdFromProcess } from './conversation/ConversationMetadataPopover';
 import { useQueue } from '../../contexts/QueueContext';
@@ -132,6 +133,10 @@ export interface ChatDetailProps {
 }
 
 export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, variant = 'inline', standalone = false, title, hideModeSelector = false, allowedModes, compactModeSelector = false, readOnly = false, disableScratchpad = false, pendingPrefix, onClearPendingPrefix, onOpenForEachRun, onOpenMapReduceRun, onStartFreshSameContext, startingFreshSameContext = false }: ChatDetailProps) {
+    // Per-clone REST client (AC-07): a remote clone's chat reads/writes go to its
+    // own server; a local clone keeps the default origin client. All process/
+    // queue/notes/canvas/skill calls below are scoped to this chat's workspace.
+    const client = useCocClient(workspaceId);
     const [task, setTask] = useState<any>(null);
     const [fullTask, setFullTask] = useState<any>(null);
 
@@ -460,7 +465,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         if (!detectedPlanFile || planPath || task?.metadata?.planFilePath || !processId) return;
         planPatchedRef.current = true;
         const merged = { ...(task?.metadata ?? {}), planFilePath: detectedPlanFile };
-        getSpaCocClient().processes.update(processId, { metadata: merged })
+        client.processes.update(processId, { metadata: merged })
             .then((data: any) => {
                 if (data?.process) setTask((prev: any) => prev ? { ...prev, metadata: data.process.metadata } : prev);
             })
@@ -474,7 +479,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         if (!detectedGoalFile || task?.metadata?.goalFilePath || !processId) return;
         goalPatchedRef.current = true;
         const merged = { ...(task?.metadata ?? {}), goalFilePath: detectedGoalFile };
-        getSpaCocClient().processes.update(processId, { metadata: merged })
+        client.processes.update(processId, { metadata: merged })
             .then((data: any) => {
                 if (data?.process) setTask((prev: any) => prev ? { ...prev, metadata: data.process.metadata } : prev);
             })
@@ -486,7 +491,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         if (!processId || !isTerminal) return;
         // Only fetch for note-chat processes
         if (task?.metadata?.notePath === undefined) return;
-        getSpaCocClient().notes.listNoteEdits(processId)
+        client.notes.listNoteEdits(processId)
             .then((edits: any) => {
                 if (Array.isArray(edits) && edits.length > 0) setNoteEdits(edits);
             })
@@ -570,7 +575,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         Promise.all(
             unknown.map(async (run) => {
                 try {
-                    const data = await getSpaCocClient().processes.get(run.processId);
+                    const data = await client.processes.get(run.processId);
                     return { processId: run.processId, status: data?.process?.status as RunLiveStatus ?? 'unknown' };
                 } catch {
                     return { processId: run.processId, status: 'unknown' as RunLiveStatus };
@@ -775,7 +780,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
 
     const refreshConversation = useCallback(async (pid: string) => {
         try {
-            const data = await getSpaCocClient().processes.get(pid);
+            const data = await client.processes.get(pid);
             setProcessDetails(data?.process || null);
             const refreshedTurns = getConversationTurns(data);
             // Preserve client-only costTimeMs across server refresh
@@ -887,6 +892,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         taskId,
         task,
         processId,
+        workspaceId,
         setIsStreaming,
         setTask,
         setProcessDetails,
@@ -941,7 +947,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         const pid = processId ?? bareTaskId;
         if (!pid) return;
         let cancelled = false;
-        getSpaCocClient().canvases.list(workspaceId, { processId: pid })
+        client.canvases.list(workspaceId, { processId: pid })
             .then(canvases => {
                 if (!cancelled && canvases.length > 0) {
                     setActiveCanvasId(prev => prev ?? canvases[0].id);
@@ -1035,7 +1041,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     useEffect(() => {
         setSkills([]);
         if (!workspaceId) return;
-        getSpaCocClient().skills.listAllWorkspace(workspaceId)
+        client.skills.listAllWorkspace(workspaceId)
             .then((data: any) => {
                 if (data?.merged && Array.isArray(data.merged)) {
                     setSkills(data.merged);
@@ -1049,7 +1055,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     // Fetch full task data for pending tasks (metadata + payload)
     useEffect(() => {
         if (!taskId || !isPending) { setFullTask(null); return; }
-        getSpaCocClient().queue.getTask(bareTaskId)
+        client.queue.getTask(bareTaskId)
             .then((data: any) => setFullTask(data?.task || null))
             .catch(() => setFullTask(null));
     }, [taskId, isPending, queueState.refreshVersion]);
@@ -1131,7 +1137,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         setLoading(false);
                         // Fire-and-forget background revalidation. Bail out if
                         // the user has navigated away or to another session.
-                        getSpaCocClient().processes.get(pid).then((processData: any) => {
+                        client.processes.get(pid).then((processData: any) => {
                             if (loadCounterRef.current !== loadId) return;
                             const loadedProcess = processData?.process ?? null;
                             if (!loadedProcess) return;
@@ -1155,7 +1161,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         return;
                     }
 
-                    const processData = await getSpaCocClient().processes.get(pid);
+                    const processData = await client.processes.get(pid);
                     if (loadCounterRef.current !== loadId) return;
                     const loadedProcess = processData?.process ?? null;
 
@@ -1185,7 +1191,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 }
 
                 // Queue fetch path — taskId may be bare or a processId that fell through
-                const queueData = await getSpaCocClient().queue.getTask(bareTaskId);
+                const queueData = await client.queue.getTask(bareTaskId);
                 if (loadCounterRef.current !== loadId) return;
                 const loadedTask = queueData?.task ?? null;
 
@@ -1206,7 +1212,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     setTask(loadedTask);
                     setTurnsAndRef(cached.turns);
                     // Background-refresh metadata
-                    getSpaCocClient().processes.get(pid)
+                    client.processes.get(pid)
                         .then((data: any) => {
                             setProcessDetails(data?.process || null);
                             seedSessionTokensFromProcess(data?.process);
@@ -1232,7 +1238,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         })
                         .catch(() => { /* metadata refresh is best-effort */ });
                 } else {
-                    const procData = await getSpaCocClient().processes.get(pid);
+                    const procData = await client.processes.get(pid);
                     if (loadCounterRef.current !== loadId) return;
 
                     // Reconcile: process status is authoritative over queue status.
@@ -1322,7 +1328,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
             try {
                 // For processId-keyed taskIds, try loading process directly first
                 if (isQueueProcessId(taskId)) {
-                    const procData = await getSpaCocClient().processes.get(taskId);
+                    const procData = await client.processes.get(taskId);
                     if (procData?.process) {
                         setTask({
                             id: taskId,
@@ -1344,7 +1350,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     // Fall through to queue fetch with bare taskId
                 }
 
-                const queueData = await getSpaCocClient().queue.getTask(bareTaskId);
+                const queueData = await client.queue.getTask(bareTaskId);
                 const refreshedTask = queueData?.task ?? null;
 
                 const pid = refreshedTask?.processId ?? (isQueueProcessId(taskId) ? taskId : toQueueProcessId(taskId));
@@ -1353,7 +1359,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     return;
                 }
 
-                const procData = await getSpaCocClient().processes.get(pid);
+                const procData = await client.processes.get(pid);
 
                 // Reconcile: process status is authoritative over queue status.
                 // Also propagate customTitle/lastMessagePreview/title from the
@@ -1423,13 +1429,13 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     useEffect(() => () => { stopStreaming(); closeFollowUpStream(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleCancel = async () => {
-        await getSpaCocClient().queue.cancel(bareTaskId);
+        await client.queue.cancel(bareTaskId);
         if (!standalone) queueDispatch({ type: 'SELECT_QUEUE_TASK', id: null, repoId: workspaceId });
         onBack?.();
     };
 
     const handleMoveToTop = async () => {
-        await getSpaCocClient().queue.moveToTop(bareTaskId);
+        await client.queue.moveToTop(bareTaskId);
         queueDispatch({ type: 'REFRESH_SELECTED_QUEUE_TASK' });
     };
 
@@ -1441,7 +1447,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const handleStop = useCallback(async () => {
         if (!processId) return;
         try {
-            await getSpaCocClient().processes.cancel(processId);
+            await client.processes.cancel(processId);
         } catch { /* best-effort: SSE will reflect the actual state */ }
     }, [processId]);
 
@@ -1451,7 +1457,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const handleDeleteTurn = useCallback((turnIndex: number) => {
         if (!processId) return;
         setTurns(prev => prev.map(t => t.turnIndex === turnIndex ? { ...t, deletedAt: new Date().toISOString() } : t));
-        getSpaCocClient().processes.deleteTurn(processId, turnIndex).catch(() => {
+        client.processes.deleteTurn(processId, turnIndex).catch(() => {
             setTurns(prev => prev.map(t => t.turnIndex === turnIndex ? { ...t, deletedAt: undefined } : t));
         });
         if (undoDelete) clearTimeout(undoDelete.timer);
@@ -1465,7 +1471,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         const { turnIndex } = undoDelete;
         setUndoDelete(null);
         setTurns(prev => prev.map(t => t.turnIndex === turnIndex ? { ...t, deletedAt: undefined } : t));
-        getSpaCocClient().processes.restoreTurn(processId, turnIndex).catch(() => {});
+        client.processes.restoreTurn(processId, turnIndex).catch(() => {});
     }, [undoDelete, processId]);
 
     const handlePinTurn = useCallback((turnIndex: number, pinned: boolean) => {
@@ -1475,7 +1481,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 ? { ...t, pinnedAt: pinned ? new Date().toISOString() : undefined, archived: pinned ? false : t.archived }
                 : t
         ));
-        getSpaCocClient().processes.pinTurn(processId, turnIndex, pinned).catch(() => {
+        client.processes.pinTurn(processId, turnIndex, pinned).catch(() => {
             setTurns(prev => prev.map(t =>
                 t.turnIndex === turnIndex
                     ? { ...t, pinnedAt: pinned ? undefined : new Date().toISOString() }
@@ -1489,7 +1495,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         setTurns(prev => prev.map(t =>
             t.turnIndex === turnIndex ? { ...t, archived } : t
         ));
-        getSpaCocClient().processes.archiveTurn(processId, turnIndex, archived).catch(() => {
+        client.processes.archiveTurn(processId, turnIndex, archived).catch(() => {
             setTurns(prev => prev.map(t =>
                 t.turnIndex === turnIndex ? { ...t, archived: !archived } : t
             ));
@@ -1503,7 +1509,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
             removed = prev.find(m => m.id === messageId);
             return prev.filter(m => m.id !== messageId);
         });
-        getSpaCocClient().processes.deletePendingMessage(processId, messageId).catch(() => {
+        client.processes.deletePendingMessage(processId, messageId).catch(() => {
             if (removed) {
                 setPendingQueue(prev => (prev.some(m => m.id === messageId) ? prev : [...prev, removed!]));
             }
@@ -1515,7 +1521,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         setResumeLaunching(true);
         setResumeFeedback(null);
         try {
-            const body = await getSpaCocClient().processes.resumeCli(processId);
+            const body = await client.processes.resumeCli(processId);
             const launched = body.launched !== false;
             setResumeFeedback({
                 type: 'success',
@@ -1533,7 +1539,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         if (!processId || forking) return;
         setForking(true);
         try {
-            const data = await getSpaCocClient().processes.fork(processId);
+            const data = await client.processes.fork(processId);
             if (data?.process?.id && workspaceId) {
                 location.hash = '#repos/' + encodeURIComponent(workspaceId) + '/activity/' + encodeURIComponent(data.process.id);
             }
@@ -1550,7 +1556,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         if (retryingTask) return;
         setRetryingTask(true);
         try {
-            const res = await getSpaCocClient().queue.retry(bareTaskId);
+            const res = await client.queue.retry(bareTaskId);
             const newId = res?.task?.id;
             if (newId) {
                 const newProcessId = toQueueProcessId(String(newId));
@@ -2123,7 +2129,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     setRenameOpen(false);
                     if (!processId) return;
                     try {
-                        await getSpaCocClient().processes.update(processId, { customTitle: newTitle });
+                        await client.processes.update(processId, { customTitle: newTitle });
                     } catch { /* WS will sync eventually */ }
                 }}
             />

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1789,6 +1789,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         pendingAskUserBatch={pendingAskUserBatch}
                         ralphGrillPlanningProgress={ralphGrillPlanningProgress}
                         onAskUserAnswered={() => setPendingAskUserBatch(null)}
+                        workspaceId={workspaceId}
                         isScrolledUp={isScrolledUp}
                         scrollRef={conversationContainerRef}
                         turnsContainerRef={turnsContainerRef}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -15,7 +15,7 @@ import { useQueueDragDrop } from '../../queue/hooks/useQueueDragDrop';
 import { useQueueTouchDragDrop } from '../../queue/hooks/useQueueTouchDragDrop';
 import { ContextMenu, type ContextMenuItem } from '../../tasks/comments/ContextMenu';
 import { RenameDialog } from '../../ui/RenameDialog';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { useWorkflowProgress } from '../workflow/hooks/useWorkflowProgress';
 import { getDraft } from './hooks/useDraftStore';
 import { useLongPress } from '../../hooks/ui/useLongPress';
@@ -740,6 +740,11 @@ export function ChatListPane({
 }: ChatListPaneProps) {
     const { state: queueState } = useQueue();
     const isTaskSubmitting = queueState.isTaskSubmitting;
+
+    // Per-clone client (AC-07): list-row queue/history/summarize/rename actions
+    // target this clone's server. workspaceId may be undefined (e.g. floating
+    // panes) → default origin client, unchanged.
+    const cloneClient = useCocClient(workspaceId);
 
     /** Check if a task is the currently selected one (processId-aware). */
     const isSelected = useCallback((taskId: string): boolean => {
@@ -1577,15 +1582,15 @@ export function ChatListPane({
     }, [visibleHistoryRangeRows]);
 
     const handleCancel = async (taskId: string) => {
-        await getSpaCocClient().queue.cancel(taskId);
+        await cloneClient.queue.cancel(taskId);
         fetchQueue();
     };
 
     const deleteChatDirect = async (taskId: string) => {
         if (workspaceId) {
-            await getSpaCocClient().workspaces.deleteHistory(workspaceId, taskId);
+            await cloneClient.workspaces.deleteHistory(workspaceId, taskId);
         } else {
-            await getSpaCocClient().queue.deleteHistoryEntry(taskId);
+            await cloneClient.queue.deleteHistoryEntry(taskId);
         }
         fetchQueue();
     };
@@ -1596,27 +1601,27 @@ export function ChatListPane({
     };
 
     const handleMoveUp = async (taskId: string) => {
-        await getSpaCocClient().queue.moveUp(taskId);
+        await cloneClient.queue.moveUp(taskId);
         fetchQueue();
     };
 
     const handleMoveToTop = async (taskId: string) => {
-        await getSpaCocClient().queue.moveToTop(taskId);
+        await cloneClient.queue.moveToTop(taskId);
         fetchQueue();
     };
 
     const handleMoveToPosition = async (taskId: string, newIndex: number) => {
-        await getSpaCocClient().queue.moveToPosition(taskId, newIndex);
+        await cloneClient.queue.moveToPosition(taskId, newIndex);
         fetchQueue();
     };
 
     const handleFreeze = async (taskId: string) => {
-        await getSpaCocClient().queue.freeze(taskId);
+        await cloneClient.queue.freeze(taskId);
         fetchQueue();
     };
 
     const handleUnfreeze = async (taskId: string) => {
-        await getSpaCocClient().queue.unfreeze(taskId);
+        await cloneClient.queue.unfreeze(taskId);
         fetchQueue();
     };
 
@@ -1625,7 +1630,7 @@ export function ChatListPane({
     const handleAdmit = async (taskId: string) => {
         setIsAdmitting(true);
         try {
-            await getSpaCocClient().queue.admit(taskId);
+            await cloneClient.queue.admit(taskId);
             await fetchQueue();
         } finally {
             setIsAdmitting(false);
@@ -1633,18 +1638,18 @@ export function ChatListPane({
     };
 
     const handleUnadmit = async (taskId: string) => {
-        await getSpaCocClient().queue.unadmit(taskId);
+        await cloneClient.queue.unadmit(taskId);
         fetchQueue();
     };
 
     const handleInsertPauseMarker = async (afterIndex: number) => {
         setInsertingPauseAt(null);
-        await getSpaCocClient().queue.insertPauseMarker({ afterIndex, ...(workspaceId ? { repoId: workspaceId } : {}) });
+        await cloneClient.queue.insertPauseMarker({ afterIndex, ...(workspaceId ? { repoId: workspaceId } : {}) });
         fetchQueue();
     };
 
     const handleRemovePauseMarker = async (markerId: string) => {
-        await getSpaCocClient().queue.removePauseMarker(markerId);
+        await cloneClient.queue.removePauseMarker(markerId);
         fetchQueue();
     };
 
@@ -1790,10 +1795,10 @@ export function ChatListPane({
         const processId = ensureQueueProcessId(renameTarget.taskId);
         setRenameTarget(null);
         try {
-            await getSpaCocClient().processes.update(processId, { customTitle: newTitle });
+            await cloneClient.processes.update(processId, { customTitle: newTitle });
             fetchQueue();
         } catch { /* WS will sync eventually */ }
-    }, [renameTarget, fetchQueue]);
+    }, [renameTarget, fetchQueue, cloneClient]);
 
     const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
         if (!contextMenu) return [];
@@ -3603,7 +3608,7 @@ export function ChatListPane({
             chatCount={summarizeDialogIds.length}
             onClose={() => setSummarizeDialogOpen(false)}
             onConfirm={async (userPrompt) => {
-                const data = await getSpaCocClient().queue.summarize({
+                const data = await cloneClient.queue.summarize({
                     processIds: summarizeDialogIds,
                     workspaceId,
                     userPrompt: userPrompt || undefined,

--- a/packages/coc/src/server/spa/client/react/features/chat/ConversationArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ConversationArea.tsx
@@ -27,6 +27,8 @@ export interface ConversationAreaProps {
     ralphGrillPlanningProgress?: RalphGrillPlanningProgress | null;
     /** Called when the user answers or skips the pending question batch. */
     onAskUserAnswered?: () => void;
+    /** Owning workspace, so an ask_user reply routes to the chat's clone (AC-07). */
+    workspaceId?: string;
     isScrolledUp: boolean;
     scrollRef: React.RefObject<HTMLDivElement>;
     /** Ref attached to the inner turns container (for minimap navigation) */
@@ -119,6 +121,7 @@ export function ConversationArea({
     pendingAskUserBatch,
     ralphGrillPlanningProgress,
     onAskUserAnswered,
+    workspaceId,
     isScrolledUp,
     scrollRef,
     turnsContainerRef,
@@ -390,6 +393,7 @@ export function ConversationArea({
                                 batch={pendingAskUserBatch}
                                 processId={processId ?? taskId}
                                 onAnswered={onAskUserAnswered ?? (() => {})}
+                                workspaceId={workspaceId}
                             />
                         )}
                         {showRalphGrillPlanningProgress && (

--- a/packages/coc/src/server/spa/client/react/features/chat/ForEachPlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ForEachPlanReviewCard.tsx
@@ -14,7 +14,8 @@ import {
     scanForEachPlanArtifacts,
 } from '@plusplusoneplusplus/coc-client';
 import type { ClientConversationTurn } from '../../types/dashboard';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { cn } from '../../ui/cn';
 
 export interface ForEachGenerationMetadata {
@@ -190,6 +191,8 @@ export function ForEachPlanReviewCard({
     reasoningEffort,
     onApprovedRun,
 }: ForEachPlanReviewCardProps) {
+    // AC-07: plan create/update/approve route to the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const transcriptScan = useMemo(() => scanForEachPlans(turns), [turns]);
     const persistedScan = useMemo(() => getPersistedPlanState(forEach), [forEach]);
     const scan = latestScanTurn(transcriptScan) > latestScanTurn(persistedScan)
@@ -284,7 +287,7 @@ export function ForEachPlanReviewCard({
         setBusy(true);
         setError(null);
         try {
-            const client = getSpaCocClient();
+            const client = cloneClient;
             const run = forEach.runId
                 ? await client.forEach.updatePlan(workspaceId, forEach.runId, {
                     items: checked.items,

--- a/packages/coc/src/server/spa/client/react/features/chat/ForEachRunPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ForEachRunPane.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ForEachItem, ForEachItemStatus, ForEachRun, ForEachRunStatus } from '@plusplusoneplusplus/coc-client';
 import { cn } from '../../ui/cn';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { formatRelativeTime } from '../../utils/format';
 
 export interface ForEachRunPaneProps {
@@ -66,20 +67,22 @@ function promptPreview(item: ForEachItem): string {
 }
 
 export function ForEachRunPane({ workspaceId, runId, onClose, onSelectGenerationProcess, onSelectChildProcess }: ForEachRunPaneProps) {
+    // AC-07: For Each run data + actions target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const [run, setRun] = useState<ForEachRun | null | undefined>(undefined);
     const [busyAction, setBusyAction] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     const refresh = useCallback(async () => {
         try {
-            const nextRun = await getSpaCocClient().forEach.get(workspaceId, runId);
+            const nextRun = await cloneClient.forEach.get(workspaceId, runId);
             setRun(nextRun);
             setError(null);
         } catch (err) {
             setRun(null);
             setError(getSpaCocClientErrorMessage(err, 'Failed to load For Each run'));
         }
-    }, [workspaceId, runId]);
+    }, [workspaceId, runId, cloneClient]);
 
     useEffect(() => {
         setRun(undefined);
@@ -121,9 +124,9 @@ export function ForEachRunPane({ workspaceId, runId, onClose, onSelectGeneration
     const cancelEnabled = canCancel(run);
     const startOrContinue = () => {
         if (run.status === 'approved') {
-            return getSpaCocClient().forEach.start(workspaceId, run.runId);
+            return cloneClient.forEach.start(workspaceId, run.runId);
         }
-        return getSpaCocClient().forEach.continue(workspaceId, run.runId);
+        return cloneClient.forEach.continue(workspaceId, run.runId);
     };
     const generationProcessId = run.generationProcessId;
 
@@ -168,7 +171,7 @@ export function ForEachRunPane({ workspaceId, runId, onClose, onSelectGeneration
                     </button>
                     <button
                         type="button"
-                        onClick={() => runAction('cancel', () => getSpaCocClient().forEach.cancel(workspaceId, run.runId))}
+                        onClick={() => runAction('cancel', () => cloneClient.forEach.cancel(workspaceId, run.runId))}
                         disabled={!cancelEnabled || busyAction !== null}
                         data-testid="for-each-cancel-btn"
                         className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
@@ -234,8 +237,8 @@ export function ForEachRunPane({ workspaceId, runId, onClose, onSelectGeneration
                                     item={item}
                                     busyAction={busyAction}
                                     onSelectChildProcess={onSelectChildProcess}
-                                    onRetry={() => runAction(`retry:${item.id}`, () => getSpaCocClient().forEach.retryItem(workspaceId, run.runId, item.id))}
-                                    onSkip={() => runAction(`skip:${item.id}`, () => getSpaCocClient().forEach.skipItem(workspaceId, run.runId, item.id))}
+                                    onRetry={() => runAction(`retry:${item.id}`, () => cloneClient.forEach.retryItem(workspaceId, run.runId, item.id))}
+                                    onSkip={() => runAction(`skip:${item.id}`, () => cloneClient.forEach.skipItem(workspaceId, run.runId, item.id))}
                                 />
                             ))}
                         </tbody>

--- a/packages/coc/src/server/spa/client/react/features/chat/ImplementPlanCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ImplementPlanCard.tsx
@@ -8,7 +8,8 @@
  */
 
 import { useState } from 'react';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { isQueueProcessId, toQueueProcessId } from '../../utils/queue-process-id';
 import { formatRelativeTime } from '../../utils/format';
 import { cn } from '../../ui/cn';
@@ -76,6 +77,8 @@ export function ImplementPlanCard({
     sourceMetadata,
     onRecordPersisted,
 }: ImplementPlanCardProps) {
+    // AC-07: enqueue + metadata update target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const [submitting, setSubmitting] = useState(false);
     const [submitted, setSubmitted] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -90,7 +93,7 @@ export function ImplementPlanCard({
         setSubmitting(true);
         setError(null);
         try {
-            const result = await getSpaCocClient().queue.enqueue({
+            const result = await cloneClient.queue.enqueue({
                 type: 'chat',
                 priority: 'normal',
                 payload: {
@@ -121,7 +124,7 @@ export function ImplementPlanCard({
                     implementations: [...prevImpls, record],
                 };
                 try {
-                    await getSpaCocClient().processes.update(sourceProcessId, { metadata: merged } as any);
+                    await cloneClient.processes.update(sourceProcessId, { metadata: merged } as any);
                     onRecordPersisted?.(record);
                 } catch (persistErr) {
                     console.warn('Failed to persist implementation record:', persistErr);

--- a/packages/coc/src/server/spa/client/react/features/chat/MapReducePlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/MapReducePlanReviewCard.tsx
@@ -17,7 +17,8 @@ import {
     validateMapReduceDraftPlan,
 } from '@plusplusoneplusplus/coc-client';
 import type { ClientConversationTurn } from '../../types/dashboard';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { cn } from '../../ui/cn';
 
 export interface MapReduceGenerationMetadata {
@@ -213,6 +214,8 @@ export function MapReducePlanReviewCard({
     reasoningEffort,
     onApprovedRun,
 }: MapReducePlanReviewCardProps) {
+    // AC-07: plan create/update/approve route to the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const transcriptScan = useMemo(() => scanMapReducePlans(turns), [turns]);
     const persistedScan = useMemo(() => getPersistedPlanState(mapReduce), [mapReduce]);
     const scan = latestScanTurn(transcriptScan) > latestScanTurn(persistedScan)
@@ -319,7 +322,7 @@ export function MapReducePlanReviewCard({
         setBusy(true);
         setError(null);
         try {
-            const client = getSpaCocClient();
+            const client = cloneClient;
             const run = mapReduce.runId
                 ? await client.mapReduce.updatePlan(workspaceId, mapReduce.runId, {
                     items: checked.plan.items,

--- a/packages/coc/src/server/spa/client/react/features/chat/MapReduceRunPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/MapReduceRunPane.tsx
@@ -8,7 +8,8 @@ import type {
     MapReduceRunStatus,
 } from '@plusplusoneplusplus/coc-client';
 import { cn } from '../../ui/cn';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { formatRelativeTime } from '../../utils/format';
 
 export interface MapReduceRunPaneProps {
@@ -88,20 +89,22 @@ function promptPreview(item: MapReduceItem): string {
 }
 
 export function MapReduceRunPane({ workspaceId, runId, onClose, onSelectGenerationProcess, onSelectChildProcess }: MapReduceRunPaneProps) {
+    // AC-07: Map Reduce run data + actions target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const [run, setRun] = useState<MapReduceRun | null | undefined>(undefined);
     const [busyAction, setBusyAction] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     const refresh = useCallback(async () => {
         try {
-            const nextRun = await getSpaCocClient().mapReduce.get(workspaceId, runId);
+            const nextRun = await cloneClient.mapReduce.get(workspaceId, runId);
             setRun(nextRun);
             setError(null);
         } catch (err) {
             setRun(null);
             setError(getSpaCocClientErrorMessage(err, 'Failed to load Map Reduce run'));
         }
-    }, [workspaceId, runId]);
+    }, [workspaceId, runId, cloneClient]);
 
     useEffect(() => {
         setRun(undefined);
@@ -143,9 +146,9 @@ export function MapReduceRunPane({ workspaceId, runId, onClose, onSelectGenerati
     const cancelEnabled = canCancel(run);
     const startOrContinue = () => {
         if (run.status === 'approved') {
-            return getSpaCocClient().mapReduce.start(workspaceId, run.runId);
+            return cloneClient.mapReduce.start(workspaceId, run.runId);
         }
-        return getSpaCocClient().mapReduce.continue(workspaceId, run.runId);
+        return cloneClient.mapReduce.continue(workspaceId, run.runId);
     };
     const generationProcessId = run.generationProcessId;
 
@@ -192,7 +195,7 @@ export function MapReduceRunPane({ workspaceId, runId, onClose, onSelectGenerati
                     </button>
                     <button
                         type="button"
-                        onClick={() => runAction('cancel', () => getSpaCocClient().mapReduce.cancel(workspaceId, run.runId))}
+                        onClick={() => runAction('cancel', () => cloneClient.mapReduce.cancel(workspaceId, run.runId))}
                         disabled={!cancelEnabled || busyAction !== null}
                         data-testid="map-reduce-cancel-btn"
                         className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
@@ -254,7 +257,7 @@ export function MapReduceRunPane({ workspaceId, runId, onClose, onSelectGenerati
                         reduceStep={run.reduceStep}
                         busyAction={busyAction}
                         onSelectChildProcess={onSelectChildProcess}
-                        onRetry={() => runAction('retry-reduce', () => getSpaCocClient().mapReduce.retryReduce(workspaceId, run.runId))}
+                        onRetry={() => runAction('retry-reduce', () => cloneClient.mapReduce.retryReduce(workspaceId, run.runId))}
                     />
                 </section>
 
@@ -276,8 +279,8 @@ export function MapReduceRunPane({ workspaceId, runId, onClose, onSelectGenerati
                                     item={item}
                                     busyAction={busyAction}
                                     onSelectChildProcess={onSelectChildProcess}
-                                    onRetry={() => runAction(`retry:${item.id}`, () => getSpaCocClient().mapReduce.retryItem(workspaceId, run.runId, item.id))}
-                                    onSkip={() => runAction(`skip:${item.id}`, () => getSpaCocClient().mapReduce.skipItem(workspaceId, run.runId, item.id))}
+                                    onRetry={() => runAction(`retry:${item.id}`, () => cloneClient.mapReduce.retryItem(workspaceId, run.runId, item.id))}
+                                    onSkip={() => runAction(`skip:${item.id}`, () => cloneClient.mapReduce.skipItem(workspaceId, run.runId, item.id))}
                                 />
                             ))}
                         </tbody>

--- a/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/NewChatArea.tsx
@@ -16,7 +16,8 @@ import { MODE_BORDER_COLORS, cycleMode, normalizeChatMode } from '../../repos/mo
 import type { ChatMode } from '../../repos/modeConfig';
 import { useQueue } from '../../contexts/QueueContext';
 import { useApp } from '../../contexts/AppContext';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { useFileAttachments } from './hooks/useFileAttachments';
 import { isQueueProcessId, toQueueProcessId } from '../../utils/queue-process-id';
 import { useModels } from '../../hooks/useModels';
@@ -145,6 +146,8 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
     const { dispatch: queueDispatch } = useQueue();
     const { state: appState } = useApp();
     const { updateOnboarding } = useOnboardingPreferences();
+    // AC-07: enqueue the new chat onto the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
 
     function getSelectedWorkspaceRoot(): string | undefined {
         const ws = appState.workspaces?.find((w: any) => w.id === workspaceId);
@@ -152,7 +155,7 @@ export function NewChatArea({ workspaceId, onBack }: NewChatAreaProps) {
     }
 
     async function handleSubmit(submission: InitialChatComposerSubmission): Promise<string | null> {
-        const result = await getSpaCocClient().queue.enqueue({
+        const result = await cloneClient.queue.enqueue({
             type: 'chat',
             priority: 'normal',
             payload: {
@@ -234,6 +237,9 @@ export function InitialChatComposer({
      *  When set, prevents auto-derive from overwriting the user's pick for the same model.
      *  Cleared on provider or model change (triggering re-derive for the new model). */
     const userPickedForModelRef = useRef<{ provider: ChatProvider; modelId: string } | null>(null);
+
+    // AC-07: skills + per-repo chat preferences load from the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
 
     const { attachments, addFromPaste, addFromFileInput, removeAttachment, clearAttachments, error: attachmentError, toPayload } = useFileAttachments();
     const attachedContext = useAttachedContext();
@@ -413,7 +419,7 @@ export function InitialChatComposer({
     useEffect(() => {
         setSkills([]);
         if (!workspaceId) return;
-        getSpaCocClient().skills.listAllWorkspace(workspaceId)
+        cloneClient.skills.listAllWorkspace(workspaceId)
             .then((data: any) => {
                 if (data?.merged && Array.isArray(data.merged)) {
                     setSkills(data.merged);
@@ -422,7 +428,7 @@ export function InitialChatComposer({
                 }
             })
             .catch(() => { /* ignore */ });
-    }, [workspaceId]);
+    }, [workspaceId, cloneClient]);
 
     const getSelectableDefaultProvider = () => {
         return getSelectableComposerDefaultProvider(agentProviders);
@@ -437,7 +443,7 @@ export function InitialChatComposer({
             setSelectedProvider(fallbackProvider);
             return;
         }
-        getSpaCocClient().preferences.getRepo(workspaceId)
+        cloneClient.preferences.getRepo(workspaceId)
             .then((prefs: any) => {
                 if (cancelled) return;
                 const last = prefs?.lastChatProvider;
@@ -451,7 +457,7 @@ export function InitialChatComposer({
                 if (!cancelled) setSelectedProvider(fallbackProvider);
             });
         return () => { cancelled = true; };
-    }, [workspaceId, agentProviders]);
+    }, [workspaceId, agentProviders, cloneClient]);
 
     // When agentProviders load and selected provider becomes unavailable, fall back to the default provider.
     useEffect(() => {
@@ -533,7 +539,7 @@ export function InitialChatComposer({
     function handleProviderChange(provider: ChatProvider) {
         setSelectedProvider(provider);
         if (workspaceId) {
-            getSpaCocClient().preferences.patchRepo(workspaceId, { lastChatProvider: provider })
+            cloneClient.preferences.patchRepo(workspaceId, { lastChatProvider: provider })
                 .catch(() => { /* non-fatal */ });
         }
     }

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPane.tsx
@@ -24,7 +24,7 @@ import type {
 } from '@plusplusoneplusplus/coc-client';
 import { RalphWorkflowNode } from './RalphWorkflowNode';
 import { RalphFinalCheckNode } from './RalphFinalCheckNode';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { RALPH_MULTI_LOOP } from '../../featureFlags';
 import { ModalJobAiControls, type ResolvedModalJobAiSelection, useModalJobAiSelection } from '../../shared/ModalJobAiControls';
 
@@ -285,6 +285,9 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
         onSelectFile,
     } = props;
 
+    // AC-07: Ralph continue/new-loop/resume target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
+
     const [continueState, setContinueState] = useState<'idle' | 'confirm' | 'submitting'>('idle');
     const [continueError, setContinueError] = useState<string | null>(null);
 
@@ -365,7 +368,7 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
             if (onResume) {
                 await onResume(resolvedResumeSelection);
             } else {
-                await getSpaCocClient().workspaces.resumeRalphSession(
+                await cloneClient.workspaces.resumeRalphSession(
                     workspaceId,
                     sessionId,
                     buildRalphResumeRequest(resolvedResumeSelection),
@@ -388,7 +391,7 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
             if (onContinue) {
                 await onContinue(continueDefaultIterations, resolvedContinueSelection);
             } else {
-                await getSpaCocClient().workspaces.continueRalphSession(
+                await cloneClient.workspaces.continueRalphSession(
                     workspaceId,
                     sessionId,
                     buildRalphContinueRequest(continueDefaultIterations, resolvedContinueSelection),
@@ -412,7 +415,7 @@ export function RalphWorkflowPane(props: RalphWorkflowPaneProps): React.ReactEle
             if (onNewLoop) {
                 await onNewLoop(trimmed, resolvedNewLoopIterations);
             } else {
-                await getSpaCocClient().workspaces.startNewRalphLoop(workspaceId, sessionId, {
+                await cloneClient.workspaces.startNewRalphLoop(workspaceId, sessionId, {
                     newGoal: trimmed,
                     additionalIterations: resolvedNewLoopIterations,
                 });

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPaneContainer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphWorkflowPaneContainer.tsx
@@ -21,7 +21,7 @@ import {
     RalphWorkflowPane,
 } from './RalphWorkflowPane';
 import { useRalphSessionView } from './useRalphSessionView';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import type { ResolvedModalJobAiSelection } from '../../shared/ModalJobAiControls';
 
 export interface RalphWorkflowPaneContainerProps {
@@ -50,6 +50,8 @@ export function RalphWorkflowPaneContainer(
         onSelectFile,
         now,
     } = props;
+    // AC-07: Ralph continue/new-loop/resume target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const { view, refresh } = useRalphSessionView(workspaceId, sessionId);
 
     const handleSelectIteration = useCallback(
@@ -67,37 +69,37 @@ export function RalphWorkflowPaneContainer(
 
     const handleContinue = useCallback(
         async (additionalIterations: number, aiSelection?: ResolvedModalJobAiSelection) => {
-            await getSpaCocClient().workspaces.continueRalphSession(
+            await cloneClient.workspaces.continueRalphSession(
                 workspaceId,
                 sessionId,
                 buildRalphContinueRequest(additionalIterations, aiSelection),
             );
             refresh();
         },
-        [workspaceId, sessionId, refresh],
+        [workspaceId, sessionId, refresh, cloneClient],
     );
 
     const handleNewLoop = useCallback(
         async (newGoal: string, additionalIterations: number) => {
-            await getSpaCocClient().workspaces.startNewRalphLoop(workspaceId, sessionId, {
+            await cloneClient.workspaces.startNewRalphLoop(workspaceId, sessionId, {
                 newGoal,
                 additionalIterations,
             });
             refresh();
         },
-        [workspaceId, sessionId, refresh],
+        [workspaceId, sessionId, refresh, cloneClient],
     );
 
     const handleResume = useCallback(
         async (aiSelection?: ResolvedModalJobAiSelection) => {
-            await getSpaCocClient().workspaces.resumeRalphSession(
+            await cloneClient.workspaces.resumeRalphSession(
                 workspaceId,
                 sessionId,
                 buildRalphResumeRequest(aiSelection),
             );
             refresh();
         },
-        [workspaceId, sessionId, refresh],
+        [workspaceId, sessionId, refresh, cloneClient],
     );
 
     return (

--- a/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { cn } from '../../ui';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { isContainerMode, isForEachEnabled, isMapReduceEnabled } from '../../utils/config';
 import { useQueue } from '../../contexts/QueueContext';
 import { useApp } from '../../contexts/AppContext';
@@ -86,6 +86,11 @@ function getActiveProcessIds(tasks: any[]): string[] {
 
 export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
     const { state: queueState, dispatch: queueDispatch } = useQueue();
+
+    // Per-clone client (AC-07): the Activity tab's conversation LIST + queue +
+    // group-pins + forEach/mapReduce + pause/resume all load from THIS clone's
+    // server. A local clone resolves to the default origin (unchanged).
+    const cloneClient = useCocClient(workspaceId);
 
     // Seed from per-workspace caches so revisiting a repo renders the sidebar
     // instantly while the freshness fetch runs in the background.
@@ -172,7 +177,7 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
     const selectedTaskRef = useRef<any>(null);
 
     const fetchHistory = useCallback(async (offset = 0) => {
-        const data = await getSpaCocClient().workspaces.history(workspaceId, { limit: 100, offset }).catch(() => null);
+        const data = await cloneClient.workspaces.history(workspaceId, { limit: 100, offset }).catch(() => null);
         const items = (data?.history as ProcessHistoryItem[]) || [];
         const nextHasMore = data?.hasMore ?? false;
         if (offset === 0) {
@@ -186,14 +191,14 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             });
         }
         setHasMore(nextHasMore);
-    }, [workspaceId, queueDispatch]);
+    }, [workspaceId, queueDispatch, cloneClient]);
 
     const fetchQueueAndHistory = useCallback(async () => {
         // In container mode, skip fetch if agent hasn't been resolved yet —
         // the effect will re-fire once currentAgentId is set.
         if (isContainerMode() && !appState.currentAgentId) return;
         try {
-            const client = getSpaCocClient();
+            const client = cloneClient;
             const groupPinsRequest = typeof client.processes.listGroupPins === 'function'
                 ? client.processes.listGroupPins(workspaceId).catch(() => null)
                 : Promise.resolve(null);
@@ -256,7 +261,7 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             // defensive. Deliberately do NOT clear local lists — keep the cached view.
         }
         setLoading(false);
-    }, [workspaceId, queueDispatch, appState.currentAgentId]);
+    }, [workspaceId, queueDispatch, appState.currentAgentId, cloneClient]);
 
     const fetchQueue = fetchQueueAndHistory;
 
@@ -376,13 +381,13 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
 
         let cancelled = false;
         // selectedTaskId is always a processId; probe /processes/ first, fall back to /queue/
-        const probeProcess = getSpaCocClient().processes.get(selectedTaskId)
+        const probeProcess = cloneClient.processes.get(selectedTaskId)
             .then((data: any) => {
                 if (cancelled) return;
                 if (data?.process) return; // found
                 // Not found as process — try queue with derived bare taskId
                 const bareId = isQueueProcessId(selectedTaskId) ? toTaskId(selectedTaskId) : selectedTaskId;
-                return getSpaCocClient().queue.getTask(bareId).then((qData: any) => {
+                return cloneClient.queue.getTask(bareId).then((qData: any) => {
                     if (cancelled) return;
                     if (!qData?.task) throw new Error('not found');
                 });
@@ -399,7 +404,7 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             });
         void probeProcess;
         return () => { cancelled = true; };
-    }, [selectedTaskId, running, queued, history, loading, queueDispatch, workspaceId]);
+    }, [selectedTaskId, running, queued, history, loading, queueDispatch, workspaceId, cloneClient]);
 
     // Update selectedTask when lists change
     useEffect(() => {
@@ -550,9 +555,9 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         setIsPauseResumeLoading(true);
         try {
             if (isPaused) {
-                await getSpaCocClient().queue.resume({ repoId: workspaceId });
+                await cloneClient.queue.resume({ repoId: workspaceId });
             } else {
-                await getSpaCocClient().queue.pause({ repoId: workspaceId }, isQueuePauseOptions(options) ? options : undefined);
+                await cloneClient.queue.pause({ repoId: workspaceId }, isQueuePauseOptions(options) ? options : undefined);
             }
             await fetchQueue();
         } finally {
@@ -564,9 +569,9 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         setIsAutopilotPauseLoading(true);
         try {
             if (isAutopilotPaused) {
-                await getSpaCocClient().queue.resumeAutopilot({ repoId: workspaceId });
+                await cloneClient.queue.resumeAutopilot({ repoId: workspaceId });
             } else {
-                await getSpaCocClient().queue.pauseAutopilot({ repoId: workspaceId }, isQueuePauseOptions(options) ? options : undefined);
+                await cloneClient.queue.pauseAutopilot({ repoId: workspaceId }, isQueuePauseOptions(options) ? options : undefined);
             }
             await fetchQueue();
         } finally {
@@ -592,7 +597,7 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             return pinned ? [{ type, groupId, pinnedAt: nextPinnedAt }, ...remaining] : remaining;
         });
         try {
-            const result = await getSpaCocClient().processes.pinGroup(workspaceId, type, groupId, pinned);
+            const result = await cloneClient.processes.pinGroup(workspaceId, type, groupId, pinned);
             setGroupPins(prev => {
                 const remaining = prev.filter(pin => !(pin.type === type && pin.groupId === groupId));
                 return result.pin ? [result.pin, ...remaining] : remaining;
@@ -600,7 +605,7 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         } catch {
             setGroupPins(previousPins);
         }
-    }, [groupPins, workspaceId]);
+    }, [groupPins, workspaceId, cloneClient]);
 
     const [selectedRalphSessionId, setSelectedRalphSessionId] = useState<string | null>(null);
     const [selectedRalphFileName, setSelectedRalphFileName] = useState<string | null>(null);

--- a/packages/coc/src/server/spa/client/react/features/chat/RunHistoryList.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RunHistoryList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { cn } from '../../ui';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { formatRelativeTime } from '../../utils/format';
 import type { RunRecord } from '../schedules/scheduleTypes';
 
@@ -25,6 +25,8 @@ interface RunHistoryListProps {
 }
 
 export function RunHistoryList({ runs: initialRuns, scheduleId, wsId, onRunNow, isRunning }: RunHistoryListProps) {
+    // AC-07: schedule run history loads from the selected clone's server.
+    const cloneClient = useCocClient(wsId);
     const [showOutputId, setShowOutputId] = useState<string | null>(null);
     const [history, setHistory] = useState<RunRecord[]>(initialRuns);
     const [historyPage, setHistoryPage] = useState(1);
@@ -40,11 +42,11 @@ export function RunHistoryList({ runs: initialRuns, scheduleId, wsId, onRunNow, 
     const refreshHistory = useCallback(async () => {
         setRefreshing(true);
         try {
-            const history = await getSpaCocClient().schedules.history(wsId, scheduleId);
+            const history = await cloneClient.schedules.history(wsId, scheduleId);
             setHistory(history);
         } catch { /* ignore */ }
         setRefreshing(false);
-    }, [wsId, scheduleId]);
+    }, [wsId, scheduleId, cloneClient]);
 
     // Auto-poll every 3s while any run is in-progress
     useEffect(() => {

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useChatSSE.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useChatSSE.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { getApiBase } from '../../../utils/config';
+import { cloneApiBase } from '../../../repos/cloneRegistry';
 import type { ClientConversationTurn } from '../../../types/dashboard';
 import type { QueuedMessage } from '../../../utils/chatUtils';
 
@@ -103,6 +103,12 @@ export interface UseChatSSEOptions {
     taskId: string;
     task: any;
     processId: string | null;
+    /**
+     * Workspace owning this chat. When it is a remote clone, the process-event
+     * SSE stream is opened against that clone's server (AC-07); local/undefined
+     * keeps the default page-origin stream.
+     */
+    workspaceId?: string;
     setIsStreaming: (v: boolean) => void;
     setTask: (updater: (prev: any) => any) => void;
     /**
@@ -142,6 +148,7 @@ export function useChatSSE({
     taskId,
     task,
     processId,
+    workspaceId,
     setIsStreaming,
     setTask,
     setProcessDetails,
@@ -179,7 +186,7 @@ export function useChatSSE({
         if (!taskId || task?.status !== 'running' || !processId) return;
         if (typeof EventSource === 'undefined') return;
 
-        const es = new EventSource(`${getApiBase()}/processes/${encodeURIComponent(processId)}/stream`);
+        const es = new EventSource(`${cloneApiBase(workspaceId)}/processes/${encodeURIComponent(processId)}/stream`);
         eventSourceRef.current = es;
         setIsStreaming(true);
         const sseStartTime = Date.now();
@@ -484,7 +491,7 @@ export function useChatSSE({
         });
 
         return () => { es.close(); eventSourceRef.current = null; setIsStreaming(false); };
-    }, [taskId, task?.status, processId, refreshConversation]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [taskId, task?.status, processId, workspaceId, refreshConversation]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return { stopStreaming };
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useLoops.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useLoops.ts
@@ -5,7 +5,7 @@
  * loop events to keep state up to date in real time.
  */
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import { isLoopsEnabled } from '../../../utils/config';
 import type { LoopEntry } from '@plusplusoneplusplus/coc-client';
 
@@ -34,6 +34,8 @@ export function useLoops(workspaceId: string | undefined, processId: string | nu
     const [loops, setLoops] = useState<LoopEntry[]>([]);
     const [loading, setLoading] = useState(false);
     const mountedRef = useRef(true);
+    // AC-07: loop list/pause/resume/cancel target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
 
     const fetchLoops = useCallback(() => {
         if (!workspaceId) return;
@@ -43,7 +45,7 @@ export function useLoops(workspaceId: string | undefined, processId: string | nu
             return;
         }
         setLoading(true);
-        getSpaCocClient().loops.list(workspaceId)
+        cloneClient.loops.list(workspaceId)
             .then((all) => {
                 if (!mountedRef.current) return;
                 // Filter to loops for this process
@@ -56,7 +58,7 @@ export function useLoops(workspaceId: string | undefined, processId: string | nu
             .finally(() => {
                 if (mountedRef.current) setLoading(false);
             });
-    }, [workspaceId, processId]);
+    }, [workspaceId, processId, cloneClient]);
 
     useEffect(() => {
         mountedRef.current = true;
@@ -84,21 +86,21 @@ export function useLoops(workspaceId: string | undefined, processId: string | nu
 
     const pause = useCallback(async (loopId: string, reason?: string) => {
         if (!workspaceId) return;
-        await getSpaCocClient().loops.pause(workspaceId, loopId, reason);
+        await cloneClient.loops.pause(workspaceId, loopId, reason);
         fetchLoops();
-    }, [workspaceId, fetchLoops]);
+    }, [workspaceId, fetchLoops, cloneClient]);
 
     const resume = useCallback(async (loopId: string) => {
         if (!workspaceId) return;
-        await getSpaCocClient().loops.resume(workspaceId, loopId);
+        await cloneClient.loops.resume(workspaceId, loopId);
         fetchLoops();
-    }, [workspaceId, fetchLoops]);
+    }, [workspaceId, fetchLoops, cloneClient]);
 
     const cancel = useCallback(async (loopId: string) => {
         if (!workspaceId) return;
-        await getSpaCocClient().loops.delete(workspaceId, loopId);
+        await cloneClient.loops.delete(workspaceId, loopId);
         fetchLoops();
-    }, [workspaceId, fetchLoops]);
+    }, [workspaceId, fetchLoops, cloneClient]);
 
     const activeCount = loops.filter(l => l.status === 'active').length;
     const manageableCount = loops.filter(l => l.status !== 'cancelled').length;

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useSendMessage.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useSendMessage.ts
@@ -9,7 +9,8 @@ import type { ChatMode } from '../../../repos/modeConfig';
 import type { DeliveryMode } from '@plusplusoneplusplus/forge';
 import type { AttachmentPayload } from '../../../types/attachments';
 import { CocApiError, type ProcessMessageRequest } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../../api/cocClient';
+import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 import { validateSessionContextAttachmentsForSend } from '../sessionContextDrop';
 import type { RalphGrillSetup } from '../../../../../../ralph/grill-planning';
 
@@ -206,7 +207,9 @@ export function useSendMessage({
             setError(null);
             setSending(true);
             try {
-                await getSpaCocClient().processes.promoteToRalph(processId, {
+                // Route the write to the chat's clone (AC-07): a remote clone's
+                // promotion hits its own server, never the local one.
+                await getCocClientForWorkspace(workspaceId).processes.promoteToRalph(processId, {
                     workspaceId,
                     extraGuidance: userText || undefined,
                     ...(ralphGrillSetup?.enabled ? { grill: ralphGrillSetup } : {}),
@@ -269,7 +272,8 @@ export function useSendMessage({
             // Both immediate and enqueue: fire POST to /message and let the
             // server steer, buffer, or enqueue as appropriate.  No local
             // pending queue entry — the server is the source of truth.
-            void getSpaCocClient().processes.sendMessage(
+            // Routed to the chat's clone (AC-07).
+            void getCocClientForWorkspace(workspaceId).processes.sendMessage(
                 processId,
                 buildMessageRequest(rawContent, deliveryMode, extractedSkills),
             ).catch(() => {});
@@ -296,7 +300,8 @@ export function useSendMessage({
         });
 
         try {
-            await getSpaCocClient().processes.sendMessage(
+            // Idle chat: start the streaming follow-up against the chat's clone (AC-07).
+            await getCocClientForWorkspace(workspaceId).processes.sendMessage(
                 processId,
                 buildMessageRequest(rawContent, deliveryMode, extractedSkills),
             );

--- a/packages/coc/src/server/spa/client/react/features/chat/sessionContextDrop.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/sessionContextDrop.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import type { AttachedContextItem } from './hooks/useAttachedContext';
 import {
     GIT_COMMIT_CONTEXT_DRAG_KIND,
@@ -544,6 +544,8 @@ export function validateSessionContextAttachmentsForSend(options: {
 
 export function useConversationRetrievalCapability(workspaceId: string | undefined, enabled: boolean): boolean | null {
     const [available, setAvailable] = useState<boolean | null>(enabled && workspaceId ? null : false);
+    // AC-07: read the LLM-tools config from the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
 
     useEffect(() => {
         if (!enabled || !workspaceId) {
@@ -553,7 +555,7 @@ export function useConversationRetrievalCapability(workspaceId: string | undefin
 
         let cancelled = false;
         setAvailable(null);
-        getSpaCocClient().preferences.getLlmToolsConfig(workspaceId)
+        cloneClient.preferences.getLlmToolsConfig(workspaceId)
             .then((config) => {
                 if (cancelled) return;
                 const hasGetConversation = (config.tools ?? []).some(tool => tool.name === 'get_conversation');
@@ -567,7 +569,7 @@ export function useConversationRetrievalCapability(workspaceId: string | undefin
             });
 
         return () => { cancelled = true; };
-    }, [enabled, workspaceId]);
+    }, [enabled, workspaceId, cloneClient]);
 
     return available;
 }

--- a/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
@@ -12,11 +12,12 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { fetchApi } from '../../hooks/useApi';
 import type { GitPatchApplyResponse } from '@plusplusoneplusplus/coc-client';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
+import { getCocClientForWorkspace } from '../../repos/cloneRegistry';
 import { Spinner } from '../../ui';
 import { CommitList, isTouchOnly } from './commits/CommitList';
 import type { GitCommitItem } from './commits/CommitList';
@@ -62,7 +63,7 @@ async function rebindCommitChat(
 ): Promise<void> {
     if (oldHash === newHash) return;
     try {
-        await getSpaCocClient().git.rebindCommitChatBinding(workspaceId, oldHash, newHash);
+        await getCocClientForWorkspace(workspaceId).git.rebindCommitChatBinding(workspaceId, oldHash, newHash);
     } catch {
         // Best-effort — binding may not exist; ignore errors
     }
@@ -141,6 +142,9 @@ type RightPanelView =
     | { type: 'multi-commit'; commits: GitCommitItem[] };
 
 export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
+    // AC-07: ALL Git tab data (commit list, branch range, fetch/pull/push/reset,
+    // operations, per-repo prefs, enqueue) targets the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const { state, dispatch } = useApp();
     const { dispatch: queueDispatch } = useQueue();
     const { markPoppedOut } = useGitReviewPopOut();
@@ -227,7 +231,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
     );
 
     const fetchRepoState = useCallback(() => {
-        getSpaCocClient().git.getRepoState(workspaceId)
+        cloneClient.git.getRepoState(workspaceId)
             .then(data => setRepoState(data))
             .catch(() => setRepoState(null));
     }, [workspaceId]);
@@ -247,7 +251,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                 }
             }
         }
-        return getSpaCocClient().git.listCommits(workspaceId, {
+        return cloneClient.git.listCommits(workspaceId, {
             limit: 50,
             skip: skipOffset > 0 ? skipOffset : undefined,
             refresh,
@@ -288,7 +292,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                 return Promise.resolve(cached.data);
             }
         }
-        return getSpaCocClient().git.getBranchRange(workspaceId, { refresh })
+        return cloneClient.git.getBranchRange(workspaceId, { refresh })
             .then(data => {
                 if (data.onDefaultBranch) {
                     setOnDefaultBranch(true);
@@ -367,7 +371,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                         if (initialCommitHash && isGitCommitLookupEnabled() && /^[0-9a-f]{7,40}$/i.test(initialCommitHash)) {
                             setCommitLookupLoading(true);
                             setCommitLookupError(null);
-                            getSpaCocClient().git.getCommit(workspaceId, initialCommitHash)
+                            cloneClient.git.getCommit(workspaceId, initialCommitHash)
                                 .then(result => {
                                     const commit: GitCommitItem = {
                                         hash: result.hash,
@@ -408,7 +412,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
             if (isGitCommitLookupEnabled() && /^[0-9a-f]{7,40}$/i.test(hash)) {
                 setCommitLookupLoading(true);
                 setCommitLookupError(null);
-                getSpaCocClient().git.getCommit(workspaceId, hash)
+                cloneClient.git.getCommit(workspaceId, hash)
                     .then(result => {
                         const commit: GitCommitItem = {
                             hash: result.hash,
@@ -439,7 +443,8 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
     // Fetch skills once per workspace
     useEffect(() => {
         setSkills([]);
-        fetchApi(`/workspaces/${encodeURIComponent(workspaceId)}/skills`)
+        // AC-07: skills list loads from the selected clone's server.
+        cloneClient.request<{ skills?: string[] }>(`/workspaces/${encodeURIComponent(workspaceId)}/skills`)
             .then(data => {
                 if (data?.skills && Array.isArray(data.skills)) {
                     setSkills(data.skills);
@@ -451,7 +456,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
     // Fetch commit-scoped skill usage map per workspace
     useEffect(() => {
         setCommitSkillUsageMap({});
-        getSpaCocClient().preferences.getRepo(workspaceId)
+        cloneClient.preferences.getRepo(workspaceId)
             .then(prefs => {
                 if (prefs?.commitSkillUsageMap) {
                     setCommitSkillUsageMap(prefs.commitSkillUsageMap);
@@ -569,7 +574,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                 }, 500);
                 // If we're tracking a pull job, re-fetch its status on git-changed
                 if (pullJobRef.current) {
-                    getSpaCocClient().git.getOperation(workspaceId, pullJobRef.current)
+                    cloneClient.git.getOperation(workspaceId, pullJobRef.current)
                         .then((job: any) => {
                             if (job && job.status !== 'running') {
                                 stopPullPolling();
@@ -600,7 +605,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         if (pullPollRef.current) clearInterval(pullPollRef.current);
         pullPollRef.current = setInterval(async () => {
             try {
-                const job = await getSpaCocClient().git.getOperation(workspaceId, jobId);
+                const job = await cloneClient.git.getOperation(workspaceId, jobId);
                 if (!job || job.status !== 'running') {
                     stopPullPolling();
                     if (job?.status === 'failed') {
@@ -623,7 +628,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
 
     // Recover pull status on mount (page refresh recovery)
     useEffect(() => {
-        getSpaCocClient().git.getLatestOperation(workspaceId, { op: 'pull' })
+        cloneClient.git.getLatestOperation(workspaceId, { op: 'pull' })
             .then((job: any) => {
                 if (!job) return;
                 if (job.status === 'running') {
@@ -646,7 +651,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setFetching(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.fetch(workspaceId);
+            const result = await cloneClient.git.fetch(workspaceId);
             if (result.success === false) throw new Error(result.error || 'Fetch failed');
             refreshAll();
         } catch (err: any) {
@@ -661,7 +666,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setPulling(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.pull(workspaceId, { rebase: true });
+            const result = await cloneClient.git.pull(workspaceId, { rebase: true });
             if (result.jobId) {
                 // Async pull — start polling for job completion
                 startPullPolling(result.jobId);
@@ -682,7 +687,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setPushing(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.push(workspaceId);
+            const result = await cloneClient.git.push(workspaceId);
             if (result.success === false) throw new Error(result.error || 'Push failed');
             refreshAll();
         } catch (err: any) {
@@ -697,7 +702,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setPushing(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.pushTo(workspaceId, commit.hash);
+            const result = await cloneClient.git.pushTo(workspaceId, commit.hash);
             if (result.success === false) throw new Error(result.error || 'Push failed');
             refreshAll();
         } catch (err: any) {
@@ -721,13 +726,13 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setRebasing(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.rebaseAutosquash(workspaceId);
+            const result = await cloneClient.git.rebaseAutosquash(workspaceId);
             if (result.jobId) {
                 // Async rebase — poll for job completion
                 const jobId: string = result.jobId;
                 const poll = setInterval(async () => {
                     try {
-                        const job = await getSpaCocClient().git.getOperation(workspaceId, jobId);
+                        const job = await cloneClient.git.getOperation(workspaceId, jobId);
                         if (!job || job.status !== 'running') {
                             clearInterval(poll);
                             setRebasing(false);
@@ -780,7 +785,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setCommitLookupError(null);
 
         try {
-            const result = await getSpaCocClient().git.getCommit(workspaceId, normalizedSha);
+            const result = await cloneClient.git.getCommit(workspaceId, normalizedSha);
             const commit: GitCommitItem = {
                 hash: result.hash,
                 shortHash: result.shortHash,
@@ -922,7 +927,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         if (!window.confirm(`Reset to ${shortHash}? This will discard all uncommitted changes.`)) return;
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.reset(workspaceId, commit.hash, 'hard');
+            const result = await cloneClient.git.reset(workspaceId, commit.hash, 'hard');
             if (result.success === false) throw new Error(result.error || 'Reset failed');
             refreshAll();
         } catch (err: any) {
@@ -957,7 +962,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         const primaryHash = hashes[0];
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.cherryPick(workspaceId, primaryHash, {
+            const result = await cloneClient.git.cherryPick(workspaceId, primaryHash, {
                 hashes,
                 targetBranch,
             });
@@ -1001,7 +1006,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setAmendingCommit(null);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.amend(workspaceId, title, body);
+            const result = await cloneClient.git.amend(workspaceId, title, body);
             if (result.error) throw new Error(result.error);
             // Rebind commit-chat if the amend produced a new hash
             if (result.hash && result.hash !== amendingCommit.hash) {
@@ -1020,7 +1025,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         setRewordingCommit(null);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.reword(workspaceId, rewordingCommit.hash, title);
+            const result = await cloneClient.git.reword(workspaceId, rewordingCommit.hash, title);
             if (result.error) throw new Error(result.error);
             refreshAll();
             setEnqueueToast('Commit title amended.');
@@ -1034,12 +1039,12 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         closeContextMenu();
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.dropCommit(workspaceId, commit.hash);
+            const result = await cloneClient.git.dropCommit(workspaceId, commit.hash);
             if (result.jobId) {
                 const jobId: string = result.jobId;
                 const poll = setInterval(async () => {
                     try {
-                        const job = await getSpaCocClient().git.getOperation(workspaceId, jobId);
+                        const job = await cloneClient.git.getOperation(workspaceId, jobId);
                         if (!job || job.status !== 'running') {
                             clearInterval(poll);
                             if (job?.status === 'failed') {
@@ -1157,7 +1162,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
                     ? `${pendingSkillRun.commits.length} commits`
                     : branchName || 'branch';
 
-        await getSpaCocClient().queue.enqueue({
+        await cloneClient.queue.enqueue({
             type: 'chat',
             priority: 'normal',
             displayName: `Skill: ${pendingSkillRun.skillName} — ${shortId}`,
@@ -1182,7 +1187,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         // Record commit-scoped skill usage (best-effort) and optimistic local update
         const skillName = pendingSkillRun.skillName;
         setCommitSkillUsageMap(prev => ({ ...prev, [skillName]: new Date().toISOString() }));
-        getSpaCocClient().preferences.recordCommitSkillUsage(workspaceId, skillName).catch(() => {});
+        cloneClient.preferences.recordCommitSkillUsage(workspaceId, skillName).catch(() => {});
     }, [pendingSkillRun, workspaceId, branchRangeData, branchName, state.workspaces]);
 
     const handleSquashCommits = useCallback(async () => {
@@ -1238,7 +1243,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
 
         try {
             const ws = state.workspaces.find((w: any) => w.id === workspaceId);
-            await getSpaCocClient().queue.enqueue({
+            await cloneClient.queue.enqueue({
                 type: 'chat',
                 priority: 'normal',
                 displayName: `Squash ${selectedCommits.length} commits`,
@@ -1270,7 +1275,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         const promptContent = `The repository has a ${repoState.operation} in progress with conflicts in the following files:\n<files>\n${files}\n</files>\n\nFor each conflicted file, resolve the conflict markers (<<<<<<< / ======= / >>>>>>>) by choosing the best resolution that preserves both sides' intent. Then stage the resolved files with \`git add\`. After staging all resolved files, run \`${continueCmd}\`. If new conflicts arise, repeat the resolution and continue cycle until the entire operation completes successfully.`;
         try {
             const ws = state.workspaces.find((w: any) => w.id === workspaceId);
-            await getSpaCocClient().queue.enqueue({
+            await cloneClient.queue.enqueue({
                 type: 'chat',
                 priority: 'normal',
                 displayName: `Resolve ${repoState.operation} conflicts`,
@@ -1295,9 +1300,9 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         const endpoint = repoState.operation === 'merge' ? 'merge-continue' : 'rebase-continue';
         try {
             if (endpoint === 'merge-continue') {
-                await getSpaCocClient().git.mergeContinue(workspaceId);
+                await cloneClient.git.mergeContinue(workspaceId);
             } else {
-                await getSpaCocClient().git.rebaseContinue(workspaceId);
+                await cloneClient.git.rebaseContinue(workspaceId);
             }
             setEnqueueToast(`${repoState.operation} continue started`);
             setTimeout(() => setEnqueueToast(null), 3000);
@@ -1313,9 +1318,9 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         const endpoint = repoState.operation === 'merge' ? 'merge-abort' : 'rebase-abort';
         try {
             if (endpoint === 'merge-abort') {
-                await getSpaCocClient().git.mergeAbort(workspaceId);
+                await cloneClient.git.mergeAbort(workspaceId);
             } else {
-                await getSpaCocClient().git.rebaseAbort(workspaceId);
+                await cloneClient.git.rebaseAbort(workspaceId);
             }
             refreshAll();
         } catch (err: any) {
@@ -1334,7 +1339,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
         const reorderedUnpushed = pendingReorder.slice(0, unpushedCount);
         const commitHashes = [...reorderedUnpushed].reverse().map(c => c.hash);
         try {
-            const resp = await getSpaCocClient().git.rebaseReorder(workspaceId, commitHashes);
+            const resp = await cloneClient.git.rebaseReorder(workspaceId, commitHashes);
             setEnqueueToast('Reorder started');
             setTimeout(() => setEnqueueToast(null), 3000);
             setPendingReorder(null);
@@ -1342,7 +1347,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
             if (resp?.jobId) {
                 const poll = setInterval(async () => {
                     try {
-                        const job = await getSpaCocClient().git.getOperation(workspaceId, resp.jobId);
+                        const job = await cloneClient.git.getOperation(workspaceId, resp.jobId);
                         if (job?.status === 'success' || job?.status === 'failed') {
                             clearInterval(poll);
                             if (job.status === 'failed') {

--- a/packages/coc/src/server/spa/client/react/features/git/diff/FileDiffPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/FileDiffPanel.tsx
@@ -95,7 +95,7 @@ export function FileDiffPanel({
         : source.fileDiffUrl(filePath);
     const fullDiffUrl = source.supportsTruncation ? source.fileDiffUrl(filePath, true) : null;
     const { diff, loading, error, retry, truncated, totalLines, requestFullDiff, fullContextUnavailable } =
-        useFileDiff(diffUrl, fullDiffUrl);
+        useFileDiff(diffUrl, fullDiffUrl, workspaceId);
 
     // ── View mode ──
     const [viewMode, setViewMode] = useDiffViewMode();

--- a/packages/coc/src/server/spa/client/react/features/git/diff/diffSource.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/diffSource.ts
@@ -1,6 +1,5 @@
 import type { DiffCommentContext } from '../../../../comments/diff-comment-types';
-import { fetchApi } from '../../../hooks/useApi';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { getCocClientForWorkspace, requestForWorkspace } from '../../../repos/cloneRegistry';
 
 /**
  * Result of fetching a diff, including truncation metadata.
@@ -137,12 +136,12 @@ export function createCommitDiffSource(
         label: `Commit ${shortHash}`,
 
         fileDiffUrl(filePath: string, full?: boolean): string {
-            const base = getSpaCocClient().git.commitFileDiffPath(workspaceId, hash, filePath);
+            const base = getCocClientForWorkspace(workspaceId).git.commitFileDiffPath(workspaceId, hash, filePath);
             return full ? `${base}?full=true` : base;
         },
 
         fullDiffUrl(): string {
-            return getSpaCocClient().git.commitDiffPath(workspaceId, hash);
+            return getCocClientForWorkspace(workspaceId).git.commitDiffPath(workspaceId, hash);
         },
 
         commentContext(filePath: string): DiffCommentContext {
@@ -167,7 +166,7 @@ export function createCommitDiffSource(
         cacheKey: `commit:${hash}`,
 
         async fetchFileList(): Promise<string[]> {
-            const data = await getSpaCocClient().git.listCommitFiles(workspaceId, hash);
+            const data = await getCocClientForWorkspace(workspaceId).git.listCommitFiles(workspaceId, hash);
             return (data.files ?? []).map(f => f.path).sort();
         },
 
@@ -185,7 +184,7 @@ export function createBranchRangeDiffSource(
         label: 'Branch diff',
 
         fileDiffUrl(filePath: string, full?: boolean): string {
-            const base = getSpaCocClient().git.branchRangeFileDiffPath(workspaceId, filePath);
+            const base = getCocClientForWorkspace(workspaceId).git.branchRangeFileDiffPath(workspaceId, filePath);
             return full ? `${base}?full=true` : base;
         },
 
@@ -213,13 +212,21 @@ export function createBranchRangeDiffSource(
 }
 
 /**
- * Fetch a diff from the given URL and normalize the response into
- * a DiffFetchResult. Handles both response shapes:
+ * Fetch a diff from the given URL (routed to the workspace's clone) and normalize
+ * the response into a DiffFetchResult. Handles both response shapes:
  *   - { diff: string, truncated?: boolean, totalLines?: number }  (server standard)
  *   - { diff: string }  (useCachedDiff pre-populated entries)
+ *
+ * `workspaceId` selects the clone: a remote clone's diff fetch lands on its own
+ * server; a local/unknown id resolves to the default origin (unchanged).
  */
-export async function fetchDiffFromSource(url: string): Promise<DiffFetchResult> {
-    const data = await fetchApi(url);
+export async function fetchDiffFromSource(workspaceId: string, url: string): Promise<DiffFetchResult> {
+    const data = await requestForWorkspace<{
+        diff?: string;
+        truncated?: boolean;
+        totalLines?: number;
+        fullContextUnavailable?: boolean;
+    }>(workspaceId, url);
     return {
         diff: data.diff ?? '',
         truncated: !!data.truncated,
@@ -277,7 +284,7 @@ export function createPrDiffSource(
         cacheKey: `pr:${repoId}:${prId}`,
 
         async fetchFileList(): Promise<string[]> {
-            const client = getSpaCocClient();
+            const client = getCocClientForWorkspace(repoId);
             const diff = await client.pullRequests.getDiff(repoId, prId);
             return extractFilePathsFromDiff(diff);
         },

--- a/packages/coc/src/server/spa/client/react/features/git/diff/useClassification.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/useClassification.ts
@@ -21,7 +21,8 @@ import type {
     HunkIntensity,
 } from '../../pull-requests/classification-types';
 import { classificationPriority } from '../../pull-requests/classification-types';
-import { requestSpaApi } from '../../../api/cocClient';
+import { toSpaCocRequestOptions, translateSpaCocClientError } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import type { ClassificationKey } from './diffSource';
 import type { ResolvedModalJobAiSelection } from '../../../shared/ModalJobAiControls';
 
@@ -108,6 +109,21 @@ export function useClassification(
     options?: { workspaceId?: string },
 ): UseClassificationReturn {
     const workspaceId = options?.workspaceId;
+
+    // Route classify-diff REST to the workspace's clone server (AC-07). A remote
+    // clone hits its own origin; a local/unknown id resolves to the default.
+    // Mirrors requestSpaApi's error translation so behavior is unchanged locally.
+    const cloneClient = useCocClient(workspaceId);
+    const requestApi = useCallback(
+        async <T,>(path: string, opts?: RequestInit): Promise<T> => {
+            try {
+                return await cloneClient.request<T>(path, toSpaCocRequestOptions(opts));
+            } catch (error) {
+                translateSpaCocClientError(error);
+            }
+        },
+        [cloneClient],
+    );
 
     const [state, setState] = useState<ClassificationState>({
         status: 'idle',
@@ -225,7 +241,7 @@ export function useClassification(
                     type: ck.type,
                     identifier: ck.identifier,
                 });
-                const resp = await requestSpaApi<ClassificationGetResponse>(
+                const resp = await requestApi<ClassificationGetResponse>(
                     buildUrl(`?${params.toString()}`),
                 );
                 if (currentKeyRef.current !== capturedKeyStr) return; // stale — drop
@@ -238,7 +254,7 @@ export function useClassification(
                 // Transient error — keep polling
             }
         }, POLL_INTERVAL);
-    }, [keyStr, buildUrl]);
+    }, [keyStr, buildUrl, requestApi]);
 
     const classify = useCallback(() => {
         if (!classificationKey) return;
@@ -258,7 +274,7 @@ export function useClassification(
         if (ai.effortTier) postBody.effortTier = ai.effortTier;
         if (ai.autoProviderRouting) postBody.autoProviderRouting = true;
 
-        requestSpaApi<ClassifyResponse>(
+        requestApi<ClassifyResponse>(
             buildUrl(''),
             {
                 method: 'POST',
@@ -283,7 +299,7 @@ export function useClassification(
                     error: err instanceof Error ? err.message : 'Classification failed',
                 }));
             });
-    }, [keyStr, buildUrl, startPolling]);
+    }, [keyStr, buildUrl, startPolling, requestApi]);
 
     // On mount / key change, check for cached result
     useEffect(() => {
@@ -295,7 +311,7 @@ export function useClassification(
             type: ck.type,
             identifier: ck.identifier,
         });
-        requestSpaApi<ClassificationGetResponse>(
+        requestApi<ClassificationGetResponse>(
             buildUrl(`?${params.toString()}`),
         )
             .then(resp => {
@@ -308,7 +324,7 @@ export function useClassification(
                 }
             })
             .catch(() => { /* no cache — ok */ });
-    }, [keyStr, buildUrl, startPolling]);
+    }, [keyStr, buildUrl, startPolling, requestApi]);
 
     const toggleFilter = useCallback((cat: HunkCategory) => {
         setState(prev => {

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useAllCommitComments.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useAllCommitComments.ts
@@ -11,9 +11,10 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CocClient } from '@plusplusoneplusplus/coc-client';
 import { getWsPath } from '../../../utils/config';
 import { cloneWsUrl } from '../../../api/wsUrl';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import type { DiffComment } from '../../../../comments/diff-comment-types';
 import { computeStorageKey, patchDiffComment, deleteDiffCommentById } from '../../../utils/diffCommentApi';
 import type { UpdateDiffCommentRequest } from './useDiffComments';
@@ -46,12 +47,12 @@ export interface UseAllCommitCommentsReturn {
 // ============================================================================
 
 /** Poll a queued task until it completes or fails. */
-async function pollTaskResult<T>(taskId: string, timeoutMs = 180_000): Promise<T> {
+async function pollTaskResult<T>(client: CocClient, taskId: string, timeoutMs = 180_000): Promise<T> {
     const start = Date.now();
     let delay = 1000;
     while (Date.now() - start < timeoutMs) {
         await new Promise(r => setTimeout(r, delay));
-        const { task } = await getSpaCocClient().queue.getTask(taskId);
+        const { task } = await client.queue.getTask(taskId);
         if (task.status === 'completed') return task.result as T;
         if (task.status === 'failed' || task.status === 'cancelled') {
             throw new Error(task.error || `Task ${task.status}`);
@@ -62,6 +63,9 @@ async function pollTaskResult<T>(taskId: string, timeoutMs = 180_000): Promise<T
 }
 
 export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCommentsReturn {
+    // Route every commit-comment REST call to the workspace's clone server
+    // (AC-07); the WS subscription below stays on cloneWsUrl unchanged (AC-03).
+    const cloneClient = useCocClient(wsId);
     const [comments, setComments] = useState<DiffComment[]>([]);
     const [loading, setLoading] = useState(false);
     const [resolving, setResolving] = useState(false);
@@ -85,7 +89,7 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
         if (!wsId || !hash) return;
         setLoading(true);
         try {
-            const data = await getSpaCocClient().git.listDiffComments(wsId, { oldRef: `${hash}^`, newRef: hash });
+            const data = await cloneClient.git.listDiffComments(wsId, { oldRef: `${hash}^`, newRef: hash });
             if (mountedRef.current) {
                 setComments(data.comments ?? []);
             }
@@ -94,7 +98,7 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
         } finally {
             if (mountedRef.current) setLoading(false);
         }
-    }, [wsId, hash]);
+    }, [wsId, hash, cloneClient]);
 
     useEffect(() => {
         void fetchComments();
@@ -138,18 +142,18 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
     const resolveWithAI = useCallback(async (userContext?: string, skills?: string[]) => {
         setResolving(true);
         try {
-            const response = await getSpaCocClient().git.resolveDiffCommentsWithAI(wsId, {
+            const response = await cloneClient.git.resolveDiffCommentsWithAI(wsId, {
                 oldRef: `${hash}^`,
                 newRef: hash,
                 ...(userContext ? { userContext } : {}),
                 ...(skills?.length ? { skills } : {}),
             });
-            if (response.taskId) await pollTaskResult(response.taskId as string);
+            if (response.taskId) await pollTaskResult(cloneClient, response.taskId as string);
             await fetchComments();
         } finally {
             if (mountedRef.current) setResolving(false);
         }
-    }, [wsId, hash, fetchComments]);
+    }, [wsId, hash, cloneClient, fetchComments]);
 
     // ------------------------------------------------------------------
     // fixWithAI — resolve a single comment via AI
@@ -160,7 +164,7 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
         if (!comment) return;
         setAiLoadingIds(prev => new Set(prev).add(id));
         try {
-            const response = await getSpaCocClient().git.resolveDiffCommentsWithAI(wsId, {
+            const response = await cloneClient.git.resolveDiffCommentsWithAI(wsId, {
                 oldRef: comment.context.oldRef,
                 newRef: comment.context.newRef,
                 filePath: comment.context.filePath,
@@ -168,7 +172,7 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
                 ...(userContext ? { userContext } : {}),
                 ...(skills?.length ? { skills } : {}),
             });
-            if (response.taskId) await pollTaskResult(response.taskId as string);
+            if (response.taskId) await pollTaskResult(cloneClient, response.taskId as string);
             await fetchComments();
         } catch (err: any) {
             if (mountedRef.current) {
@@ -179,7 +183,7 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
                 setAiLoadingIds(prev => { const s = new Set(prev); s.delete(id); return s; });
             }
         }
-    }, [wsId, fetchComments]);
+    }, [wsId, cloneClient, fetchComments]);
 
     // ------------------------------------------------------------------
     // clearAiError

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useAllCommitComments.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useAllCommitComments.ts
@@ -12,6 +12,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getWsPath } from '../../../utils/config';
+import { cloneWsUrl } from '../../../api/wsUrl';
 import { getSpaCocClient } from '../../../api/cocClient';
 import type { DiffComment } from '../../../../comments/diff-comment-types';
 import { computeStorageKey, patchDiffComment, deleteDiffCommentById } from '../../../utils/diffCommentApi';
@@ -228,8 +229,7 @@ export function useAllCommitComments(wsId: string, hash: string): UseAllCommitCo
 
     useEffect(() => {
         if (!wsId || !hash) return;
-        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${protocol}://${window.location.host}${getWsPath()}`);
+        const ws = new WebSocket(cloneWsUrl(getWsPath()));
         ws.addEventListener('open', () => {
             ws.send(JSON.stringify({ type: 'subscribe-commit-diff', wsId, hash }));
         });

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitClassificationStatus.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitClassificationStatus.ts
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { requestSpaApi } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 
 interface BatchStatusResponse {
     statuses: Record<string, 'none' | 'ready' | 'running'>;
@@ -34,6 +34,8 @@ export function useCommitClassificationStatus(
     hashes: string[],
 ): UseCommitClassificationStatusReturn {
     const [classifiedHashes, setClassifiedHashes] = useState<ReadonlySet<string>>(new Set());
+    // Route the batch-status fetch to the workspace's clone server (AC-07).
+    const cloneClient = useCocClient(workspaceId);
     // Stable join used as effect dependency — avoids re-fetching on reference changes.
     const sortedJoin = hashes.length > 0 ? [...hashes].sort().join(',') : '';
     const refreshCountRef = useRef(0);
@@ -52,7 +54,7 @@ export function useCommitClassificationStatus(
             ...(workspaceId && workspaceId !== repoId ? { workspaceId } : {}),
         });
 
-        requestSpaApi<BatchStatusResponse>(
+        cloneClient.request<BatchStatusResponse>(
             `/repos/${encodeURIComponent(repoId)}/classify-diff/batch-status?${params.toString()}`,
         )
             .then(resp => {
@@ -66,7 +68,7 @@ export function useCommitClassificationStatus(
             .catch(() => { /* best-effort — leave previous state */ });
 
         return () => { cancelled = true; };
-    }, [repoId, workspaceId, sortedJoin, refreshTick]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [repoId, workspaceId, sortedJoin, refreshTick, cloneClient]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const refresh = useCallback(() => {
         refreshCountRef.current += 1;

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitCommentTotals.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitCommentTotals.ts
@@ -13,7 +13,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getWsPath } from '../../../utils/config';
 import { cloneWsUrl } from '../../../api/wsUrl';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 
 export interface CommitCommentCounts {
     open: number;
@@ -25,6 +25,9 @@ export function useCommitCommentTotals(
     commitHashes: string[],
 ): Map<string, CommitCommentCounts> {
     const [totals, setTotals] = useState<Map<string, CommitCommentCounts>>(new Map());
+    // Route the totals fetch to the workspace's clone server (AC-07); the WS
+    // subscription below stays on cloneWsUrl(getWsPath()) unchanged (AC-03).
+    const cloneClient = useCocClient(wsId);
 
     // Stable key for the hash list so the effect only re-runs when the
     // set of commits actually changes.
@@ -37,10 +40,10 @@ export function useCommitCommentTotals(
         }
         const commits = commitsKey.split(',').filter(Boolean);
         Promise.all([
-            getSpaCocClient().git
+            cloneClient.git
                 .getDiffCommentTotals(wsId, { commits, status: 'open' })
                 .then(data => data.totals),
-            getSpaCocClient().git
+            cloneClient.git
                 .getDiffCommentTotals(wsId, { commits, status: 'resolved' })
                 .then(data => data.totals),
         ])
@@ -59,7 +62,7 @@ export function useCommitCommentTotals(
             .catch(() => {
                 // Fail silently — comment totals are non-critical
             });
-    }, [wsId, commitsKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [wsId, commitsKey, cloneClient]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         if (commitHashes.length === 0) {

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitCommentTotals.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitCommentTotals.ts
@@ -12,6 +12,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { getWsPath } from '../../../utils/config';
+import { cloneWsUrl } from '../../../api/wsUrl';
 import { getSpaCocClient } from '../../../api/cocClient';
 
 export interface CommitCommentCounts {
@@ -72,8 +73,7 @@ export function useCommitCommentTotals(
     // WebSocket subscription for instant refresh on diff-comment-updated
     useEffect(() => {
         if (!wsId) return;
-        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${protocol}://${window.location.host}${getWsPath()}`);
+        const ws = new WebSocket(cloneWsUrl(getWsPath()));
         ws.addEventListener('message', (event) => {
             try {
                 const msg = JSON.parse(event.data as string) as { type: string; workspaceId?: string };

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitDiffCache.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useCommitDiffCache.ts
@@ -14,8 +14,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { fetchApi } from '../../../hooks/useApi';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { getCocClientForWorkspace, requestForWorkspace } from '../../../repos/cloneRegistry';
 
 /** Module-level cache — survives re-renders, cleared on page reload. */
 const diffCache = new Map<string, string>();
@@ -45,7 +44,7 @@ export function splitDiffByFile(fullDiff: string): Array<[string, string]> {
  * Build a per-file diff API URL matching the server route convention.
  */
 export function buildFileDiffUrl(workspaceId: string, hash: string, filePath: string): string {
-    return getSpaCocClient().git.commitFileDiffPath(workspaceId, hash, filePath);
+    return getCocClientForWorkspace(workspaceId).git.commitFileDiffPath(workspaceId, hash, filePath);
 }
 
 /**
@@ -103,7 +102,7 @@ export function useCachedDiff(
         setLoading(true);
         setError(null);
         setDiff(null);
-        fetchApi(url)
+        requestForWorkspace<{ diff?: string }>(workspaceId, url)
             .then(data => {
                 const raw: string = data.diff || '';
                 diffCache.set(url, raw);

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useDiffComments.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useDiffComments.ts
@@ -9,6 +9,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getWsPath } from '../../../utils/config';
 import { getSpaCocClient } from '../../../api/cocClient';
+import { cloneWsUrl } from '../../../api/wsUrl';
 import type { DiffComment, DiffCommentContext, DiffCommentSelection } from '../../../../comments/diff-comment-types';
 import type { DiffLine } from '../diff/UnifiedDiffViewer';
 import { relocateDiffAnchor } from '../../../utils/relocateDiffAnchor';
@@ -477,8 +478,7 @@ export function useDiffComments(
 
     useEffect(() => {
         if (!context) return;
-        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${protocol}://${window.location.host}${getWsPath()}`);
+        const ws = new WebSocket(cloneWsUrl(getWsPath()));
         ws.addEventListener('open', () => {
             ws.send(JSON.stringify({ type: 'subscribe-diff', context }));
         });

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useDiffComments.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useDiffComments.ts
@@ -7,8 +7,9 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CocClient } from '@plusplusoneplusplus/coc-client';
 import { getWsPath } from '../../../utils/config';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import { cloneWsUrl } from '../../../api/wsUrl';
 import type { DiffComment, DiffCommentContext, DiffCommentSelection } from '../../../../comments/diff-comment-types';
 import type { DiffLine } from '../diff/UnifiedDiffViewer';
@@ -74,12 +75,12 @@ export interface UseDiffCommentsReturn {
 // computeStorageKey, patchDiffComment, deleteDiffCommentById are imported from ../utils/diffCommentApi.
 
 /** Poll a queued task until it completes or fails. Returns the task result. */
-async function pollTaskResult<T>(taskId: string, timeoutMs = 180_000): Promise<T> {
+async function pollTaskResult<T>(client: CocClient, taskId: string, timeoutMs = 180_000): Promise<T> {
     const start = Date.now();
     let delay = 1000;
     while (Date.now() - start < timeoutMs) {
         await new Promise(r => setTimeout(r, delay));
-        const { task } = await getSpaCocClient().queue.getTask(taskId);
+        const { task } = await client.queue.getTask(taskId);
         if (task.status === 'completed') {
             return task.result as T;
         }
@@ -109,6 +110,10 @@ export function useDiffComments(
     wsId: string,
     context: DiffCommentContext | null,
 ): UseDiffCommentsReturn {
+    // Route every diff-comment REST call to the selected clone's server (AC-07).
+    // The diff-comment-updated WebSocket subscription below keeps using
+    // cloneWsUrl(getWsPath()) unchanged (AC-03).
+    const cloneClient = useCocClient(wsId);
     const [comments, setComments] = useState<DiffComment[]>([]);
     const [loading, setLoading]   = useState(true);
     const [error, setError]       = useState<string | null>(null);
@@ -144,7 +149,7 @@ export function useDiffComments(
         setLoading(true);
         setError(null);
         try {
-            const data = await getSpaCocClient().git.listDiffComments(wsId, {
+            const data = await cloneClient.git.listDiffComments(wsId, {
                 oldRef: ctx.oldRef,
                 newRef: ctx.newRef,
             });
@@ -163,7 +168,7 @@ export function useDiffComments(
         } finally {
             if (mountedRef.current) setLoading(false);
         }
-    }, [wsId]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [wsId, cloneClient]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         void fetchComments();
@@ -181,7 +186,7 @@ export function useDiffComments(
     ): Promise<DiffComment> => {
         const ctx = contextRef.current;
         if (!ctx) throw new Error('No diff context');
-        const data = await getSpaCocClient().git.createDiffComment(wsId, {
+        const data = await cloneClient.git.createDiffComment(wsId, {
             context: ctx,
             selection,
             selectedText,
@@ -193,7 +198,7 @@ export function useDiffComments(
             setComments(prev => [...prev, comment]);
         }
         return comment;
-    }, [wsId]);
+    }, [wsId, cloneClient]);
 
     // ------------------------------------------------------------------
     // updateComment — PATCH /api/diff-comments/:wsId/:storageKey/:id
@@ -273,12 +278,12 @@ export function useDiffComments(
         setAiErrors(prev => { const m = new Map(prev); m.delete(id); return m; });
         try {
             const storageKey = await computeStorageKey(ctx);
-            const data = await getSpaCocClient().git.askDiffCommentAI(wsId, storageKey, id, { commandId, customQuestion });
+            const data = await cloneClient.git.askDiffCommentAI(wsId, storageKey, id, { commandId, customQuestion });
             let aiResponse: string | undefined;
             if (data.aiResponse) {
                 aiResponse = data.aiResponse as string;
             } else if (data.taskId) {
-                const result = await pollTaskResult<{ aiResponse: string }>(data.taskId as string);
+                const result = await pollTaskResult<{ aiResponse: string }>(cloneClient, data.taskId as string);
                 aiResponse = result.aiResponse;
             }
             if (mountedRef.current && aiResponse !== undefined) {
@@ -294,7 +299,7 @@ export function useDiffComments(
                 setAiLoadingIds(prev => { const s = new Set(prev); s.delete(id); return s; });
             }
         }
-    }, [wsId]);
+    }, [wsId, cloneClient]);
 
     // ------------------------------------------------------------------
     // clearAiError
@@ -378,7 +383,7 @@ export function useDiffComments(
         if (!ctx) throw new Error('No diff context');
         setResolving(true);
         try {
-            const data = await getSpaCocClient().git.resolveDiffCommentsWithAI(wsId, {
+            const data = await cloneClient.git.resolveDiffCommentsWithAI(wsId, {
                 oldRef: ctx.oldRef,
                 newRef: ctx.newRef,
                 filePath: ctx.filePath,
@@ -386,14 +391,14 @@ export function useDiffComments(
                 ...(skills?.length ? { skills } : {}),
             });
             if (data.taskId) {
-                await pollTaskResult(data.taskId as string);
+                await pollTaskResult(cloneClient, data.taskId as string);
             }
             await fetchComments();
             return { totalCount: data.totalCount ?? 0 };
         } finally {
             if (mountedRef.current) setResolving(false);
         }
-    }, [wsId, fetchComments]);
+    }, [wsId, cloneClient, fetchComments]);
 
     // ------------------------------------------------------------------
     // fixWithAI — resolve a single comment via AI
@@ -404,7 +409,7 @@ export function useDiffComments(
         if (!ctx) return;
         setAiLoadingIds(prev => new Set(prev).add(id));
         try {
-            const data = await getSpaCocClient().git.resolveDiffCommentsWithAI(wsId, {
+            const data = await cloneClient.git.resolveDiffCommentsWithAI(wsId, {
                 oldRef: ctx.oldRef,
                 newRef: ctx.newRef,
                 filePath: ctx.filePath,
@@ -413,7 +418,7 @@ export function useDiffComments(
                 ...(skills?.length ? { skills } : {}),
             });
             if (data.taskId) {
-                await pollTaskResult(data.taskId as string);
+                await pollTaskResult(cloneClient, data.taskId as string);
             }
             await fetchComments();
         } catch (err) {
@@ -426,7 +431,7 @@ export function useDiffComments(
                 setAiLoadingIds(prev => { const s = new Set(prev); s.delete(id); return s; });
             }
         }
-    }, [wsId, fetchComments]);
+    }, [wsId, cloneClient, fetchComments]);
 
     // ------------------------------------------------------------------
     // copyResolvePrompt — copy a resolve prompt to clipboard

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useFileCommentCounts.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useFileCommentCounts.ts
@@ -11,7 +11,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getWsPath } from '../../../utils/config';
 import { cloneWsUrl } from '../../../api/wsUrl';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 
 export function useFileCommentCounts(
     wsId: string,
@@ -19,13 +19,16 @@ export function useFileCommentCounts(
     newRef: string | null,
 ): Map<string, number> {
     const [counts, setCounts] = useState<Map<string, number>>(new Map());
+    // Route the count fetch to the workspace's clone server (AC-07); the WS
+    // subscription below stays on cloneWsUrl(getWsPath()) unchanged (AC-03).
+    const cloneClient = useCocClient(wsId);
 
     const fetchCounts = useCallback(() => {
         if (!wsId || !oldRef || !newRef) {
             setCounts(new Map());
             return;
         }
-        getSpaCocClient().git.getDiffCommentCounts(wsId, { oldRef, newRef, status: 'open' })
+        cloneClient.git.getDiffCommentCounts(wsId, { oldRef, newRef, status: 'open' })
             .then((data: { counts: Record<string, number> }) => {
                 const map = new Map<string, number>();
                 for (const [k, v] of Object.entries(data.counts)) {
@@ -36,7 +39,7 @@ export function useFileCommentCounts(
             .catch(() => {
                 // Fail silently — comment counts are non-critical
             });
-    }, [wsId, oldRef, newRef]);
+    }, [wsId, oldRef, newRef, cloneClient]);
 
     useEffect(() => {
         fetchCounts();

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useFileCommentCounts.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useFileCommentCounts.ts
@@ -10,6 +10,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { getWsPath } from '../../../utils/config';
+import { cloneWsUrl } from '../../../api/wsUrl';
 import { getSpaCocClient } from '../../../api/cocClient';
 
 export function useFileCommentCounts(
@@ -44,8 +45,7 @@ export function useFileCommentCounts(
     // WebSocket subscription for instant refresh on diff-comment-updated
     useEffect(() => {
         if (!wsId) return;
-        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${protocol}://${window.location.host}${getWsPath()}`);
+        const ws = new WebSocket(cloneWsUrl(getWsPath()));
         ws.addEventListener('message', (event) => {
             try {
                 const msg = JSON.parse(event.data as string) as { type: string; workspaceId?: string };

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useFileDiff.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useFileDiff.ts
@@ -36,10 +36,14 @@ export interface FileDiffState {
  *                      Pass null to skip fetching.
  * @param fullUrl     - API URL with ?full=true for the full (non-truncated) diff.
  *                      Pass null when the source doesn't support truncation.
+ * @param workspaceId - Clone to route the fetch to. A remote clone's diff lands
+ *                      on its own server; a local/unknown id (or undefined) uses
+ *                      the default origin (unchanged).
  */
 export function useFileDiff(
     url: string | null,
     fullUrl?: string | null,
+    workspaceId?: string,
 ): FileDiffState {
     const [diff, setDiff] = useState<string | null>(null);
     const [loading, setLoading] = useState(url !== null);
@@ -56,7 +60,7 @@ export function useFileDiff(
     const doFetch = useCallback((fetchUrl: string) => {
         setLoading(true);
         setError(null);
-        fetchDiffFromSource(fetchUrl)
+        fetchDiffFromSource(workspaceId ?? '', fetchUrl)
             .then((result: DiffFetchResult) => {
                 // Guard against stale responses after url changed
                 if (urlRef.current !== url) return;
@@ -73,7 +77,7 @@ export function useFileDiff(
                 if (urlRef.current !== url) return;
                 setLoading(false);
             });
-    }, [url]);
+    }, [url, workspaceId]);
 
     // Initial fetch on URL change
     useEffect(() => {

--- a/packages/coc/src/server/spa/client/react/features/git/hooks/useGitInfo.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/hooks/useGitInfo.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 
 export interface GitInfo {
     branch: string | null;
@@ -28,11 +28,14 @@ const DEFAULT_GIT_INFO: GitInfo = {
 
 export function useGitInfo(workspaceId: string): GitInfo {
     const [state, setState] = useState<GitInfo>(DEFAULT_GIT_INFO);
+    // Route to the workspace's clone: a remote clone reads git-info from its own
+    // server, a local clone from the default origin (AC-07).
+    const client = useCocClient(workspaceId);
 
     useEffect(() => {
         let cancelled = false;
         setState(prev => ({ ...prev, loading: true, error: false }));
-        getSpaCocClient().workspaces.gitInfo(workspaceId)
+        client.workspaces.gitInfo(workspaceId)
             .then((data: any) => {
                 if (cancelled) return;
                 setState({
@@ -51,7 +54,7 @@ export function useGitInfo(workspaceId: string): GitInfo {
         return () => {
             cancelled = true;
         };
-    }, [workspaceId]);
+    }, [workspaceId, client]);
 
     return state;
 }

--- a/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTree.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import { Spinner } from '../../../ui';
 import { copyToClipboard } from '../../../utils/format';
 import type { DiffComment } from '../../../../comments/diff-comment-types';
@@ -265,11 +265,15 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
     const [workingChangesExpanded, setWorkingChangesExpanded] = useState(false);
     const [allWorkingComments, setAllWorkingComments] = useState<DiffComment[]>([]);
 
+    // Route every working-tree call to the selected clone's server (AC-07): a
+    // remote clone hits its own origin; a local/unknown id resolves to the default.
+    const cloneClient = useCocClient(workspaceId);
+
     const fetchChanges = useCallback(() => {
-        return getSpaCocClient().git.getWorkingTreeChanges(workspaceId)
+        return cloneClient.git.getWorkingTreeChanges(workspaceId)
             .then(data => setChanges(data.changes ?? []))
             .catch(err => setError(err.message || 'Failed to load changes'));
-    }, [workspaceId]);
+    }, [workspaceId, cloneClient]);
 
     useEffect(() => {
         setLoading(true);
@@ -279,10 +283,10 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
 
     // Fetch working-tree comment count for the badge in the header.
     useEffect(() => {
-        getSpaCocClient().git.listDiffComments(workspaceId, { newRef: 'working-tree' })
+        cloneClient.git.listDiffComments(workspaceId, { newRef: 'working-tree' })
             .then((data: { comments?: DiffComment[] }) => setAllWorkingComments(data.comments ?? []))
             .catch(() => setAllWorkingComments([]));
-    }, [workspaceId]);
+    }, [workspaceId, cloneClient]);
 
     // Re-fetch when parent increments refreshKey (e.g. Refresh button click)
     const refreshKeyMountedRef = useRef(false);
@@ -319,13 +323,13 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
         try {
             let result: { success: boolean; error?: string };
             if (action === 'stage') {
-                result = await getSpaCocClient().git.stageFile(workspaceId, filePath);
+                result = await cloneClient.git.stageFile(workspaceId, filePath);
             } else if (action === 'unstage') {
-                result = await getSpaCocClient().git.unstageFile(workspaceId, filePath);
+                result = await cloneClient.git.unstageFile(workspaceId, filePath);
             } else if (action === 'discard') {
-                result = await getSpaCocClient().git.discardFile(workspaceId, filePath);
+                result = await cloneClient.git.discardFile(workspaceId, filePath);
             } else {
-                result = await getSpaCocClient().git.deleteUntrackedFile(workspaceId, filePath);
+                result = await cloneClient.git.deleteUntrackedFile(workspaceId, filePath);
             }
             if (result.success === false) throw new Error(result.error || `${action} failed`);
             await fetchChanges();
@@ -335,13 +339,13 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
         } finally {
             setBusy(filePath, false);
         }
-    }, [workspaceId, fetchChanges, onRefresh]);
+    }, [workspaceId, cloneClient, fetchChanges, onRefresh]);
 
     const handleStageAll = useCallback(async (files: WorkingTreeChange[]) => {
         setStagingAll(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.stageFiles(workspaceId, files.map(f => f.filePath));
+            const result = await cloneClient.git.stageFiles(workspaceId, files.map(f => f.filePath));
             if (result.success === false) {
                 throw new Error(result.errors?.join(', ') || 'Stage failed');
             }
@@ -352,13 +356,13 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
         } finally {
             setStagingAll(false);
         }
-    }, [workspaceId, fetchChanges, onRefresh]);
+    }, [workspaceId, cloneClient, fetchChanges, onRefresh]);
 
     const handleUnstageAll = useCallback(async (files: WorkingTreeChange[]) => {
         setStagingAll(true);
         setActionError(null);
         try {
-            const result = await getSpaCocClient().git.unstageFiles(workspaceId, files.map(f => f.filePath));
+            const result = await cloneClient.git.unstageFiles(workspaceId, files.map(f => f.filePath));
             if (result.success === false) {
                 throw new Error(result.errors?.join(', ') || 'Unstage failed');
             }
@@ -369,7 +373,7 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
         } finally {
             setStagingAll(false);
         }
-    }, [workspaceId, fetchChanges, onRefresh]);
+    }, [workspaceId, cloneClient, fetchChanges, onRefresh]);
 
     const staged    = changes.filter(c => c.stage === 'staged');
     const unstaged  = changes.filter(c => c.stage === 'unstaged');

--- a/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTreeAllComments.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTreeAllComments.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import { Spinner } from '../../../ui';
 import { CommentSidebar } from '../../../tasks/comments/CommentSidebar';
 import type { DiffComment } from '../../../../comments/diff-comment-types';
@@ -18,6 +18,9 @@ export function WorkingTreeAllComments({ workspaceId }: WorkingTreeAllCommentsPr
     const [comments, setComments] = useState<DiffComment[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+
+    // Route the all-comments fetch to the selected clone's server (AC-07).
+    const cloneClient = useCocClient(workspaceId);
 
     const copyAllCommentsAsPrompt = useCallback(() => {
         const openComments = comments.filter(c => c.status === 'open');
@@ -53,11 +56,11 @@ export function WorkingTreeAllComments({ workspaceId }: WorkingTreeAllCommentsPr
     const fetchComments = useCallback(() => {
         setLoading(true);
         setError(null);
-        getSpaCocClient().git.listDiffComments(workspaceId, { newRef: 'working-tree' })
+        cloneClient.git.listDiffComments(workspaceId, { newRef: 'working-tree' })
             .then((data: { comments?: DiffComment[] }) => setComments(data.comments ?? []))
             .catch((err: any) => setError(err.message || 'Failed to load comments'))
             .finally(() => setLoading(false));
-    }, [workspaceId]);
+    }, [workspaceId, cloneClient]);
 
     useEffect(() => {
         fetchComments();

--- a/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTreeFileDiff.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTreeFileDiff.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import { Spinner, Button, TruncatedPath } from '../../../ui';
 import { UnifiedDiffViewer, HunkNavButtons } from '../diff/UnifiedDiffViewer';
 import type { UnifiedDiffViewerHandle, DiffLine } from '../diff/UnifiedDiffViewer';
@@ -69,6 +69,9 @@ export function WorkingTreeFileDiff({ workspaceId, filePath, stage, workingTreeF
     const [diffLines, setDiffLines] = useState<DiffLine[]>([]);
     const [viewMode, setViewMode] = useDiffViewMode();
 
+    // Route this file's diff fetch to the selected clone's server (AC-07).
+    const cloneClient = useCocClient(workspaceId);
+
     const { handleNext, handlePrev } = useCrossFileNav({
         filePath,
         files: workingTreeFiles ?? [],
@@ -113,7 +116,7 @@ export function WorkingTreeFileDiff({ workspaceId, filePath, stage, workingTreeF
         setLoading(true);
         setError(null);
         setDiff(null);
-        getSpaCocClient().git.getWorkingTreeFileDiff(workspaceId, filePath, { stage, full })
+        cloneClient.git.getWorkingTreeFileDiff(workspaceId, filePath, { stage, full })
             .then(data => {
                 setDiff(data.diff ?? '');
                 setTruncated(!!data.truncated);
@@ -121,7 +124,7 @@ export function WorkingTreeFileDiff({ workspaceId, filePath, stage, workingTreeF
             })
             .catch(err => setError(err.message || 'Failed to load diff'))
             .finally(() => setLoading(false));
-    }, [workspaceId, filePath, stage]);
+    }, [workspaceId, filePath, stage, cloneClient]);
 
     useEffect(() => {
         setFullRequested(false);

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/useComments.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/useComments.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import { notesApi, type CommentThread, type Comment } from '../notesApi';
 import type { TextAnchor } from './textAnchor';
 
@@ -64,6 +64,7 @@ function filterThreads(threads: CommentThread[], filter: CommentFilter): Comment
 
 export function useComments(options: UseCommentsOptions): UseCommentsReturn {
     const { workspaceId, notePath, root, parentProcessId, selectedMode, onThreadSelect } = options;
+    const cloneClient = useCocClient(workspaceId); // AC-07: comment-resolution message routes to the clone's server.
 
     const [allThreads, setAllThreads] = useState<CommentThread[]>([]);
     const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
@@ -81,6 +82,7 @@ export function useComments(options: UseCommentsOptions): UseCommentsReturn {
     const onThreadSelectRef = useRef(onThreadSelect);
     const threadsRef = useRef(allThreads);
     const lastFetchedPathRef = useRef<string | null>(null);
+    const cloneClientRef = useRef(cloneClient);
 
     workspaceIdRef.current = workspaceId;
     notePathRef.current = notePath;
@@ -89,6 +91,7 @@ export function useComments(options: UseCommentsOptions): UseCommentsReturn {
     selectedModeRef.current = selectedMode;
     onThreadSelectRef.current = onThreadSelect;
     threadsRef.current = allThreads;
+    cloneClientRef.current = cloneClient;
 
     const fetchThreads = useCallback(async (targetPath: string) => {
         setLoading(true);
@@ -275,7 +278,7 @@ export function useComments(options: UseCommentsOptions): UseCommentsReturn {
                 });
                 message += `\nThe current document content is provided. Please address each comment and make the necessary changes.`;
 
-                await getSpaCocClient().notes.sendCommentResolutionMessage(ppId, {
+                await cloneClientRef.current.notes.sendCommentResolutionMessage(ppId, {
                     content: message,
                     ...(selectedModeRef.current ? { mode: selectedModeRef.current } : {}),
                     noteContent: documentContent,

--- a/packages/coc/src/server/spa/client/react/features/notes/hooks/useNotesChat.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/hooks/useNotesChat.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import type { AttachmentPayload } from '../../../types/attachments';
 import { isCommitChatLensEnabled } from '../../../utils/config';
 
@@ -105,6 +105,7 @@ export function formatNoteAttachmentPrompt(prompt: string, workspaceId: string, 
  */
 export function useNotesChat(opts: UseNotesChatOptions): UseNotesChatReturn {
     const { workspaceId, notePath, noteTitle, defaultScope = 'per-workspace' } = opts;
+    const cloneClient = useCocClient(workspaceId); // AC-07: notes chat bindings on the selected clone's server.
     const key = storageKey(workspaceId);
 
     // ── Scope state ──────────────────────────────────────────────────────────
@@ -133,7 +134,7 @@ export function useNotesChat(opts: UseNotesChatOptions): UseNotesChatReturn {
         if (seededWorkspaceRef.current === workspaceId) return;
         seededWorkspaceRef.current = workspaceId;
         let cancelled = false;
-        void getSpaCocClient().notes.listChatBindings(workspaceId).then(res => {
+        void cloneClient.notes.listChatBindings(workspaceId).then(res => {
             if (cancelled) return;
             const next: Record<string, string> = {};
             for (const [path, binding] of Object.entries(res.bindings ?? {})) {
@@ -144,7 +145,7 @@ export function useNotesChat(opts: UseNotesChatOptions): UseNotesChatReturn {
             // Best-effort: if the request fails, leave the map empty.
         });
         return () => { cancelled = true; };
-    }, [workspaceId]);
+    }, [workspaceId, cloneClient]);
 
     // ── Derived task ID ──────────────────────────────────────────────────────
 
@@ -184,7 +185,7 @@ export function useNotesChat(opts: UseNotesChatOptions): UseNotesChatReturn {
 
     const createChat = useCallback(async (prompt: string, model?: string | null, mode: 'ask' | 'autopilot' = 'ask', skills?: string[], attachments?: AttachmentPayload[]): Promise<string | null> => {
         try {
-            const res = await getSpaCocClient().notes.createChat(workspaceId, {
+            const res = await cloneClient.notes.createChat(workspaceId, {
                 prompt: formatNoteAttachmentPrompt(prompt, workspaceId, notePath),
                 notePath,
                 noteTitle,
@@ -213,7 +214,7 @@ export function useNotesChat(opts: UseNotesChatOptions): UseNotesChatReturn {
         } catch {
             return null;
         }
-    }, [workspaceId, notePath, noteTitle, scope]);
+    }, [workspaceId, notePath, noteTitle, scope, cloneClient]);
 
     // ── resetChat ────────────────────────────────────────────────────────────
 
@@ -227,10 +228,10 @@ export function useNotesChat(opts: UseNotesChatOptions): UseNotesChatReturn {
                 return next;
             });
             // Best-effort server cleanup; failures are tolerated.
-            void getSpaCocClient().notes.deleteChatBindingByPath(workspaceId, notePath).catch(() => undefined);
+            void cloneClient.notes.deleteChatBindingByPath(workspaceId, notePath).catch(() => undefined);
         }
         setChatNoteContext(null);
-    }, [scope, notePath, workspaceId]);
+    }, [scope, notePath, workspaceId, cloneClient]);
 
     return { taskId, chatNoteContext, createChat, resetChat, scope, setScope };
 }

--- a/packages/coc/src/server/spa/client/react/features/notes/notesApi.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/notesApi.ts
@@ -33,7 +33,8 @@ import {
     type TextAnchor,
     type UploadNoteImageResponse,
 } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient, translateSpaCocClientError } from '../../api/cocClient';
+import { translateSpaCocClientError } from '../../api/cocClient';
+import { getCocClientForWorkspace } from '../../repos/cloneRegistry';
 import { isCommitChatLensEnabled } from '../../utils/config';
 
 const INHERITED_LENS_CHAT_MODE = {
@@ -77,99 +78,103 @@ async function withConflictError<T>(request: Promise<T>): Promise<T> {
     }
 }
 
-const notesClient = () => getSpaCocClient().notes;
+/**
+ * Notes domain client for a workspace, routed to the workspace's clone (AC-07):
+ * remote clones hit their server, local clones the default origin.
+ */
+const notesClient = (wsId: string) => getCocClientForWorkspace(wsId).notes;
 
 export const notesApi = {
     getTree(wsId: string, root?: string): Promise<NoteTreeResponse> {
-        return withSpaErrors(notesClient().getTree(wsId, root));
+        return withSpaErrors(notesClient(wsId).getTree(wsId, root));
     },
 
     listRoots(wsId: string): Promise<NotesRootsResponse> {
-        return withSpaErrors(notesClient().listRoots(wsId));
+        return withSpaErrors(notesClient(wsId).listRoots(wsId));
     },
 
     addRoot(wsId: string, rootPath: string): Promise<NotesRootEntry> {
-        return withSpaErrors(notesClient().addRoot(wsId, rootPath));
+        return withSpaErrors(notesClient(wsId).addRoot(wsId, rootPath));
     },
 
     removeRoot(wsId: string, rootPath: string): Promise<{ removed: string }> {
-        return withSpaErrors(notesClient().removeRoot(wsId, rootPath));
+        return withSpaErrors(notesClient(wsId).removeRoot(wsId, rootPath));
     },
 
     getContent(wsId: string, notePath: string, root?: string): Promise<NoteContentResponse> {
-        return withSpaErrors(notesClient().getContent(wsId, notePath, root));
+        return withSpaErrors(notesClient(wsId).getContent(wsId, notePath, root));
     },
 
     saveContent(wsId: string, notePath: string, content: string, expectedMtime?: number, root?: string): Promise<SaveNoteContentResponse> {
-        return withConflictError(notesClient().saveContent(wsId, notePath, content, expectedMtime, root));
+        return withConflictError(notesClient(wsId).saveContent(wsId, notePath, content, expectedMtime, root));
     },
 
     createNode(wsId: string, nodePath: string, type: NoteNodeType, root?: string): Promise<CreateNoteNodeResponse> {
-        return withSpaErrors(notesClient().createNode(wsId, nodePath, type, root));
+        return withSpaErrors(notesClient(wsId).createNode(wsId, nodePath, type, root));
     },
 
     renameNode(wsId: string, oldPath: string, newPath: string, root?: string): Promise<RenameNoteNodeResponse> {
-        return withSpaErrors(notesClient().renameNode(wsId, oldPath, newPath, root));
+        return withSpaErrors(notesClient(wsId).renameNode(wsId, oldPath, newPath, root));
     },
 
     deleteNode(wsId: string, nodePath: string, root?: string): Promise<void> {
-        return withSpaErrors(notesClient().deleteNode(wsId, nodePath, root));
+        return withSpaErrors(notesClient(wsId).deleteNode(wsId, nodePath, root));
     },
 
     reorder(wsId: string, parentPath: string, order: string[], root?: string): Promise<ReorderNotesResponse> {
-        return withSpaErrors(notesClient().reorder(wsId, parentPath, order, root));
+        return withSpaErrors(notesClient(wsId).reorder(wsId, parentPath, order, root));
     },
 
     search(wsId: string, query: string, root?: string): Promise<NoteSearchResponse> {
-        return withSpaErrors(notesClient().search(wsId, query, root));
+        return withSpaErrors(notesClient(wsId).search(wsId, query, root));
     },
 
     uploadImage(wsId: string, fileName: string, data: string, root?: string): Promise<UploadNoteImageResponse> {
-        return withSpaErrors(notesClient().uploadImage(wsId, fileName, data, root));
+        return withSpaErrors(notesClient(wsId).uploadImage(wsId, fileName, data, root));
     },
 
     getFilePreview(wsId: string, filePath: string): Promise<NoteFilePreviewResponse> {
-        return withSpaErrors(notesClient().previewFile(wsId, filePath));
+        return withSpaErrors(notesClient(wsId).previewFile(wsId, filePath));
     },
 
     getComments(wsId: string, notePath: string, root?: string): Promise<NoteSidecar> {
-        return withSpaErrors(notesClient().getComments(wsId, notePath, root));
+        return withSpaErrors(notesClient(wsId).getComments(wsId, notePath, root));
     },
 
     saveComments(wsId: string, notePath: string, threads: Record<string, CommentThread>, root?: string): Promise<void> {
-        return withSpaErrors(notesClient().saveComments(wsId, notePath, threads, root));
+        return withSpaErrors(notesClient(wsId).saveComments(wsId, notePath, threads, root));
     },
 
     createThread(wsId: string, notePath: string, thread: CommentThread, root?: string): Promise<{ thread: CommentThread }> {
-        return withSpaErrors(notesClient().createThread(wsId, notePath, thread, root));
+        return withSpaErrors(notesClient(wsId).createThread(wsId, notePath, thread, root));
     },
 
     updateThread(wsId: string, notePath: string, threadId: string, status: CommentThreadStatus, root?: string): Promise<{ thread: CommentThread }> {
-        return withSpaErrors(notesClient().updateThread(wsId, notePath, threadId, status, root));
+        return withSpaErrors(notesClient(wsId).updateThread(wsId, notePath, threadId, status, root));
     },
 
     deleteThread(wsId: string, notePath: string, threadId: string, root?: string): Promise<void> {
-        return withSpaErrors(notesClient().deleteThread(wsId, notePath, threadId, root));
+        return withSpaErrors(notesClient(wsId).deleteThread(wsId, notePath, threadId, root));
     },
 
     addComment(wsId: string, notePath: string, threadId: string, content: string, root?: string): Promise<{ comment: Comment }> {
-        return withSpaErrors(notesClient().addComment(wsId, notePath, threadId, content, root));
+        return withSpaErrors(notesClient(wsId).addComment(wsId, notePath, threadId, content, root));
     },
 
     editComment(wsId: string, notePath: string, threadId: string, commentId: string, content: string, root?: string): Promise<{ comment: Comment }> {
-        return withSpaErrors(notesClient().editComment(wsId, notePath, threadId, commentId, content, root));
+        return withSpaErrors(notesClient(wsId).editComment(wsId, notePath, threadId, commentId, content, root));
     },
 
     deleteComment(wsId: string, notePath: string, threadId: string, commentId: string, root?: string): Promise<void> {
-        return withSpaErrors(notesClient().deleteComment(wsId, notePath, threadId, commentId, root));
+        return withSpaErrors(notesClient(wsId).deleteComment(wsId, notePath, threadId, commentId, root));
     },
 
     batchResolve(wsId: string, notePath: string, documentContent: string, userContext?: string, root?: string): Promise<{ taskId: string }> {
-        return withSpaErrors(notesClient().batchResolve(wsId, notePath, documentContent, userContext, root));
+        return withSpaErrors(notesClient(wsId).batchResolve(wsId, notePath, documentContent, userContext, root));
     },
 
     createWithAI(wsId: string, prompt: string, chatTaskId?: string): Promise<CreateNoteWithAIResponse> {
-        return withSpaErrors(notesClient().createWithAI(
+        return withSpaErrors(notesClient(wsId).createWithAI(
             wsId,
             prompt,
             chatTaskId,
@@ -178,58 +183,58 @@ export const notesApi = {
     },
 
     initializeGit(wsId: string): Promise<{ initialized: boolean }> {
-        return withSpaErrors(notesClient().initializeGit(wsId));
+        return withSpaErrors(notesClient(wsId).initializeGit(wsId));
     },
 
     deinitGit(wsId: string): Promise<{ deinitialized: boolean }> {
-        return withSpaErrors(notesClient().deinitializeGit(wsId));
+        return withSpaErrors(notesClient(wsId).deinitializeGit(wsId));
     },
 
     getGitStatus(wsId: string): Promise<NotesGitStatus> {
-        return withSpaErrors(notesClient().getGitStatus(wsId));
+        return withSpaErrors(notesClient(wsId).getGitStatus(wsId));
     },
 
     getGitLog(wsId: string, limit?: number, offset?: number): Promise<NotesGitLogResponse> {
-        return withSpaErrors(notesClient().getGitLog(wsId, { limit, offset }));
+        return withSpaErrors(notesClient(wsId).getGitLog(wsId, { limit, offset }));
     },
 
     getGitDiff(wsId: string, hash?: string): Promise<NotesGitDiff> {
-        return withSpaErrors(notesClient().getGitDiff(wsId, hash));
+        return withSpaErrors(notesClient(wsId).getGitDiff(wsId, hash));
     },
 
     commitGit(wsId: string, message?: string): Promise<NotesGitCommitResponse> {
-        return withSpaErrors(notesClient().commitGit(wsId, message));
+        return withSpaErrors(notesClient(wsId).commitGit(wsId, message));
     },
 
     getAutoCommitStatus(wsId: string): Promise<NotesGitAutoCommitStatus> {
-        return withSpaErrors(notesClient().getAutoCommitStatus(wsId));
+        return withSpaErrors(notesClient(wsId).getAutoCommitStatus(wsId));
     },
 
     enableAutoCommit(wsId: string, intervalMs?: number): Promise<{ enabled: boolean; intervalMs: number }> {
-        return withSpaErrors(notesClient().enableAutoCommit(wsId, intervalMs));
+        return withSpaErrors(notesClient(wsId).enableAutoCommit(wsId, intervalMs));
     },
 
     disableAutoCommit(wsId: string): Promise<{ deleted: boolean }> {
-        return withSpaErrors(notesClient().disableAutoCommit(wsId));
+        return withSpaErrors(notesClient(wsId).disableAutoCommit(wsId));
     },
 
     updateAutoCommitInterval(wsId: string, intervalMs: number): Promise<{ enabled: boolean; intervalMs: number }> {
-        return withSpaErrors(notesClient().updateAutoCommitInterval(wsId, intervalMs));
+        return withSpaErrors(notesClient(wsId).updateAutoCommitInterval(wsId, intervalMs));
     },
 
     getFileLog(wsId: string, notePath: string, limit = 50): Promise<NoteFileLogResponse> {
-        return withSpaErrors(notesClient().getFileLog(wsId, notePath, limit));
+        return withSpaErrors(notesClient(wsId).getFileLog(wsId, notePath, limit));
     },
 
     getFileContentAtRevision(wsId: string, hash: string, notePath: string): Promise<NoteFileContentAtRevisionResponse> {
-        return withSpaErrors(notesClient().getFileContentAtRevision(wsId, hash, notePath));
+        return withSpaErrors(notesClient(wsId).getFileContentAtRevision(wsId, hash, notePath));
     },
 
     saveCheckpoint(wsId: string, notePath: string, name: string): Promise<SaveNoteCheckpointResponse> {
-        return withSpaErrors(notesClient().saveCheckpoint(wsId, notePath, name));
+        return withSpaErrors(notesClient(wsId).saveCheckpoint(wsId, notePath, name));
     },
 
     restoreVersion(wsId: string, notePath: string, hash: string): Promise<RestoreNoteVersionResponse> {
-        return withSpaErrors(notesClient().restoreVersion(wsId, notePath, hash));
+        return withSpaErrors(notesClient(wsId).restoreVersion(wsId, notePath, hash));
     },
 };

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestsTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestsTab.tsx
@@ -15,7 +15,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CocApiError } from '@plusplusoneplusplus/coc-client';
 import type { PullRequestCoworkerRosterEntry, PrSuggestion, RecentOpenedPullRequestEntry } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { useApp } from '../../contexts/AppContext';
 import { cn } from '../../ui';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
@@ -165,6 +166,9 @@ function buildRecentOpenedRecord(pr: unknown, prNumber: number): { number: numbe
 
 export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
     const { state, dispatch } = useApp();
+    // Route PR list/suggestions/roster/classification to the workspace's clone
+    // (AC-07). All PR calls here are scoped to this workspace's repo.
+    const cloneClient = useCocClient(workspaceId);
     const sessionContextDragEnabled = isSessionContextAttachmentsEnabled();
     const [prs, setPrs] = useState<PullRequest[]>([]);
     const [loading, setLoading] = useState(false);
@@ -279,7 +283,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
             skipRef.current = 0;
         }
 
-        getSpaCocClient().pullRequests.list(
+        cloneClient.pullRequests.list(
             repoId,
             {
                 status: STATUS_FILTER,
@@ -326,7 +330,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
                 }
             })
             .finally(() => setLoading(false));
-    }, [repoId, effectiveScope, cacheKey]);
+    }, [repoId, effectiveScope, cacheKey, cloneClient]);
 
     // Re-fetch from scratch whenever the active scope changes.
     useEffect(() => {
@@ -336,7 +340,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
     useEffect(() => {
         let cancelled = false;
         setRecentOpenedPrs([]);
-        getSpaCocClient().pullRequests.listRecentOpened(repoId, workspaceId)
+        cloneClient.pullRequests.listRecentOpened(repoId, workspaceId)
             .then(data => {
                 if (!cancelled) {
                     setRecentOpenedPrs(data.entries ?? []);
@@ -348,7 +352,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
                 }
             });
         return () => { cancelled = true; };
-    }, [repoId, workspaceId]);
+    }, [repoId, workspaceId, cloneClient]);
 
     useEffect(() => {
         let cancelled = false;
@@ -356,7 +360,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         setInactiveCoworkerKeys(new Set());
         setCoworkerPickerKey('');
         setCoworkerRosterError(null);
-        getSpaCocClient().pullRequests.listCoworkerRoster(repoId, workspaceId)
+        cloneClient.pullRequests.listCoworkerRoster(repoId, workspaceId)
             .then(data => {
                 if (!cancelled) {
                     setCoworkerRoster(data.entries ?? []);
@@ -368,7 +372,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
                 }
             });
         return () => { cancelled = true; };
-    }, [repoId, workspaceId]);
+    }, [repoId, workspaceId, cloneClient]);
 
     useEffect(() => {
         const rosterKeys = new Set(coworkerRoster.map(getCoworkerRosterIdentityKey));
@@ -389,13 +393,13 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
     // Fetch cached suggestions on mount when feature is enabled.
     useEffect(() => {
         if (!suggestionsEnabled) return;
-        getSpaCocClient().pullRequests.getSuggestions(repoId)
+        cloneClient.pullRequests.getSuggestions(repoId)
             .then(data => {
                 setSuggestions(data.suggestions ?? []);
                 setSuggestionsRankedAt(data.rankedAt ?? null);
             })
             .catch(() => { /* non-fatal */ });
-    }, [repoId, suggestionsEnabled]);
+    }, [repoId, suggestionsEnabled, cloneClient]);
 
     const handleRefreshSuggestions = useCallback(() => {
         if (suggestionsLoading) return;
@@ -403,7 +407,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         setSuggestionsInfo(null);
         setSuggestionsError(null);
         setSuggestionsStatus('Fetching review history...');
-        const client = getSpaCocClient().pullRequests;
+        const client = cloneClient.pullRequests;
         client.refreshReviewHistory(repoId)
             .then(history => {
                 if ((history.reviews ?? []).length === 0) {
@@ -428,7 +432,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
                 setSuggestionsError(getSpaCocClientErrorMessage(err, 'Failed to generate PR suggestions.'));
             })
             .finally(() => setSuggestionsLoading(false));
-    }, [repoId, suggestionsLoading]);
+    }, [repoId, suggestionsLoading, cloneClient]);
 
     const filteredBySearch = useMemo(() => {
         if (!searchText) return prs;
@@ -578,7 +582,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         setTeamClassificationLoading(true);
         setTeamClassificationError(null);
         try {
-            const data = await getSpaCocClient().pullRequests.getClassificationBatchStatus(repoId, {
+            const data = await cloneClient.pullRequests.getClassificationBatchStatus(repoId, {
                 type: 'pr',
                 identifiers: teamAutoClassificationIdentifiers,
                 workspaceId,
@@ -590,7 +594,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         } finally {
             setTeamClassificationLoading(false);
         }
-    }, [repoId, teamAutoClassificationEnabled, teamAutoClassificationIdentifiers, teamAutoClassificationIdentifiersKey, workspaceId]);
+    }, [repoId, teamAutoClassificationEnabled, teamAutoClassificationIdentifiers, teamAutoClassificationIdentifiersKey, workspaceId, cloneClient]);
 
     useEffect(() => {
         void loadTeamClassificationStatuses();
@@ -602,7 +606,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         setTeamClassificationQueueing(true);
         setTeamClassificationError(null);
         try {
-            const result = await getSpaCocClient().pullRequests.autoClassifyTeam(repoId, {
+            const result = await cloneClient.pullRequests.autoClassifyTeam(repoId, {
                 workspaceId,
                 pullRequests: teamAutoClassificationPrs,
             });
@@ -623,6 +627,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         teamAutoClassificationPrs,
         teamClassificationQueueing,
         workspaceId,
+        cloneClient,
     ]);
 
     useEffect(() => {
@@ -709,7 +714,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         setCoworkerRosterSavingKey('add');
         setCoworkerRosterError(null);
         try {
-            const data = await getSpaCocClient().pullRequests.addCoworkerToRoster(repoId, workspaceId, {
+            const data = await cloneClient.pullRequests.addCoworkerToRoster(repoId, workspaceId, {
                 id: candidate.id,
                 displayName: candidate.displayName,
                 ...(candidate.email ? { email: candidate.email } : {}),
@@ -722,7 +727,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         } finally {
             setCoworkerRosterSavingKey(null);
         }
-    }, [addableCoworkerCandidates, coworkerPickerKey, repoId, workspaceId]);
+    }, [addableCoworkerCandidates, coworkerPickerKey, repoId, workspaceId, cloneClient]);
 
     const handleRemoveCoworker = useCallback(async (entry: Pick<PullRequestCoworkerRosterEntry, 'id' | 'displayName'>) => {
         const key = getCoworkerRosterIdentityKey(entry);
@@ -734,7 +739,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         setCoworkerRosterSavingKey(`remove:${key}`);
         setCoworkerRosterError(null);
         try {
-            const data = await getSpaCocClient().pullRequests.removeCoworkerFromRoster(repoId, workspaceId, key);
+            const data = await cloneClient.pullRequests.removeCoworkerFromRoster(repoId, workspaceId, key);
             setCoworkerRoster(data.entries ?? []);
             setInactiveCoworkerKeys(prev => {
                 if (!prev.has(key)) return prev;
@@ -747,7 +752,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         } finally {
             setCoworkerRosterSavingKey(null);
         }
-    }, [repoId, workspaceId]);
+    }, [repoId, workspaceId, cloneClient]);
 
     function handleToggleBatchMode() {
         setBatchMode(prev => {
@@ -771,7 +776,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
     const openPrInRepo = useCallback(async (targetRepoId: string, prNumber: number): Promise<unknown> => {
         let pr: unknown;
         try {
-            pr = await getSpaCocClient().pullRequests.get(targetRepoId, String(prNumber));
+            pr = await cloneClient.pullRequests.get(targetRepoId, String(prNumber));
         } catch (err) {
             if (err instanceof CocApiError && err.status === 404) {
                 throw new PullRequestOpenError(`Pull request #${prNumber} not found.`, 404);
@@ -783,7 +788,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         window.location.hash = `#repos/${encodeURIComponent(targetRepoId)}/pull-requests/${prNumber}/overview`;
         if (isMobile) setMobileShowDetail(true);
         return pr;
-    }, [dispatch, isMobile]);
+    }, [dispatch, isMobile, cloneClient]);
 
     const recordRecentOpenedPr = useCallback(async (
         targetRepoId: string,
@@ -791,7 +796,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         prNumber: number,
         pr: unknown,
     ) => {
-        const data = await getSpaCocClient().pullRequests.recordRecentOpened(
+        const data = await cloneClient.pullRequests.recordRecentOpened(
             targetRepoId,
             targetWorkspaceId,
             buildRecentOpenedRecord(pr, prNumber),
@@ -799,10 +804,10 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         if (targetRepoId === repoId && targetWorkspaceId === workspaceId) {
             setRecentOpenedPrs(data.entries ?? []);
         }
-    }, [repoId, workspaceId]);
+    }, [repoId, workspaceId, cloneClient]);
 
     const removeRecentOpenedPr = useCallback(async (entry: RecentOpenedPullRequestEntry) => {
-        const data = await getSpaCocClient().pullRequests.removeRecentOpened(
+        const data = await cloneClient.pullRequests.removeRecentOpened(
             entry.repoId,
             entry.workspaceId,
             entry.number,
@@ -810,7 +815,7 @@ export function PullRequestsTab({ repoId, workspaceId }: PullRequestsTabProps) {
         if (entry.repoId === repoId && entry.workspaceId === workspaceId) {
             setRecentOpenedPrs(data.entries ?? []);
         }
-    }, [repoId, workspaceId]);
+    }, [repoId, workspaceId, cloneClient]);
 
     const handleRecentOpenedClick = useCallback(async (entry: RecentOpenedPullRequestEntry) => {
         if (openPrLoading) return;

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/hooks/usePullRequestChatBinding.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/hooks/usePullRequestChatBinding.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import type { AttachmentPayload } from '../../../types/attachments';
 
 export interface UsePullRequestChatBindingOptions {
@@ -43,6 +43,7 @@ export interface UsePullRequestChatBindingReturn {
 
 export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions): UsePullRequestChatBindingReturn {
     const { workspaceId, prId, prNumber, prTitle, repoId } = opts;
+    const cloneClient = useCocClient(workspaceId); // AC-07: PR chat binding on the selected clone's server.
     const [taskId, setTaskId] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -70,7 +71,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
         setTaskId(null);
         setStartingFresh(false);
 
-        getSpaCocClient().pullRequests.getChatBinding(workspaceId, prId)
+        cloneClient.pullRequests.getChatBinding(workspaceId, prId)
             .then(data => { if (!cancelled) setTaskId(data.taskId); })
             .catch(err => {
                 if (cancelled) return;
@@ -80,7 +81,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
             .finally(() => { if (!cancelled) setLoading(false); });
 
         return () => { cancelled = true; };
-    }, [workspaceId, prId]);
+    }, [workspaceId, prId, cloneClient]);
 
     const createChat = useCallback(async (prompt: string, options: ReviewChatComposerSendOptions = {}): Promise<string | null> => {
         if (!prId) return null;
@@ -90,7 +91,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
             setError(null);
         }
         try {
-            const res = await getSpaCocClient().queue.enqueue({
+            const res = await cloneClient.queue.enqueue({
                 type: 'chat',
                 priority: 'normal',
                 payload: {
@@ -113,7 +114,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
             const newTaskId = res.task?.id ?? (res as { id?: string }).id;
             if (!newTaskId) throw new Error('Failed to create pull request chat task');
 
-            await getSpaCocClient().pullRequests.createChatBinding(workspaceId, prId, newTaskId);
+            await cloneClient.pullRequests.createChatBinding(workspaceId, prId, newTaskId);
 
             if (isCurrentRequest(requestedWorkspaceId, requestedPrId)) {
                 setError(null);
@@ -126,7 +127,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
             }
             return null;
         }
-    }, [workspaceId, prId, prNumber, prTitle, repoId, isCurrentRequest]);
+    }, [workspaceId, prId, prNumber, prTitle, repoId, isCurrentRequest, cloneClient]);
 
     const startFreshChat = useCallback(async (): Promise<boolean> => {
         if (!prId) return false;
@@ -137,7 +138,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
             setError(null);
         }
         try {
-            await getSpaCocClient().pullRequests.startFreshChat(workspaceId, prId);
+            await cloneClient.pullRequests.startFreshChat(workspaceId, prId);
             if (isCurrentRequest(requestedWorkspaceId, requestedPrId)) {
                 setTaskId(null);
                 setError(null);
@@ -153,7 +154,7 @@ export function usePullRequestChatBinding(opts: UsePullRequestChatBindingOptions
                 setStartingFresh(false);
             }
         }
-    }, [workspaceId, prId, isCurrentRequest]);
+    }, [workspaceId, prId, isCurrentRequest, cloneClient]);
 
     return { taskId, loading, error, createChat, startFreshChat, startingFresh };
 }

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -27,7 +27,7 @@ import { useUiLayoutMode } from '../../hooks/preferences/useUiLayoutMode';
 import { useRepoQueueStats, isHidden as isHiddenTask } from '../../queue/hooks/useRepoQueueStats';
 import { useGitInfo } from '../git/hooks/useGitInfo';
 import { computeVisibleSubTabs, type SubTabDef } from '../repo-detail/repoSubTabs';
-import { groupReposByRemote, truncatePath } from '../../repos/repoGrouping';
+import { groupReposByRemote, isRemoteRepo, truncatePath } from '../../repos/repoGrouping';
 import {
     partitionShellTabs, computeCloneStatusMap, cloneStatusColor, summarizeRemote, computeVisibleTabKeys,
 } from './shellModel';
@@ -83,6 +83,11 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
         return groups.find(g => g.repos.some(r => String(r.workspace.id) === cloneId)) ?? null;
     }, [repos, cloneId]);
     const clones = group?.repos ?? [repo];
+    // Index of the first LOCAL clone (clones are sorted local-first by
+    // groupReposByRemote). -1 ⇒ a remote-only group, whose first remote row is
+    // then the primary entry. Drives the PRIMARY marker so an aggregated remote
+    // clone never displaces a local primary.
+    const primaryIdx = clones.findIndex(c => !isRemoteRepo(c));
     const cloneStatus = useMemo(
         () => computeCloneStatusMap(repos, queueState.repoQueueMap, isHiddenTask),
         [repos, queueState.repoQueueMap],
@@ -257,10 +262,20 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                             const cid = String(c.workspace.id);
                             const isSel = cid === cloneId;
                             const st = cloneStatus[cid];
+                            const isRemote = isRemoteRepo(c);
+                            // Anchor PRIMARY on the first LOCAL clone; clones are sorted
+                            // local-first so that's the first non-remote row. A remote-only
+                            // group has no local clone (primaryIdx === -1) — its first
+                            // remote row is then the sole/primary entry.
+                            const isPrimary = primaryIdx >= 0 ? i === primaryIdx : i === 0;
+                            const serverLabel = isRemote
+                                ? String((c.workspace as { remote?: { serverLabel?: unknown } }).remote?.serverLabel ?? 'remote')
+                                : null;
                             return (
                                 <button
                                     key={cid}
                                     data-testid="clone-popover-item"
+                                    data-remote={isRemote ? 'true' : 'false'}
                                     role="menuitem"
                                     onClick={() => { selectClone(cid); setCloneOpen(false); }}
                                     className={
@@ -272,7 +287,16 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                                     <span className="flex-1 min-w-0">
                                         <span className="flex items-center gap-1.5">
                                             <span className={'text-[12.5px] font-semibold truncate ' + (isSel ? 'text-[#0969da] dark:text-[#79c0ff]' : 'text-[#1e1e1e] dark:text-[#cccccc]')}>{c.workspace.name}</span>
-                                            {i === 0 && clones.length > 1 && <span className="text-[9px] font-bold uppercase px-1.5 py-px rounded bg-[#ddf4ff] dark:bg-[#3794ff]/20 text-[#0969da] dark:text-[#79c0ff]">primary</span>}
+                                            {isPrimary && clones.length > 1 && <span className="text-[9px] font-bold uppercase px-1.5 py-px rounded bg-[#ddf4ff] dark:bg-[#3794ff]/20 text-[#0969da] dark:text-[#79c0ff]">primary</span>}
+                                            {serverLabel && (
+                                                <span
+                                                    data-testid="clone-remote-badge"
+                                                    title={`Remote · ${serverLabel}`}
+                                                    className="inline-flex items-center max-w-[110px] truncate text-[9px] font-bold uppercase tracking-[0.04em] px-1.5 py-px rounded bg-[#8250df]/12 text-[#8250df] dark:bg-[#a371f7]/15 dark:text-[#a371f7]"
+                                                >
+                                                    {serverLabel}
+                                                </span>
+                                            )}
                                             {st === 'running' && <span className="text-[9px] font-bold uppercase px-1.5 py-px rounded bg-[#16a34a]/15 text-[#16a34a]">running</span>}
                                         </span>
                                         <span className="block font-mono text-[10.5px] text-[#848484] dark:text-[#777] truncate mt-0.5">{truncatePath(c.workspace.rootPath || '', 36)}</span>

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -276,6 +276,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                                     key={cid}
                                     data-testid="clone-popover-item"
                                     data-remote={isRemote ? 'true' : 'false'}
+                                    data-clone-status={st ?? 'idle'}
                                     role="menuitem"
                                     onClick={() => { selectClone(cid); setCloneOpen(false); }}
                                     className={

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -263,6 +263,12 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                             const isSel = cid === cloneId;
                             const st = cloneStatus[cid];
                             const isRemote = isRemoteRepo(c);
+                            // Offline (AC-06): reuse the AC-05 blended status — a remote
+                            // clone whose server is offline/failed resolves to 'offline'.
+                            // An offline row is greyed + non-interactive so its live tabs
+                            // are never opened; it flips back the moment the marker reports
+                            // online again (aggregateRemoteWorkspaces re-run).
+                            const isOffline = isRemote && st === 'offline';
                             // Anchor PRIMARY on the first LOCAL clone; clones are sorted
                             // local-first so that's the first non-remote row. A remote-only
                             // group has no local clone (primaryIdx === -1) — its first
@@ -277,17 +283,29 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                                     data-testid="clone-popover-item"
                                     data-remote={isRemote ? 'true' : 'false'}
                                     data-clone-status={st ?? 'idle'}
+                                    data-offline={isOffline ? 'true' : 'false'}
+                                    disabled={isOffline}
+                                    aria-disabled={isOffline}
                                     role="menuitem"
-                                    onClick={() => { selectClone(cid); setCloneOpen(false); }}
+                                    title={isOffline ? `${c.workspace.name} · offline (server unreachable)` : undefined}
+                                    onClick={() => {
+                                        // Block selection/navigation for offline clones so a
+                                        // dead remote server's tabs are never opened.
+                                        if (isOffline) return;
+                                        selectClone(cid);
+                                        setCloneOpen(false);
+                                    }}
                                     className={
                                         'w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-left transition-colors ' +
-                                        (isSel ? 'bg-[#ddf4ff] dark:bg-[#3794ff]/15' : 'hover:bg-black/[0.04] dark:hover:bg-white/[0.06]')
+                                        (isOffline
+                                            ? 'opacity-50 grayscale cursor-not-allowed'
+                                            : (isSel ? 'bg-[#ddf4ff] dark:bg-[#3794ff]/15' : 'hover:bg-black/[0.04] dark:hover:bg-white/[0.06]'))
                                     }
                                 >
                                     <span className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0 mt-0.5" style={{ background: cloneStatusColor(st, (c.workspace.color as string) || remoteColor) }} aria-hidden />
                                     <span className="flex-1 min-w-0">
                                         <span className="flex items-center gap-1.5">
-                                            <span className={'text-[12.5px] font-semibold truncate ' + (isSel ? 'text-[#0969da] dark:text-[#79c0ff]' : 'text-[#1e1e1e] dark:text-[#cccccc]')}>{c.workspace.name}</span>
+                                            <span className={'text-[12.5px] font-semibold truncate ' + (isSel && !isOffline ? 'text-[#0969da] dark:text-[#79c0ff]' : 'text-[#1e1e1e] dark:text-[#cccccc]')}>{c.workspace.name}</span>
                                             {isPrimary && clones.length > 1 && <span className="text-[9px] font-bold uppercase px-1.5 py-px rounded bg-[#ddf4ff] dark:bg-[#3794ff]/20 text-[#0969da] dark:text-[#79c0ff]">primary</span>}
                                             {serverLabel && (
                                                 <span
@@ -298,7 +316,17 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                                                     {serverLabel}
                                                 </span>
                                             )}
-                                            {st === 'running' && <span className="text-[9px] font-bold uppercase px-1.5 py-px rounded bg-[#16a34a]/15 text-[#16a34a]">running</span>}
+                                            {isOffline && (
+                                                <span
+                                                    data-testid="clone-offline-badge"
+                                                    title="Server offline — showing last-known state"
+                                                    className="inline-flex items-center gap-1 text-[9px] font-bold uppercase tracking-[0.04em] px-1.5 py-px rounded bg-[#8c959f]/15 text-[#6e7781] dark:text-[#8c959f]"
+                                                >
+                                                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#8c959f]" aria-hidden />
+                                                    offline
+                                                </span>
+                                            )}
+                                            {!isOffline && st === 'running' && <span className="text-[9px] font-bold uppercase px-1.5 py-px rounded bg-[#16a34a]/15 text-[#16a34a]">running</span>}
                                         </span>
                                         <span className="block font-mono text-[10.5px] text-[#848484] dark:text-[#777] truncate mt-0.5">{truncatePath(c.workspace.rootPath || '', 36)}</span>
                                     </span>

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/shellModel.ts
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/shellModel.ts
@@ -11,6 +11,7 @@
  */
 
 import type { RepoData, RepoGroup } from '../../repos/repoGrouping';
+import type { RemoteConnectionStatus, RemoteQueueStatus } from '../../repos/remoteWorkspaceAggregation';
 import type { RepoSubTab } from '../../types/dashboard';
 import type { SubTabDef } from '../repo-detail/repoSubTabs';
 
@@ -80,11 +81,52 @@ export function computeVisibleTabKeys(
 
 // ── Clone status ─────────────────────────────────────────────────────────────
 
-export type CloneStatus = 'idle' | 'running' | 'queued' | 'paused';
+/**
+ * Per-clone status driving the dropdown's status dot.
+ *   • Local clones: queue-derived (idle/running/queued/paused), unchanged.
+ *   • Remote clones (AC-05): connection-first — `offline` / `connecting` win over
+ *     the queue; when the server is online the remote queue status is used.
+ */
+export type CloneStatus = 'idle' | 'running' | 'queued' | 'paused' | 'offline' | 'connecting';
+
+/** Minimal remote marker shape this module reads off a workspace (set by AC-01/05). */
+interface RemoteStatusMarker {
+    connection?: RemoteConnectionStatus;
+    queue?: RemoteQueueStatus;
+}
 
 /**
- * Derive per-clone queue status from the QueueContext repoQueueMap, mirroring
- * RepoTabStrip's logic. `isHiddenTask` is injected to keep this module pure.
+ * Read a workspace's remote marker when present. Inlined (not imported from the
+ * network-aware aggregation module) to keep shellModel pure and dependency-light;
+ * local workspaces return `undefined`.
+ */
+function remoteMarker(workspace: unknown): RemoteStatusMarker | undefined {
+    const ws = workspace as { remote?: unknown } | undefined;
+    if (ws && typeof ws.remote === 'object' && ws.remote !== null) {
+        return ws.remote as RemoteStatusMarker;
+    }
+    return undefined;
+}
+
+/**
+ * Blend a remote clone's connection + queue into a single status (AC-05).
+ * Connection comes first: a server that is not online shows offline/connecting
+ * regardless of its last-known queue; once online, the remote queue status is
+ * used (mirroring local semantics).
+ */
+export function blendRemoteCloneStatus(marker: RemoteStatusMarker): CloneStatus {
+    const connection = marker.connection ?? 'offline';
+    if (connection === 'offline' || connection === 'failed') return 'offline';
+    if (connection !== 'online') return 'connecting'; // 'connecting' | 'idle' (not yet online)
+    return marker.queue ?? 'idle';
+}
+
+/**
+ * Derive per-clone status from the QueueContext repoQueueMap, mirroring
+ * RepoTabStrip's logic for LOCAL clones. For REMOTE clones (carrying an AC-01
+ * marker), the status is blended from the marker's connection + remote queue
+ * (AC-05) instead of the local queue map. `isHiddenTask` is injected to keep
+ * this module pure.
  */
 export function computeCloneStatusMap(
     repos: RepoData[],
@@ -94,6 +136,8 @@ export function computeCloneStatusMap(
     const map: Record<string, CloneStatus> = {};
     for (const repo of repos) {
         const id = String(repo.workspace.id);
+        const marker = remoteMarker(repo.workspace);
+        if (marker) { map[id] = blendRemoteCloneStatus(marker); continue; }
         const entry = repoQueueMap?.[id];
         if (!entry) { map[id] = 'idle'; continue; }
         if (entry.stats?.isPaused) { map[id] = 'paused'; continue; }
@@ -105,11 +149,17 @@ export function computeCloneStatusMap(
     return map;
 }
 
-/** Resolve the dot color for a clone given its status, falling back to the remote color. */
+/**
+ * Resolve the dot color for a clone given its status, falling back to the remote
+ * color for idle/unknown. Remote-only states get distinct hues: `offline` is a
+ * dim grey ("inactive"), `connecting` a blue in-progress hue (NOT queued orange).
+ */
 export function cloneStatusColor(status: CloneStatus | undefined, fallback: string): string {
     if (status === 'running') return '#16a34a';
     if (status === 'queued') return '#c98410';
     if (status === 'paused') return '#f14c4c';
+    if (status === 'connecting') return '#3b82f6';
+    if (status === 'offline') return '#8c959f';
     return fallback;
 }
 

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/explorer/explorerApi.ts
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/explorer/explorerApi.ts
@@ -7,29 +7,31 @@ import type {
     ExplorerTreeResponse,
 } from '@plusplusoneplusplus/coc-client';
 import { getSpaCocClient } from '../../../api/cocClient';
+import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 
 export const explorerApi = {
     tree(workspaceId: string, options?: ExplorerTreeOptions): Promise<ExplorerTreeResponse> {
-        return getSpaCocClient().explorer.tree(workspaceId, options);
+        return getCocClientForWorkspace(workspaceId).explorer.tree(workspaceId, options);
     },
 
     searchFiles(workspaceId: string, query: string, options?: ExplorerSearchOptions & Pick<CocRequestOptions, 'signal'>): Promise<ExplorerSearchResponse> {
-        return getSpaCocClient().explorer.searchFiles(workspaceId, query, options);
+        return getCocClientForWorkspace(workspaceId).explorer.searchFiles(workspaceId, query, options);
     },
 
     readBlob(workspaceId: string, path: string, options?: Pick<CocRequestOptions, 'signal'>): Promise<ExplorerBlobResponse> {
-        return getSpaCocClient().explorer.readBlob(workspaceId, path, options);
+        return getCocClientForWorkspace(workspaceId).explorer.readBlob(workspaceId, path, options);
     },
 
     writeBlob(workspaceId: string, path: string, content: string): Promise<{ success: boolean }> {
-        return getSpaCocClient().explorer.writeBlob(workspaceId, path, content);
+        return getCocClientForWorkspace(workspaceId).explorer.writeBlob(workspaceId, path, content);
     },
 
     reveal(workspaceId: string, path: string): Promise<void> {
-        return getSpaCocClient().explorer.reveal(workspaceId, path);
+        return getCocClientForWorkspace(workspaceId).explorer.reveal(workspaceId, path);
     },
 
     readTrustedBlob(path: string, options?: Pick<CocRequestOptions, 'signal'>): Promise<ExplorerBlobResponse> {
+        // Trusted-blob reads are not workspace-scoped; keep them on the local client.
         return getSpaCocClient().explorer.readTrustedBlob(path, options);
     },
 };

--- a/packages/coc/src/server/spa/client/react/features/schedules/CreateScheduleForm.tsx
+++ b/packages/coc/src/server/spa/client/react/features/schedules/CreateScheduleForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Button, cn } from '../../ui';
 import { SegmentedControl } from '../../ui/SegmentedControl';
 import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { getActiveProvider } from '../../utils/config';
 import { fetchWorkflows } from '../workflow/workflow-api';
 import { describeCron, parseCronToInterval, intervalToCron } from '../../utils/cron';
@@ -197,6 +198,9 @@ export function CreateScheduleForm({ workspaceId, onCreated, onCancel, mode: for
     scheduleId?: string;
     initialValues?: ScheduleFormInitialValues;
 }) {
+    // AC-07: schedule create/update target the selected clone's server (provider
+    // model catalog stays on the default origin — it is not workspace-scoped).
+    const cloneClient = useCocClient(workspaceId);
     const workflowsEnabled = useWorkflowsEnabled();
     const inferredActionKind = inferActionKind(initialValues);
     const workflowActionBlocked = !workflowsEnabled && inferredActionKind === 'workflow';
@@ -391,9 +395,9 @@ export function CreateScheduleForm({ workspaceId, onCreated, onCancel, mode: for
                 mode: targetType === 'prompt' ? chatMode : undefined,
             };
             if (formMode === 'edit' && scheduleId) {
-                await getSpaCocClient().schedules.update(workspaceId, scheduleId, payload);
+                await cloneClient.schedules.update(workspaceId, scheduleId, payload);
             } else {
-                await getSpaCocClient().schedules.create(workspaceId, payload);
+                await cloneClient.schedules.create(workspaceId, payload);
             }
             onCreated();
         } catch (err) {

--- a/packages/coc/src/server/spa/client/react/features/schedules/PromptScheduleForm.tsx
+++ b/packages/coc/src/server/spa/client/react/features/schedules/PromptScheduleForm.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'react';
 import { Button, cn } from '../../ui';
 import { SegmentedControl } from '../../ui/SegmentedControl';
 import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { getActiveProvider } from '../../utils/config';
 import { ScheduleTriggerPanel } from './ScheduleTriggerPanel';
 import {
@@ -57,6 +58,8 @@ export function PromptScheduleForm({ workspaceId, onCreated, onCancel, onAdvance
     scheduleId?: string;
     initialValues?: PromptScheduleFormValues;
 }) {
+    // AC-07: schedule create/update/disable target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     // Infer preset from existing cron on edit
     const inferred = initialValues?.cron ? inferPresetFromCron(initialValues.cron) : null;
 
@@ -154,11 +157,11 @@ export function PromptScheduleForm({ workspaceId, onCreated, onCancel, onAdvance
                 mode: chatMode,
             };
             if (formMode === 'edit' && scheduleId) {
-                await getSpaCocClient().schedules.update(workspaceId, scheduleId, payload);
+                await cloneClient.schedules.update(workspaceId, scheduleId, payload);
             } else {
-                const result = await getSpaCocClient().schedules.create(workspaceId, payload);
+                const result = await cloneClient.schedules.create(workspaceId, payload);
                 if (shouldPause && result?.id) {
-                    try { await getSpaCocClient().schedules.disable(workspaceId, result.id); } catch { /* best effort */ }
+                    try { await cloneClient.schedules.disable(workspaceId, result.id); } catch { /* best effort */ }
                 }
             }
             onCreated();

--- a/packages/coc/src/server/spa/client/react/features/schedules/RepoSchedulesTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/schedules/RepoSchedulesTab.tsx
@@ -4,8 +4,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { cn } from '../../ui';
-import { fetchApi } from '../../hooks/useApi';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { useApp } from '../../contexts/AppContext';
@@ -30,6 +29,8 @@ interface RepoSchedulesTabProps {
 
 export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
     const { state, dispatch } = useApp();
+    // Route schedule CRUD + notes-git status to the workspace's clone (AC-07).
+    const client = useCocClient(workspaceId);
     const [schedules, setSchedules] = useState<Schedule[]>([]);
     const [loading, setLoading] = useState(true);
     const [selectedId, setSelectedId] = useState<string | null>(state.selectedScheduleId);
@@ -54,23 +55,23 @@ export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
     useEffect(() => {
         if (notesGitCheckedRef.current === workspaceId) return;
         notesGitCheckedRef.current = workspaceId;
-        fetchApi(`/workspaces/${encodeURIComponent(workspaceId)}/notes/git/status`)
+        client.notes.getGitStatus(workspaceId)
             .then((data: any) => {
                 if (data?.initialized) setNotesGitInitialized(true);
                 else setNotesGitInitialized(false);
             })
             .catch(() => setNotesGitInitialized(false));
-    }, [workspaceId]);
+    }, [workspaceId, client]);
 
     const fetchSchedules = useCallback(async () => {
         try {
-            const nextSchedules = await getSpaCocClient().schedules.list(workspaceId);
+            const nextSchedules = await client.schedules.list(workspaceId);
             setSchedules(nextSchedules);
         } catch {
             setSchedules([]);
         }
         setLoading(false);
-    }, [workspaceId]);
+    }, [workspaceId, client]);
 
     useEffect(() => {
         setLoading(true);
@@ -98,7 +99,7 @@ export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
     useEffect(() => {
         if (!selectedId) return;
         let cancelled = false;
-        getSpaCocClient().schedules.history(workspaceId, selectedId)
+        client.schedules.history(workspaceId, selectedId)
             .then(nextHistory => {
                 if (!cancelled) setHistory(nextHistory);
             })
@@ -106,7 +107,7 @@ export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
                 if (!cancelled) setHistory([]);
             });
         return () => { cancelled = true; };
-    }, [selectedId, workspaceId]);
+    }, [selectedId, workspaceId, client]);
 
     // Auto-select first schedule when schedules load and nothing is selected
     useEffect(() => {
@@ -120,18 +121,18 @@ export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
 
     const handlePauseResume = async (schedule: Schedule) => {
         if (schedule.status === 'active') {
-            await getSpaCocClient().schedules.disable(workspaceId, schedule.id);
+            await client.schedules.disable(workspaceId, schedule.id);
         } else {
-            await getSpaCocClient().schedules.enable(workspaceId, schedule.id);
+            await client.schedules.enable(workspaceId, schedule.id);
         }
         fetchSchedules();
     };
 
     const handleRunNow = async (scheduleId: string) => {
-        await getSpaCocClient().schedules.run(workspaceId, scheduleId);
+        await client.schedules.run(workspaceId, scheduleId);
         fetchSchedules();
         if (selectedId === scheduleId) {
-            const nextHistory = await getSpaCocClient().schedules.history(workspaceId, scheduleId);
+            const nextHistory = await client.schedules.history(workspaceId, scheduleId);
             setHistory(nextHistory);
         }
     };
@@ -143,7 +144,7 @@ export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
             ? `This will permanently delete .github/schedules/${slug}.yaml. This cannot be undone. Continue?`
             : 'Delete this schedule?';
         if (!confirm(message)) return;
-        await getSpaCocClient().schedules.delete(workspaceId, scheduleId);
+        await client.schedules.delete(workspaceId, scheduleId);
         if (selectedId === scheduleId) {
             setSelectedId(null);
             dispatch({ type: 'SET_SELECTED_SCHEDULE', id: null });
@@ -153,7 +154,7 @@ export function RepoSchedulesTab({ workspaceId }: RepoSchedulesTabProps) {
     };
 
     const handleMove = async (scheduleId: string, destination: 'user' | 'repo') => {
-        await getSpaCocClient().schedules.move(workspaceId, scheduleId, destination);
+        await client.schedules.move(workspaceId, scheduleId, destination);
         fetchSchedules();
     };
 

--- a/packages/coc/src/server/spa/client/react/features/terminal/TerminalView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/terminal/TerminalView.tsx
@@ -8,7 +8,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { cn } from '../../ui/cn';
 import { TerminalPanel } from './TerminalPanel';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { CocApiError } from '@plusplusoneplusplus/coc-client';
 import type { TerminalSessionInfo } from './hooks/useTerminalWebSocket';
 
@@ -27,6 +27,9 @@ interface TerminalTab {
 
 
 export function TerminalView({ workspaceId }: TerminalViewProps) {
+    // Route terminal REST (list/pin) to the workspace's clone (AC-07). The PTY
+    // socket itself is routed inside useTerminalWebSocket via the same registry.
+    const client = useCocClient(workspaceId);
     const [terminals, setTerminals] = useState<TerminalTab[]>([]);
     const [activeId, setActiveId] = useState<string>('');
     const [editingId, setEditingId] = useState<string | null>(null);
@@ -48,7 +51,7 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
         let cancelled = false;
 
         async function hydratePinnedTerminals() {
-            const body = await getSpaCocClient().workspaces.listTerminals(workspaceId);
+            const body = await client.workspaces.listTerminals(workspaceId);
             const pinnedSessions = (Array.isArray(body.sessions) ? body.sessions : [])
                 .filter(session => session.pinned);
             if (cancelled) return;
@@ -92,7 +95,7 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
         return () => {
             cancelled = true;
         };
-    }, [workspaceId]);
+    }, [workspaceId, client]);
 
     const closeTerminal = useCallback((id: string) => {
         setTerminals(prev => {
@@ -144,7 +147,7 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
         try {
             let body: { sessionId: string; pinned: boolean };
             try {
-                body = await getSpaCocClient().workspaces.pinTerminal(workspaceId, tab.serverSessionId, requestedPinned);
+                body = await client.workspaces.pinTerminal(workspaceId, tab.serverSessionId, requestedPinned);
             } catch (err) {
                 if (err instanceof CocApiError && err.status === 404) {
                     markSessionMissing(id);
@@ -167,7 +170,7 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
         } finally {
             markPinning(id, false);
         }
-    }, [markPinning, markSessionMissing, pinningIds, terminals, workspaceId]);
+    }, [markPinning, markSessionMissing, pinningIds, terminals, workspaceId, client]);
 
     const handleServerSessionCreated = useCallback((id: string, session: TerminalSessionInfo) => {
         setTerminals(prev =>

--- a/packages/coc/src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket.ts
+++ b/packages/coc/src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket.ts
@@ -7,6 +7,7 @@
 
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { getWsPath } from '../../../utils/config';
+import { cloneWsUrl } from '../../../api/wsUrl';
 
 export type { WsStatus } from '../../../hooks/useWebSocket';
 type WsStatus = 'connecting' | 'open' | 'closed';
@@ -112,9 +113,10 @@ export function useTerminalWebSocket({
             wsRef.current.close();
         }
 
-        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
         const basePath = getWsPath();
-        const wsUrl = `${protocol}//${location.host}${basePath}/terminal?workspaceId=${encodeURIComponent(params.workspaceId)}&cols=${params.cols}&rows=${params.rows}`;
+        // baseUrl omitted → page-origin URL (local behavior unchanged). AC-07 wires
+        // a remote clone's baseUrl in so its terminal targets that server.
+        const wsUrl = cloneWsUrl(`${basePath}/terminal?workspaceId=${encodeURIComponent(params.workspaceId)}&cols=${params.cols}&rows=${params.rows}`);
         setStatus('connecting');
 
         const ws = new WebSocket(wsUrl);

--- a/packages/coc/src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket.ts
+++ b/packages/coc/src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket.ts
@@ -8,6 +8,7 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { getWsPath } from '../../../utils/config';
 import { cloneWsUrl } from '../../../api/wsUrl';
+import { lookupCloneBaseUrl } from '../../../repos/cloneRegistry';
 
 export type { WsStatus } from '../../../hooks/useWebSocket';
 type WsStatus = 'connecting' | 'open' | 'closed';
@@ -114,9 +115,14 @@ export function useTerminalWebSocket({
         }
 
         const basePath = getWsPath();
-        // baseUrl omitted → page-origin URL (local behavior unchanged). AC-07 wires
-        // a remote clone's baseUrl in so its terminal targets that server.
-        const wsUrl = cloneWsUrl(`${basePath}/terminal?workspaceId=${encodeURIComponent(params.workspaceId)}&cols=${params.cols}&rows=${params.rows}`);
+        // Route the terminal PTY socket to the workspace's clone (AC-07): a remote
+        // clone targets its server's baseUrl; a local clone resolves to undefined →
+        // the legacy page-origin URL, so local behavior is unchanged.
+        const cloneBaseUrl = lookupCloneBaseUrl(params.workspaceId);
+        const wsUrl = cloneWsUrl(
+            `${basePath}/terminal?workspaceId=${encodeURIComponent(params.workspaceId)}&cols=${params.cols}&rows=${params.rows}`,
+            cloneBaseUrl,
+        );
         setStatus('connecting');
 
         const ws = new WebSocket(wsUrl);

--- a/packages/coc/src/server/spa/client/react/features/work-items/CreateWorkItemDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/CreateWorkItemDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button } from '../../ui';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { isWorkItemsHierarchyEnabled, isWorkItemsWorkflowEnabled } from '../../utils/config';
 
 type WorkItemTypeAll = 'work-item' | 'bug' | 'goal' | 'epic' | 'feature' | 'pbi';
@@ -29,6 +29,7 @@ export interface CreateWorkItemDialogProps {
 }
 
 export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fromChatId, itemType = 'work-item', parentId }: CreateWorkItemDialogProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: create on the selected clone's server.
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
     const [priority, setPriority] = useState<'normal' | 'high' | 'low'>('normal');
@@ -63,10 +64,10 @@ export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fr
         try {
             let data: any;
             if (fromChatId) {
-                data = await getSpaCocClient().workItems.createFromChat(workspaceId, { processId: fromChatId });
+                data = await cloneClient.workItems.createFromChat(workspaceId, { processId: fromChatId });
             } else {
                 const parsedTags = tags.split(',').map(t => t.trim()).filter(Boolean);
-                data = await getSpaCocClient().workItems.create(workspaceId, {
+                data = await cloneClient.workItems.create(workspaceId, {
                     title: title.trim(),
                     description: description.trim() || undefined,
                     priority,
@@ -84,7 +85,7 @@ export function CreateWorkItemDialog({ open, onClose, workspaceId, onCreated, fr
         } finally {
             setLoading(false);
         }
-    }, [workspaceId, fromChatId, title, description, priority, tags, successCriteria, selectedType, hierarchyEnabled, parentId, onCreated, onClose]);
+    }, [workspaceId, fromChatId, title, description, priority, tags, successCriteria, selectedType, hierarchyEnabled, parentId, onCreated, onClose, cloneClient]);
 
     const effectiveType = selectedType;
     const isBug = effectiveType === 'bug';

--- a/packages/coc/src/server/spa/client/react/features/work-items/ImportFromGitHubDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/ImportFromGitHubDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button, cn } from '../../ui';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import type { WorkItemSyncProvider } from '@plusplusoneplusplus/coc-client';
 
 export interface ImportFromGitHubDialogProps {
@@ -26,6 +26,7 @@ export function ImportFromGitHubDialog({
     providerOptions,
     onImported,
 }: ImportFromGitHubDialogProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: import onto the selected clone's server.
     const providerOptionsKey = providerOptions?.join('|') ?? 'all';
     const allowedProviders = useMemo(() => {
         if (providerOptionsKey === 'all') return undefined;
@@ -65,13 +66,13 @@ export function ImportFromGitHubDialog({
                 const request = /^\d+$/.test(trimmedInput)
                     ? { issueNumber: Number(trimmedInput) }
                     : { issueUrl: trimmedInput };
-                const item = await getSpaCocClient().workItems.importFromGitHub(workspaceId, request);
+                const item = await cloneClient.workItems.importFromGitHub(workspaceId, request);
                 onImported?.(item, provider);
             } else {
                 const request = /^\d+$/.test(trimmedInput)
                     ? { workItemId: Number(trimmedInput) }
                     : { workItemUrl: trimmedInput };
-                const item = await getSpaCocClient().workItems.importFromAzureBoards(workspaceId, request);
+                const item = await cloneClient.workItems.importFromAzureBoards(workspaceId, request);
                 onImported?.(item, provider);
             }
             onClose();
@@ -84,7 +85,7 @@ export function ImportFromGitHubDialog({
         } finally {
             setLoading(false);
         }
-    }, [workspaceId, provider, remoteInput, onImported, onClose]);
+    }, [workspaceId, provider, remoteInput, onImported, onClose, cloneClient]);
 
     const isGitHub = provider === 'github';
     const inputTestId = isGitHub ? 'import-github-issue-input' : 'import-azure-boards-work-item-input';

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemAiComposer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemAiComposer.tsx
@@ -17,7 +17,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button, cn, Spinner } from '../../ui';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { isWorkItemsHierarchyEnabled } from '../../utils/config';
 import type {
     WorkItemAiGenerationResponse,
@@ -100,6 +100,7 @@ export function WorkItemAiComposer({
     onCreated,
     onImproved,
 }: WorkItemAiComposerProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: AI compose/create/improve on the selected clone's server.
     const [phase, setPhase] = useState<Phase>('idle');
 
     // Prompt & clarification
@@ -173,7 +174,7 @@ export function WorkItemAiComposer({
             let resp: WorkItemAiGenerationResponse;
 
             if (mode === 'create') {
-                resp = await getSpaCocClient().workItems.aiDraft(workspaceId, {
+                resp = await cloneClient.workItems.aiDraft(workspaceId, {
                     prompt: prompt.trim(),
                     type: (itemType as WorkItemType) ?? 'work-item',
                     parentId: parentId ?? undefined,
@@ -181,7 +182,7 @@ export function WorkItemAiComposer({
                     clarificationCount: effectiveClarifyCount,
                 });
             } else {
-                resp = await getSpaCocClient().workItems.aiImprove(workspaceId, existingItem!.id, {
+                resp = await cloneClient.workItems.aiImprove(workspaceId, existingItem!.id, {
                     prompt: prompt.trim(),
                     targets: ['fields', 'goal', 'childTasks'],
                     clarificationAnswers: clarifyAnswers.length > 0 ? clarifyAnswers : undefined,
@@ -202,7 +203,7 @@ export function WorkItemAiComposer({
             // Restore the previous phase so the user can retry
             setPhase(clarifyCount > 0 ? 'clarifying' : 'idle');
         }
-    }, [prompt, mode, workspaceId, existingItem, itemType, parentId, clarifyAnswers, clarifyCount, applyDraft]);
+    }, [prompt, mode, workspaceId, existingItem, itemType, parentId, clarifyAnswers, clarifyCount, applyDraft, cloneClient]);
 
     // Persist the approved draft via the standard create/update/plan routes
     const handleApprove = useCallback(async () => {
@@ -230,7 +231,7 @@ export function WorkItemAiComposer({
                         : `## Tasks\n${checklist}`;
                 }
 
-                const created = await getSpaCocClient().workItems.create(workspaceId, {
+                const created = await cloneClient.workItems.create(workspaceId, {
                     title: draftWorkItem.title,
                     description: draftWorkItem.description || undefined,
                     priority: draftWorkItem.priority,
@@ -249,7 +250,7 @@ export function WorkItemAiComposer({
                 if (hierarchyEnabled && draftChildTasks.length > 0) {
                     for (const child of draftChildTasks) {
                         if (!child.title.trim()) continue;
-                        await getSpaCocClient().workItems.create(workspaceId, {
+                        await cloneClient.workItems.create(workspaceId, {
                             title: child.title.trim(),
                             description: child.description || undefined,
                             type: (child.type as WorkItemType) || 'work-item',
@@ -263,7 +264,7 @@ export function WorkItemAiComposer({
                 onClose();
             } else {
                 // improve mode — patch the changed fields
-                await getSpaCocClient().workItems.update(workspaceId, existingItem!.id, {
+                await cloneClient.workItems.update(workspaceId, existingItem!.id, {
                     title: draftWorkItem.title,
                     description: draftWorkItem.description,
                     priority: draftWorkItem.priority,
@@ -272,7 +273,7 @@ export function WorkItemAiComposer({
 
                 // Update plan if the content changed from the current plan
                 if (draftGoal && draftGoal !== existingItem?.plan?.content) {
-                    await getSpaCocClient().workItems.updatePlan(workspaceId, existingItem!.id, draftGoal);
+                    await cloneClient.workItems.updatePlan(workspaceId, existingItem!.id, draftGoal);
                 }
 
                 onImproved?.();
@@ -285,7 +286,7 @@ export function WorkItemAiComposer({
     }, [
         mode, workspaceId, existingItem, parentId, hierarchyEnabled,
         draftWorkItem, draftGoal, draftChildTasks,
-        onCreated, onImproved, onClose,
+        onCreated, onImproved, onClose, cloneClient,
     ]);
 
     const isBusy = phase === 'generating' || phase === 'saving';

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemAiDraftApplyDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemAiDraftApplyDialog.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button, Spinner } from '../../ui';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import type { WorkItem, WorkItemAiClarificationResponse } from '@plusplusoneplusplus/coc-client';
 
 type DraftPhase = 'idle' | 'generating' | 'clarifying' | 'failed';
@@ -45,6 +46,7 @@ function isAbortError(error: unknown): boolean {
 }
 
 export function WorkItemAiDraftApplyDialog({ open, workspaceId, item, onClose, onApplied }: WorkItemAiDraftApplyDialogProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: apply AI draft on the selected clone's server.
     const [phase, setPhase] = useState<DraftPhase>('idle');
     const [questions, setQuestions] = useState<string[]>([]);
     const [answers, setAnswers] = useState<string[]>([]);
@@ -67,7 +69,7 @@ export function WorkItemAiDraftApplyDialog({ open, workspaceId, item, onClose, o
             const effectiveClarificationCount = options.forceDraft
                 ? MAX_CLARIFICATION_ROUNDS
                 : options.clarificationCount ?? clarificationCount;
-            const response = await getSpaCocClient().workItems.applyAiDraft(
+            const response = await cloneClient.workItems.applyAiDraft(
                 workspaceId,
                 item.id,
                 {
@@ -104,7 +106,7 @@ export function WorkItemAiDraftApplyDialog({ open, workspaceId, item, onClose, o
                 abortRef.current = null;
             }
         }
-    }, [clarificationCount, isRevision, item, onApplied, onClose, prompt, workspaceId]);
+    }, [clarificationCount, isRevision, item, onApplied, onClose, prompt, workspaceId, cloneClient]);
 
     useEffect(() => {
         if (!open) return;

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemDetail.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Button, cn } from '../../ui';
 import { fetchApi } from '../../hooks/useApi';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { formatRelativeTime } from '../../utils/format';
 import { WorkItemPlanSection, PLAN_MODE_OPTIONS } from './WorkItemPlanSection';
 import type { PlanViewMode } from './WorkItemPlanSection';
@@ -313,6 +313,8 @@ function ConflictValueCard({ label, value, selected, onSelect }: { label: string
 }
 
 export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, onViewTask, onViewCommit, onNavigateToTasksTab }: WorkItemDetailProps) {
+    // AC-07: all work-item detail reads/writes target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
     const [item, setItem] = useState<WorkItemFull | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -383,7 +385,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         setLoading(true);
         setError(null);
         try {
-            const data = await getSpaCocClient().workItems.get(requestedWorkspaceId, requestedWorkItemId);
+            const data = await cloneClient.workItems.get(requestedWorkspaceId, requestedWorkItemId);
             const current = currentSelectionRef.current;
             if (
                 requestSeq !== fetchRequestSeqRef.current ||
@@ -413,7 +415,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                 setLoading(false);
             }
         }
-    }, [workspaceId, workItemId]);
+    }, [workspaceId, workItemId, cloneClient]);
 
     useEffect(() => { fetchItem(); }, [fetchItem]);
 
@@ -524,7 +526,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
     const handleAcceptDone = async () => {
         setAcceptingDone(true);
         try {
-            await getSpaCocClient().workItems.updateStatus(workspaceId, workItemId, 'done', { completedAt: new Date().toISOString() });
+            await cloneClient.workItems.updateStatus(workspaceId, workItemId, 'done', { completedAt: new Date().toISOString() });
             await fetchItem();
         } catch (err: any) {
             setError(err.message || 'Failed to accept');
@@ -541,7 +543,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         }
         setRequestingChanges(true);
         try {
-            await getSpaCocClient().workItems.requestChanges(workspaceId, workItemId, { comments });
+            await cloneClient.workItems.requestChanges(workspaceId, workItemId, { comments });
             setReviewComment('');
             await fetchItem();
         } catch (err: any) {
@@ -556,7 +558,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         setSubmittingPr(true);
         setError(null);
         try {
-            await getSpaCocClient().workItems.submitPullRequest(workspaceId, workItemId, {
+            await cloneClient.workItems.submitPullRequest(workspaceId, workItemId, {
                 changeId: latestReviewChange.id,
             });
             await fetchItem();
@@ -572,7 +574,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         setStartingAiReview(true);
         setError(null);
         try {
-            const result = await getSpaCocClient().workItems.startAiReview(workspaceId, workItemId);
+            const result = await cloneClient.workItems.startAiReview(workspaceId, workItemId);
             if (result.workItem) {
                 dispatch({ type: 'WORK_ITEM_UPDATED', repoId: workspaceId, item: result.workItem as any });
             }
@@ -622,7 +624,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
             );
 
             // Call request-changes with diff-comments source
-            await getSpaCocClient().workItems.requestChanges(workspaceId, workItemId, { comments: formatted, source: 'diff-comments' });
+            await cloneClient.workItems.requestChanges(workspaceId, workItemId, { comments: formatted, source: 'diff-comments' });
 
             // Batch-resolve the open diff comments
             await Promise.all(
@@ -645,7 +647,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         if (!item) return;
         setResolvingCommitSha(sha);
         try {
-            const result = await getSpaCocClient().workItems.resolveComments(workspaceId, workItemId, {
+            const result = await cloneClient.workItems.resolveComments(workspaceId, workItemId, {
                 type: 'commit',
                 commitSha: sha,
                 ...(sourceRunIndex != null ? { sourceRunIndex } : {}),
@@ -670,7 +672,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
             for (const commit of commits) {
                 const ct = commentTotals.get(commit.sha);
                 if (!ct || ct.open === 0) continue;
-                await getSpaCocClient().workItems.resolveComments(workspaceId, workItemId, {
+                await cloneClient.workItems.resolveComments(workspaceId, workItemId, {
                     type: 'commit',
                     commitSha: commit.sha,
                     sourceRunIndex,
@@ -722,7 +724,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
 
             let updated: WorkItemFull = item;
             if (Object.keys(updates).length > 0) {
-                updated = await getSpaCocClient().workItems.update(workspaceId, workItemId, updates) as any;
+                updated = await cloneClient.workItems.update(workspaceId, workItemId, updates) as any;
             }
             setDraft(draftToSave);
             setSyncConflict(null);
@@ -741,7 +743,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         } finally {
             setSaving(false);
         }
-    }, [item, planDraft, workspaceId, workItemId, dispatch, fetchItem]);
+    }, [item, planDraft, workspaceId, workItemId, dispatch, fetchItem, cloneClient]);
 
     const handleSave = useCallback(async () => {
         if (!draft) return;
@@ -851,7 +853,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         setError(null);
         try {
             const sessionId = createRalphSessionId();
-            const result = await getSpaCocClient().queue.enqueue({
+            const result = await cloneClient.queue.enqueue({
                 type: 'chat',
                 priority: 'normal',
                 payload: {
@@ -884,8 +886,8 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
             const taskId = result.task?.id ?? (result as { id?: string }).id;
             if (!taskId) throw new Error('Failed to create Goal grilling chat task');
 
-            await getSpaCocClient().workItems.createChatBinding(workspaceId, workItemId, taskId);
-            await getSpaCocClient().workItems.update(workspaceId, workItemId, {
+            await cloneClient.workItems.createChatBinding(workspaceId, workItemId, taskId);
+            await cloneClient.workItems.update(workspaceId, workItemId, {
                 grillSessionId: ensureQueueProcessId(taskId),
                 ...(item.status === 'created' ? { status: 'drafting' } : {}),
             });
@@ -896,7 +898,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
         } finally {
             setStartingGoalGrilling(false);
         }
-    }, [fetchItem, item, openWorkItemChat, workItemId, workspaceId]);
+    }, [fetchItem, item, openWorkItemChat, workItemId, workspaceId, cloneClient]);
 
     if (loading) {
         return <div className="flex items-center justify-center h-full text-sm text-[#848484]">Loading…</div>;
@@ -1154,7 +1156,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                                 checked={item.autoExecute ?? false}
                                 onChange={async (e) => {
                                     try {
-                                        await getSpaCocClient().workItems.update(workspaceId, workItemId, { autoExecute: e.target.checked });
+                                        await cloneClient.workItems.update(workspaceId, workItemId, { autoExecute: e.target.checked });
                                         await fetchItem();
                                     } catch (err: any) {
                                         setError(err.message || 'Failed to update');
@@ -1249,7 +1251,7 @@ export function WorkItemDetail({ workItemId, workspaceId, onBack, onExecuted, on
                             type="button"
                             onClick={async () => {
                                 if (confirm('Delete this work item?')) {
-                                    await getSpaCocClient().workItems.delete(workspaceId, workItemId);
+                                    await cloneClient.workItems.delete(workspaceId, workItemId);
                                     closeWorkItemChat();
                                     onBack?.();
                                 }

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecuteDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecuteDialog.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Dialog, Button } from '../../ui';
 import { useRecentSkills } from '../../features/skills/hooks/useRecentSkills';
 import { fetchApi } from '../../hooks/useApi';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { RunSkillPanel } from '../../shared/RunSkillPanel';
 import type { SkillItem } from '../../shared/RunSkillPanel';
 import { ModalJobAiControls, useModalJobAiSelection } from '../../shared/ModalJobAiControls';
@@ -35,6 +35,7 @@ export function WorkItemExecuteDialog({
     onClose,
     onExecuted,
 }: WorkItemExecuteDialogProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: execute on the selected clone's server.
     const { recentItems, trackUsage } = useRecentSkills(workspaceId);
     const aiSelection = useModalJobAiSelection({ workspaceId, mode: 'autopilot' });
 
@@ -82,7 +83,7 @@ export function WorkItemExecuteDialog({
         setSubmitting(true);
         setError(null);
         try {
-            await getSpaCocClient().workItems.execute(workspaceId, workItemId, {
+            await cloneClient.workItems.execute(workspaceId, workItemId, {
                 ...(allowExecutionModeSelection ? { executionMode } : {}),
                 skillNames,
                 ...(aiSelection.resolved.provider ? { provider: aiSelection.resolved.provider } : {}),
@@ -95,7 +96,7 @@ export function WorkItemExecuteDialog({
             // Track skill usage (fire-and-forget)
             for (const name of skillNames) {
                 trackUsage(name);
-                getSpaCocClient().preferences.recordSkillUsage(workspaceId, name).catch(() => {});
+                cloneClient.preferences.recordSkillUsage(workspaceId, name).catch(() => {});
             }
 
             onExecuted();
@@ -105,7 +106,7 @@ export function WorkItemExecuteDialog({
         } finally {
             setSubmitting(false);
         }
-    }, [workspaceId, workItemId, allowExecutionModeSelection, executionMode, aiSelection.resolved, trackUsage, onExecuted, onClose]);
+    }, [workspaceId, workItemId, allowExecutionModeSelection, executionMode, aiSelection.resolved, trackUsage, onExecuted, onClose, cloneClient]);
 
     if (!open) return null;
 

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecutionSession.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecutionSession.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { Badge, Spinner } from '../../ui';
 import { ConversationArea } from '../chat/ConversationArea';
 import { ConversationMiniMap } from '../chat/conversation/ConversationMiniMap';
@@ -29,6 +29,8 @@ export interface WorkItemExecutionSessionProps {
 }
 
 export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkItemExecutionSessionProps) {
+    // AC-07: the work-item execution session reads its process/turns from the clone.
+    const cloneClient = useCocClient(workspaceId);
     const [task, setTask] = useState<any>(null);
     const [loading, setLoading] = useState(true);
     const [turns, setTurns] = useState<ClientConversationTurn[]>([]);
@@ -56,7 +58,7 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
 
     const refreshConversation = useCallback(async (pid: string) => {
         try {
-            const data = await getSpaCocClient().processes.get(pid);
+            const data = await cloneClient.processes.get(pid);
             setProcessDetails(data?.process ?? null);
             const refreshedTurns = getConversationTurns(data);
             // Preserve client-only costTimeMs across server refresh
@@ -74,7 +76,7 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
                 });
             });
         } catch { /* keep current turns on error */ }
-    }, [setTurnsAndRef]);
+    }, [setTurnsAndRef, cloneClient]);
 
     // Load task and conversation on mount / taskId change
     useEffect(() => {
@@ -89,7 +91,7 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
 
         (async () => {
             try {
-                const queueData = await getSpaCocClient().queue.getTask(taskId);
+                const queueData = await cloneClient.queue.getTask(taskId);
                 if (cancelled) return;
                 const loadedTask = queueData?.task ?? null;
                 setTask(loadedTask);
@@ -105,7 +107,7 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
                 }
 
                 const pid = loadedTask.processId ?? `queue_${taskId}`;
-                const procData = await getSpaCocClient().processes.get(pid);
+                const procData = await cloneClient.processes.get(pid);
                 if (cancelled) return;
 
                 setProcessDetails(procData?.process ?? null);
@@ -130,27 +132,27 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
         })();
 
         return () => { cancelled = true; };
-    }, [taskId, setTurnsAndRef]);
+    }, [taskId, setTurnsAndRef, cloneClient]);
 
     // Fetch resolved prompt while task is queued
     useEffect(() => {
         if (!isPending || !taskId) return;
-        getSpaCocClient().queue.resolvedPrompt(taskId)
+        cloneClient.queue.resolvedPrompt(taskId)
             .then((data: any) => { if (data) setResolvedPrompt(data); })
             .catch(() => { /* non-fatal */ });
-    }, [taskId, isPending]);
+    }, [taskId, isPending, cloneClient]);
 
     // Derive queue position while task is queued
     useEffect(() => {
         if (!isPending) { setQueuePosition(null); return; }
-        getSpaCocClient().queue.list()
+        cloneClient.queue.list()
             .then((data: any) => {
                 const queued: any[] = data?.queued ?? [];
                 const idx = queued.findIndex((t: any) => t.id === taskId);
                 setQueuePosition(idx >= 0 ? idx + 1 : null);
             })
             .catch(() => { /* non-fatal */ });
-    }, [taskId, isPending]);
+    }, [taskId, isPending, cloneClient]);
 
     // Track scroll position for the "scroll to bottom" button
     useEffect(() => {
@@ -203,13 +205,13 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
     const handleDeleteTurn = useCallback((turnIndex: number) => {
         if (!processId) return;
         setTurns(prev => prev.map(t => t.turnIndex === turnIndex ? { ...t, deletedAt: new Date().toISOString() } : t));
-        getSpaCocClient().request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}`, { method: 'DELETE' }).catch(() => {
+        cloneClient.request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}`, { method: 'DELETE' }).catch(() => {
             setTurns(prev => prev.map(t => t.turnIndex === turnIndex ? { ...t, deletedAt: undefined } : t));
         });
         if (undoDelete) clearTimeout(undoDelete.timer);
         const timer = setTimeout(() => setUndoDelete(null), 5000);
         setUndoDelete({ turnIndex, timer });
-    }, [processId, undoDelete]);
+    }, [processId, undoDelete, cloneClient]);
 
     const handleUndoDelete = useCallback(() => {
         if (!undoDelete || !processId) return;
@@ -217,11 +219,11 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
         const { turnIndex } = undoDelete;
         setUndoDelete(null);
         setTurns(prev => prev.map(t => t.turnIndex === turnIndex ? { ...t, deletedAt: undefined } : t));
-        getSpaCocClient().request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}/restore`, {
+        cloneClient.request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}/restore`, {
             method: 'PATCH',
             body: {},
         }).catch(() => {});
-    }, [undoDelete, processId]);
+    }, [undoDelete, processId, cloneClient]);
 
     const handlePinTurn = useCallback((turnIndex: number, pinned: boolean) => {
         if (!processId) return;
@@ -230,7 +232,7 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
                 ? { ...t, pinnedAt: pinned ? new Date().toISOString() : undefined, archived: pinned ? false : t.archived }
                 : t
         ));
-        getSpaCocClient().request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}/pin`, {
+        cloneClient.request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}/pin`, {
             method: 'PATCH',
             body: { pinned },
         }).catch(() => {
@@ -240,14 +242,14 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
                     : t
             ));
         });
-    }, [processId]);
+    }, [processId, cloneClient]);
 
     const handleArchiveTurn = useCallback((turnIndex: number, archived: boolean) => {
         if (!processId) return;
         setTurns(prev => prev.map(t =>
             t.turnIndex === turnIndex ? { ...t, archived } : t
         ));
-        getSpaCocClient().request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}/archive`, {
+        cloneClient.request(`/processes/${encodeURIComponent(processId)}/turns/${turnIndex}/archive`, {
             method: 'PATCH',
             body: { archived },
         }).catch(() => {
@@ -255,7 +257,7 @@ export function WorkItemExecutionSession({ taskId, workspaceId, onBack }: WorkIt
                 t.turnIndex === turnIndex ? { ...t, archived: !archived } : t
             ));
         });
-    }, [processId]);
+    }, [processId, cloneClient]);
 
     // ── Derived display values ──────────────────────────────────────────────
     const statusLabel =

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemHierarchyTree.tsx
@@ -6,7 +6,8 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Button, cn } from '../../ui';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { useWorkItems } from '../../contexts/WorkItemContext';
 import { WorkItemHierarchyNode } from './WorkItemHierarchyNode';
 import { WorkItemParentPicker } from './WorkItemParentPicker';
@@ -209,6 +210,8 @@ export function WorkItemHierarchyTree({
     highlightedWorkItemId,
     isMobile = false,
 }: WorkItemHierarchyTreeProps) {
+    // Route work-item tree/mutations to the workspace's clone (AC-07).
+    const client = useCocClient(workspaceId);
     const [treeData, setTreeData] = useState<WorkItemTreeNode[]>([]);
     const [total, setTotal] = useState(0);
     const [loading, setLoading] = useState(true);
@@ -287,7 +290,7 @@ export function WorkItemHierarchyTree({
                 showDone,
             });
             const responses: WorkItemTreeResponse[] = await Promise.all(
-                filters.map(filter => getSpaCocClient().workItems.tree(workspaceId, filter)),
+                filters.map(filter => client.workItems.tree(workspaceId, filter)),
             );
             if (responses.some(resp => resp.disabled)) {
                 setError('Hierarchy feature is disabled.');
@@ -301,7 +304,7 @@ export function WorkItemHierarchyTree({
         } finally {
             setLoading(false);
         }
-    }, [workspaceId, effectiveTrackerKinds, isRemoteView, searchQuery, showArchived, showDone]);
+    }, [workspaceId, effectiveTrackerKinds, isRemoteView, searchQuery, showArchived, showDone, client]);
 
     // Initial load
     useEffect(() => { fetchTree(); }, [fetchTree]);
@@ -327,7 +330,7 @@ export function WorkItemHierarchyTree({
         }
         let cancelled = false;
         setRemoteStatus({ loading: true });
-        getSpaCocClient().workItems.syncStatus(workspaceId)
+        client.workItems.syncStatus(workspaceId)
             .then(response => {
                 if (!cancelled) setRemoteStatus({ loading: false, response });
             })
@@ -340,7 +343,7 @@ export function WorkItemHierarchyTree({
                 }
             });
         return () => { cancelled = true; };
-    }, [isRemoteView, onDetectedRemoteProviderChange, workItemsSyncEnabled, workspaceId]);
+    }, [isRemoteView, onDetectedRemoteProviderChange, workItemsSyncEnabled, workspaceId, client]);
 
     useEffect(() => {
         if (!isRemoteView) return;
@@ -396,12 +399,12 @@ export function WorkItemHierarchyTree({
     const handleDelete = useCallback(async (id: string) => {
         if (!confirm('Delete this work item? Children must be moved or deleted first.')) return;
         try {
-            await getSpaCocClient().workItems.delete(workspaceId, id);
+            await client.workItems.delete(workspaceId, id);
             fetchTree();
         } catch (err: any) {
             alert(err.message ?? 'Failed to delete');
         }
-    }, [workspaceId, fetchTree]);
+    }, [workspaceId, fetchTree, client]);
 
     const buildContextMenuItems = useCallback((node: WorkItemTreeNode): ContextMenuItem[] => {
         const effectiveType = (node.item.type ?? 'work-item') as WorkItemTypeLabel;
@@ -450,7 +453,7 @@ export function WorkItemHierarchyTree({
                     icon: '🔓',
                     onClick: async () => {
                         try {
-                            await getSpaCocClient().workItems.update(workspaceId, node.item.id, { parentId: null });
+                            await client.workItems.update(workspaceId, node.item.id, { parentId: null });
                             fetchTree();
                         } catch (err: any) {
                             alert(err.message ?? 'Failed to unlink');
@@ -467,7 +470,7 @@ export function WorkItemHierarchyTree({
             separator: true,
             onClick: async () => {
                 try {
-                    await getSpaCocClient().workItems.pin(workspaceId, node.item.id, !node.item.pinnedAt);
+                    await client.workItems.pin(workspaceId, node.item.id, !node.item.pinnedAt);
                     fetchTree();
                 } catch (err: any) {
                     alert(err.message ?? 'Failed to pin');
@@ -479,7 +482,7 @@ export function WorkItemHierarchyTree({
             icon: '🗄️',
             onClick: async () => {
                 try {
-                    await getSpaCocClient().workItems.archive(workspaceId, node.item.id, !node.item.archivedAt);
+                    await client.workItems.archive(workspaceId, node.item.id, !node.item.archivedAt);
                     fetchTree();
                 } catch (err: any) {
                     alert(err.message ?? 'Failed to archive');
@@ -493,7 +496,7 @@ export function WorkItemHierarchyTree({
         });
 
         return items;
-    }, [workspaceId, onCreateItem, fetchTree, handleDelete]);
+    }, [workspaceId, onCreateItem, fetchTree, handleDelete, client]);
 
     /** Recursively render a tree node and its children. */
     const renderNode = useCallback((node: WorkItemTreeNode, depth: number): React.ReactNode => {

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemParentPicker.tsx
@@ -6,7 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Dialog } from '../../ui/Dialog';
 import { Button } from '../../ui';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { ALLOWED_PARENT_TYPES } from '@plusplusoneplusplus/coc-client';
 import { TYPE_LABELS } from './WorkItemHierarchyNode';
 import type { WorkItemTypeLabel } from './WorkItemHierarchyNode';
@@ -55,6 +55,7 @@ export function WorkItemParentPicker({
     onParentChanged,
     onlyPick = false,
 }: WorkItemParentPickerProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: list/update parent on the selected clone's server.
     const [searchQuery, setSearchQuery] = useState('');
     const [candidates, setCandidates] = useState<ParentCandidate[]>([]);
     const [loading, setLoading] = useState(false);
@@ -71,7 +72,7 @@ export function WorkItemParentPicker({
         try {
             const results: ParentCandidate[] = [];
             for (const parentType of validParentTypes) {
-                const resp = await getSpaCocClient().workItems.list(workspaceId, {
+                const resp = await cloneClient.workItems.list(workspaceId, {
                     type: parentType,
                     q: searchQuery || undefined,
                     limit: 50,
@@ -93,7 +94,7 @@ export function WorkItemParentPicker({
         } finally {
             setLoading(false);
         }
-    }, [workspaceId, itemId, validParentTypes, searchQuery]);
+    }, [workspaceId, itemId, validParentTypes, searchQuery, cloneClient]);
 
     useEffect(() => {
         if (open) {
@@ -120,7 +121,7 @@ export function WorkItemParentPicker({
         setSaving(true);
         setError(null);
         try {
-            await getSpaCocClient().workItems.update(workspaceId, itemId, { parentId: selectedId ?? undefined });
+            await cloneClient.workItems.update(workspaceId, itemId, { parentId: selectedId ?? undefined });
             onParentChanged(selectedId);
             onClose();
         } catch (err: any) {
@@ -134,7 +135,7 @@ export function WorkItemParentPicker({
         setSaving(true);
         setError(null);
         try {
-            await getSpaCocClient().workItems.update(workspaceId, itemId, { parentId: null });
+            await cloneClient.workItems.update(workspaceId, itemId, { parentId: null });
             onParentChanged(null);
             onClose();
         } catch (err: any) {

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemPlanSection.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemPlanSection.tsx
@@ -16,7 +16,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Button, cn } from '../../ui';
 import { Dialog } from '../../ui/Dialog';
 import { fetchApi } from '../../hooks/useApi';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { formatRelativeTime } from '../../utils/format';
 import { useMarkdownPreview } from '../../hooks/ui/useMarkdownPreview';
 import { SourceEditor } from '../../shared/SourceEditor';
@@ -126,6 +126,7 @@ export function WorkItemPlanSection({
     workspaceId, workItemId, plan, canEdit, draftContent, onDraftChange, onUpdated, onError, onNavigateToTasksTab,
     viewMode: controlledMode, onViewModeChange, enableVersionActions = false, hasUnsavedChanges = false,
 }: WorkItemPlanSectionProps) {
+    const cloneClient = useCocClient(workspaceId); // AC-07: plan versions/updates on the selected clone's server.
     // ── Plan version state ──────────────────────────────────────────────────
     const [versions, setVersions] = useState<PlanVersionMeta[]>([]);
     const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
@@ -196,10 +197,10 @@ export function WorkItemPlanSection({
     const loadVersions = useCallback(async () => {
         if (!plan) return;
         try {
-            const data: PlanVersionMeta[] = await getSpaCocClient().workItems.planVersions(workspaceId, workItemId);
+            const data: PlanVersionMeta[] = await cloneClient.workItems.planVersions(workspaceId, workItemId);
             setVersions(data || []);
         } catch { /* ignore */ }
-    }, [workspaceId, workItemId, plan]);
+    }, [workspaceId, workItemId, plan, cloneClient]);
 
     useEffect(() => { loadVersions(); }, [loadVersions]);
 
@@ -219,7 +220,7 @@ export function WorkItemPlanSection({
         setSelectedVersion(v);
         setLoadingVersion(true);
         try {
-            const data: PlanVersionFull = await getSpaCocClient().workItems.getPlanVersion(workspaceId, workItemId, v);
+            const data: PlanVersionFull = await cloneClient.workItems.getPlanVersion(workspaceId, workItemId, v);
             setSelectedContent(data.content ?? '');
         } catch {
             onError('Failed to load plan version');
@@ -245,7 +246,7 @@ export function WorkItemPlanSection({
         setComparison(null);
         setComparisonError(null);
         try {
-            const data = await getSpaCocClient().workItems.comparePlanVersions(workspaceId, workItemId, selectedVersion, currentVersion);
+            const data = await cloneClient.workItems.comparePlanVersions(workspaceId, workItemId, selectedVersion, currentVersion);
             setComparison(data);
         } catch (err: any) {
             setComparison(null);
@@ -253,14 +254,14 @@ export function WorkItemPlanSection({
         } finally {
             setComparisonLoading(false);
         }
-    }, [canActOnSelectedVersion, currentVersion, selectedVersion, workspaceId, workItemId]);
+    }, [canActOnSelectedVersion, currentVersion, selectedVersion, workspaceId, workItemId, cloneClient]);
 
     const handleRestoreSelectedVersion = useCallback(async () => {
         if (!canActOnSelectedVersion || selectedVersion === null || restoreDisabled) return;
         if (!window.confirm(`Restore plan v${selectedVersion} as a new current version?`)) return;
         setRestoreLoading(true);
         try {
-            await getSpaCocClient().workItems.restorePlanVersion(workspaceId, workItemId, selectedVersion, {
+            await cloneClient.workItems.restorePlanVersion(workspaceId, workItemId, selectedVersion, {
                 reason: `Restored plan v${selectedVersion} from version history`,
                 summary: `Restored plan v${selectedVersion}`,
             });
@@ -272,7 +273,7 @@ export function WorkItemPlanSection({
         } finally {
             setRestoreLoading(false);
         }
-    }, [canActOnSelectedVersion, onError, onUpdated, restoreDisabled, selectedVersion, workspaceId, workItemId]);
+    }, [canActOnSelectedVersion, onError, onUpdated, restoreDisabled, selectedVersion, workspaceId, workItemId, cloneClient]);
 
     // Resolve inline comments with AI — creates a Run# execution session
     const handleResolveAllWithAI = useCallback(async () => {
@@ -280,14 +281,14 @@ export function WorkItemPlanSection({
         if (open.length === 0) return;
         setResolving(true);
         try {
-            await getSpaCocClient().workItems.resolveComments(workspaceId, workItemId, { type: 'plan' });
+            await cloneClient.workItems.resolveComments(workspaceId, workItemId, { type: 'plan' });
             onUpdated();
         } catch (err: any) {
             onError(err.message || 'Failed to resolve plan comments');
         } finally {
             setResolving(false);
         }
-    }, [planComments, workspaceId, workItemId, onUpdated, onError]);
+    }, [planComments, workspaceId, workItemId, onUpdated, onError, cloneClient]);
 
     // Enqueue an AI run session to resolve a single plan comment.
     // Intentionally does NOT call onNavigateToTasksTab — user stays on the work item page.

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemSection.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemSection.tsx
@@ -18,7 +18,7 @@ import { useWorkItemSearch } from './hooks/useWorkItemSearch';
 import { formatRelativeTime } from '../../utils/format';
 import { ContextMenu } from '../../tasks/comments/ContextMenu';
 import type { ContextMenuItem } from '../../tasks/comments/ContextMenu';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 import { createWorkItemContextDragPayload, writePointerContextDragData } from '../chat/sessionContextDrag';
 import { isSessionContextAttachmentsEnabled } from '../../utils/config';
 
@@ -93,6 +93,8 @@ interface WorkItemSectionProps {
 
 export function WorkItemSection({ workspaceId, onSelectWorkItem, selectedWorkItemId, highlightedWorkItemId }: WorkItemSectionProps) {
     const { state, dispatch } = useWorkItems();
+    // Route work-item list/mutations to the workspace's clone (AC-07).
+    const client = useCocClient(workspaceId);
     const items = state.workItemsByRepo[workspaceId] || [];
     const pagination = state.paginationByRepo[workspaceId];
     const isLoading = state.loading[workspaceId] ?? false;
@@ -127,7 +129,7 @@ export function WorkItemSection({ workspaceId, onSelectWorkItem, selectedWorkIte
     const fetchGroupedWorkItems = useCallback(async (query?: string) => {
         dispatch({ type: 'SET_LOADING', repoId: workspaceId, loading: true });
         try {
-            const data = await getSpaCocClient().workItems.grouped(workspaceId, {
+            const data = await client.workItems.grouped(workspaceId, {
                 limit: PAGE_SIZE,
                 q: query,
             });
@@ -137,7 +139,7 @@ export function WorkItemSection({ workspaceId, onSelectWorkItem, selectedWorkIte
         } finally {
             dispatch({ type: 'SET_LOADING', repoId: workspaceId, loading: false });
         }
-    }, [workspaceId, dispatch]);
+    }, [workspaceId, dispatch, client]);
 
     // Load more items for a specific status group (per-category infinite scroll)
     const loadMoreForStatus = useCallback(async (status: string) => {
@@ -147,7 +149,7 @@ export function WorkItemSection({ workspaceId, onSelectWorkItem, selectedWorkIte
 
         loadingStatusesRef.current.add(status);
         try {
-            const data = await getSpaCocClient().workItems.list(workspaceId, {
+            const data = await client.workItems.list(workspaceId, {
                 status,
                 limit: PAGE_SIZE,
                 offset: statusPagination.offset,
@@ -167,7 +169,7 @@ export function WorkItemSection({ workspaceId, onSelectWorkItem, selectedWorkIte
         } finally {
             loadingStatusesRef.current.delete(status);
         }
-    }, [workspaceId, dispatch, searchQuery, pagination]);
+    }, [workspaceId, dispatch, searchQuery, pagination, client]);
 
     // Initial fetch
     useEffect(() => { fetchGroupedWorkItems(); }, [fetchGroupedWorkItems]);
@@ -187,33 +189,33 @@ export function WorkItemSection({ workspaceId, onSelectWorkItem, selectedWorkIte
         // Optimistic update
         dispatch({ type: 'WORK_ITEM_UPDATED', repoId: workspaceId, item: { ...item, pinnedAt: pinned ? new Date().toISOString() : undefined } });
         try {
-            await getSpaCocClient().workItems.pin(workspaceId, item.id, pinned);
+            await client.workItems.pin(workspaceId, item.id, pinned);
         } catch {
             // Revert on failure
             dispatch({ type: 'WORK_ITEM_UPDATED', repoId: workspaceId, item });
         }
-    }, [workspaceId, dispatch]);
+    }, [workspaceId, dispatch, client]);
 
     const handleArchive = useCallback(async (item: WorkItemSummary) => {
         const archived = !item.archivedAt;
         dispatch({ type: 'WORK_ITEM_UPDATED', repoId: workspaceId, item: { ...item, archivedAt: archived ? new Date().toISOString() : undefined } });
         try {
-            await getSpaCocClient().workItems.archive(workspaceId, item.id, archived);
+            await client.workItems.archive(workspaceId, item.id, archived);
         } catch {
             dispatch({ type: 'WORK_ITEM_UPDATED', repoId: workspaceId, item });
         }
-    }, [workspaceId, dispatch]);
+    }, [workspaceId, dispatch, client]);
 
     const handleDelete = useCallback(async (item: WorkItemSummary) => {
         if (!confirm('Delete this work item?')) return;
         dispatch({ type: 'WORK_ITEM_REMOVED', repoId: workspaceId, id: item.id });
         try {
-            await getSpaCocClient().workItems.delete(workspaceId, item.id);
+            await client.workItems.delete(workspaceId, item.id);
         } catch {
             // Re-add on failure
             dispatch({ type: 'WORK_ITEM_ADDED', repoId: workspaceId, item });
         }
-    }, [workspaceId, dispatch]);
+    }, [workspaceId, dispatch, client]);
 
     const handleContextMenu = useCallback((e: React.MouseEvent, item: WorkItemSummary) => {
         e.preventDefault();

--- a/packages/coc/src/server/spa/client/react/features/work-items/hooks/useWorkItemChatBinding.ts
+++ b/packages/coc/src/server/spa/client/react/features/work-items/hooks/useWorkItemChatBinding.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { useCocClient } from '../../../repos/cloneRouting';
 import type { AttachmentPayload } from '../../../types/attachments';
 import { formatAttachedContext, type AttachedWorkItemContextItem } from '../../chat/hooks/useAttachedContext';
 
@@ -61,6 +61,7 @@ function prependWorkItemPointer(prompt: string, opts: UseWorkItemChatBindingOpti
 
 export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): UseWorkItemChatBindingReturn {
     const { workspaceId, workItemId, status, type, workItemNumber } = opts;
+    const cloneClient = useCocClient(workspaceId); // AC-07: work-item chat binding on the selected clone's server.
     const [taskId, setTaskId] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -88,7 +89,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
         setTaskId(null);
         setStartingFresh(false);
 
-        getSpaCocClient().workItems.getChatBinding(workspaceId, workItemId)
+        cloneClient.workItems.getChatBinding(workspaceId, workItemId)
             .then(data => { if (!cancelled) setTaskId(data.taskId); })
             .catch(err => {
                 if (cancelled) return;
@@ -98,7 +99,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
             .finally(() => { if (!cancelled) setLoading(false); });
 
         return () => { cancelled = true; };
-    }, [workspaceId, workItemId]);
+    }, [workspaceId, workItemId, cloneClient]);
 
     const createChat = useCallback(async (prompt: string, options: WorkItemChatComposerSendOptions = {}): Promise<string | null> => {
         if (!workItemId) return null;
@@ -109,7 +110,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
         }
         try {
             const promptWithPointer = prependWorkItemPointer(prompt, { workspaceId, workItemId, status, type, workItemNumber });
-            const res = await getSpaCocClient().queue.enqueue({
+            const res = await cloneClient.queue.enqueue({
                 type: 'chat',
                 priority: 'normal',
                 payload: {
@@ -132,7 +133,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
             const newTaskId = res.task?.id ?? (res as { id?: string }).id;
             if (!newTaskId) throw new Error('Failed to create work item chat task');
 
-            await getSpaCocClient().workItems.createChatBinding(workspaceId, workItemId, newTaskId);
+            await cloneClient.workItems.createChatBinding(workspaceId, workItemId, newTaskId);
 
             if (isCurrentRequest(requestedWorkspaceId, requestedWorkItemId)) {
                 setError(null);
@@ -145,7 +146,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
             }
             return null;
         }
-    }, [workspaceId, workItemId, status, type, workItemNumber, isCurrentRequest]);
+    }, [workspaceId, workItemId, status, type, workItemNumber, isCurrentRequest, cloneClient]);
 
     const startFreshChat = useCallback(async (): Promise<boolean> => {
         if (!workItemId) return false;
@@ -156,7 +157,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
             setError(null);
         }
         try {
-            await getSpaCocClient().workItems.startFreshChat(workspaceId, workItemId);
+            await cloneClient.workItems.startFreshChat(workspaceId, workItemId);
             if (isCurrentRequest(requestedWorkspaceId, requestedWorkItemId)) {
                 setTaskId(null);
                 setError(null);
@@ -172,7 +173,7 @@ export function useWorkItemChatBinding(opts: UseWorkItemChatBindingOptions): Use
                 setStartingFresh(false);
             }
         }
-    }, [workspaceId, workItemId, isCurrentRequest]);
+    }, [workspaceId, workItemId, isCurrentRequest, cloneClient]);
 
     return { taskId, loading, error, createChat, startFreshChat, startingFresh };
 }

--- a/packages/coc/src/server/spa/client/react/hooks/preferences/seenStateApi.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/preferences/seenStateApi.ts
@@ -3,13 +3,15 @@
  */
 
 import type { SeenStateEntry, SeenStateMap } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient } from '../../api/cocClient';
+import { getCocClientForWorkspace } from '../../repos/cloneRegistry';
 
 /**
  * Fetch the full seen map (processId → seenAt) for a workspace.
+ * Routed to the workspace's clone (AC-07): a remote clone's seen-state lives on
+ * its own server; local clones use the default origin.
  */
 export async function fetchSeenMap(workspaceId: string): Promise<SeenStateMap> {
-    return getSpaCocClient().seenState.getMap(workspaceId);
+    return getCocClientForWorkspace(workspaceId).seenState.getMap(workspaceId);
 }
 
 /**
@@ -19,20 +21,20 @@ export async function patchSeenState(
     workspaceId: string,
     entries: SeenStateEntry[],
 ): Promise<SeenStateMap> {
-    return getSpaCocClient().seenState.updateMany(workspaceId, entries);
+    return getCocClientForWorkspace(workspaceId).seenState.updateMany(workspaceId, entries);
 }
 
 /**
  * Mark a single process as unseen (delete its seen_at).
  */
 export async function deleteSeenEntry(workspaceId: string, processId: string): Promise<void> {
-    await getSpaCocClient().seenState.markUnseen(workspaceId, processId);
+    await getCocClientForWorkspace(workspaceId).seenState.markUnseen(workspaceId, processId);
 }
 
 /**
  * Fetch the server-computed unseen count for a workspace.
  */
 export async function fetchUnseenCount(workspaceId: string): Promise<number> {
-    const res = await getSpaCocClient().seenState.getUnseenCount(workspaceId);
+    const res = await getCocClientForWorkspace(workspaceId).seenState.getUnseenCount(workspaceId);
     return res.unseenCount;
 }

--- a/packages/coc/src/server/spa/client/react/processes/hooks/useProcessSearch.ts
+++ b/packages/coc/src/server/spa/client/react/processes/hooks/useProcessSearch.ts
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { CocNetworkError } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 
 export interface ProcessSearchResult {
     processId: string;
@@ -83,8 +83,12 @@ export function useProcessSearch(
     const queryRef = useRef(query);
     queryRef.current = query;
 
+    // Route a single-workspace search to that clone's server (AC-07); an
+    // all-workspace search ('__all'/undefined) resolves to the default client.
+    const client = useCocClient(workspace);
+
     const executeSearch = useCallback(async (q: string, signal: AbortSignal, offset = 0) => {
-        return getSpaCocClient().processes.search({
+        return client.processes.search({
             q,
             ...(workspace && workspace !== '__all' ? { workspace } : {}),
             ...(statusFilter && statusFilter !== '__all' ? { status: statusFilter } : {}),
@@ -92,7 +96,7 @@ export function useProcessSearch(
             limit,
             ...(offset > 0 ? { offset } : {}),
         }, { signal });
-    }, [workspace, statusFilter, typeFilter, limit]);
+    }, [client, workspace, statusFilter, typeFilter, limit]);
 
     useEffect(() => {
         // Clear debounce on every query/filter change

--- a/packages/coc/src/server/spa/client/react/repos/cloneRegistry.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneRegistry.ts
@@ -28,7 +28,7 @@
  */
 
 import type { CocClient } from '@plusplusoneplusplus/coc-client';
-import { getCocClientFor, getSpaCocClient } from '../api/cocClient';
+import { getCocClientFor, getSpaCocClient, toSpaCocRequestOptions, translateSpaCocClientError } from '../api/cocClient';
 import { cloneWsUrl } from '../api/wsUrl';
 import { getApiBase } from '../utils/config';
 
@@ -78,6 +78,31 @@ export function getCocClientForWorkspace(workspaceId: string | null | undefined)
     // Local clone: call getSpaCocClient() directly (not getCocClientFor(undefined))
     // so this is identical to the pre-AC-07 code path — byte-for-byte unchanged.
     return baseUrl ? getCocClientFor(baseUrl) : getSpaCocClient();
+}
+
+/**
+ * Fetch a RELATIVE API `url` (e.g. `/workspaces/ws-x/git/changes/...`) against a
+ * workspace's clone — the non-hook seam for the git diff-viewing layer, whose
+ * `DiffSource` factories build a bare path string and then need to fetch it.
+ *
+ *   • Local clone  → the default client: `'' + getApiBase() + url`. This is the
+ *     EXACT path `fetchApi(url)` (→ `requestSpaApi`) takes today, so local clones
+ *     stay byte-for-byte unchanged.
+ *   • Remote clone → its client: `${baseUrl}${apiBase}${url}` (apiBase = `/api`).
+ *
+ * Error translation mirrors `requestSpaApi` so callers see the same `Error`
+ * shape they did before routing was introduced.
+ */
+export async function requestForWorkspace<T = unknown>(
+    workspaceId: string | null | undefined,
+    url: string,
+    options?: RequestInit,
+): Promise<T> {
+    try {
+        return await getCocClientForWorkspace(workspaceId).request<T>(url, toSpaCocRequestOptions(options));
+    } catch (error) {
+        translateSpaCocClientError(error);
+    }
 }
 
 /**

--- a/packages/coc/src/server/spa/client/react/repos/cloneRegistry.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneRegistry.ts
@@ -1,0 +1,116 @@
+/**
+ * Per-workspace clone→baseUrl LOOKUP registry (AC-07).
+ *
+ * AC-03 gives React code `useCocClient(ref)` / `useCloneWsUrl(ref)`, which resolve
+ * a clone's remote `baseUrl` from the live ReposContext. But plain (non-React)
+ * services — `explorerApi`, `notesApi`, schedules/work-item/PR call sites — only
+ * receive a bare `workspaceId` and call `getSpaCocClient()` directly; they have no
+ * access to React context. This module is the seam for them.
+ *
+ * It holds a module-level `workspaceId → baseUrl` map covering REMOTE workspaces
+ * only. AC-01's `aggregateRemoteWorkspaces` populates it every refresh (so the
+ * registry tracks devtunnel port reassignment). Services resolve the right client
+ * via `getCocClientForWorkspace(workspaceId)`.
+ *
+ * Crucially this is a per-workspace LOOKUP, NOT a global mutable "active baseUrl"
+ * override:
+ *   • A LOCAL workspace id is absent from the map → `lookupCloneBaseUrl` returns
+ *     `undefined` → `getCocClientFor(undefined)` → the EXISTING default
+ *     `getSpaCocClient()` singleton. Local clones are byte-for-byte unchanged.
+ *   • A REMOTE workspace id resolves to its server's effectiveUrl → a cached
+ *     CocClient pinned to that origin. A remote clone therefore NEVER falls
+ *     through to the local server ("no local fallthrough" guarantee): its
+ *     clone-scoped REST/WS always targets the remote `baseUrl`.
+ *
+ * The repos-list / git-info AGGREGATION itself is never rerouted through here —
+ * it keeps using the default client (AC-01 owns its own self-contained remote
+ * fetch). This registry only serves per-clone, workspace-scoped tab data.
+ */
+
+import type { CocClient } from '@plusplusoneplusplus/coc-client';
+import { getCocClientFor, getSpaCocClient } from '../api/cocClient';
+import { cloneWsUrl } from '../api/wsUrl';
+import { getApiBase } from '../utils/config';
+
+/** workspaceId → remote baseUrl. Remote workspaces only; local ids are absent. */
+const cloneBaseUrlByWorkspace = new Map<string, string>();
+
+/** A minimal remote-workspace shape: just the routing essentials. */
+export interface CloneRegistryEntry {
+    workspaceId: string;
+    baseUrl: string;
+}
+
+/**
+ * Replace the registry's remote entries with `entries` (remote workspaces only).
+ *
+ * A full replace — not a merge — so a server that drops a workspace (or goes
+ * away entirely) stops resolving to a stale baseUrl. Called by AC-01's
+ * aggregation on every repo refresh, so the map always mirrors the current set
+ * of reachable/cached remote clones (and follows devtunnel port reassignment).
+ */
+export function registerCloneBaseUrls(entries: Iterable<CloneRegistryEntry>): void {
+    cloneBaseUrlByWorkspace.clear();
+    for (const { workspaceId, baseUrl } of entries) {
+        if (workspaceId && baseUrl) {
+            cloneBaseUrlByWorkspace.set(workspaceId, baseUrl);
+        }
+    }
+}
+
+/**
+ * Look up a workspace's remote `baseUrl`, or `undefined` when it is a LOCAL
+ * workspace (or unknown). Local/unknown ids deliberately resolve to `undefined`
+ * so downstream `getCocClientFor(undefined)` returns the default local client.
+ */
+export function lookupCloneBaseUrl(workspaceId: string | null | undefined): string | undefined {
+    if (!workspaceId) return undefined;
+    return cloneBaseUrlByWorkspace.get(workspaceId);
+}
+
+/**
+ * Resolve the CocClient for a workspace id: the remote-routed client for a remote
+ * clone, else the default page-origin client. The single entry point services use
+ * in place of `getSpaCocClient()` so their workspace-scoped calls follow the clone.
+ */
+export function getCocClientForWorkspace(workspaceId: string | null | undefined): CocClient {
+    const baseUrl = lookupCloneBaseUrl(workspaceId);
+    // Local clone: call getSpaCocClient() directly (not getCocClientFor(undefined))
+    // so this is identical to the pre-AC-07 code path — byte-for-byte unchanged.
+    return baseUrl ? getCocClientFor(baseUrl) : getSpaCocClient();
+}
+
+/**
+ * Absolute REST API base for a workspace's clone, suitable for call sites that
+ * build a URL by hand instead of going through CocClient (e.g. the `EventSource`
+ * process stream, which cannot use the client's fetch).
+ *
+ *   • Remote clone → `${baseUrl}${apiBasePath}` (e.g. `http://127.0.0.1:4000/api`).
+ *   • Local clone  → `getApiBase()` (unchanged; honors container agent prefix).
+ *
+ * Remote CoC servers are never in container mode, so the agent prefix is not
+ * applied to the remote base — it uses the plain configured `apiBasePath`.
+ */
+export function cloneApiBase(workspaceId: string | null | undefined): string {
+    const baseUrl = lookupCloneBaseUrl(workspaceId);
+    if (!baseUrl) {
+        return getApiBase();
+    }
+    const apiBasePath = (globalThis as { window?: { __DASHBOARD_CONFIG__?: { apiBasePath?: string } } })
+        .window?.__DASHBOARD_CONFIG__?.apiBasePath ?? '/api';
+    return baseUrl.replace(/\/+$/, '') + apiBasePath;
+}
+
+/**
+ * Build a WebSocket URL for `path`, routed to a workspace's clone when remote and
+ * to the page origin when local. Convenience wrapper over `cloneWsUrl` for
+ * non-hook call sites that have only a `workspaceId`.
+ */
+export function cloneWsUrlForWorkspace(path: string, workspaceId: string | null | undefined): string {
+    return cloneWsUrl(path, lookupCloneBaseUrl(workspaceId));
+}
+
+/** Test-only: clear the registry between cases. */
+export function resetCloneRegistryForTests(): void {
+    cloneBaseUrlByWorkspace.clear();
+}

--- a/packages/coc/src/server/spa/client/react/repos/cloneRouting.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneRouting.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-clone request routing (AC-03).
+ *
+ * Resolves a clone (workspace) to its remote `baseUrl`, then hands callers a
+ * CocClient routed to that clone — remote clones to their server's origin, local
+ * clones to the default page origin. The source of truth is AC-01's remote
+ * markers: a workspace tagged by `aggregateRemoteWorkspaces` carries
+ * `{ remote, baseUrl }`; local workspaces carry neither (`isRemoteWorkspace`
+ * distinguishes them).
+ *
+ * These are the PRIMITIVES; wiring them into individual tabs is AC-07.
+ */
+
+import type { CocClient } from '@plusplusoneplusplus/coc-client';
+import { useMemo } from 'react';
+import { getCocClientFor } from '../api/cocClient';
+import { cloneWsUrl } from '../api/wsUrl';
+import { useRepos } from '../contexts/ReposContext';
+import { isRemoteWorkspace } from './remoteWorkspaceAggregation';
+import type { RepoData } from './repoGrouping';
+
+/** A workspace object, or a bare workspace id. */
+export type CloneRef = string | { id?: unknown; baseUrl?: unknown; remote?: unknown };
+
+function refId(ref: CloneRef | undefined): string | undefined {
+    if (ref === undefined || ref === null) return undefined;
+    if (typeof ref === 'string') return ref || undefined;
+    return typeof ref.id === 'string' ? ref.id : undefined;
+}
+
+/**
+ * Resolve a clone's remote `baseUrl`, or `undefined` for a local clone.
+ *
+ * Accepts either a workspace object (checked directly via its remote marker) or
+ * a workspace id (looked up in the supplied `repos` list). Pure — no React, no
+ * context access — so it is unit-testable and reusable from non-React code.
+ */
+export function resolveCloneBaseUrl(ref: CloneRef | undefined, repos: RepoData[] = []): string | undefined {
+    // Direct object with a remote marker — trust it without a lookup.
+    if (ref && typeof ref === 'object' && isRemoteWorkspace(ref)) {
+        return ref.baseUrl;
+    }
+    const id = refId(ref);
+    if (!id) return undefined;
+
+    const match = repos.find(r => r.workspace?.id === id);
+    if (match && isRemoteWorkspace(match.workspace)) {
+        return match.workspace.baseUrl;
+    }
+    return undefined;
+}
+
+// ── React hooks ──────────────────────────────────────────────────────────────
+
+/**
+ * Hook returning a resolver bound to the live ReposContext repo list, so callers
+ * can map a workspace id → its remote baseUrl (or undefined when local).
+ */
+export function useResolveCloneBaseUrl(): (ref: CloneRef | undefined) => string | undefined {
+    const { repos } = useRepos();
+    return useMemo(() => (ref: CloneRef | undefined) => resolveCloneBaseUrl(ref, repos), [repos]);
+}
+
+/**
+ * Hook returning the CocClient for a given clone: routed to the clone's remote
+ * server when it is remote, else the default origin client. Pass `undefined` to
+ * always get the default client.
+ */
+export function useCocClient(ref?: CloneRef): CocClient {
+    const { repos } = useRepos();
+    const baseUrl = resolveCloneBaseUrl(ref, repos);
+    return useMemo(() => getCocClientFor(baseUrl), [baseUrl]);
+}
+
+/**
+ * Hook returning a `cloneWsUrl`-style builder pre-bound to a clone's baseUrl:
+ * `buildWsUrl(path)` yields a remote ws(s) URL for a remote clone, or the
+ * legacy page-origin URL for a local clone. AC-07 wires this into the WS hooks.
+ */
+export function useCloneWsUrl(ref?: CloneRef): (path: string) => string {
+    const { repos } = useRepos();
+    const baseUrl = resolveCloneBaseUrl(ref, repos);
+    return useMemo(() => (path: string) => cloneWsUrl(path, baseUrl), [baseUrl]);
+}

--- a/packages/coc/src/server/spa/client/react/repos/cloneRouting.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneRouting.ts
@@ -13,9 +13,9 @@
 
 import type { CocClient } from '@plusplusoneplusplus/coc-client';
 import { useMemo } from 'react';
-import { getCocClientFor } from '../api/cocClient';
+import { getCocClientFor, getSpaCocClient } from '../api/cocClient';
 import { cloneWsUrl } from '../api/wsUrl';
-import { useRepos } from '../contexts/ReposContext';
+import { lookupCloneBaseUrl } from './cloneRegistry';
 import { isRemoteWorkspace } from './remoteWorkspaceAggregation';
 import type { RepoData } from './repoGrouping';
 
@@ -53,12 +53,31 @@ export function resolveCloneBaseUrl(ref: CloneRef | undefined, repos: RepoData[]
 // ── React hooks ──────────────────────────────────────────────────────────────
 
 /**
- * Hook returning a resolver bound to the live ReposContext repo list, so callers
- * can map a workspace id → its remote baseUrl (or undefined when local).
+ * Resolve a clone's remote baseUrl for the hooks, WITHOUT any React context.
+ *
+ *  • A bare workspace id resolves through the module-level registry, which AC-01's
+ *    aggregation keeps in sync with the live repo list (online + cached/offline
+ *    remote clones). This needs no ReposProvider, so the hooks are safe in deep
+ *    per-tab components and in unit tests that don't mount the app shell.
+ *  • A workspace OBJECT resolves purely from its own remote marker.
+ *
+ * The registry is the single source of truth for id→baseUrl; the hooks never read
+ * the ReposContext, avoiding a hard provider dependency for every tab.
+ */
+function resolveCloneBaseUrlForHook(ref: CloneRef | undefined): string | undefined {
+    if (typeof ref === 'string') {
+        return lookupCloneBaseUrl(ref);
+    }
+    // Object marker (or undefined) — no repos list needed.
+    return resolveCloneBaseUrl(ref);
+}
+
+/**
+ * Hook returning a resolver that maps a workspace id (or object) → its remote
+ * baseUrl (or undefined when local). Registry-backed; no ReposProvider required.
  */
 export function useResolveCloneBaseUrl(): (ref: CloneRef | undefined) => string | undefined {
-    const { repos } = useRepos();
-    return useMemo(() => (ref: CloneRef | undefined) => resolveCloneBaseUrl(ref, repos), [repos]);
+    return useMemo(() => (ref: CloneRef | undefined) => resolveCloneBaseUrlForHook(ref), []);
 }
 
 /**
@@ -67,9 +86,10 @@ export function useResolveCloneBaseUrl(): (ref: CloneRef | undefined) => string 
  * always get the default client.
  */
 export function useCocClient(ref?: CloneRef): CocClient {
-    const { repos } = useRepos();
-    const baseUrl = resolveCloneBaseUrl(ref, repos);
-    return useMemo(() => getCocClientFor(baseUrl), [baseUrl]);
+    const baseUrl = resolveCloneBaseUrlForHook(ref);
+    // Local clone resolves to the default singleton via getSpaCocClient() directly
+    // (not getCocClientFor(undefined)), so local-clone behavior is unchanged.
+    return useMemo(() => (baseUrl ? getCocClientFor(baseUrl) : getSpaCocClient()), [baseUrl]);
 }
 
 /**
@@ -78,7 +98,6 @@ export function useCocClient(ref?: CloneRef): CocClient {
  * legacy page-origin URL for a local clone. AC-07 wires this into the WS hooks.
  */
 export function useCloneWsUrl(ref?: CloneRef): (path: string) => string {
-    const { repos } = useRepos();
-    const baseUrl = resolveCloneBaseUrl(ref, repos);
+    const baseUrl = resolveCloneBaseUrlForHook(ref);
     return useMemo(() => (path: string) => cloneWsUrl(path, baseUrl), [baseUrl]);
 }

--- a/packages/coc/src/server/spa/client/react/repos/remoteSelectionPersistence.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteSelectionPersistence.ts
@@ -1,0 +1,114 @@
+/**
+ * Remote-clone selection persistence (AC-08).
+ *
+ * A REMOTE clone selection must survive a full page reload — and survive
+ * devtunnel PORT REASSIGNMENT, where the server's `baseUrl` (the routing key)
+ * changes between sessions. So the persisted key is the STABLE pair
+ * `{ serverId, workspaceId }`, never the volatile `baseUrl` and never a
+ * composite/encoded id (IMMUTABLE decision: no composite workspace IDs).
+ *
+ * On load, once `aggregateRemoteWorkspaces` has repopulated `ReposContext.repos`,
+ * `resolvePersistedRemoteSelection` matches the persisted pair against the
+ * CURRENT remote workspaces by `remote.serverId === serverId && id === workspaceId`.
+ * Because the match is on the stable `serverId` (not `baseUrl`), a changed
+ * port/baseUrl still resolves to the same clone. The resolved value is the
+ * workspace's CURRENT id, which the caller restores as the active selection.
+ *
+ * LOCAL clones are NOT persisted here: they keep riding the existing
+ * `#repos/{id}` hash mechanism unchanged. This module is purely additive on top
+ * of that — it only ever writes/reads a remote pair, so local-clone
+ * persistence/behavior is byte-for-byte unchanged.
+ */
+
+import { isRemoteWorkspace, type RemoteWorkspaceInfo } from './remoteWorkspaceAggregation';
+
+const STORAGE_KEY = 'coc-remote-clone-selection';
+
+/** The stable pair persisted for a selected remote clone. */
+export interface PersistedRemoteSelection {
+    /** Stable registry id of the contributing server (survives port reassignment). */
+    serverId: string;
+    /** The remote workspace's own id (stable; NOT composite). */
+    workspaceId: string;
+}
+
+function isPersistedRemoteSelection(value: unknown): value is PersistedRemoteSelection {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as PersistedRemoteSelection).serverId === 'string' &&
+        (value as PersistedRemoteSelection).serverId.length > 0 &&
+        typeof (value as PersistedRemoteSelection).workspaceId === 'string' &&
+        (value as PersistedRemoteSelection).workspaceId.length > 0
+    );
+}
+
+/**
+ * Persist the selected remote clone's stable `{ serverId, workspaceId }` pair.
+ * No-op (and a console-free swallow) when storage is unavailable (SSR / quota).
+ */
+export function persistRemoteSelection(selection: PersistedRemoteSelection): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(selection));
+    } catch {
+        // SSR / test / quota — nothing to persist; the hash still carries the id
+        // for the current session.
+    }
+}
+
+/**
+ * Clear any persisted remote-clone selection. Called when the active selection
+ * becomes a LOCAL clone (or is cleared), so a stale remote pair never fights the
+ * hash-restored local selection on the next reload.
+ */
+export function clearPersistedRemoteSelection(): void {
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // SSR / test / quota — ignore.
+    }
+}
+
+/** Read the persisted remote-clone selection, or `null` when none / malformed. */
+export function loadPersistedRemoteSelection(): PersistedRemoteSelection | null {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as unknown;
+        return isPersistedRemoteSelection(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Resolve a persisted `{ serverId, workspaceId }` pair to the CURRENT matching
+ * remote workspace's id, scanning the freshly-aggregated remote workspaces.
+ *
+ * Match is on the stable `remote.serverId` plus the workspace `id` — so a clone
+ * whose `baseUrl`/port changed (devtunnel reassignment) still resolves, and a
+ * workspace id that collides ACROSS two servers disambiguates by serverId.
+ * Returns the matching workspace id (its current id) or `null` when no remote
+ * workspace matches (e.g. the server was removed and nothing is cached).
+ */
+export function resolvePersistedRemoteSelection(
+    selection: PersistedRemoteSelection | null,
+    workspaces: ReadonlyArray<{ id: string } & Partial<RemoteWorkspaceInfo>>,
+): string | null {
+    if (!selection) return null;
+    for (const workspace of workspaces) {
+        if (
+            isRemoteWorkspace(workspace) &&
+            workspace.remote.serverId === selection.serverId &&
+            workspace.id === selection.workspaceId
+        ) {
+            return workspace.id;
+        }
+    }
+    return null;
+}
+
+/** Test-only: clear the persisted selection between cases. @internal */
+export function _resetRemoteSelectionForTests(): void {
+    clearPersistedRemoteSelection();
+}

--- a/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
@@ -22,7 +22,9 @@
 import {
     CocClient,
     type GitInfoResponse,
+    type QueueReposResponse,
     type RemoteServer,
+    type RemoteServerRuntimeStatus,
     type WorkspaceInfo,
     type WorkspacesResponse,
 } from '@plusplusoneplusplus/coc-client';
@@ -32,6 +34,21 @@ import {
     loadRemoteWorkspaceCache,
     saveRemoteWorkspaceCacheEntry,
 } from './remoteWorkspaceCache';
+
+/**
+ * Remote server connection state, mirrored from the registry's runtime status.
+ * Drives the status dot's connection-first blend (AC-05): `offline`/`failed` →
+ * offline indicator, `connecting`/`idle` (not yet online) → connecting indicator,
+ * `online` → defer to the remote queue status.
+ */
+export type RemoteConnectionStatus = RemoteServerRuntimeStatus;
+
+/**
+ * Remote queue state for a single remote workspace, derived from the remote
+ * server's `/api/queue/repos`. Same vocabulary as the local clone-status map so
+ * the dot renders identically once a server is online.
+ */
+export type RemoteQueueStatus = 'idle' | 'running' | 'queued' | 'paused';
 
 /** Per-remote routing + provenance attached to every aggregated remote workspace. */
 export interface RemoteWorkspaceMarker {
@@ -43,6 +60,18 @@ export interface RemoteWorkspaceMarker {
     serverLabel: string;
     /** True when this entry came from cache because the server is offline/unreachable. */
     offline: boolean;
+    /**
+     * Raw connection state of the contributing server (AC-05). Lets the status
+     * dot distinguish `connecting` from `offline` even though both currently take
+     * the cached-workspace path. `idle`/`connecting` ⇒ connecting; `offline`/
+     * `failed` ⇒ offline; `online` ⇒ use `queue`.
+     */
+    connection: RemoteConnectionStatus;
+    /**
+     * Remote queue status for THIS workspace (AC-05), present only for online
+     * sources; `'idle'` when the server is offline or the queue fetch failed.
+     */
+    queue: RemoteQueueStatus;
 }
 
 /**
@@ -99,17 +128,30 @@ export function isRemoteWorkspace(workspace: unknown): workspace is RemoteWorksp
     );
 }
 
+/** Optional connection + per-workspace queue enrichment for `tagRemoteWorkspaces`. */
+export interface RemoteTagStatus {
+    /** Raw connection state of the server (defaults to `offline` when omitted). */
+    connection?: RemoteConnectionStatus;
+    /** Remote queue status keyed by workspace id (missing ⇒ `idle`). */
+    queueByWorkspace?: Record<string, RemoteQueueStatus>;
+}
+
 /**
  * Tag a server's raw workspace list with its remote marker. Pure: no I/O.
- * `offline` flags entries served from cache for an unreachable server.
+ * `offline` flags entries served from cache for an unreachable server. `status`
+ * carries the AC-05 connection state and per-workspace remote queue status; when
+ * omitted (e.g. cache path before queue is known) each row defaults to an
+ * offline connection with an idle queue.
  */
 export function tagRemoteWorkspaces(
     server: Pick<RemoteServer, 'id' | 'label'>,
     baseUrl: string,
     workspaces: WorkspaceInfo[],
     offline: boolean,
+    status: RemoteTagStatus = {},
 ): RemoteWorkspaceInfo[] {
     const serverLabel = server.label || server.id;
+    const connection: RemoteConnectionStatus = status.connection ?? (offline ? 'offline' : 'online');
     return workspaces.map(workspace => ({
         ...workspace,
         baseUrl,
@@ -118,8 +160,38 @@ export function tagRemoteWorkspaces(
             serverId: server.id,
             serverLabel,
             offline,
+            connection,
+            queue: status.queueByWorkspace?.[workspace.id] ?? 'idle',
         },
     }));
+}
+
+/**
+ * Derive a remote workspace's queue status from a `/api/queue/repos` entry.
+ * Mirrors the local clone-status precedence: paused > running > queued > idle.
+ * Pure; tolerant of partial/legacy entries.
+ */
+export function remoteQueueStatusFromRepo(
+    entry: { isPaused?: boolean; runningCount?: number; queuedCount?: number } | undefined,
+): RemoteQueueStatus {
+    if (!entry) return 'idle';
+    if (entry.isPaused) return 'paused';
+    if ((entry.runningCount ?? 0) > 0) return 'running';
+    if ((entry.queuedCount ?? 0) > 0) return 'queued';
+    return 'idle';
+}
+
+/**
+ * Build the per-workspace remote queue map for one online server from its
+ * `queue.repos()` response. The endpoint keys by `repoId`, which equals the
+ * workspace id in this codebase (the local `repoQueueMap` is keyed the same way).
+ */
+function queueMapFromReposResponse(response: QueueReposResponse | undefined): Record<string, RemoteQueueStatus> {
+    const map: Record<string, RemoteQueueStatus> = {};
+    for (const entry of response?.repos ?? []) {
+        map[entry.repoId] = remoteQueueStatusFromRepo(entry);
+    }
+    return map;
 }
 
 /** Whether a server is currently connected (online) with a reachable base URL. */
@@ -145,12 +217,15 @@ function offlineSourceFromCache(
     }
     // Prefer the server's current effectiveUrl, else the cached one used last time.
     const baseUrl = server.effectiveUrl || cached.baseUrl;
+    // Preserve the real connection state so the dot can show CONNECTING (not just
+    // OFFLINE) while a server is still coming up. No live queue for cached rows.
+    const connection: RemoteConnectionStatus = server.status ?? 'offline';
     return {
         serverId: server.id,
         serverLabel: server.label || server.id,
         baseUrl,
         online: false,
-        workspaces: tagRemoteWorkspaces(server, baseUrl, cached.workspaces, true),
+        workspaces: tagRemoteWorkspaces(server, baseUrl, cached.workspaces, true, { connection }),
         gitInfo: {},
     };
 }
@@ -174,6 +249,15 @@ async function loadOnlineSource(
             ? (await remoteClient.workspaces.gitInfoBatch(visible.map(ws => ws.id))).results ?? {}
             : {};
 
+        // Remote queue status (AC-05) for the status dot. Resilient: a queue
+        // fetch failure must never drop the server — fall back to an idle map.
+        let queueByWorkspace: Record<string, RemoteQueueStatus> = {};
+        try {
+            queueByWorkspace = queueMapFromReposResponse(await remoteClient.queue.repos());
+        } catch {
+            queueByWorkspace = {};
+        }
+
         // Persist the raw (untagged) list so a later offline load can re-tag it.
         saveRemoteWorkspaceCacheEntry(server.id, { baseUrl, workspaces: visible });
 
@@ -183,7 +267,10 @@ async function loadOnlineSource(
                 serverLabel,
                 baseUrl,
                 online: true,
-                workspaces: tagRemoteWorkspaces(server, baseUrl, visible, false),
+                workspaces: tagRemoteWorkspaces(server, baseUrl, visible, false, {
+                    connection: 'online',
+                    queueByWorkspace,
+                }),
                 gitInfo,
             },
         };

--- a/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
@@ -1,0 +1,242 @@
+/**
+ * Remote workspace aggregation (AC-01).
+ *
+ * Folds workspaces from SSH/devtunnel-connected remote CoC servers into the
+ * local repo data flow. For each ONLINE remote server we fetch its
+ * `/api/workspaces` + git-info batch DIRECTLY at the server's `effectiveUrl`
+ * (the already-forwarded `http://127.0.0.1:{localPort}`), tag every workspace
+ * with `{ baseUrl, serverId, serverLabel }` plus a remote marker, and merge the
+ * result with the local list. Offline / unreachable servers contribute their
+ * LAST-KNOWN list from a persisted cache, each entry flagged `offline`.
+ *
+ * Routing seam (IMMUTABLE): a remote workspace carries `baseUrl` (= the server's
+ * effectiveUrl); local workspaces have none. There are NO composite workspace
+ * IDs and NO new serverId namespace — `baseUrl` is the routing key, `serverId`
+ * is referenced for persistence/caching only.
+ *
+ * The remote fetch here is intentionally self-contained (a small CocClient bound
+ * to `effectiveUrl`); it does NOT re-plumb the shared SPA client (AC-03 owns
+ * per-clone request routing).
+ */
+
+import {
+    CocClient,
+    type GitInfoResponse,
+    type RemoteServer,
+    type WorkspaceInfo,
+    type WorkspacesResponse,
+} from '@plusplusoneplusplus/coc-client';
+import { getSpaCocClient } from '../api/cocClient';
+import { isRemoteShellEnabled } from '../utils/config';
+import {
+    loadRemoteWorkspaceCache,
+    saveRemoteWorkspaceCacheEntry,
+} from './remoteWorkspaceCache';
+
+/** Per-remote routing + provenance attached to every aggregated remote workspace. */
+export interface RemoteWorkspaceMarker {
+    /** Routing key: the remote server's effectiveUrl (e.g. http://127.0.0.1:4000). */
+    baseUrl: string;
+    /** Stable registry id of the contributing server (persistence/caching only). */
+    serverId: string;
+    /** Human-readable server label for badges/grouping. */
+    serverLabel: string;
+    /** True when this entry came from cache because the server is offline/unreachable. */
+    offline: boolean;
+}
+
+/**
+ * A workspace tagged as remote. The marker lives under the `remote` key so
+ * downstream code (AC-03/04/05) can reliably tell remote from local: local
+ * workspaces never carry `remote` / `baseUrl`.
+ */
+export type RemoteWorkspaceInfo = WorkspaceInfo & {
+    /** Present on remote workspaces only; absent on local ones. */
+    remote: RemoteWorkspaceMarker;
+    /** Convenience mirror of `remote.baseUrl` (the routing key). */
+    baseUrl: string;
+};
+
+/** Per-server git-info results keyed by remote workspace id. */
+export type RemoteGitInfoMap = Record<string, GitInfoResponse | null>;
+
+export interface RemoteWorkspaceSource {
+    serverId: string;
+    serverLabel: string;
+    baseUrl: string;
+    /** Whether the contributed workspaces are live (online) or cached (offline). */
+    online: boolean;
+    workspaces: RemoteWorkspaceInfo[];
+    /** git-info keyed by remote workspace id; empty for offline (cached) sources. */
+    gitInfo: RemoteGitInfoMap;
+}
+
+export interface AggregatedRemoteWorkspaces {
+    sources: RemoteWorkspaceSource[];
+    /** Flat list of all tagged remote workspaces across every source. */
+    workspaces: RemoteWorkspaceInfo[];
+    /** Merged git-info across all online sources, keyed by remote workspace id. */
+    gitInfo: RemoteGitInfoMap;
+    /** Non-fatal per-server problems (e.g. fetch failures) for surfacing/logging. */
+    warnings: string[];
+}
+
+const EMPTY_AGGREGATE: AggregatedRemoteWorkspaces = {
+    sources: [],
+    workspaces: [],
+    gitInfo: {},
+    warnings: [],
+};
+
+/** True when a remote workspace (carries a `remote` marker / `baseUrl`). */
+export function isRemoteWorkspace(workspace: unknown): workspace is RemoteWorkspaceInfo {
+    return (
+        typeof workspace === 'object' &&
+        workspace !== null &&
+        typeof (workspace as { baseUrl?: unknown }).baseUrl === 'string' &&
+        typeof (workspace as { remote?: unknown }).remote === 'object' &&
+        (workspace as { remote?: unknown }).remote !== null
+    );
+}
+
+/**
+ * Tag a server's raw workspace list with its remote marker. Pure: no I/O.
+ * `offline` flags entries served from cache for an unreachable server.
+ */
+export function tagRemoteWorkspaces(
+    server: Pick<RemoteServer, 'id' | 'label'>,
+    baseUrl: string,
+    workspaces: WorkspaceInfo[],
+    offline: boolean,
+): RemoteWorkspaceInfo[] {
+    const serverLabel = server.label || server.id;
+    return workspaces.map(workspace => ({
+        ...workspace,
+        baseUrl,
+        remote: {
+            baseUrl,
+            serverId: server.id,
+            serverLabel,
+            offline,
+        },
+    }));
+}
+
+/** Whether a server is currently connected (online) with a reachable base URL. */
+function isServerOnline(server: RemoteServer): server is RemoteServer & { effectiveUrl: string } {
+    return server.status === 'online' && typeof server.effectiveUrl === 'string' && server.effectiveUrl.length > 0;
+}
+
+function normalizeWorkspacesResponse(response: WorkspacesResponse | WorkspaceInfo[]): WorkspaceInfo[] {
+    if (Array.isArray(response)) {
+        return response;
+    }
+    return Array.isArray(response?.workspaces) ? response.workspaces : [];
+}
+
+/** Build an offline source from the last-known cache for a server, or null when nothing is cached. */
+function offlineSourceFromCache(
+    server: RemoteServer,
+    cache: ReturnType<typeof loadRemoteWorkspaceCache>,
+): RemoteWorkspaceSource | null {
+    const cached = cache[server.id];
+    if (!cached || cached.workspaces.length === 0) {
+        return null;
+    }
+    // Prefer the server's current effectiveUrl, else the cached one used last time.
+    const baseUrl = server.effectiveUrl || cached.baseUrl;
+    return {
+        serverId: server.id,
+        serverLabel: server.label || server.id,
+        baseUrl,
+        online: false,
+        workspaces: tagRemoteWorkspaces(server, baseUrl, cached.workspaces, true),
+        gitInfo: {},
+    };
+}
+
+/**
+ * Fetch + tag one online server's workspaces (and git-info batch) directly at
+ * its effectiveUrl, and refresh its cache entry. On failure, fall back to the
+ * cached (offline-flagged) list so a transient error never drops the server.
+ */
+async function loadOnlineSource(
+    server: RemoteServer & { effectiveUrl: string },
+    cache: ReturnType<typeof loadRemoteWorkspaceCache>,
+): Promise<{ source?: RemoteWorkspaceSource; warning?: string }> {
+    const serverLabel = server.label || server.id;
+    const baseUrl = server.effectiveUrl;
+    try {
+        const remoteClient = new CocClient({ baseUrl, fetch, timeoutMs: 15_000 });
+        const rawWorkspaces = normalizeWorkspacesResponse(await remoteClient.workspaces.list());
+        const visible = rawWorkspaces.filter(ws => !ws.virtual);
+        const gitInfo: RemoteGitInfoMap = visible.length > 0
+            ? (await remoteClient.workspaces.gitInfoBatch(visible.map(ws => ws.id))).results ?? {}
+            : {};
+
+        // Persist the raw (untagged) list so a later offline load can re-tag it.
+        saveRemoteWorkspaceCacheEntry(server.id, { baseUrl, workspaces: visible });
+
+        return {
+            source: {
+                serverId: server.id,
+                serverLabel,
+                baseUrl,
+                online: true,
+                workspaces: tagRemoteWorkspaces(server, baseUrl, visible, false),
+                gitInfo,
+            },
+        };
+    } catch (error) {
+        const offline = offlineSourceFromCache(server, cache);
+        const reason = error instanceof Error ? error.message : 'failed to load remote workspaces';
+        if (offline) {
+            return { source: offline, warning: `${serverLabel}: ${reason} (showing cached)` };
+        }
+        return { warning: `${serverLabel}: ${reason}` };
+    }
+}
+
+/**
+ * Aggregate remote workspaces across all configured servers.
+ *
+ * Online servers are fetched live (and cached); offline/unreachable servers
+ * yield their last-known cached entries flagged `offline`. Returns an empty
+ * aggregate (no work, no warnings) when `features.remoteShell` is OFF, so the
+ * classic flow is byte-for-byte unchanged.
+ */
+export async function aggregateRemoteWorkspaces(): Promise<AggregatedRemoteWorkspaces> {
+    if (!isRemoteShellEnabled()) {
+        return EMPTY_AGGREGATE;
+    }
+
+    let servers: RemoteServer[];
+    try {
+        servers = await getSpaCocClient().servers.list();
+    } catch {
+        // Registry unavailable: nothing to aggregate. Local flow is unaffected.
+        return EMPTY_AGGREGATE;
+    }
+
+    const cache = loadRemoteWorkspaceCache();
+
+    const results = await Promise.all(servers.map(async (server): Promise<{ source?: RemoteWorkspaceSource; warning?: string }> => {
+        if (isServerOnline(server)) {
+            return loadOnlineSource(server, cache);
+        }
+        const offline = offlineSourceFromCache(server, cache);
+        return offline ? { source: offline } : {};
+    }));
+
+    const sources = results.flatMap(result => (result.source ? [result.source] : []));
+    const warnings = results.flatMap(result => (result.warning ? [result.warning] : []));
+
+    const workspaces: RemoteWorkspaceInfo[] = [];
+    const gitInfo: RemoteGitInfoMap = {};
+    for (const source of sources) {
+        workspaces.push(...source.workspaces);
+        Object.assign(gitInfo, source.gitInfo);
+    }
+
+    return { sources, workspaces, gitInfo, warnings };
+}

--- a/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
@@ -30,6 +30,7 @@ import {
 } from '@plusplusoneplusplus/coc-client';
 import { getSpaCocClient } from '../api/cocClient';
 import { isRemoteShellEnabled } from '../utils/config';
+import { registerCloneBaseUrls } from './cloneRegistry';
 import {
     loadRemoteWorkspaceCache,
     saveRemoteWorkspaceCacheEntry,
@@ -294,6 +295,9 @@ async function loadOnlineSource(
  */
 export async function aggregateRemoteWorkspaces(): Promise<AggregatedRemoteWorkspaces> {
     if (!isRemoteShellEnabled()) {
+        // Flag off: clear any stale lookup entries so per-clone routing reverts to
+        // the local default for every id.
+        registerCloneBaseUrls([]);
         return EMPTY_AGGREGATE;
     }
 
@@ -302,6 +306,7 @@ export async function aggregateRemoteWorkspaces(): Promise<AggregatedRemoteWorks
         servers = await getSpaCocClient().servers.list();
     } catch {
         // Registry unavailable: nothing to aggregate. Local flow is unaffected.
+        registerCloneBaseUrls([]);
         return EMPTY_AGGREGATE;
     }
 
@@ -324,6 +329,13 @@ export async function aggregateRemoteWorkspaces(): Promise<AggregatedRemoteWorks
         workspaces.push(...source.workspaces);
         Object.assign(gitInfo, source.gitInfo);
     }
+
+    // Publish the workspaceId → baseUrl lookup (AC-07) so non-React services and
+    // hooks route a remote clone's per-clone REST/WS to its server. Full replace,
+    // covering online AND cached/offline remote rows (an offline-selected clone
+    // still resolves to its last-known baseUrl rather than silently hitting the
+    // local server).
+    registerCloneBaseUrls(workspaces.map(ws => ({ workspaceId: ws.id, baseUrl: ws.baseUrl })));
 
     return { sources, workspaces, gitInfo, warnings };
 }

--- a/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceCache.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceCache.ts
@@ -1,0 +1,98 @@
+/**
+ * Last-known remote workspace cache (AC-01).
+ *
+ * Persists the per-server workspace list so offline / unreachable servers can
+ * still contribute their last-known clones (flagged offline) to the dashboard.
+ *
+ * Two-layer, matching the existing dashboard pattern (see serverRegistry.ts /
+ * ReposGrid.tsx): an in-memory map (fast, survives within a session even when
+ * localStorage is unavailable) backed by localStorage for cross-reload
+ * persistence. Keyed by the stable registry `serverId` — robust to devtunnel
+ * port reassignment, since the cached `baseUrl` is only a fallback.
+ */
+
+import type { WorkspaceInfo } from '@plusplusoneplusplus/coc-client';
+
+const CACHE_KEY = 'coc-remote-workspace-cache';
+
+export interface RemoteWorkspaceCacheEntry {
+    /** The effectiveUrl the workspaces were last fetched from. */
+    baseUrl: string;
+    /** Last-known raw (untagged) workspace list for the server. */
+    workspaces: WorkspaceInfo[];
+    /** Epoch ms of the last successful refresh. */
+    updatedAt: number;
+}
+
+export type RemoteWorkspaceCache = Record<string, RemoteWorkspaceCacheEntry>;
+
+/** Session-scoped mirror; the source of truth when localStorage is unavailable. */
+let memoryCache: RemoteWorkspaceCache | null = null;
+
+function isCacheEntry(value: unknown): value is RemoteWorkspaceCacheEntry {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as RemoteWorkspaceCacheEntry).baseUrl === 'string' &&
+        Array.isArray((value as RemoteWorkspaceCacheEntry).workspaces)
+    );
+}
+
+function readFromStorage(): RemoteWorkspaceCache {
+    try {
+        const raw = localStorage.getItem(CACHE_KEY);
+        if (!raw) return {};
+        const parsed = JSON.parse(raw) as unknown;
+        if (typeof parsed !== 'object' || parsed === null) return {};
+        const out: RemoteWorkspaceCache = {};
+        for (const [serverId, entry] of Object.entries(parsed as Record<string, unknown>)) {
+            if (isCacheEntry(entry)) {
+                out[serverId] = entry;
+            }
+        }
+        return out;
+    } catch {
+        // SSR / test / quota — fall back to whatever is in memory.
+        return {};
+    }
+}
+
+function writeToStorage(cache: RemoteWorkspaceCache): void {
+    try {
+        localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+    } catch {
+        // SSR / test / quota — in-memory copy still serves this session.
+    }
+}
+
+/** Load the full cache (in-memory mirror seeded from localStorage on first read). */
+export function loadRemoteWorkspaceCache(): RemoteWorkspaceCache {
+    if (!memoryCache) {
+        memoryCache = readFromStorage();
+    }
+    return memoryCache;
+}
+
+/** Upsert one server's last-known list. Stamps `updatedAt` and persists. */
+export function saveRemoteWorkspaceCacheEntry(
+    serverId: string,
+    entry: { baseUrl: string; workspaces: WorkspaceInfo[] },
+): void {
+    const cache = loadRemoteWorkspaceCache();
+    cache[serverId] = {
+        baseUrl: entry.baseUrl,
+        workspaces: entry.workspaces,
+        updatedAt: Date.now(),
+    };
+    writeToStorage(cache);
+}
+
+/** Reset both layers. Exposed for tests. @internal */
+export function _resetRemoteWorkspaceCache(): void {
+    memoryCache = null;
+    try {
+        localStorage.removeItem(CACHE_KEY);
+    } catch {
+        // ignore
+    }
+}

--- a/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
+++ b/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
@@ -39,6 +39,39 @@ export interface RepoGroup {
     expanded: boolean;
 }
 
+/**
+ * True when a repo's workspace is a remote checkout aggregated from another CoC
+ * server (carries AC-01's `remote` marker / `baseUrl`). Inlined here as a tiny
+ * pure guard so this grouping module stays dependency-light and never pulls the
+ * network-aware aggregation module into classic-flow bundles.
+ */
+export function isRemoteRepo(repo: RepoData): boolean {
+    const ws = repo.workspace as { baseUrl?: unknown; remote?: unknown } | undefined;
+    return (
+        !!ws &&
+        typeof ws.baseUrl === 'string' &&
+        typeof ws.remote === 'object' &&
+        ws.remote !== null
+    );
+}
+
+/**
+ * Order a group's clones so LOCAL checkouts come before REMOTE ones, preserving
+ * the original relative order within each partition (stable). This keeps the
+ * PRIMARY marker (the first clone) on a local checkout whenever the group has
+ * one, so an aggregated remote clone can never displace the local primary. A
+ * remote-only group (all remote) is left as-is, so its sole/first remote clone
+ * is the primary. No-op when the remote shell is off (no remote repos exist).
+ */
+export function sortClonesLocalFirst(repos: RepoData[]): RepoData[] {
+    const locals: RepoData[] = [];
+    const remotes: RepoData[] = [];
+    for (const repo of repos) {
+        (isRemoteRepo(repo) ? remotes : locals).push(repo);
+    }
+    return remotes.length === 0 ? repos : [...locals, ...remotes];
+}
+
 /** Extract a short display label from a normalized remote URL. */
 export function remoteUrlLabel(normalized: string): string {
     const parts = normalized.split('/');
@@ -78,6 +111,13 @@ export function groupReposByRemote(
             });
         }
         groups.get(normalized)!.repos.push(repo);
+    }
+
+    // Within every group, keep LOCAL clones before REMOTE ones so the PRIMARY
+    // marker (first clone) lands on a local checkout when one exists. No-op when
+    // no remote checkouts are present (i.e. remote shell off / no remote repos).
+    for (const g of groups.values()) {
+        g.repos = sortClonesLocalFirst(g.repos);
     }
 
     const result: RepoGroup[] = [];

--- a/packages/coc/src/server/spa/client/react/tasks/hooks/useTaskComments.ts
+++ b/packages/coc/src/server/spa/client/react/tasks/hooks/useTaskComments.ts
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getWsPath } from '../../utils/config';
 import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { cloneWsUrl } from '../../api/wsUrl';
 import type {
     TaskComment,
     TaskCommentStatus,
@@ -231,8 +232,7 @@ export function useTaskComments(wsId: string, taskPath: string): UseTaskComments
     // Subscribe to file-scoped WebSocket events for instant comment-resolved updates
     useEffect(() => {
         if (!taskPath) return;
-        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${protocol}://${window.location.host}${getWsPath()}`);
+        const ws = new WebSocket(cloneWsUrl(getWsPath()));
         ws.addEventListener('open', () => {
             ws.send(JSON.stringify({ type: 'subscribe-file', filePath: taskPath }));
         });

--- a/packages/coc/src/server/spa/client/react/utils/diffCommentApi.ts
+++ b/packages/coc/src/server/spa/client/react/utils/diffCommentApi.ts
@@ -9,7 +9,7 @@
 import { getApiBase } from './config';
 import type { DiffComment, DiffCommentContext } from '../../comments/diff-comment-types';
 import type { UpdateDiffCommentRequest } from '../features/git/hooks/useDiffComments';
-import { getSpaCocClient } from '../api/cocClient';
+import { getCocClientForWorkspace } from '../repos/cloneRegistry';
 
 // ============================================================================
 // Storage key
@@ -53,7 +53,9 @@ export async function patchDiffComment(
     id: string,
     updates: UpdateDiffCommentRequest,
 ): Promise<DiffComment> {
-    const data = await getSpaCocClient().git.updateDiffComment(wsId, storageKey, id, updates);
+    // Route to the workspace's clone (AC-07): remote clones hit their own server,
+    // local/unknown ids resolve to the default origin (unchanged).
+    const data = await getCocClientForWorkspace(wsId).git.updateDiffComment(wsId, storageKey, id, updates);
     return data.comment as DiffComment;
 }
 
@@ -63,5 +65,5 @@ export async function deleteDiffCommentById(
     storageKey: string,
     id: string,
 ): Promise<void> {
-    await getSpaCocClient().git.deleteDiffComment(wsId, storageKey, id);
+    await getCocClientForWorkspace(wsId).git.deleteDiffComment(wsId, storageKey, id);
 }

--- a/packages/coc/src/server/streaming/websocket.ts
+++ b/packages/coc/src/server/streaming/websocket.ts
@@ -18,6 +18,7 @@ import type { Duplex } from 'stream';
 import { WebSocketServer, WebSocket } from 'ws';
 import type { AIProcess, MarkdownComment } from '@plusplusoneplusplus/forge';
 import { getServerLogger } from '../logging/server-logger';
+import { isLoopbackOrigin } from '../shared/cors';
 
 // ============================================================================
 // Types
@@ -538,6 +539,13 @@ export function toCommentSummary(comment: MarkdownComment): MarkdownCommentSumma
  * - `/ws`          → processWs (ProcessWebSocketServer)
  * - `/ws/terminal` → terminalWs (TerminalWebSocketServer), if provided
  * - anything else  → socket.destroy()
+ *
+ * Cross-origin policy (mirrors the REST CORS layer via {@link isLoopbackOrigin}):
+ * a browser always sends an `Origin` on a WS upgrade. When present, it MUST be a
+ * loopback origin — this lets the dashboard SPA open the terminal/activity WS on
+ * a forwarded remote CoC at `http://127.0.0.1:{localPort}` while rejecting any
+ * non-loopback page (e.g. http://evil.com). A missing Origin (non-browser
+ * clients such as container-link or tooling) is allowed, matching the REST path.
  */
 export function attachWebSocketUpgradeHandler(
     server: http.Server,
@@ -545,6 +553,13 @@ export function attachWebSocketUpgradeHandler(
     terminalWs?: { handleUpgrade(req: http.IncomingMessage, socket: Duplex, head: Buffer): void },
 ): void {
     server.on('upgrade', (req, socket: Duplex, head: Buffer) => {
+        if (!isWebSocketOriginAllowed(req.headers['origin'])) {
+            // Reject cross-origin (non-loopback) browser upgrades before handing
+            // off to any ws server. Reply with 403 then destroy the socket.
+            socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
+            socket.destroy();
+            return;
+        }
         const url = new URL(req.url!, `http://${req.headers.host}`);
         if (url.pathname === '/ws') {
             processWs.handleUpgrade(req, socket, head);
@@ -554,4 +569,24 @@ export function attachWebSocketUpgradeHandler(
             socket.destroy();
         }
     });
+}
+
+/**
+ * WebSocket-origin acceptance decision, shared with the REST CORS layer via
+ * {@link isLoopbackOrigin}. Returns true when the upgrade may proceed:
+ *   - no `Origin` header (non-browser client) → allowed
+ *   - `Origin` is a loopback origin           → allowed
+ *   - any other `Origin`                       → rejected
+ *
+ * Exported for direct unit testing of the WS-origin rule.
+ */
+export function isWebSocketOriginAllowed(origin: string | string[] | undefined): boolean {
+    if (origin === undefined) {
+        return true;
+    }
+    // A duplicated Origin header (string[]) is non-conformant for upgrades; reject.
+    if (Array.isArray(origin)) {
+        return false;
+    }
+    return isLoopbackOrigin(origin);
 }

--- a/packages/coc/test/server.test.ts
+++ b/packages/coc/test/server.test.ts
@@ -138,7 +138,10 @@ describe('Server', () => {
         server = await startTestServer();
         const res = await request(`${server.url}/api/health`);
 
-        expect(res.headers['access-control-allow-origin']).toBe('*');
+        // AC-02: applyCorsHeaders no longer emits a wildcard ACAO. A no-Origin
+        // request (same-origin / non-browser) gets no Access-Control-Allow-Origin
+        // header; the methods header is still emitted.
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
         expect(res.headers['access-control-allow-methods']).toContain('GET');
         expect(res.headers['access-control-allow-methods']).toContain('POST');
     });

--- a/packages/coc/test/server/cors.test.ts
+++ b/packages/coc/test/server/cors.test.ts
@@ -118,10 +118,12 @@ describe('CORS headers', () => {
 
     afterAll(async () => { await stopServer(server); });
 
-    it('OPTIONS /api/processes returns 204 with CORS headers', async () => {
+    it('OPTIONS /api/processes (no Origin) returns 204 without an ACAO header', async () => {
         const { status, headers } = await rawRequest(baseUrl, '/api/processes', { method: 'OPTIONS' });
         expect(status).toBe(204);
-        expect(headers['access-control-allow-origin']).toBe('*');
+        // No Origin → not a cross-origin request; no ACAO header is emitted and
+        // the wildcard `*` is never used.
+        expect(headers['access-control-allow-origin']).toBeUndefined();
     });
 
     it('OPTIONS response includes all required methods', async () => {
@@ -139,15 +141,24 @@ describe('CORS headers', () => {
         expect(addProcessCallCount).toBe(callsBefore);
     });
 
-    it('GET /api/processes includes Access-Control-Allow-Origin: *', async () => {
+    it('GET /api/processes (no Origin) omits Access-Control-Allow-Origin', async () => {
         const { status, headers } = await rawRequest(baseUrl, '/api/processes');
         expect(status).toBe(200);
-        expect(headers['access-control-allow-origin']).toBe('*');
+        expect(headers['access-control-allow-origin']).toBeUndefined();
     });
 
-    it('POST /api/processes includes Access-Control-Allow-Origin: *', async () => {
+    it('GET /api/processes reflects a loopback Origin (never wildcard)', async () => {
+        const loopback = `http://127.0.0.1:${new URL(baseUrl).port}`;
+        const { status, headers } = await rawRequest(baseUrl, '/api/processes', { origin: loopback });
+        expect(status).toBe(200);
+        expect(headers['access-control-allow-origin']).toBe(loopback);
+    });
+
+    it('POST /api/processes from a loopback Origin reflects it', async () => {
+        const loopback = `http://localhost:${new URL(baseUrl).port}`;
         const { status, headers } = await rawRequest(baseUrl, '/api/processes', {
             method: 'POST',
+            origin: loopback,
             body: JSON.stringify({
                 id: 'cors-proc-1',
                 promptPreview: 'hi',
@@ -155,9 +166,10 @@ describe('CORS headers', () => {
                 startTime: new Date().toISOString(),
             }),
         });
-        // Either 201 or 400 — either way CORS headers must be present
+        // Either 201 or 400 — either way the loopback origin is reflected and
+        // the wildcard is never used.
         expect([201, 400]).toContain(status);
-        expect(headers['access-control-allow-origin']).toBe('*');
+        expect(headers['access-control-allow-origin']).toBe(loopback);
     });
 
     it('Access-Control-Allow-Headers is set on all responses', async () => {
@@ -189,10 +201,20 @@ describe('CORS headers', () => {
         expect(headers['access-control-allow-credentials']).toBe('true');
     });
 
-    it('unknown origin gets wildcard (no credentials)', async () => {
+    it('non-loopback origin is NOT reflected and never gets wildcard', async () => {
         const { headers } = await rawRequest(baseUrl, '/api/processes', { origin: 'https://evil.example.com' });
-        expect(headers['access-control-allow-origin']).toBe('*');
+        expect(headers['access-control-allow-origin']).toBeUndefined();
         expect(headers['access-control-allow-credentials']).toBeUndefined();
+    });
+
+    it('private-LAN origin is NOT reflected (loopback ≠ private network)', async () => {
+        const { headers } = await rawRequest(baseUrl, '/api/processes', { origin: 'http://192.168.1.10:4000' });
+        expect(headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('look-alike subdomain origin is rejected', async () => {
+        const { headers } = await rawRequest(baseUrl, '/api/processes', { origin: 'http://attacker.localhost.evil.com' });
+        expect(headers['access-control-allow-origin']).toBeUndefined();
     });
 
     it('OPTIONS preflight from localhost reflects origin', async () => {
@@ -202,9 +224,9 @@ describe('CORS headers', () => {
         expect(headers['access-control-allow-origin']).toBe(localhostOrigin);
     });
 
-    it('OPTIONS preflight from unknown origin gets wildcard', async () => {
+    it('OPTIONS preflight from a non-loopback origin is not reflected (no wildcard)', async () => {
         const { status, headers } = await rawRequest(baseUrl, '/api/processes', { method: 'OPTIONS', origin: 'https://remote.devtunnels.ms' });
         expect(status).toBe(204);
-        expect(headers['access-control-allow-origin']).toBe('*');
+        expect(headers['access-control-allow-origin']).toBeUndefined();
     });
 });

--- a/packages/coc/test/server/loopback-origin.test.ts
+++ b/packages/coc/test/server/loopback-origin.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Loopback Cross-Origin Policy Tests (AC-02)
+ *
+ * The dashboard SPA is served from one localhost origin but talks directly to a
+ * forwarded remote CoC server at `http://127.0.0.1:{localPort}` — a different
+ * origin (differs by port). That target server must therefore allow cross-origin
+ * REST + WebSocket from loopback/localhost origins ONLY, and must NEVER use a
+ * wildcard `*` or reflect a non-loopback origin.
+ *
+ * Three layers are covered here:
+ *   1. `isLoopbackOrigin` predicate (shared by REST CORS + WS upgrade).
+ *   2. `isWebSocketOriginAllowed` WS-origin decision.
+ *   3. An integration-style boot of a real HTTP server with the upgrade handler:
+ *      a loopback WS upgrade connects; a non-loopback WS upgrade is rejected.
+ *
+ * Cross-platform compatible (Linux/macOS/Windows).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import { WebSocket } from 'ws';
+import { isLoopbackOrigin } from '../../src/server/shared/cors';
+import {
+    ProcessWebSocketServer,
+    attachWebSocketUpgradeHandler,
+    isWebSocketOriginAllowed,
+} from '../../src/server/streaming/websocket';
+
+// ============================================================================
+// 1) isLoopbackOrigin predicate
+// ============================================================================
+
+describe('isLoopbackOrigin', () => {
+    const allowed = [
+        'http://127.0.0.1:4000',
+        'http://127.0.0.1',
+        'http://localhost:5000',
+        'http://localhost',
+        'https://localhost:5000',
+        'https://127.0.0.1:4000',
+        'http://[::1]:4000',
+        'https://[::1]',
+    ];
+    for (const origin of allowed) {
+        it(`allows loopback origin ${origin}`, () => {
+            expect(isLoopbackOrigin(origin)).toBe(true);
+        });
+    }
+
+    const rejected = [
+        'http://evil.com',
+        'https://evil.com',
+        'http://192.168.1.10',
+        'http://192.168.1.10:4000',
+        'http://10.0.0.5:4000',
+        'http://attacker.localhost.evil.com',
+        'http://localhost.evil.com',
+        'http://notlocalhost',
+        'http://remote.devtunnels.ms',
+        'https://remote.devtunnels.ms',
+        // Non-http(s) schemes are rejected even on loopback hosts.
+        'ws://127.0.0.1:4000',
+        'file://localhost/etc/passwd',
+        // Malformed / empty values.
+        'not a url',
+        '',
+    ];
+    for (const origin of rejected) {
+        it(`rejects non-loopback origin ${JSON.stringify(origin)}`, () => {
+            expect(isLoopbackOrigin(origin)).toBe(false);
+        });
+    }
+
+    it('rejects undefined / null', () => {
+        expect(isLoopbackOrigin(undefined)).toBe(false);
+        expect(isLoopbackOrigin(null)).toBe(false);
+    });
+});
+
+// ============================================================================
+// 2) isWebSocketOriginAllowed (WS upgrade decision)
+// ============================================================================
+
+describe('isWebSocketOriginAllowed', () => {
+    it('allows a missing Origin (non-browser client)', () => {
+        expect(isWebSocketOriginAllowed(undefined)).toBe(true);
+    });
+
+    it('allows loopback origins', () => {
+        expect(isWebSocketOriginAllowed('http://127.0.0.1:4000')).toBe(true);
+        expect(isWebSocketOriginAllowed('http://localhost:5000')).toBe(true);
+        expect(isWebSocketOriginAllowed('http://[::1]:4000')).toBe(true);
+    });
+
+    it('rejects non-loopback origins', () => {
+        expect(isWebSocketOriginAllowed('http://evil.com')).toBe(false);
+        expect(isWebSocketOriginAllowed('http://192.168.1.10')).toBe(false);
+        expect(isWebSocketOriginAllowed('http://attacker.localhost.evil.com')).toBe(false);
+    });
+
+    it('rejects a duplicated (array) Origin header', () => {
+        expect(isWebSocketOriginAllowed(['http://localhost:5000', 'http://evil.com'])).toBe(false);
+    });
+});
+
+// ============================================================================
+// 3) Integration: real server upgrade handler honors the WS-origin rule
+// ============================================================================
+
+describe('attachWebSocketUpgradeHandler origin enforcement', () => {
+    let server: http.Server | undefined;
+    let wsServer: ProcessWebSocketServer | undefined;
+
+    afterEach(async () => {
+        try { wsServer?.closeAll(); } catch { /* ignore */ }
+        if (server) {
+            await new Promise<void>(resolve => server!.close(() => resolve()));
+        }
+        server = undefined;
+        wsServer = undefined;
+    });
+
+    async function boot(): Promise<number> {
+        wsServer = new ProcessWebSocketServer();
+        wsServer.attachConnectionHandler();
+        server = http.createServer((_req, res) => { res.writeHead(404); res.end(); });
+        attachWebSocketUpgradeHandler(server, wsServer);
+        await new Promise<void>((resolve, reject) => {
+            server!.on('error', reject);
+            server!.listen(0, '127.0.0.1', resolve);
+        });
+        return (server!.address() as AddressInfo).port;
+    }
+
+    /** Attempt a WS connection with an explicit Origin; resolve open/close/error. */
+    function tryConnect(port: number, origin?: string): Promise<{ opened: boolean; code?: number; errored: boolean }> {
+        return new Promise((resolve) => {
+            const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, origin ? { origin } : undefined);
+            let settled = false;
+            const settle = (result: { opened: boolean; code?: number; errored: boolean }) => {
+                if (settled) { return; }
+                settled = true;
+                ws.removeAllListeners();
+                resolve(result);
+            };
+            ws.on('open', () => {
+                // Only an established connection can be cleanly closed; the
+                // rejection paths must NOT call close()/terminate() on the ws
+                // wrapper (it throws "closed before connection established").
+                try { ws.close(); } catch { /* ignore */ }
+                settle({ opened: true, errored: false });
+            });
+            ws.on('unexpected-response', (_req, res) => {
+                const code = res.statusCode;
+                res.resume(); // drain so the socket can close
+                settle({ opened: false, code, errored: true });
+            });
+            ws.on('error', () => settle({ opened: false, errored: true }));
+        });
+    }
+
+    it('accepts a loopback Origin WS upgrade', async () => {
+        const port = await boot();
+        const result = await tryConnect(port, `http://127.0.0.1:${port}`);
+        expect(result.opened).toBe(true);
+        expect(result.errored).toBe(false);
+    });
+
+    it('accepts a localhost Origin WS upgrade (cross-port)', async () => {
+        const port = await boot();
+        const result = await tryConnect(port, 'http://localhost:5173');
+        expect(result.opened).toBe(true);
+    });
+
+    it('accepts an upgrade with no Origin (non-browser client)', async () => {
+        const port = await boot();
+        const result = await tryConnect(port, undefined);
+        expect(result.opened).toBe(true);
+    });
+
+    it('rejects a non-loopback Origin WS upgrade with 403', async () => {
+        const port = await boot();
+        const result = await tryConnect(port, 'http://evil.com');
+        expect(result.opened).toBe(false);
+        expect(result.errored).toBe(true);
+        expect(result.code).toBe(403);
+    });
+
+    it('rejects a private-LAN Origin WS upgrade', async () => {
+        const port = await boot();
+        const result = await tryConnect(port, 'http://192.168.1.10:4000');
+        expect(result.opened).toBe(false);
+        expect(result.errored).toBe(true);
+    });
+});

--- a/packages/coc/test/server/preferences-handler.test.ts
+++ b/packages/coc/test/server/preferences-handler.test.ts
@@ -1519,7 +1519,8 @@ describe('Preferences REST API', () => {
 
     it('GET includes CORS headers', async () => {
         const res = await getJSON(`${baseUrl}/api/preferences`);
-        expect(res.headers['access-control-allow-origin']).toBe('*');
+        // AC-02: no wildcard ACAO; a no-Origin request gets no ACAO header.
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
     });
 
     // -- Content-Type --
@@ -1838,7 +1839,8 @@ describe('Per-Repo Preferences REST API', () => {
 
     it('GET includes CORS headers', async () => {
         const res = await getJSON(repoUrl(repoId));
-        expect(res.headers['access-control-allow-origin']).toBe('*');
+        // AC-02: no wildcard ACAO; a no-Origin request gets no ACAO header.
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
     });
 
     // -- PUT --

--- a/packages/coc/test/server/remote-server-routes.test.ts
+++ b/packages/coc/test/server/remote-server-routes.test.ts
@@ -291,6 +291,67 @@ describe('remote server routes', () => {
         expect((await request(baseUrl, 'POST', `/api/servers/${created.body.id}/disconnect`)).status).toBe(400);
     });
 
+    describe('url-kind runtime reachability', () => {
+        it('reports a reachable URL server as online with its configured url as effectiveUrl', async () => {
+            const remoteBase = await startRemoteCoc();
+            const baseUrl = await startApi(new DevTunnelConnector());
+
+            // Creation probes reachability up front, so the create response already
+            // reflects the live status (no connector maintains url-kind state).
+            const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Reachable', url: remoteBase });
+            expect(created.status).toBe(201);
+            expect(created.body).toMatchObject({
+                kind: 'url',
+                status: 'online',
+                effectiveUrl: remoteBase,
+            });
+
+            // GET /api/servers (the dashboard's source) must surface the same online
+            // status so aggregateRemoteWorkspaces fetches this remote's clones.
+            const list = await request(baseUrl, 'GET', '/api/servers');
+            expect(list.status).toBe(200);
+            expect(list.body).toHaveLength(1);
+            expect(list.body[0]).toMatchObject({
+                kind: 'url',
+                status: 'online',
+                effectiveUrl: remoteBase,
+            });
+        });
+
+        it('reports an unreachable URL server as offline (never online)', async () => {
+            // Start then immediately stop a server to obtain a guaranteed-refused
+            // endpoint (fast ECONNREFUSED rather than a slow timeout).
+            const deadServer = http.createServer(() => {});
+            const dead = await start(deadServer);
+            await stop(deadServer);
+
+            const baseUrl = await startApi(new DevTunnelConnector());
+            const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Unreachable', url: dead.baseUrl });
+            expect(created.status).toBe(201);
+            expect(created.body.kind).toBe('url');
+            expect(created.body.status).toBe('offline');
+            expect(created.body.status).not.toBe('online');
+            expect(created.body.effectiveUrl).toBe(dead.baseUrl);
+
+            const list = await request(baseUrl, 'GET', '/api/servers');
+            expect(list.body[0].status).toBe('offline');
+            expect(list.body[0].status).not.toBe('online');
+        });
+
+        it('reflects a /health probe result in the subsequent /api/servers listing', async () => {
+            const remoteBase = await startRemoteCoc();
+            const baseUrl = await startApi(new DevTunnelConnector());
+            const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Reachable', url: remoteBase });
+
+            // An explicit health check refreshes the cached reachability the list reads.
+            const health = await request(baseUrl, 'GET', `/api/servers/${created.body.id}/health`);
+            expect(health.body).toMatchObject({ kind: 'url', status: 'online', effectiveUrl: remoteBase });
+
+            const list = await request(baseUrl, 'GET', '/api/servers');
+            expect(list.body[0]).toMatchObject({ status: 'online', effectiveUrl: remoteBase });
+        });
+    });
+
     describe('cherry-pick transfer orchestration', () => {
         let extraServers: http.Server[] = [];
 

--- a/packages/coc/test/server/shared/router.test.ts
+++ b/packages/coc/test/server/shared/router.test.ts
@@ -518,14 +518,17 @@ describe('CORS handling', () => {
 
     it('sets CORS headers on API responses', async () => {
         const res = await request(`${baseUrl}/api/test`);
-        expect(res.headers['access-control-allow-origin']).toBe('*');
+        // AC-02: no wildcard ACAO; a no-Origin request gets no ACAO header, but
+        // the methods/headers advertisements are still emitted.
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
         expect(res.headers['access-control-allow-methods']).toContain('GET');
         expect(res.headers['access-control-allow-headers']).toContain('Content-Type');
     });
 
     it('sets CORS headers on SPA responses', async () => {
         const res = await request(`${baseUrl}/`);
-        expect(res.headers['access-control-allow-origin']).toBe('*');
+        // AC-02: no wildcard ACAO for a no-Origin request.
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
     });
 });
 

--- a/packages/coc/test/server/spa/client/hooks/useClassification.test.ts
+++ b/packages/coc/test/server/spa/client/hooks/useClassification.test.ts
@@ -21,14 +21,32 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
 // ── Hoist mock factory before any imports ─────────────────────────────────
+// AC-07: useClassification now routes classify-diff REST through the clone's
+// CocClient via useCocClient(workspaceId).request(path, opts). We mock
+// useCocClient to hand back a stub whose .request IS our spy, and stub
+// toSpaCocRequestOptions to an identity so the spy still sees the raw
+// { method, body } RequestInit the POST-body assertions inspect.
 
-const mocks = vi.hoisted(() => ({
-    requestSpaApi: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
-}));
+const mocks = vi.hoisted(() => {
+    const requestSpaApi = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+    // A STABLE stub client so useCocClient returns the same identity each render
+    // (matches the real memoized hook); an unstable object would re-run the
+    // GET/poll effects every render and desync the mock-call queue.
+    const stubClient = { request: requestSpaApi };
+    return { requestSpaApi, stubClient };
+});
 
 vi.mock(
     '../../../../../src/server/spa/client/react/api/cocClient',
-    () => ({ requestSpaApi: mocks.requestSpaApi }),
+    () => ({
+        toSpaCocRequestOptions: (opts?: unknown) => opts,
+        translateSpaCocClientError: (e: unknown) => { throw e; },
+    }),
+);
+
+vi.mock(
+    '../../../../../src/server/spa/client/react/repos/cloneRouting',
+    () => ({ useCocClient: () => mocks.stubClient }),
 );
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-queue-id.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-queue-id.test.ts
@@ -80,8 +80,10 @@ describe('ChatDetail source-level regression', () => {
     });
 
     it('never passes raw taskId to typed queue task methods', () => {
+        // AC-07: ChatDetail routes queue calls through the clone-aware client
+        // (`useCocClient(workspaceId)` → `client.queue.*`), so match that call form.
         const queueTaskCallLines = src.split('\n').filter(line =>
-            line.includes('getSpaCocClient().queue.') && line.includes('taskId'),
+            line.includes('client.queue.') && line.includes('taskId'),
         );
 
         for (const line of queueTaskCallLines) {
@@ -94,10 +96,10 @@ describe('ChatDetail source-level regression', () => {
     });
 
     it('handleCancel uses bareTaskId', () => {
-        expect(src).toContain('getSpaCocClient().queue.cancel(bareTaskId)');
+        expect(src).toContain('client.queue.cancel(bareTaskId)');
     });
 
     it('handleMoveToTop uses bareTaskId', () => {
-        expect(src).toContain('getSpaCocClient().queue.moveToTop(bareTaskId)');
+        expect(src).toContain('client.queue.moveToTop(bareTaskId)');
     });
 });

--- a/packages/coc/test/server/task-comments-handler.test.ts
+++ b/packages/coc/test/server/task-comments-handler.test.ts
@@ -639,7 +639,8 @@ describe('Task Comments REST API', () => {
 
         it('includes CORS headers', async () => {
             const res = await getJSON(commentsUrl());
-            expect(res.headers['access-control-allow-origin']).toBe('*');
+            // AC-02: no wildcard ACAO; a no-Origin request gets no ACAO header.
+            expect(res.headers['access-control-allow-origin']).toBeUndefined();
         });
     });
 

--- a/packages/coc/test/server/wiki-static-cors.test.ts
+++ b/packages/coc/test/server/wiki-static-cors.test.ts
@@ -65,7 +65,9 @@ function request(
 }
 
 function assertCorsHeaders(headers: Record<string, string>): void {
-    expect(headers['access-control-allow-origin']).toBe('*');
+    // AC-02: no wildcard ACAO; these no-Origin requests get no ACAO header, but
+    // the methods/headers advertisements are still emitted.
+    expect(headers['access-control-allow-origin']).toBeUndefined();
     expect(headers['access-control-allow-methods']).toContain('GET');
     expect(headers['access-control-allow-methods']).toContain('POST');
     expect(headers['access-control-allow-methods']).toContain('DELETE');

--- a/packages/coc/test/spa/react/RepoGitTab.test.ts
+++ b/packages/coc/test/spa/react/RepoGitTab.test.ts
@@ -43,7 +43,9 @@ describe('RepoGitTab', () => {
         });
 
         it('imports typed CoC client', () => {
-            expect(source).toContain("import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient'");
+            // AC-07: routes Git tab data through the clone-aware client (useCocClient).
+            expect(source).toContain("import { getSpaCocClientErrorMessage } from '../../api/cocClient'");
+            expect(source).toContain("import { useCocClient } from '../../repos/cloneRouting'");
         });
 
         it('fetches branch-range data', () => {
@@ -254,16 +256,16 @@ describe('RepoGitTab', () => {
         });
 
         it('delegates Content-Type handling to typed client', () => {
-            expect(source).toContain('getSpaCocClient().git.pull');
+            expect(source).toContain('cloneClient.git.pull');
         });
 
         it('all action handlers use typed git methods', () => {
             const fetchBlock = source.match(/handleFetch[\s\S]*?(?=const handlePull)/);
             const pullBlock = source.match(/handlePull[\s\S]*?(?=const handlePush)/);
             const pushBlock = source.match(/handlePush[\s\S]*?(?=const handleSelect)/);
-            expect(fetchBlock![0]).toContain('getSpaCocClient().git.fetch');
-            expect(pullBlock![0]).toContain('getSpaCocClient().git.pull');
-            expect(pushBlock![0]).toContain('getSpaCocClient().git.push');
+            expect(fetchBlock![0]).toContain('cloneClient.git.fetch');
+            expect(pullBlock![0]).toContain('cloneClient.git.pull');
+            expect(pushBlock![0]).toContain('cloneClient.git.push');
         });
 
         it('handleFetch guards against concurrent calls', () => {
@@ -968,7 +970,9 @@ describe('RepoGitTab', () => {
         });
 
         it('imports typed CoC client utility', () => {
-            expect(source).toContain("import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient'");
+            // AC-07: routes Git tab data through the clone-aware client (useCocClient).
+            expect(source).toContain("import { getSpaCocClientErrorMessage } from '../../api/cocClient'");
+            expect(source).toContain("import { useCocClient } from '../../repos/cloneRouting'");
         });
 
         it('imports useMemo from react', () => {
@@ -1134,7 +1138,7 @@ describe('RepoGitTab', () => {
         });
 
         it('handleConfirmSkillRun enqueues through typed queue client', () => {
-            expect(source).toContain('getSpaCocClient().queue.enqueue');
+            expect(source).toContain('cloneClient.queue.enqueue');
         });
 
         it('handleConfirmSkillRun appends user context to prompt when non-empty', () => {

--- a/packages/coc/test/spa/react/RepoSchedulesTab-edit.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab-edit.test.tsx
@@ -55,7 +55,13 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({ schedules: mockSchedulesClient, models: mockModelsClient, agentProviders: mockAgentProvidersClient }),
+    getSpaCocClient: () => ({
+        schedules: mockSchedulesClient,
+        models: mockModelsClient,
+        agentProviders: mockAgentProvidersClient,
+        // AC-07: the tab now reads notes-git status via the clone-aware client.
+        notes: { getGitStatus: vi.fn().mockResolvedValue({ initialized: false }) },
+    }),
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({

--- a/packages/coc/test/spa/react/RepoSchedulesTab-lifecycle.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab-lifecycle.test.tsx
@@ -67,7 +67,11 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({ schedules: mockSchedulesClient }),
+    getSpaCocClient: () => ({
+        schedules: mockSchedulesClient,
+        // AC-07: the tab now reads notes-git status via the clone-aware client.
+        notes: { getGitStatus: vi.fn().mockResolvedValue({ initialized: false }) },
+    }),
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({

--- a/packages/coc/test/spa/react/RepoSchedulesTab-split-panel.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab-split-panel.test.tsx
@@ -70,7 +70,13 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({ schedules: mockSchedulesClient, models: mockModelsClient, agentProviders: mockAgentProvidersClient }),
+    getSpaCocClient: () => ({
+        schedules: mockSchedulesClient,
+        models: mockModelsClient,
+        agentProviders: mockAgentProvidersClient,
+        // AC-07: the tab now reads notes-git status via the clone-aware client.
+        notes: { getGitStatus: vi.fn().mockResolvedValue({ initialized: false }) },
+    }),
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({

--- a/packages/coc/test/spa/react/RepoSchedulesTab.test.tsx
+++ b/packages/coc/test/spa/react/RepoSchedulesTab.test.tsx
@@ -46,7 +46,14 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 }));
 
 vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({ schedules: mockSchedulesClient, models: mockModelsClient, workflow: mockWorkflowClient, agentProviders: mockAgentProvidersClient }),
+    getSpaCocClient: () => ({
+        schedules: mockSchedulesClient,
+        models: mockModelsClient,
+        workflow: mockWorkflowClient,
+        agentProviders: mockAgentProvidersClient,
+        // AC-07: the tab now reads notes-git status via the clone-aware client.
+        notes: { getGitStatus: vi.fn().mockResolvedValue({ initialized: false }) },
+    }),
 }));
 
 vi.mock('../../../src/server/spa/client/react/utils/config', () => ({

--- a/packages/coc/test/spa/react/ReposView.test.tsx
+++ b/packages/coc/test/spa/react/ReposView.test.tsx
@@ -978,8 +978,9 @@ describe('ReposContext — async git-info', () => {
         const fetchReposStart = source.indexOf('const fetchRepos = useCallback');
         const fetchReposEnd = source.indexOf('}, [dispatch, refreshUnseenCounts, seedRepoQueueStats]);', fetchReposStart);
         const fetchReposBody = source.substring(fetchReposStart, fetchReposEnd);
-        // setRepos and setLoading(false) should appear before the phase-2 git-info loop
-        const setReposIdx = fetchReposBody.indexOf('setRepos(enriched)');
+        // setRepos and setLoading(false) should appear before the phase-2 git-info loop.
+        // `combined` = local enriched repos plus any merged remote-server repos.
+        const setReposIdx = fetchReposBody.indexOf('setRepos(combined)');
         const setLoadingIdx = fetchReposBody.indexOf('setLoading(false)');
         const phase2Idx = fetchReposBody.indexOf('Phase 2');
         expect(setReposIdx).toBeGreaterThan(-1);

--- a/packages/coc/test/spa/react/api/cocClient-routing.test.ts
+++ b/packages/coc/test/spa/react/api/cocClient-routing.test.ts
@@ -1,0 +1,131 @@
+/**
+ * AC-03 — per-clone client factory (getCocClientFor) and WS URL derivation
+ * (cloneWsUrl). Verifies remote routing is opt-in and local behavior is unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApiUrl } from '@plusplusoneplusplus/coc-client';
+import { getCocClientFor, getSpaCocClient, resetSpaCocClientForTests } from '../../../../src/server/spa/client/react/api/cocClient';
+import { cloneWsUrl } from '../../../../src/server/spa/client/react/api/wsUrl';
+
+beforeEach(() => {
+    resetSpaCocClientForTests();
+});
+
+afterEach(() => {
+    resetSpaCocClientForTests();
+});
+
+// ── getCocClientFor ───────────────────────────────────────────────────────────
+
+describe('getCocClientFor', () => {
+    it('returns the default singleton when baseUrl is undefined', () => {
+        expect(getCocClientFor(undefined)).toBe(getSpaCocClient());
+    });
+
+    it('returns the default singleton when baseUrl is empty string', () => {
+        expect(getCocClientFor('')).toBe(getSpaCocClient());
+    });
+
+    it('returns a client bound to the given baseUrl for a remote clone', () => {
+        const client = getCocClientFor('http://127.0.0.1:4000');
+        expect(client.options.baseUrl).toBe('http://127.0.0.1:4000');
+        // Must NOT be the default origin singleton.
+        expect(client).not.toBe(getSpaCocClient());
+        // Default singleton stays at the page origin (empty baseUrl) — unchanged.
+        expect(getSpaCocClient().options.baseUrl).toBe('');
+    });
+
+    it('caches and reuses the client per baseUrl (stable identity)', () => {
+        const a = getCocClientFor('http://127.0.0.1:4000');
+        const b = getCocClientFor('http://127.0.0.1:4000');
+        expect(a).toBe(b);
+    });
+
+    it('normalizes a trailing slash so it hits the same cache entry', () => {
+        const a = getCocClientFor('http://127.0.0.1:4000');
+        const b = getCocClientFor('http://127.0.0.1:4000/');
+        expect(a).toBe(b);
+        expect(b.options.baseUrl).toBe('http://127.0.0.1:4000');
+    });
+
+    it('returns distinct clients for distinct baseUrls', () => {
+        const a = getCocClientFor('http://127.0.0.1:4000');
+        const b = getCocClientFor('http://127.0.0.1:4001');
+        expect(a).not.toBe(b);
+        expect(a.options.baseUrl).toBe('http://127.0.0.1:4000');
+        expect(b.options.baseUrl).toBe('http://127.0.0.1:4001');
+    });
+
+    it('routes REST requests to the remote origin (api base preserved)', () => {
+        const client = getCocClientFor('http://127.0.0.1:4000');
+        // The transport builds request URLs via buildApiUrl(baseUrl, apiBasePath, …);
+        // assert that resolves against the remote origin with the standard /api base.
+        const url = buildApiUrl(client.options.baseUrl, client.options.apiBasePath, '/workspaces');
+        expect(url).toBe('http://127.0.0.1:4000/api/workspaces');
+    });
+});
+
+// ── cloneWsUrl ────────────────────────────────────────────────────────────────
+
+describe('cloneWsUrl — local (no baseUrl)', () => {
+    const original = window.location;
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', { value: original, configurable: true, writable: true });
+    });
+
+    function setLocation(href: string) {
+        const url = new URL(href);
+        Object.defineProperty(window, 'location', {
+            value: { ...original, protocol: url.protocol, host: url.host, href },
+            configurable: true,
+            writable: true,
+        });
+    }
+
+    it('derives ws:// from an http page origin (legacy behavior)', () => {
+        setLocation('http://localhost:3000/dashboard');
+        expect(cloneWsUrl('/ws')).toBe('ws://localhost:3000/ws');
+    });
+
+    it('derives wss:// from an https page origin', () => {
+        setLocation('https://coc.example.com/dashboard');
+        expect(cloneWsUrl('/ws')).toBe('wss://coc.example.com/ws');
+    });
+
+    it('preserves a terminal path with query string verbatim', () => {
+        setLocation('http://localhost:3000/');
+        expect(cloneWsUrl('/ws/terminal?workspaceId=abc&cols=80&rows=24'))
+            .toBe('ws://localhost:3000/ws/terminal?workspaceId=abc&cols=80&rows=24');
+    });
+
+    it('adds a leading slash when the path lacks one', () => {
+        setLocation('http://localhost:3000/');
+        expect(cloneWsUrl('ws')).toBe('ws://localhost:3000/ws');
+    });
+});
+
+describe('cloneWsUrl — remote (with baseUrl)', () => {
+    it('maps an http baseUrl to ws:// at that host:port', () => {
+        expect(cloneWsUrl('/ws', 'http://127.0.0.1:4000')).toBe('ws://127.0.0.1:4000/ws');
+    });
+
+    it('maps an https baseUrl to wss://', () => {
+        expect(cloneWsUrl('/ws', 'https://remote.example.com')).toBe('wss://remote.example.com/ws');
+    });
+
+    it('keeps the host:port from the baseUrl, not the page origin', () => {
+        // Even though the page is on :3000, the socket targets the remote :4000.
+        expect(cloneWsUrl('/ws', 'http://127.0.0.1:4000')).toContain('127.0.0.1:4000');
+    });
+
+    it('preserves a terminal path + query against the remote origin', () => {
+        expect(cloneWsUrl('/ws/terminal?workspaceId=abc&cols=80&rows=24', 'http://127.0.0.1:4000'))
+            .toBe('ws://127.0.0.1:4000/ws/terminal?workspaceId=abc&cols=80&rows=24');
+    });
+
+    it('ignores a trailing slash / path on the baseUrl (origin only)', () => {
+        expect(cloneWsUrl('/ws', 'http://127.0.0.1:4000/')).toBe('ws://127.0.0.1:4000/ws');
+    });
+});

--- a/packages/coc/test/spa/react/context/ReposContext.test.tsx
+++ b/packages/coc/test/spa/react/context/ReposContext.test.tsx
@@ -36,9 +36,25 @@ vi.mock('../../../../src/server/spa/client/react/repos/repositoryService', () =>
     ...repositoryServiceMocks,
 }));
 
+// Stub only aggregateRemoteWorkspaces so the test controls the remote workspaces
+// deterministically (no live remote servers). The real isRemoteWorkspace /
+// tagRemoteWorkspaces are preserved — ReposContext's AC-08 write/restore logic
+// relies on the genuine remote marker shape.
+const aggregateRemoteWorkspacesMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation')>();
+    return { ...actual, aggregateRemoteWorkspaces: aggregateRemoteWorkspacesMock };
+});
+
 import { ReposProvider, useRepos } from '../../../../src/server/spa/client/react/contexts/ReposContext';
 import { AppProvider, useApp } from '../../../../src/server/spa/client/react/contexts/AppContext';
 import { QueueProvider } from '../../../../src/server/spa/client/react/contexts/QueueContext';
+import { tagRemoteWorkspaces, type AggregatedRemoteWorkspaces } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
+import {
+    _resetRemoteSelectionForTests,
+    loadPersistedRemoteSelection,
+    persistRemoteSelection,
+} from '../../../../src/server/spa/client/react/repos/remoteSelectionPersistence';
 
 afterEach(() => {
     vi.clearAllMocks();
@@ -53,6 +69,25 @@ const makeWorkspace = (id: string, name = id) => ({
 
 function makeWorkspacesResponse(workspaces: any[]) {
     return { workspaces };
+}
+
+function emptyAggregate(): AggregatedRemoteWorkspaces {
+    return { sources: [], workspaces: [], gitInfo: {}, warnings: [] };
+}
+
+/**
+ * Build an aggregate with a single online remote workspace, tagged with the real
+ * marker. `baseUrl` is varied across "reloads" to exercise port reassignment.
+ */
+function remoteAggregate(serverId: string, baseUrl: string, wsId: string, wsName = wsId): AggregatedRemoteWorkspaces {
+    const tagged = tagRemoteWorkspaces(
+        { id: serverId, label: serverId },
+        baseUrl,
+        [{ id: wsId, name: wsName, rootPath: `/repos/${wsId}` }],
+        false,
+        { connection: 'online' },
+    );
+    return { sources: [], workspaces: tagged, gitInfo: {}, warnings: [] };
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -141,6 +176,13 @@ describe('ReposContext', () => {
         repositoryServiceMocks.getWorkspaceGitInfoBatch.mockResolvedValue({ results: {} });
         repositoryServiceMocks.getWorkspaceGitInfo.mockResolvedValue({ branch: null, dirty: false, isGitRepo: false, remoteUrl: null });
         repositoryServiceMocks.listQueueRepos.mockResolvedValue({ repos: [] });
+        // Default: no remote workspaces (classic flow). Overridden per AC-08 test.
+        aggregateRemoteWorkspacesMock.mockResolvedValue(emptyAggregate());
+        _resetRemoteSelectionForTests();
+    });
+
+    afterEach(() => {
+        _resetRemoteSelectionForTests();
     });
 
     it('throws when useRepos is used outside ReposProvider', () => {
@@ -260,5 +302,117 @@ describe('ReposContext', () => {
 
         // Selection should have been cleared because 'removed-ws' is gone
         expect(screen.getByTestId('selected-repo').textContent).toBe('none');
+    });
+
+    // ── AC-08: remote-clone selection persistence across reload ──────────────
+    describe('remote-clone selection persistence (AC-08)', () => {
+        it('restores the persisted remote clone once aggregation completes (cold reload, no hash)', async () => {
+            // Simulate a prior session having selected the remote clone.
+            persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'remote-ws' });
+            // Reload: local workspaces load first; the remote clone appears only
+            // after aggregateRemoteWorkspaces resolves.
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:4000', 'remote-ws'));
+
+            // No pre-selection (nothing set the hash) — restore must drive it.
+            render(
+                <Wrapper>
+                    <ReposProvider>
+                        <SelectedRepoConsumer />
+                    </ReposProvider>
+                </Wrapper>
+            );
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+            });
+            // The remote workspace is present in the merged list.
+            expect(screen.getByTestId('repo-remote-ws')).toBeTruthy();
+        });
+
+        it('restores via serverId after devtunnel PORT REASSIGNMENT (baseUrl differs on reload)', async () => {
+            // Persisted at :4000; on reload the SAME server is forwarded at :9999.
+            persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'remote-ws' });
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:9999', 'remote-ws'));
+
+            render(
+                <Wrapper>
+                    <ReposProvider>
+                        <SelectedRepoConsumer />
+                    </ReposProvider>
+                </Wrapper>
+            );
+
+            // Resolved purely via the stable serverId — the changed baseUrl/port
+            // does not prevent restoration.
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+            });
+        });
+
+        it('keeps a hash-restored remote selection (id matches the persisted pair)', async () => {
+            // Cold load where the hash DID set the remote id (via Router); restore
+            // confirms it via serverId and leaves it selected (idempotent).
+            persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'remote-ws' });
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:4000', 'remote-ws'));
+
+            render(<ProviderWithPreselectedRepo repoId="remote-ws" />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('repo-loading').textContent).toBe('false');
+            });
+            expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+        });
+
+        it('does not hijack an unrelated active local selection', async () => {
+            // A remote clone is persisted, but on this load the user is on a local
+            // repo. Restore must NOT yank them to the remote clone.
+            persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'remote-ws' });
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:4000', 'remote-ws'));
+
+            render(<ProviderWithPreselectedRepo repoId="local-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('repo-loading').textContent).toBe('false');
+            });
+            // Stays on the local repo the user is actually viewing.
+            expect(screen.getByTestId('selected-repo').textContent).toBe('local-1');
+        });
+
+        it('selecting a LOCAL clone clears any persisted remote pair (local unchanged)', async () => {
+            // Stale remote pair from before; the active selection is local. The
+            // write effect drops the remote pair so a later reload won't resurrect it.
+            persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'remote-ws' });
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
+            // No remote workspace this time (server gone) so local-1 is the only repo.
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce(emptyAggregate());
+
+            render(<ProviderWithPreselectedRepo repoId="local-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-repo').textContent).toBe('local-1');
+            });
+            await waitFor(() => {
+                expect(loadPersistedRemoteSelection()).toBeNull();
+            });
+        });
+
+        it('persists the { serverId, workspaceId } pair when a remote clone is selected', async () => {
+            // Remote clone present and selected → the stable pair is written.
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:4000', 'remote-ws'));
+
+            render(<ProviderWithPreselectedRepo repoId="remote-ws" />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+            });
+            await waitFor(() => {
+                expect(loadPersistedRemoteSelection()).toEqual({ serverId: 'srv-1', workspaceId: 'remote-ws' });
+            });
+        });
     });
 });

--- a/packages/coc/test/spa/react/features/chat/AskUserInline.test.tsx
+++ b/packages/coc/test/spa/react/features/chat/AskUserInline.test.tsx
@@ -508,7 +508,8 @@ describe('AskUserInline', () => {
             'utf-8',
         );
         expect(source).not.toMatch(/\bfetch\s*\(/);
-        expect(source).toContain('getSpaCocClient');
+        // AC-07: routes the ask_user reply through the clone-aware typed client.
+        expect(source).toContain('useCocClient');
     });
 
     describe('markdown rendering', () => {

--- a/packages/coc/test/spa/react/features/git/useGitInfo.routing.test.tsx
+++ b/packages/coc/test/spa/react/features/git/useGitInfo.routing.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * AC-07 — useGitInfo routes to the workspace's clone.
+ *
+ * The Git tab reads `/workspaces/:id/git-info` through useGitInfo, which now uses
+ * useCocClient(workspaceId). A remote clone must read its sync status from its own
+ * server; a local clone from the default origin client.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+// ── client factory: LOCAL stub + per-baseUrl stubs ────────────────────────────
+const gitInfoCalls: Array<{ baseUrl: string; workspaceId: string }> = [];
+
+function makeClient(baseUrl: string) {
+    return {
+        options: { baseUrl },
+        workspaces: {
+            gitInfo: vi.fn(async (workspaceId: string) => {
+                gitInfoCalls.push({ baseUrl, workspaceId });
+                return { branch: 'main', ahead: 1, behind: 2, dirty: true };
+            }),
+        },
+    };
+}
+const LOCAL = makeClient('');
+const remoteClients = new Map<string, ReturnType<typeof makeClient>>();
+vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => LOCAL,
+    getCocClientFor: (baseUrl?: string) => {
+        if (!baseUrl) return LOCAL;
+        let c = remoteClients.get(baseUrl);
+        if (!c) { c = makeClient(baseUrl); remoteClients.set(baseUrl, c); }
+        return c;
+    },
+}));
+
+// The clone registry (not React context) drives bare-id resolution in useCocClient.
+import {
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+} from '../../../../../src/server/spa/client/react/repos/cloneRegistry';
+import { useGitInfo } from '../../../../../src/server/spa/client/react/features/git/hooks/useGitInfo';
+
+beforeEach(() => {
+    resetCloneRegistryForTests();
+    gitInfoCalls.length = 0;
+    remoteClients.clear();
+    LOCAL.workspaces.gitInfo.mockClear();
+    registerCloneBaseUrls([{ workspaceId: 'w1', baseUrl: 'http://127.0.0.1:4000' }]);
+});
+
+afterEach(() => {
+    resetCloneRegistryForTests();
+});
+
+describe('useGitInfo routing', () => {
+    it('reads a remote clone git-info from the remote server', async () => {
+        const { result } = renderHook(() => useGitInfo('w1'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(gitInfoCalls).toEqual([{ baseUrl: 'http://127.0.0.1:4000', workspaceId: 'w1' }]);
+        expect(LOCAL.workspaces.gitInfo).not.toHaveBeenCalled();
+        expect(result.current.branch).toBe('main');
+    });
+
+    it('reads a LOCAL clone git-info from the default origin client', async () => {
+        // 'w2' is not registered → resolves to the default local client.
+        const { result } = renderHook(() => useGitInfo('w2'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(LOCAL.workspaces.gitInfo).toHaveBeenCalledWith('w2');
+        expect(gitInfoCalls).toEqual([{ baseUrl: '', workspaceId: 'w2' }]);
+    });
+});

--- a/packages/coc/test/spa/react/hooks/useNotesChat.test.ts
+++ b/packages/coc/test/spa/react/hooks/useNotesChat.test.ts
@@ -123,7 +123,7 @@ describe('useNotesChat', () => {
 
     describe('createChat creates queue task', () => {
         it('POSTs to /queue with chat payload', () => {
-            expect(source).toContain('getSpaCocClient().notes.createChat');
+            expect(source).toContain('cloneClient.notes.createChat');
         });
 
         it('accepts ask and autopilot as valid modes', () => {

--- a/packages/coc/test/spa/react/hooks/usePullRequestChatBinding.test.ts
+++ b/packages/coc/test/spa/react/hooks/usePullRequestChatBinding.test.ts
@@ -78,7 +78,7 @@ describe('usePullRequestChatBinding', () => {
         });
 
         it('uses useEffect with workspaceId+prId dependency', () => {
-            expect(source).toContain('[workspaceId, prId]');
+            expect(source).toContain('[workspaceId, prId, cloneClient]');
         });
     });
 
@@ -97,7 +97,7 @@ describe('usePullRequestChatBinding', () => {
         it('resets taskId to null on prId change', () => {
             const effectBlock = source.substring(
                 source.indexOf('useEffect(() => {'),
-                source.indexOf('[workspaceId, prId]') + 50,
+                source.indexOf('[workspaceId, prId, cloneClient]') + 50,
             );
             expect(effectBlock).toContain('setTaskId(null)');
             expect(effectBlock).toContain('setLoading(true)');

--- a/packages/coc/test/spa/react/hooks/useTerminalWebSocket.test.ts
+++ b/packages/coc/test/spa/react/hooks/useTerminalWebSocket.test.ts
@@ -5,6 +5,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useTerminalWebSocket } from '../../../../src/server/spa/client/react/features/terminal/hooks/useTerminalWebSocket';
+import {
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 
 // ── Minimal WebSocket mock ────────────────────────────────────────────
 
@@ -66,12 +70,14 @@ describe('useTerminalWebSocket', () => {
         MockWebSocket.reset();
         vi.stubGlobal('WebSocket', MockWebSocket);
         vi.useFakeTimers();
+        resetCloneRegistryForTests();
     });
 
     afterEach(() => {
         vi.unstubAllGlobals();
         vi.useRealTimers();
         vi.restoreAllMocks();
+        resetCloneRegistryForTests();
     });
 
     it('exports hook with correct API shape', () => {
@@ -96,6 +102,29 @@ describe('useTerminalWebSocket', () => {
         act(() => { result.current.connect('ws-123', 80, 24); });
         expect(MockWebSocket.last.url).toBe(
             'ws://localhost/ws/terminal?workspaceId=ws-123&cols=80&rows=24'
+        );
+    });
+
+    it('AC-07: opens a remote clone PTY against the remote server', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-ws', baseUrl: 'http://127.0.0.1:4000' }]);
+        const { result } = renderHook(() =>
+            useTerminalWebSocket({ onMessage: vi.fn() }),
+        );
+        act(() => { result.current.connect('remote-ws', 80, 24); });
+        expect(MockWebSocket.last.url).toBe(
+            'ws://127.0.0.1:4000/ws/terminal?workspaceId=remote-ws&cols=80&rows=24'
+        );
+    });
+
+    it('AC-07: opens a LOCAL clone PTY against the page origin (unchanged)', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-ws', baseUrl: 'http://127.0.0.1:4000' }]);
+        const { result } = renderHook(() =>
+            useTerminalWebSocket({ onMessage: vi.fn() }),
+        );
+        // 'local-ws' is not registered → page-origin URL.
+        act(() => { result.current.connect('local-ws', 80, 24); });
+        expect(MockWebSocket.last.url).toBe(
+            'ws://localhost/ws/terminal?workspaceId=local-ws&cols=80&rows=24'
         );
     });
 

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -40,12 +40,21 @@ const repo = (id: string, name: string, branch = 'main') => ({
     gitInfo: { isGitRepo: true, branch, dirty: false, remoteUrl: SHORTCUTS },
 });
 
-// A remote checkout (AC-01 marker) of the same origin, foldable into the group.
-const remoteRepo = (id: string, name: string, serverLabel = 'devbox', remoteUrl: string | undefined = SHORTCUTS, branch = 'main') => ({
+// A remote checkout (AC-01/05 marker) of the same origin, foldable into the group.
+// `connection`/`queue` drive the AC-05 status dot; defaults keep an online, idle clone.
+const remoteRepo = (
+    id: string,
+    name: string,
+    serverLabel = 'devbox',
+    remoteUrl: string | undefined = SHORTCUTS,
+    branch = 'main',
+    connection: string = 'online',
+    queue: string = 'idle',
+) => ({
     workspace: {
         id, name, color: '#0078d4', remoteUrl, rootPath: `/remote/${id}`,
         baseUrl: 'http://127.0.0.1:4000',
-        remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline: false },
+        remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline: connection !== 'online', connection, queue },
     },
     gitInfo: remoteUrl ? { isGitRepo: true, branch, dirty: false, remoteUrl } : undefined,
 });
@@ -169,5 +178,43 @@ describe('RemoteSubBar', () => {
         screen.getAllByTestId('clone-popover-item').forEach(el => {
             expect(el.getAttribute('data-remote')).toBe('false');
         });
+    });
+
+    // ── AC-05: blended status dot reflected on each clone row ─────────────────
+
+    const openAndGetRow = (repos: any[], activeId: string, rowId: string) => {
+        const active = repos.find(r => r.workspace.id === activeId);
+        render(<RemoteSubBar repo={active as any} repos={repos as any} />);
+        fireEvent.click(screen.getByTestId('clone-switch'));
+        return screen.getAllByTestId('clone-popover-item')
+            .find(el => el.textContent?.includes(repos.find(r => r.workspace.id === rowId)!.workspace.name))!;
+    };
+
+    it('blends an online+running remote clone to a running dot status', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'online', 'running');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        expect(row.getAttribute('data-remote')).toBe('true');
+        expect(row.getAttribute('data-clone-status')).toBe('running');
+    });
+
+    it('shows an offline status for a remote clone whose server is offline', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'offline', 'running');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        expect(row.getAttribute('data-clone-status')).toBe('offline');
+    });
+
+    it('shows a connecting status for a remote clone whose server is connecting', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'connecting', 'queued');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        expect(row.getAttribute('data-clone-status')).toBe('connecting');
+    });
+
+    it('keeps local clone dot status queue-derived (idle with no queue)', () => {
+        const row = openAndGetRow([repo('a', 'shortcuts'), repo('b', 'shortcuts-2', 'feat/x')], 'a', 'b');
+        expect(row.getAttribute('data-remote')).toBe('false');
+        expect(row.getAttribute('data-clone-status')).toBe('idle');
     });
 });

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -40,6 +40,16 @@ const repo = (id: string, name: string, branch = 'main') => ({
     gitInfo: { isGitRepo: true, branch, dirty: false, remoteUrl: SHORTCUTS },
 });
 
+// A remote checkout (AC-01 marker) of the same origin, foldable into the group.
+const remoteRepo = (id: string, name: string, serverLabel = 'devbox', remoteUrl: string | undefined = SHORTCUTS, branch = 'main') => ({
+    workspace: {
+        id, name, color: '#0078d4', remoteUrl, rootPath: `/remote/${id}`,
+        baseUrl: 'http://127.0.0.1:4000',
+        remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline: false },
+    },
+    gitInfo: remoteUrl ? { isGitRepo: true, branch, dirty: false, remoteUrl } : undefined,
+});
+
 const renderBar = () => {
     const repos = [repo('a', 'shortcuts'), repo('b', 'shortcuts-2', 'feat/x')];
     return render(<RemoteSubBar repo={repos[0] as any} repos={repos as any} />);
@@ -108,5 +118,56 @@ describe('RemoteSubBar', () => {
         mockQueueStats = { running: 2, queued: 0 };
         renderBar();
         expect(screen.getByTestId('subbar-running-badge').textContent).toBe('2');
+    });
+
+    // ── AC-04: remote clones in the CLONE dropdown ───────────────────────────
+
+    it('folds a remote clone into the dropdown and badges it with the server label', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox');
+        render(<RemoteSubBar repo={local as any} repos={[local, remote] as any} />);
+        fireEvent.click(screen.getByTestId('clone-switch'));
+        const items = screen.getAllByTestId('clone-popover-item');
+        expect(items).toHaveLength(2);
+        // Exactly the remote row carries the server-label badge.
+        const badges = screen.getAllByTestId('clone-remote-badge');
+        expect(badges).toHaveLength(1);
+        expect(badges[0].textContent).toBe('devbox');
+        const remoteRow = items.find(el => el.getAttribute('data-remote') === 'true')!;
+        expect(remoteRow.querySelector('[data-testid="clone-remote-badge"]')).toBeTruthy();
+    });
+
+    it('keeps the PRIMARY marker on the local clone, never the remote', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox');
+        // Remote passed FIRST — grouping must still sort the local clone ahead.
+        render(<RemoteSubBar repo={local as any} repos={[remote, local] as any} />);
+        fireEvent.click(screen.getByTestId('clone-switch'));
+        const items = screen.getAllByTestId('clone-popover-item');
+        const primaryRow = items.find(el => el.textContent?.toLowerCase().includes('primary'))!;
+        expect(primaryRow).toBeTruthy();
+        expect(primaryRow.getAttribute('data-remote')).toBe('false');
+        // The remote row must NOT be marked primary.
+        const remoteRow = items.find(el => el.getAttribute('data-remote') === 'true')!;
+        expect(remoteRow.textContent?.toLowerCase()).not.toContain('primary');
+    });
+
+    it('renders a remote-only clone (no local counterpart) with its server badge', () => {
+        const remote = remoteRepo('only', 'remote-only', 'edge-1');
+        render(<RemoteSubBar repo={remote as any} repos={[remote] as any} />);
+        fireEvent.click(screen.getByTestId('clone-switch'));
+        const items = screen.getAllByTestId('clone-popover-item');
+        expect(items).toHaveLength(1);
+        expect(items[0].getAttribute('data-remote')).toBe('true');
+        expect(screen.getByTestId('clone-remote-badge').textContent).toBe('edge-1');
+    });
+
+    it('does not badge any row when every clone is local', () => {
+        renderBar();
+        fireEvent.click(screen.getByTestId('clone-switch'));
+        expect(screen.queryByTestId('clone-remote-badge')).toBeNull();
+        screen.getAllByTestId('clone-popover-item').forEach(el => {
+            expect(el.getAttribute('data-remote')).toBe('false');
+        });
     });
 });

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -217,4 +217,82 @@ describe('RemoteSubBar', () => {
         expect(row.getAttribute('data-remote')).toBe('false');
         expect(row.getAttribute('data-clone-status')).toBe('idle');
     });
+
+    // ── AC-06: offline remote clones are greyed + non-interactive ─────────────
+
+    it('greys an offline remote clone, badges it offline, and disables the row', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'offline', 'running');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        // Greyed treatment + disabled state.
+        expect(row.getAttribute('data-offline')).toBe('true');
+        expect((row as HTMLButtonElement).disabled).toBe(true);
+        expect(row.getAttribute('aria-disabled')).toBe('true');
+        expect(row.className).toContain('opacity-50');
+        expect(row.className).toContain('cursor-not-allowed');
+        // Offline badge present (in addition to the server-label badge).
+        const offlineBadge = row.querySelector('[data-testid="clone-offline-badge"]');
+        expect(offlineBadge).toBeTruthy();
+        expect(offlineBadge!.textContent?.toLowerCase()).toContain('offline');
+        expect(row.querySelector('[data-testid="clone-remote-badge"]')).toBeTruthy();
+    });
+
+    it('does NOT select/navigate when an offline remote clone is clicked', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'offline', 'running');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        fireEvent.click(row);
+        expect(mockSelectClone).not.toHaveBeenCalled();
+        // Popover stays open (no navigation happened).
+        expect(screen.queryByTestId('clone-popover')).toBeTruthy();
+    });
+
+    it('treats a failed-connection remote clone as offline (greyed + non-interactive)', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'failed', 'idle');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        expect(row.getAttribute('data-clone-status')).toBe('offline');
+        expect(row.getAttribute('data-offline')).toBe('true');
+        fireEvent.click(row);
+        expect(mockSelectClone).not.toHaveBeenCalled();
+    });
+
+    it('the ONLINE variant of the same remote clone is interactive and not greyed', () => {
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'online', 'idle');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        expect(row.getAttribute('data-offline')).toBe('false');
+        expect((row as HTMLButtonElement).disabled).toBe(false);
+        expect(row.querySelector('[data-testid="clone-offline-badge"]')).toBeNull();
+        fireEvent.click(row);
+        expect(mockSelectClone).toHaveBeenCalledWith('b');
+    });
+
+    it('keeps the offline clone VISIBLE in its group (row still rendered)', () => {
+        // Group stays stable: an offline remote clone folds in and is still listed.
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'offline', 'idle');
+        render(<RemoteSubBar repo={local as any} repos={[local, remote] as any} />);
+        fireEvent.click(screen.getByTestId('clone-switch'));
+        const items = screen.getAllByTestId('clone-popover-item');
+        expect(items).toHaveLength(2);
+        expect(items.some(el => el.getAttribute('data-offline') === 'true')).toBe(true);
+    });
+
+    it('does not grey or disable a connecting (not-yet-offline) remote clone', () => {
+        // 'connecting' is distinct from offline — the row stays interactive.
+        const local = repo('a', 'shortcuts');
+        const remote = remoteRepo('b', 'shortcuts-remote', 'devbox', SHORTCUTS, 'main', 'connecting', 'idle');
+        const row = openAndGetRow([local, remote], 'a', 'b');
+        expect(row.getAttribute('data-offline')).toBe('false');
+        expect((row as HTMLButtonElement).disabled).toBe(false);
+        fireEvent.click(row);
+        expect(mockSelectClone).toHaveBeenCalledWith('b');
+    });
+
+    it('never greys a LOCAL clone (offline treatment is remote-only)', () => {
+        const row = openAndGetRow([repo('a', 'shortcuts'), repo('b', 'shortcuts-2', 'feat/x')], 'a', 'b');
+        expect(row.getAttribute('data-offline')).toBe('false');
+        expect((row as HTMLButtonElement).disabled).toBe(false);
+    });
 });

--- a/packages/coc/test/spa/react/remote-shell/RemoteTopBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteTopBar.test.tsx
@@ -41,8 +41,19 @@ const repo = (id: string, name: string, remoteUrl: string, color = '#123456') =>
     gitInfo: { isGitRepo: true, branch: 'main', dirty: false, remoteUrl },
 });
 
+// A remote checkout aggregated by AC-01 (carries baseUrl + remote marker).
+const remoteRepo = (id: string, name: string, remoteUrl: string, serverLabel = 'devbox') => ({
+    workspace: {
+        id, name, color: '#123456', remoteUrl, rootPath: `/remote/${id}`,
+        baseUrl: 'http://127.0.0.1:4000',
+        remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline: false },
+    },
+    gitInfo: { isGitRepo: true, branch: 'main', dirty: false, remoteUrl },
+});
+
 const SHORTCUTS = 'https://github.com/acme/shortcuts.git';
 const FORGE = 'https://github.com/acme/forge.git';
+const REMOTE_ONLY = 'https://github.com/acme/edge-svc.git';
 
 beforeEach(() => {
     cleanup();
@@ -124,5 +135,39 @@ describe('RemoteTopBar', () => {
         fireEvent.click(screen.getByTestId('remote-add-btn'));
         fireEvent.click(screen.getByTestId('remote-clone-repo-option'));
         expect(screen.getByTestId('clone-repo-dialog')).toBeTruthy();
+    });
+
+    // ── AC-04: remote-only repos surface as their own top-row entry ──────────
+
+    it('surfaces a remote-only repo as its own remote tab', () => {
+        mockRepos = [
+            repo('a', 'shortcuts', SHORTCUTS),
+            remoteRepo('edge', 'edge-svc', REMOTE_ONLY, 'edge-1'),
+        ];
+        render(<RemoteTopBar />);
+        const tabs = screen.getAllByTestId('remote-tab');
+        expect(tabs).toHaveLength(2);
+        const remoteOnly = tabs.find(el => el.getAttribute('data-remote-key')?.includes('edge-svc'));
+        expect(remoteOnly).toBeTruthy();
+    });
+
+    it('selecting a remote-only tab picks its remote clone', () => {
+        mockRepos = [remoteRepo('edge', 'edge-svc', REMOTE_ONLY, 'edge-1')];
+        render(<RemoteTopBar />);
+        fireEvent.click(screen.getAllByTestId('remote-tab')[0]);
+        expect(mockSelectClone).toHaveBeenCalledWith('edge');
+    });
+
+    it('picks the LOCAL clone when selecting a remote that also has a remote checkout', () => {
+        // Local + remote of the same origin fold into one tab; clicking it must
+        // select the local clone (sorted first), never the remote.
+        mockRepos = [
+            repo('local', 'shortcuts', SHORTCUTS),
+            remoteRepo('remote', 'shortcuts-remote', SHORTCUTS, 'devbox'),
+        ];
+        render(<RemoteTopBar />);
+        expect(screen.getAllByTestId('remote-tab')).toHaveLength(1);
+        fireEvent.click(screen.getAllByTestId('remote-tab')[0]);
+        expect(mockSelectClone).toHaveBeenCalledWith('local');
     });
 });

--- a/packages/coc/test/spa/react/remote-shell/shellModel.test.ts
+++ b/packages/coc/test/spa/react/remote-shell/shellModel.test.ts
@@ -7,16 +7,27 @@ import {
     computeVisibleTabKeys,
     computeCloneStatusMap,
     cloneStatusColor,
+    blendRemoteCloneStatus,
     summarizeRemote,
     REMOTE_SCOPE_KEYS,
 } from '../../../../src/server/spa/client/react/features/remote-shell/shellModel';
 import type { SubTabDef } from '../../../../src/server/spa/client/react/features/repo-detail/repoSubTabs';
 import type { RepoData, RepoGroup } from '../../../../src/server/spa/client/react/repos/repoGrouping';
+import type { RemoteConnectionStatus, RemoteQueueStatus } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
 import type { RepoSubTab } from '../../../../src/server/spa/client/react/types/dashboard';
 
 const tab = (key: RepoSubTab, label = key): SubTabDef => ({ key, label });
 const repo = (id: string, color?: string): RepoData =>
     ({ workspace: { id, name: id, color, rootPath: `/r/${id}` } } as RepoData);
+
+/** A remote clone (AC-01/05 marker) carrying a connection + remote queue status. */
+const remoteRepo = (id: string, connection: RemoteConnectionStatus, queue: RemoteQueueStatus = 'idle'): RepoData =>
+    ({
+        workspace: {
+            id, name: id, rootPath: `/remote/${id}`, baseUrl: 'http://127.0.0.1:4000',
+            remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel: 'devbox', offline: connection !== 'online', connection, queue },
+        },
+    } as RepoData);
 
 describe('scope key sets', () => {
     it('declares Work Items + Pull Requests as remote-scoped', () => {
@@ -95,6 +106,32 @@ describe('computeCloneStatusMap', () => {
         const map = computeCloneStatusMap([repo('a')], { a: { running: [{ hidden: true }], queued: [] } }, (t: any) => t.hidden);
         expect(map.a).toBe('idle');
     });
+
+    // ── AC-05: remote clones blend connection + remote queue ─────────────────
+
+    it('blends remote clones from their marker, ignoring the local queue map', () => {
+        const repos = [
+            remoteRepo('off', 'offline', 'running'),       // connection wins → offline
+            remoteRepo('conn', 'connecting', 'queued'),    // connecting wins → connecting
+            remoteRepo('run', 'online', 'running'),        // online → remote queue
+            remoteRepo('idle', 'online', 'idle'),          // online idle → idle
+        ];
+        // A local queue entry keyed by a remote id must NOT influence remote rows.
+        const map = computeCloneStatusMap(repos, { run: { running: [], queued: [] } }, noneHidden);
+        expect(map).toEqual({ off: 'offline', conn: 'connecting', run: 'running', idle: 'idle' });
+    });
+
+    it('leaves LOCAL clones queue-derived when mixed with remote clones', () => {
+        const repos = [repo('local'), remoteRepo('remote', 'online', 'running')];
+        const map = computeCloneStatusMap(repos, { local: { running: [{}], queued: [] } }, noneHidden);
+        expect(map.local).toBe('running'); // from local queue map
+        expect(map.remote).toBe('running'); // from remote marker
+    });
+
+    it('maps an online remote clone with a paused remote queue to paused', () => {
+        const map = computeCloneStatusMap([remoteRepo('p', 'online', 'paused')], {}, noneHidden);
+        expect(map.p).toBe('paused');
+    });
 });
 
 describe('cloneStatusColor', () => {
@@ -104,6 +141,38 @@ describe('cloneStatusColor', () => {
         expect(cloneStatusColor('paused', '#000')).toBe('#f14c4c');
         expect(cloneStatusColor('idle', '#abc')).toBe('#abc');
         expect(cloneStatusColor(undefined, '#abc')).toBe('#abc');
+    });
+
+    it('maps the AC-05 remote-only states to distinct hues', () => {
+        // offline = dim grey (inactive); connecting = blue in-progress (NOT queued orange).
+        expect(cloneStatusColor('offline', '#abc')).toBe('#8c959f');
+        expect(cloneStatusColor('connecting', '#abc')).toBe('#3b82f6');
+        // connecting must be visually distinct from queued.
+        expect(cloneStatusColor('connecting', '#abc')).not.toBe(cloneStatusColor('queued', '#abc'));
+    });
+});
+
+describe('blendRemoteCloneStatus (AC-05)', () => {
+    it('shows offline for an offline or failed connection regardless of queue', () => {
+        expect(blendRemoteCloneStatus({ connection: 'offline', queue: 'running' })).toBe('offline');
+        expect(blendRemoteCloneStatus({ connection: 'failed', queue: 'queued' })).toBe('offline');
+    });
+
+    it('shows connecting for a connecting/idle (not-yet-online) connection', () => {
+        expect(blendRemoteCloneStatus({ connection: 'connecting', queue: 'running' })).toBe('connecting');
+        expect(blendRemoteCloneStatus({ connection: 'idle', queue: 'queued' })).toBe('connecting');
+    });
+
+    it('defers to the remote queue status when online', () => {
+        expect(blendRemoteCloneStatus({ connection: 'online', queue: 'running' })).toBe('running');
+        expect(blendRemoteCloneStatus({ connection: 'online', queue: 'queued' })).toBe('queued');
+        expect(blendRemoteCloneStatus({ connection: 'online', queue: 'paused' })).toBe('paused');
+        expect(blendRemoteCloneStatus({ connection: 'online', queue: 'idle' })).toBe('idle');
+    });
+
+    it('defaults missing connection to offline and missing online queue to idle', () => {
+        expect(blendRemoteCloneStatus({})).toBe('offline');
+        expect(blendRemoteCloneStatus({ connection: 'online' })).toBe('idle');
     });
 });
 

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -230,7 +230,8 @@ describe('ChatDetail', () => {
         });
 
         it('fetches skills from the workspaces API', () => {
-            expect(source).toContain('getSpaCocClient().skills.listAllWorkspace');
+            // AC-07: ChatDetail routes through the clone-aware client.
+            expect(source).toContain('client.skills.listAllWorkspace');
         });
 
         it('initializes useSlashCommands with augmentedSkills', () => {
@@ -317,7 +318,8 @@ describe('ChatDetail', () => {
 
     describe('follow-up send', () => {
         it('sends through the typed processes client message endpoint', () => {
-            expect(USE_SEND_MESSAGE_SOURCE).toContain('getSpaCocClient().processes.sendMessage');
+            // AC-07: the follow-up send is routed to the chat's clone server.
+            expect(USE_SEND_MESSAGE_SOURCE).toContain('getCocClientForWorkspace(workspaceId).processes.sendMessage');
         });
 
         it('sends content in the body', () => {
@@ -417,7 +419,7 @@ describe('ChatDetail', () => {
                 USE_SEND_MESSAGE_SOURCE.indexOf('const sendFollowUp') + 10000,
             );
             // Should NOT set lastFailedMessageRef eagerly before the typed client request
-            const preamble = sendBlock.substring(0, sendBlock.indexOf('await getSpaCocClient().processes.sendMessage'));
+            const preamble = sendBlock.substring(0, sendBlock.indexOf('await getCocClientForWorkspace(workspaceId).processes.sendMessage'));
             expect(preamble).not.toContain('lastFailedMessageRef.current = rawContent');
 
             // Typed client failures converge through the catch path.
@@ -476,13 +478,13 @@ describe('ChatDetail', () => {
     describe('cancel and move-to-top actions', () => {
         it('defines handleCancel that deletes the queue task', () => {
             expect(source).toContain('handleCancel');
-            expect(source).toContain('getSpaCocClient().queue.cancel(bareTaskId)');
+            expect(source).toContain('client.queue.cancel(bareTaskId)');
             expect(source).toContain("SELECT_QUEUE_TASK', id: null");
         });
 
         it('defines handleMoveToTop that POSTs move-to-top', () => {
             expect(source).toContain('handleMoveToTop');
-            expect(source).toContain('getSpaCocClient().queue.moveToTop(bareTaskId)');
+            expect(source).toContain('client.queue.moveToTop(bareTaskId)');
         });
 
         it('passes cancel and moveToTop to PendingTaskInfoPanel', () => {
@@ -1153,7 +1155,7 @@ describe('ChatDetail', () => {
                 source.indexOf('planPatchedRef.current = true'),
                 source.indexOf('planPatchedRef.current = true') + 400,
             );
-            expect(patchBlock).toContain('getSpaCocClient().processes.update');
+            expect(patchBlock).toContain('client.processes.update');
         });
 
         it('PATCH guard checks: no detectedPlanFile, or planPath already set, or metadata already has it', () => {
@@ -1285,7 +1287,7 @@ describe('ChatDetail', () => {
                 source.indexOf('handleCancel'),
                 source.indexOf('handleCancel') + 400,
             );
-            expect(cancelBlock).toContain('getSpaCocClient().queue.cancel(bareTaskId)');
+            expect(cancelBlock).toContain('client.queue.cancel(bareTaskId)');
         });
 
         it('stop button in FollowUpInputArea calls onStop on click', () => {
@@ -1356,7 +1358,7 @@ describe('ChatDetail', () => {
             const handleStopIdx = source.indexOf('handleStop');
             expect(handleStopIdx).toBeGreaterThan(-1);
             const handleStopBlock = source.substring(handleStopIdx, handleStopIdx + 300);
-            expect(handleStopBlock).toContain('getSpaCocClient().processes.cancel');
+            expect(handleStopBlock).toContain('client.processes.cancel');
         });
 
         it('ChatDetail passes onStop={handleStop} to FollowUpInputArea', () => {

--- a/packages/coc/test/spa/react/repos/ChatListPane.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatListPane.test.ts
@@ -252,8 +252,9 @@ describe('ChatListPane pinned chats', () => {
         });
 
         it('deletes chat history through the typed client', () => {
-            expect(source).toContain('getSpaCocClient().workspaces.deleteHistory');
-            expect(source).toContain('getSpaCocClient().queue.deleteHistoryEntry');
+            // AC-07: ChatListPane routes through the clone-aware client (useCocClient).
+            expect(source).toContain('cloneClient.workspaces.deleteHistory');
+            expect(source).toContain('cloneClient.queue.deleteHistoryEntry');
         });
 
         it('shows a confirmation before deleting', () => {
@@ -506,7 +507,7 @@ describe('ChatListPane pinned chats', () => {
                 const dialogIdx = source.indexOf('<SummarizeChatDialog');
                 expect(dialogIdx).toBeGreaterThan(-1);
                 const block = source.substring(dialogIdx, dialogIdx + 1500);
-                expect(block).toContain('getSpaCocClient().queue.summarize');
+                expect(block).toContain('cloneClient.queue.summarize');
             });
 
             it('summarize sends processIds and workspaceId in body', () => {
@@ -557,7 +558,7 @@ describe('ChatListPane pinned chats', () => {
                 const dialogIdx = source.indexOf('<SummarizeChatDialog');
                 expect(dialogIdx).toBeGreaterThan(-1);
                 const block = source.substring(dialogIdx, dialogIdx + 1500);
-                expect(block).toContain('getSpaCocClient().queue.summarize');
+                expect(block).toContain('cloneClient.queue.summarize');
             });
 
             it('summarize calls closeContextMenu before fetch', () => {

--- a/packages/coc/test/spa/react/repos/CommitDetail.classification.test.tsx
+++ b/packages/coc/test/spa/react/repos/CommitDetail.classification.test.tsx
@@ -34,8 +34,39 @@ vi.mock('../../../../src/server/spa/client/react/features/git/hooks/useAllCommit
     }),
 }));
 
+const TWO_FILE_DIFF = {
+    diff: 'diff --git a/src/foo.ts b/src/foo.ts\n--- a/src/foo.ts\n+++ b/src/foo.ts\n@@ -1 +1 @@\n-old\n+new\ndiff --git a/src/bar.ts b/src/bar.ts\n--- a/src/bar.ts\n+++ b/src/bar.ts\n@@ -1 +1 @@\n-old\n+new',
+};
+
 vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
-    fetchApi: () => Promise.resolve({ diff: 'diff --git a/src/foo.ts b/src/foo.ts\n--- a/src/foo.ts\n+++ b/src/foo.ts\n@@ -1 +1 @@\n-old\n+new\ndiff --git a/src/bar.ts b/src/bar.ts\n--- a/src/bar.ts\n+++ b/src/bar.ts\n@@ -1 +1 @@\n-old\n+new' }),
+    fetchApi: () => Promise.resolve(TWO_FILE_DIFF),
+}));
+
+// AC-07: CommitDetail's diff is now fetched through useCachedDiff →
+// requestForWorkspace (cloneRegistry → getCocClientFor + stub.request), so the
+// commit diff must come from the routed client, not just fetchApi. The
+// commitDiffPath builder stays pure.
+const cocStub = {
+    git: {
+        commitDiffPath: (workspaceId: string, hash: string) =>
+            `/workspaces/${encodeURIComponent(workspaceId)}/git/commits/${hash}/diff`,
+    },
+    preferences: {
+        getRepo: vi.fn().mockResolvedValue({}),
+        patchRepo: vi.fn().mockResolvedValue({}),
+    },
+    agentProviders: {
+        getReasoningEfforts: vi.fn().mockResolvedValue({ reasoningEfforts: {} }),
+        getEffortTiers: vi.fn().mockResolvedValue({ effortTiers: {}, defaults: {} }),
+    },
+    request: () => Promise.resolve(TWO_FILE_DIFF),
+};
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => cocStub,
+    getCocClientFor: () => cocStub,
+    toSpaCocRequestOptions: (opts?: unknown) => opts,
+    translateSpaCocClientError: (e: unknown) => { throw e; },
 }));
 
 vi.mock('react-dom', async (importOriginal) => {

--- a/packages/coc/test/spa/react/repos/DiffView.ai-scroll.test.tsx
+++ b/packages/coc/test/spa/react/repos/DiffView.ai-scroll.test.tsx
@@ -17,16 +17,28 @@ vi.mock('../../../../src/server/spa/client/react/features/git/hooks/useDiffComme
     useDiffComments: (...args: any[]) => mockUseDiffComments(...args),
 }));
 
+const DIFF_BODY = { diff: '+added line\n context' };
+
 vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
-    fetchApi: () => Promise.resolve({ diff: '+added line\n context' }),
+    fetchApi: () => Promise.resolve(DIFF_BODY),
 }));
 
+// AC-07: FileDiffPanel fetches diffs via requestForWorkspace (cloneRegistry →
+// getCocClientFor + stub.request); WorkingTreeFileDiff uses
+// useCocClient(ws).git.getWorkingTreeFileDiff. One stub serves both, resolved
+// for the default origin (local workspace).
+const cocStub = {
+    git: {
+        getWorkingTreeFileDiff: () => Promise.resolve(DIFF_BODY),
+    },
+    request: () => Promise.resolve(DIFF_BODY),
+};
+
 vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({
-        git: {
-            getWorkingTreeFileDiff: () => Promise.resolve({ diff: '+added line\n context' }),
-        },
-    }),
+    getSpaCocClient: () => cocStub,
+    getCocClientFor: () => cocStub,
+    toSpaCocRequestOptions: (opts?: unknown) => opts,
+    translateSpaCocClientError: (e: unknown) => { throw e; },
 }));
 
 vi.mock('react-dom', async (importOriginal) => {

--- a/packages/coc/test/spa/react/repos/DiffViewToggle.wiring.test.tsx
+++ b/packages/coc/test/spa/react/repos/DiffViewToggle.wiring.test.tsx
@@ -31,29 +31,46 @@ vi.mock('../../../../src/server/spa/client/react/features/git/hooks/useDiffComme
     }),
 }));
 
+const DIFF_BODY = { diff: '@@ -1,2 +1,2 @@\n-old\n+new' };
+
 vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
-    fetchApi: () => Promise.resolve({ diff: '@@ -1,2 +1,2 @@\n-old\n+new' }),
+    fetchApi: () => Promise.resolve(DIFF_BODY),
 }));
 
+// AC-07: the diff-viewing layer now routes through getCocClientForWorkspace /
+// requestForWorkspace (cloneRegistry), which call getCocClientFor + the stub's
+// generic .request(). Provide a single stub for both getSpaCocClient and
+// getCocClientFor so a default-origin (local) workspace resolves here.
+const cocStub = {
+    git: {
+        commitDiffPath: (workspaceId: string, hash: string) =>
+            `/workspaces/${encodeURIComponent(workspaceId)}/git/commits/${hash}/diff`,
+        commitFileDiffPath: (workspaceId: string, hash: string, filePath: string) =>
+            `/workspaces/${encodeURIComponent(workspaceId)}/git/commits/${hash}/files/${encodeURIComponent(filePath)}/diff`,
+        branchRangeFileDiffPath: (workspaceId: string, filePath: string) =>
+            `/workspaces/${encodeURIComponent(workspaceId)}/git/branch-range/files/${encodeURIComponent(filePath)}/diff`,
+        getWorkingTreeFileDiff: () => Promise.resolve(DIFF_BODY),
+    },
+    explorer: {
+        readBlob: () => Promise.resolve({ content: '', encoding: 'base64', mimeType: 'application/octet-stream' }),
+    },
+    preferences: {
+        getRepo: vi.fn().mockResolvedValue({}),
+        patchRepo: vi.fn().mockResolvedValue({}),
+    },
+    agentProviders: {
+        getReasoningEfforts: vi.fn().mockResolvedValue({ reasoningEfforts: {} }),
+        getEffortTiers: vi.fn().mockResolvedValue({ effortTiers: {}, defaults: {} }),
+    },
+    // Generic transport used by requestForWorkspace (diff fetches).
+    request: () => Promise.resolve(DIFF_BODY),
+};
+
 vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({
-        git: {
-            commitDiffPath: (workspaceId: string, hash: string) =>
-                `/workspaces/${encodeURIComponent(workspaceId)}/git/commits/${hash}/diff`,
-            getWorkingTreeFileDiff: () => Promise.resolve({ diff: '@@ -1,2 +1,2 @@\n-old\n+new' }),
-        },
-        explorer: {
-            readBlob: () => Promise.resolve({ content: '', encoding: 'base64', mimeType: 'application/octet-stream' }),
-        },
-        preferences: {
-            getRepo: vi.fn().mockResolvedValue({}),
-            patchRepo: vi.fn().mockResolvedValue({}),
-        },
-        agentProviders: {
-            getReasoningEfforts: vi.fn().mockResolvedValue({ reasoningEfforts: {} }),
-            getEffortTiers: vi.fn().mockResolvedValue({ effortTiers: {}, defaults: {} }),
-        },
-    }),
+    getSpaCocClient: () => cocStub,
+    getCocClientFor: () => cocStub,
+    toSpaCocRequestOptions: (opts?: unknown) => opts,
+    translateSpaCocClientError: (e: unknown) => { throw e; },
     requestSpaApi: vi.fn().mockResolvedValue(null),
 }));
 

--- a/packages/coc/test/spa/react/repos/FileDiffPanel.test.tsx
+++ b/packages/coc/test/spa/react/repos/FileDiffPanel.test.tsx
@@ -665,6 +665,7 @@ describe('FileDiffPanel', () => {
         expect(mockUseFileDiff).toHaveBeenCalledWith(
             '/ws/branch-range/files/src/foo.ts/diff',
             '/ws/branch-range/files/src/foo.ts/diff?full=true',
+            'ws1',
         );
     });
 
@@ -675,6 +676,7 @@ describe('FileDiffPanel', () => {
         expect(mockUseFileDiff).toHaveBeenCalledWith(
             '/ws/commits/abc123/files/src/foo.ts/diff',
             null,
+            'ws1',
         );
     });
 
@@ -747,6 +749,7 @@ describe('FileDiffPanel', () => {
         expect(mockUseFileDiff).toHaveBeenLastCalledWith(
             `/api/repos/repo1/pull-requests/42/diff/files/src/foo.ts`,
             null,
+            'ws1',
         );
 
         await act(async () => {
@@ -757,6 +760,7 @@ describe('FileDiffPanel', () => {
         expect(mockUseFileDiff).toHaveBeenLastCalledWith(
             `/api/repos/repo1/pull-requests/42/diff/files/src/foo.ts?fullContext=true`,
             null,
+            'ws1',
         );
     });
 
@@ -801,6 +805,7 @@ describe('FileDiffPanel', () => {
         expect(mockUseFileDiff).toHaveBeenLastCalledWith(
             `/api/repos/repo1/pull-requests/42/diff/files/src/foo.ts?fullContext=true`,
             null,
+            'ws1',
         );
 
         // Navigate to a different file
@@ -810,6 +815,7 @@ describe('FileDiffPanel', () => {
         expect(mockUseFileDiff).toHaveBeenLastCalledWith(
             `/api/repos/repo1/pull-requests/42/diff/files/src/bar.ts`,
             null,
+            'ws1',
         );
     });
 });

--- a/packages/coc/test/spa/react/repos/WorkItemHierarchy.layout.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemHierarchy.layout.test.ts
@@ -112,7 +112,9 @@ describe('WorkItemHierarchyTree — structure', () => {
 
     it('fetches tree using coc-client workItems.tree()', () => {
         expect(src).toContain('workItems.tree(');
-        expect(src).toContain('getSpaCocClient()');
+        // AC-07: clone-aware client (useCocClient(workspaceId)) instead of the
+        // default getSpaCocClient() singleton.
+        expect(src).toContain('useCocClient(');
     });
 
     it('has top-level Epic create action', () => {

--- a/packages/coc/test/spa/react/repos/WorkItemSection.grouped.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemSection.grouped.test.ts
@@ -22,7 +22,8 @@ describe('WorkItemSection — grouped endpoint and infinite scroll', () => {
     });
 
     it('uses the typed grouped work item client for initial load', () => {
-        expect(src).toContain('getSpaCocClient().workItems.grouped(workspaceId');
+        // AC-07: routed through the clone-aware client (useCocClient(workspaceId)).
+        expect(src).toContain('client.workItems.grouped(workspaceId');
     });
 
     it('dispatches SET_GROUPED_WORK_ITEMS on initial fetch', () => {
@@ -64,7 +65,7 @@ describe('WorkItemSection — grouped endpoint and infinite scroll', () => {
     });
 
     it('loads more for a specific status using the typed list client with status filter', () => {
-        expect(src).toContain('getSpaCocClient().workItems.list(workspaceId');
+        expect(src).toContain('client.workItems.list(workspaceId');
         expect(src).toContain('status,');
     });
 

--- a/packages/coc/test/spa/react/repos/WorkItemsClientMigration.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemsClientMigration.test.ts
@@ -27,8 +27,8 @@ describe('work items SPA client migration', () => {
     });
 
     it('creates manual and chat-derived work items through client.workItems', () => {
-        expect(createDialog).toContain('getSpaCocClient().workItems.createFromChat(workspaceId');
-        expect(createDialog).toContain('getSpaCocClient().workItems.create(workspaceId');
+        expect(createDialog).toContain('cloneClient.workItems.createFromChat(workspaceId');
+        expect(createDialog).toContain('cloneClient.workItems.create(workspaceId');
         expect(createDialog).not.toContain('/work-items/from-chat');
     });
 

--- a/packages/coc/test/spa/react/repos/cloneRegistry.test.ts
+++ b/packages/coc/test/spa/react/repos/cloneRegistry.test.ts
@@ -1,0 +1,139 @@
+/**
+ * AC-07 — workspace→baseUrl LOOKUP registry.
+ *
+ * The registry is the seam non-React services (explorerApi, notesApi, etc.) use
+ * to route a remote clone's per-clone REST/WS to its server, while local clones
+ * fall through to the default origin client. AC-01's aggregation populates it.
+ *
+ * Guarantees under test:
+ *   • local / unknown ids → undefined → default client (no fallthrough surprises)
+ *   • remote ids → their baseUrl → a client pinned to that origin (no LOCAL client)
+ *   • registration is a FULL replace (dropped remotes stop resolving)
+ *   • cloneApiBase builds an absolute remote REST base for hand-built URLs
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+    cloneApiBase,
+    cloneWsUrlForWorkspace,
+    getCocClientForWorkspace,
+    lookupCloneBaseUrl,
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
+import {
+    getCocClientFor,
+    getSpaCocClient,
+    resetSpaCocClientForTests,
+} from '../../../../src/server/spa/client/react/api/cocClient';
+
+beforeEach(() => {
+    resetCloneRegistryForTests();
+    resetSpaCocClientForTests();
+});
+
+afterEach(() => {
+    resetCloneRegistryForTests();
+    resetSpaCocClientForTests();
+});
+
+describe('lookupCloneBaseUrl', () => {
+    it('returns undefined for a local / unregistered workspace id', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(lookupCloneBaseUrl('local-1')).toBeUndefined();
+    });
+
+    it('returns the remote baseUrl for a registered remote workspace id', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(lookupCloneBaseUrl('remote-1')).toBe('http://127.0.0.1:4000');
+    });
+
+    it('returns undefined for null/undefined/empty ids', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(lookupCloneBaseUrl(undefined)).toBeUndefined();
+        expect(lookupCloneBaseUrl(null)).toBeUndefined();
+        expect(lookupCloneBaseUrl('')).toBeUndefined();
+    });
+
+    it('full-replaces on each registration (a dropped remote stops resolving)', () => {
+        registerCloneBaseUrls([
+            { workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' },
+            { workspaceId: 'remote-2', baseUrl: 'http://127.0.0.1:4001' },
+        ]);
+        expect(lookupCloneBaseUrl('remote-2')).toBe('http://127.0.0.1:4001');
+
+        // A later refresh only sees remote-1 (remote-2's server went away).
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(lookupCloneBaseUrl('remote-1')).toBe('http://127.0.0.1:4000');
+        expect(lookupCloneBaseUrl('remote-2')).toBeUndefined();
+    });
+
+    it('tracks devtunnel port reassignment (same id, new baseUrl)', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:9999' }]);
+        expect(lookupCloneBaseUrl('remote-1')).toBe('http://127.0.0.1:9999');
+    });
+
+    it('ignores entries with a missing id or baseUrl', () => {
+        registerCloneBaseUrls([
+            { workspaceId: '', baseUrl: 'http://127.0.0.1:4000' },
+            { workspaceId: 'remote-1', baseUrl: '' },
+        ]);
+        expect(lookupCloneBaseUrl('remote-1')).toBeUndefined();
+    });
+});
+
+describe('getCocClientForWorkspace', () => {
+    it('returns the default LOCAL singleton for a local / unknown id (no fallthrough to a remote)', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(getCocClientForWorkspace('local-1')).toBe(getSpaCocClient());
+        expect(getCocClientForWorkspace(undefined)).toBe(getSpaCocClient());
+    });
+
+    it('returns a REMOTE-routed client for a remote id, never the local singleton', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        const client = getCocClientForWorkspace('remote-1');
+        expect(client).toBe(getCocClientFor('http://127.0.0.1:4000'));
+        expect(client.options.baseUrl).toBe('http://127.0.0.1:4000');
+        // No local fallthrough: the remote clone's client is NOT the default origin one.
+        expect(client).not.toBe(getSpaCocClient());
+    });
+
+    it('routes two different remote clones to two different servers', () => {
+        registerCloneBaseUrls([
+            { workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' },
+            { workspaceId: 'remote-2', baseUrl: 'http://127.0.0.1:4001' },
+        ]);
+        expect(getCocClientForWorkspace('remote-1').options.baseUrl).toBe('http://127.0.0.1:4000');
+        expect(getCocClientForWorkspace('remote-2').options.baseUrl).toBe('http://127.0.0.1:4001');
+    });
+});
+
+describe('cloneApiBase', () => {
+    it('returns the default local /api base for a local id', () => {
+        // jsdom: no remote registered → the default page-origin api base.
+        expect(cloneApiBase('local-1')).toBe('/api');
+    });
+
+    it('returns an absolute remote REST base for a remote id', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(cloneApiBase('remote-1')).toBe('http://127.0.0.1:4000/api');
+    });
+
+    it('strips a trailing slash on the remote baseUrl before appending /api', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000/' }]);
+        expect(cloneApiBase('remote-1')).toBe('http://127.0.0.1:4000/api');
+    });
+});
+
+describe('cloneWsUrlForWorkspace', () => {
+    it('builds a page-origin WS URL for a local id', () => {
+        expect(cloneWsUrlForWorkspace('/ws', 'local-1')).toMatch(/^ws:\/\/localhost(:\d+)?\/ws$/);
+    });
+
+    it('builds a remote WS URL (with verbatim query) for a remote id', () => {
+        registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
+        expect(cloneWsUrlForWorkspace('/ws/terminal?workspaceId=remote-1', 'remote-1'))
+            .toBe('ws://127.0.0.1:4000/ws/terminal?workspaceId=remote-1');
+    });
+});

--- a/packages/coc/test/spa/react/repos/cloneRouting.git.test.ts
+++ b/packages/coc/test/spa/react/repos/cloneRouting.git.test.ts
@@ -1,0 +1,220 @@
+/**
+ * AC-07 — per-clone routing for the git DIFF-VIEWING layer.
+ *
+ * The working-tree file list, single-file diffs, and diff-comment fetches must
+ * land on a remote clone's OWN server (its baseUrl), and a local clone's on the
+ * default origin — with NO local fallthrough for remote clones. We mock the
+ * client factory so each clone resolves to a tagged stub and assert the call
+ * landed on the right one.
+ *
+ * Mirrors cloneRouting.tabs.test.ts (explorer/notes/activity) for the git tab.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, renderHook, waitFor } from '@testing-library/react';
+
+// ── Mock the client factory layer ────────────────────────────────────────────
+// getSpaCocClient → the LOCAL stub; getCocClientFor(baseUrl) → a per-baseUrl stub.
+// Each stub records which baseUrl handled a call so tests can assert routing.
+
+interface StubClient {
+    baseUrl: string;
+    git: Record<string, ReturnType<typeof vi.fn>>;
+    preferences: Record<string, ReturnType<typeof vi.fn>>;
+    request: ReturnType<typeof vi.fn>;
+}
+
+const stubsByBaseUrl = new Map<string, StubClient>();
+
+function makeStub(baseUrl: string): StubClient {
+    return {
+        baseUrl,
+        git: {
+            getWorkingTreeChanges: vi.fn(async () => ({ changes: [], baseUrl })),
+            getWorkingTreeFileDiff: vi.fn(async () => ({ diff: `diff@${baseUrl}`, truncated: false, totalLines: 0 })),
+            listDiffComments: vi.fn(async () => ({ comments: [], baseUrl })),
+            getDiffCommentCounts: vi.fn(async () => ({ counts: {} })),
+            getDiffCommentTotals: vi.fn(async () => ({ totals: {} })),
+            // Path builders are pure — return a stable relative path regardless of stub.
+            commitFileDiffPath: vi.fn((ws: string, hash: string, fp: string) =>
+                `/workspaces/${ws}/git/commits/${hash}/files/${encodeURIComponent(fp)}/diff`),
+            commitDiffPath: vi.fn((ws: string, hash: string) =>
+                `/workspaces/${ws}/git/commits/${hash}/diff`),
+            branchRangeFileDiffPath: vi.fn((ws: string, fp: string) =>
+                `/workspaces/${ws}/git/branch-range/files/${encodeURIComponent(fp)}/diff`),
+            stageFile: vi.fn(async () => ({ success: true, baseUrl })),
+        },
+        preferences: {
+            getRepo: vi.fn(async () => ({})),
+        },
+        // The generic transport used by requestForWorkspace (diff fetches).
+        request: vi.fn(async (path: string) => ({ diff: `body@${baseUrl}:${path}`, truncated: false, totalLines: 0 })),
+    };
+}
+
+const LOCAL = makeStub('LOCAL');
+
+function clientFor(baseUrl?: string): StubClient {
+    if (!baseUrl) return LOCAL;
+    let stub = stubsByBaseUrl.get(baseUrl);
+    if (!stub) {
+        stub = makeStub(baseUrl);
+        stubsByBaseUrl.set(baseUrl, stub);
+    }
+    return stub;
+}
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => LOCAL,
+    getCocClientFor: (baseUrl?: string) => clientFor(baseUrl),
+    // cloneRegistry imports these; keep them passthrough so requestForWorkspace's
+    // error translation and option mapping behave like production.
+    toSpaCocRequestOptions: (opts?: unknown) => opts,
+    translateSpaCocClientError: (e: unknown) => { throw e; },
+}));
+
+// cloneRegistry reads getApiBase().
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    getApiBase: () => '/api',
+}));
+
+// Import after mocks.
+import {
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+    getCocClientForWorkspace,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
+import { useCocClient } from '../../../../src/server/spa/client/react/repos/cloneRouting';
+import { fetchDiffFromSource } from '../../../../src/server/spa/client/react/features/git/diff/diffSource';
+import { createElement } from 'react';
+import { WorkingTree } from '../../../../src/server/spa/client/react/features/git/working-tree/WorkingTree';
+
+const REMOTE_WS = 'remote-ws';
+const REMOTE_URL = 'http://127.0.0.1:4000';
+const LOCAL_WS = 'local-ws';
+
+function clearAllMocks(stub: StubClient): void {
+    for (const fn of Object.values(stub.git)) fn.mockClear();
+    for (const fn of Object.values(stub.preferences)) fn.mockClear();
+    stub.request.mockClear();
+}
+
+beforeEach(() => {
+    resetCloneRegistryForTests();
+    stubsByBaseUrl.clear();
+    clearAllMocks(LOCAL);
+    registerCloneBaseUrls([{ workspaceId: REMOTE_WS, baseUrl: REMOTE_URL }]);
+});
+
+afterEach(() => {
+    resetCloneRegistryForTests();
+});
+
+// ── Working-tree file list (WorkingTree.getWorkingTreeChanges) ─────────────────
+
+describe('Working-tree changes routing (useCocClient)', () => {
+    it('loads a remote clone working-tree change list from the REMOTE server', async () => {
+        const { result } = renderHook(() => useCocClient(REMOTE_WS));
+        const client = result.current as unknown as StubClient;
+
+        await client.git.getWorkingTreeChanges(REMOTE_WS);
+
+        expect(clientFor(REMOTE_URL).git.getWorkingTreeChanges).toHaveBeenCalledWith(REMOTE_WS);
+        // No local fallthrough for a remote clone.
+        expect(LOCAL.git.getWorkingTreeChanges).not.toHaveBeenCalled();
+    });
+
+    it('loads a LOCAL clone working-tree change list from the default origin client', async () => {
+        const { result } = renderHook(() => useCocClient(LOCAL_WS));
+        const client = result.current as unknown as StubClient;
+
+        await client.git.getWorkingTreeChanges(LOCAL_WS);
+
+        expect(LOCAL.git.getWorkingTreeChanges).toHaveBeenCalledWith(LOCAL_WS);
+        // The remote server stub must not even be created for a local id.
+        expect(stubsByBaseUrl.has(REMOTE_URL)).toBe(false);
+    });
+});
+
+// ── Working-tree comment list (listDiffComments) ──────────────────────────────
+
+describe('Working-tree comment routing (useCocClient)', () => {
+    it('reads a remote clone working-tree comments from the REMOTE server', async () => {
+        const { result } = renderHook(() => useCocClient(REMOTE_WS));
+        const client = result.current as unknown as StubClient;
+
+        await client.git.listDiffComments(REMOTE_WS, { newRef: 'working-tree' });
+
+        expect(clientFor(REMOTE_URL).git.listDiffComments).toHaveBeenCalledWith(REMOTE_WS, { newRef: 'working-tree' });
+        expect(LOCAL.git.listDiffComments).not.toHaveBeenCalled();
+    });
+});
+
+// ── Single-file diff fetch (fetchDiffFromSource → requestForWorkspace) ─────────
+
+describe('Diff fetch routing (fetchDiffFromSource)', () => {
+    it('fetches a remote clone diff from the REMOTE server (no local fallthrough)', async () => {
+        const url = `/workspaces/${REMOTE_WS}/git/commits/abc123/files/src%2Ffoo.ts/diff`;
+        const result = await fetchDiffFromSource(REMOTE_WS, url);
+
+        const remote = clientFor(REMOTE_URL);
+        expect(remote.request).toHaveBeenCalledWith(url, undefined);
+        expect(result.diff).toBe(`body@${REMOTE_URL}:${url}`);
+        // Must NOT hit the default origin client for a remote clone.
+        expect(LOCAL.request).not.toHaveBeenCalled();
+    });
+
+    it('fetches a LOCAL clone diff from the default origin client', async () => {
+        const url = `/workspaces/${LOCAL_WS}/git/commits/abc123/files/src%2Ffoo.ts/diff`;
+        const result = await fetchDiffFromSource(LOCAL_WS, url);
+
+        expect(LOCAL.request).toHaveBeenCalledWith(url, undefined);
+        expect(result.diff).toBe(`body@LOCAL:${url}`);
+        expect(stubsByBaseUrl.has(REMOTE_URL)).toBe(false);
+    });
+});
+
+// ── Non-hook seam used by WorkingTree's siblings (getCocClientForWorkspace) ────
+
+describe('Working-tree action routing (getCocClientForWorkspace)', () => {
+    it('routes a remote clone stage-file action to the REMOTE server', async () => {
+        await getCocClientForWorkspace(REMOTE_WS).git.stageFile(REMOTE_WS, 'a.ts');
+        expect(clientFor(REMOTE_URL).git.stageFile).toHaveBeenCalledWith(REMOTE_WS, 'a.ts');
+        expect(LOCAL.git.stageFile).not.toHaveBeenCalled();
+    });
+
+    it('routes a LOCAL clone stage-file action to the default origin client', async () => {
+        await getCocClientForWorkspace(LOCAL_WS).git.stageFile(LOCAL_WS, 'a.ts');
+        expect(LOCAL.git.stageFile).toHaveBeenCalledWith(LOCAL_WS, 'a.ts');
+        expect(stubsByBaseUrl.has(REMOTE_URL)).toBe(false);
+    });
+});
+
+// ── End-to-end: the real WorkingTree component wires the clone client ──────────
+
+describe('WorkingTree component routing (end-to-end)', () => {
+    it('fetches a remote clone working-tree from the REMOTE server on mount', async () => {
+        render(createElement(WorkingTree, { workspaceId: REMOTE_WS }));
+
+        await waitFor(() =>
+            expect(clientFor(REMOTE_URL).git.getWorkingTreeChanges).toHaveBeenCalledWith(REMOTE_WS),
+        );
+        // The comment-count badge fetch also routes to the remote server.
+        await waitFor(() =>
+            expect(clientFor(REMOTE_URL).git.listDiffComments).toHaveBeenCalledWith(REMOTE_WS, { newRef: 'working-tree' }),
+        );
+        // No local fallthrough for a remote clone.
+        expect(LOCAL.git.getWorkingTreeChanges).not.toHaveBeenCalled();
+        expect(LOCAL.git.listDiffComments).not.toHaveBeenCalled();
+    });
+
+    it('fetches a LOCAL clone working-tree from the default origin client on mount', async () => {
+        render(createElement(WorkingTree, { workspaceId: LOCAL_WS }));
+
+        await waitFor(() =>
+            expect(LOCAL.git.getWorkingTreeChanges).toHaveBeenCalledWith(LOCAL_WS),
+        );
+        // The remote server stub must not be created for a local id.
+        expect(stubsByBaseUrl.has(REMOTE_URL)).toBe(false);
+    });
+});

--- a/packages/coc/test/spa/react/repos/cloneRouting.tabs.test.ts
+++ b/packages/coc/test/spa/react/repos/cloneRouting.tabs.test.ts
@@ -1,0 +1,161 @@
+/**
+ * AC-07 — per-tab remote routing through the workspace→baseUrl lookup registry.
+ *
+ * Each in-scope tab's NON-React data service (explorer, notes) must send a remote
+ * clone's clone-scoped REST to that clone's server (its baseUrl), and a local
+ * clone's to the default origin client — with NO local fallthrough for remote
+ * clones. We mock the client factory so each clone resolves to a tagged stub and
+ * assert the call landed on the right one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock the client factory layer ────────────────────────────────────────────
+// getSpaCocClient → the LOCAL stub; getCocClientFor(baseUrl) → a per-baseUrl stub.
+// Each stub records which baseUrl handled a call so tests can assert routing.
+
+interface StubClient {
+    baseUrl: string;
+    explorer: Record<string, ReturnType<typeof vi.fn>>;
+    notes: Record<string, ReturnType<typeof vi.fn>>;
+    processes: Record<string, ReturnType<typeof vi.fn>>;
+}
+
+const stubsByBaseUrl = new Map<string, StubClient>();
+
+function makeStub(baseUrl: string): StubClient {
+    return {
+        baseUrl,
+        explorer: {
+            tree: vi.fn(async () => ({ baseUrl })),
+            writeBlob: vi.fn(async () => ({ success: true, baseUrl })),
+            readTrustedBlob: vi.fn(async () => ({ baseUrl })),
+        },
+        notes: {
+            getTree: vi.fn(async () => ({ baseUrl })),
+            saveContent: vi.fn(async () => ({ baseUrl })),
+        },
+        processes: {
+            sendMessage: vi.fn(async () => ({ baseUrl })),
+            promoteToRalph: vi.fn(async () => ({ baseUrl })),
+        },
+    };
+}
+
+const LOCAL = makeStub('LOCAL');
+
+function clientFor(baseUrl?: string): StubClient {
+    if (!baseUrl) return LOCAL;
+    let stub = stubsByBaseUrl.get(baseUrl);
+    if (!stub) {
+        stub = makeStub(baseUrl);
+        stubsByBaseUrl.set(baseUrl, stub);
+    }
+    return stub;
+}
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => LOCAL,
+    getCocClientFor: (baseUrl?: string) => clientFor(baseUrl),
+    // notesApi imports these error translators; keep them passthrough.
+    translateSpaCocClientError: (e: unknown) => { throw e; },
+    getSpaCocClientErrorMessage: () => 'err',
+}));
+
+// Config: notesApi reads isCommitChatLensEnabled; cloneRegistry reads getApiBase.
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isCommitChatLensEnabled: () => false,
+    getApiBase: () => '/api',
+}));
+
+// Import after mocks.
+import {
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+    getCocClientForWorkspace,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
+import { explorerApi } from '../../../../src/server/spa/client/react/features/repo-detail/explorer/explorerApi';
+import { notesApi } from '../../../../src/server/spa/client/react/features/notes/notesApi';
+
+const REMOTE_WS = 'remote-ws';
+const REMOTE_URL = 'http://127.0.0.1:4000';
+const LOCAL_WS = 'local-ws';
+
+beforeEach(() => {
+    resetCloneRegistryForTests();
+    stubsByBaseUrl.clear();
+    LOCAL.explorer.tree.mockClear();
+    LOCAL.explorer.writeBlob.mockClear();
+    LOCAL.notes.getTree.mockClear();
+    LOCAL.notes.saveContent.mockClear();
+    registerCloneBaseUrls([{ workspaceId: REMOTE_WS, baseUrl: REMOTE_URL }]);
+});
+
+afterEach(() => {
+    resetCloneRegistryForTests();
+});
+
+// ── Explorer tab ──────────────────────────────────────────────────────────────
+
+describe('Explorer tab routing', () => {
+    it('reads a remote clone tree from the remote server (not local)', async () => {
+        await explorerApi.tree(REMOTE_WS);
+        expect(clientFor(REMOTE_URL).explorer.tree).toHaveBeenCalledWith(REMOTE_WS, undefined);
+        expect(LOCAL.explorer.tree).not.toHaveBeenCalled();
+    });
+
+    it('writes a remote clone blob to the remote server (write action)', async () => {
+        await explorerApi.writeBlob(REMOTE_WS, 'a.txt', 'hi');
+        expect(clientFor(REMOTE_URL).explorer.writeBlob).toHaveBeenCalledWith(REMOTE_WS, 'a.txt', 'hi');
+        expect(LOCAL.explorer.writeBlob).not.toHaveBeenCalled();
+    });
+
+    it('reads a LOCAL clone tree from the default origin client', async () => {
+        await explorerApi.tree(LOCAL_WS);
+        expect(LOCAL.explorer.tree).toHaveBeenCalledWith(LOCAL_WS, undefined);
+        // The remote server stub must NOT have been created/used for a local id.
+        expect(stubsByBaseUrl.has(REMOTE_URL)).toBe(false);
+    });
+});
+
+// ── Notes tab ───────────────────────────────────────────────────────────────
+
+describe('Notes tab routing', () => {
+    it('reads a remote clone note tree from the remote server', async () => {
+        await notesApi.getTree(REMOTE_WS);
+        expect(clientFor(REMOTE_URL).notes.getTree).toHaveBeenCalledWith(REMOTE_WS, undefined);
+        expect(LOCAL.notes.getTree).not.toHaveBeenCalled();
+    });
+
+    it('saves a remote clone note to the remote server (write action)', async () => {
+        await notesApi.saveContent(REMOTE_WS, 'n.md', 'body');
+        expect(clientFor(REMOTE_URL).notes.saveContent).toHaveBeenCalledWith(REMOTE_WS, 'n.md', 'body', undefined, undefined);
+        expect(LOCAL.notes.saveContent).not.toHaveBeenCalled();
+    });
+
+    it('reads a LOCAL clone note tree from the default origin client', async () => {
+        await notesApi.getTree(LOCAL_WS);
+        expect(LOCAL.notes.getTree).toHaveBeenCalledWith(LOCAL_WS, undefined);
+    });
+});
+
+// ── WRITE-action seam shared by the Activity tab (useSendMessage) ──────────────
+
+describe('Activity write-action routing (getCocClientForWorkspace)', () => {
+    it('routes a remote clone chat send to the remote server', async () => {
+        await getCocClientForWorkspace(REMOTE_WS).processes.sendMessage('proc-1', { content: 'hi' } as never);
+        expect(clientFor(REMOTE_URL).processes.sendMessage).toHaveBeenCalled();
+        expect(LOCAL.processes.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('routes a remote clone Ralph promotion to the remote server', async () => {
+        await getCocClientForWorkspace(REMOTE_WS).processes.promoteToRalph('proc-1', {} as never);
+        expect(clientFor(REMOTE_URL).processes.promoteToRalph).toHaveBeenCalled();
+        expect(LOCAL.processes.promoteToRalph).not.toHaveBeenCalled();
+    });
+
+    it('routes a LOCAL clone chat send to the default origin client', async () => {
+        await getCocClientForWorkspace(LOCAL_WS).processes.sendMessage('proc-1', { content: 'hi' } as never);
+        expect(LOCAL.processes.sendMessage).toHaveBeenCalled();
+    });
+});

--- a/packages/coc/test/spa/react/repos/cloneRouting.tabs.test.ts
+++ b/packages/coc/test/spa/react/repos/cloneRouting.tabs.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 
 // ── Mock the client factory layer ────────────────────────────────────────────
 // getSpaCocClient → the LOCAL stub; getCocClientFor(baseUrl) → a per-baseUrl stub.
@@ -19,6 +20,9 @@ interface StubClient {
     explorer: Record<string, ReturnType<typeof vi.fn>>;
     notes: Record<string, ReturnType<typeof vi.fn>>;
     processes: Record<string, ReturnType<typeof vi.fn>>;
+    workspaces: Record<string, ReturnType<typeof vi.fn>>;
+    queue: Record<string, ReturnType<typeof vi.fn>>;
+    seenState: Record<string, ReturnType<typeof vi.fn>>;
 }
 
 const stubsByBaseUrl = new Map<string, StubClient>();
@@ -38,6 +42,18 @@ function makeStub(baseUrl: string): StubClient {
         processes: {
             sendMessage: vi.fn(async () => ({ baseUrl })),
             promoteToRalph: vi.fn(async () => ({ baseUrl })),
+            listGroupPins: vi.fn(async () => []),
+        },
+        // Activity-tab conversation LIST domains (the path that regressed).
+        workspaces: {
+            history: vi.fn(async () => ({ items: [], hasMore: false, baseUrl })),
+        },
+        queue: {
+            list: vi.fn(async () => ({ tasks: [], baseUrl })),
+        },
+        seenState: {
+            getMap: vi.fn(async () => ({})),
+            getUnseenCount: vi.fn(async () => ({ unseenCount: 0 })),
         },
     };
 }
@@ -76,18 +92,23 @@ import {
 } from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 import { explorerApi } from '../../../../src/server/spa/client/react/features/repo-detail/explorer/explorerApi';
 import { notesApi } from '../../../../src/server/spa/client/react/features/notes/notesApi';
+import { useCocClient } from '../../../../src/server/spa/client/react/repos/cloneRouting';
+import { fetchSeenMap, fetchUnseenCount } from '../../../../src/server/spa/client/react/hooks/preferences/seenStateApi';
 
 const REMOTE_WS = 'remote-ws';
 const REMOTE_URL = 'http://127.0.0.1:4000';
 const LOCAL_WS = 'local-ws';
 
+function clearAllMocks(stub: StubClient): void {
+    for (const domain of [stub.explorer, stub.notes, stub.processes, stub.workspaces, stub.queue, stub.seenState]) {
+        for (const fn of Object.values(domain)) fn.mockClear();
+    }
+}
+
 beforeEach(() => {
     resetCloneRegistryForTests();
     stubsByBaseUrl.clear();
-    LOCAL.explorer.tree.mockClear();
-    LOCAL.explorer.writeBlob.mockClear();
-    LOCAL.notes.getTree.mockClear();
-    LOCAL.notes.saveContent.mockClear();
+    clearAllMocks(LOCAL);
     registerCloneBaseUrls([{ workspaceId: REMOTE_WS, baseUrl: REMOTE_URL }]);
 });
 
@@ -157,5 +178,60 @@ describe('Activity write-action routing (getCocClientForWorkspace)', () => {
     it('routes a LOCAL clone chat send to the default origin client', async () => {
         await getCocClientForWorkspace(LOCAL_WS).processes.sendMessage('proc-1', { content: 'hi' } as never);
         expect(LOCAL.processes.sendMessage).toHaveBeenCalled();
+    });
+});
+
+// ── Activity conversation LIST routing (RepoChatTab / ChatListPane path) ───────
+// REGRESSION: the conversation LIST + queue fetch used getSpaCocClient() (LOCAL)
+// even for a remote clone, leaving the Activity tab empty. RepoChatTab now resolves
+// the list client via useCocClient(workspaceId); these assert that resolution.
+
+describe('Activity conversation-list routing (useCocClient)', () => {
+    it('loads the conversation history + queue + group-pins from the REMOTE server for a remote clone', async () => {
+        const { result } = renderHook(() => useCocClient(REMOTE_WS));
+        const client = result.current as unknown as StubClient;
+
+        await client.workspaces.history(REMOTE_WS, { limit: 100, offset: 0 });
+        await client.queue.list({ repoId: REMOTE_WS });
+        await client.processes.listGroupPins(REMOTE_WS);
+
+        const remote = clientFor(REMOTE_URL);
+        expect(remote.workspaces.history).toHaveBeenCalledWith(REMOTE_WS, { limit: 100, offset: 0 });
+        expect(remote.queue.list).toHaveBeenCalledWith({ repoId: REMOTE_WS });
+        expect(remote.processes.listGroupPins).toHaveBeenCalledWith(REMOTE_WS);
+        // No local fallthrough: the list must NOT hit the default origin client.
+        expect(LOCAL.workspaces.history).not.toHaveBeenCalled();
+        expect(LOCAL.queue.list).not.toHaveBeenCalled();
+        expect(LOCAL.processes.listGroupPins).not.toHaveBeenCalled();
+    });
+
+    it('loads the conversation history + queue from the default origin client for a LOCAL clone', async () => {
+        const { result } = renderHook(() => useCocClient(LOCAL_WS));
+        const client = result.current as unknown as StubClient;
+
+        await client.workspaces.history(LOCAL_WS, { limit: 100, offset: 0 });
+        await client.queue.list({ repoId: LOCAL_WS });
+
+        expect(LOCAL.workspaces.history).toHaveBeenCalledWith(LOCAL_WS, { limit: 100, offset: 0 });
+        expect(LOCAL.queue.list).toHaveBeenCalledWith({ repoId: LOCAL_WS });
+        // The remote server stub must not even be created for a local id.
+        expect(stubsByBaseUrl.has(REMOTE_URL)).toBe(false);
+    });
+});
+
+// ── Seen-state routing (useUnseenChat → seenStateApi, non-React) ───────────────
+
+describe('Seen-state routing (seenStateApi)', () => {
+    it('reads a remote clone seen-map + unseen-count from the remote server', async () => {
+        await fetchSeenMap(REMOTE_WS);
+        await fetchUnseenCount(REMOTE_WS);
+        expect(clientFor(REMOTE_URL).seenState.getMap).toHaveBeenCalledWith(REMOTE_WS);
+        expect(clientFor(REMOTE_URL).seenState.getUnseenCount).toHaveBeenCalledWith(REMOTE_WS);
+        expect(LOCAL.seenState.getMap).not.toHaveBeenCalled();
+    });
+
+    it('reads a LOCAL clone seen-map from the default origin client', async () => {
+        await fetchSeenMap(LOCAL_WS);
+        expect(LOCAL.seenState.getMap).toHaveBeenCalledWith(LOCAL_WS);
     });
 });

--- a/packages/coc/test/spa/react/repos/cloneRouting.test.tsx
+++ b/packages/coc/test/spa/react/repos/cloneRouting.test.tsx
@@ -2,21 +2,19 @@
  * AC-03 — clone→baseUrl resolver and the React routing hooks.
  *
  * resolveCloneBaseUrl is pure (workspace object or id + repos list → baseUrl).
- * The hooks (useResolveCloneBaseUrl / useCocClient / useCloneWsUrl) read the live
- * ReposContext repo list; ReposContext is mocked so no real fetching occurs.
+ * The hooks (useResolveCloneBaseUrl / useCocClient / useCloneWsUrl) resolve a bare
+ * workspace id through the module-level clone registry (no React context), so
+ * they need no ReposProvider; the registry is driven directly in the hook cases.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { WorkspaceInfo } from '@plusplusoneplusplus/coc-client';
 import { tagRemoteWorkspaces } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
 import type { RepoData } from '../../../../src/server/spa/client/react/repos/repoGrouping';
 
-// ── ReposContext mock (drives the hooks) ─────────────────────────────────────
+// Backing list for the PURE resolveCloneBaseUrl(ref, repos) cases (explicit list).
 let mockRepos: RepoData[] = [];
-vi.mock('../../../../src/server/spa/client/react/contexts/ReposContext', () => ({
-    useRepos: () => ({ repos: mockRepos, loading: false, fetchRepos: vi.fn(), unseenCounts: {} }),
-}));
 
 import {
     resolveCloneBaseUrl,
@@ -24,6 +22,10 @@ import {
     useCocClient,
     useCloneWsUrl,
 } from '../../../../src/server/spa/client/react/repos/cloneRouting';
+import {
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 import { getCocClientFor, getSpaCocClient, resetSpaCocClientForTests } from '../../../../src/server/spa/client/react/api/cocClient';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -44,10 +46,12 @@ function repo(workspace: WorkspaceInfo | ReturnType<typeof remoteWs>): RepoData 
 beforeEach(() => {
     mockRepos = [];
     resetSpaCocClientForTests();
+    resetCloneRegistryForTests();
 });
 
 afterEach(() => {
     resetSpaCocClientForTests();
+    resetCloneRegistryForTests();
 });
 
 // ── resolveCloneBaseUrl (pure) ───────────────────────────────────────────────
@@ -93,17 +97,22 @@ describe('resolveCloneBaseUrl', () => {
 // ── hooks ────────────────────────────────────────────────────────────────────
 
 describe('useResolveCloneBaseUrl', () => {
-    it('resolves ids against the live repos list', () => {
-        mockRepos = [repo(remoteWs('w1', 'http://127.0.0.1:4002'))];
+    it('resolves a bare id against the clone registry', () => {
+        registerCloneBaseUrls([{ workspaceId: 'w1', baseUrl: 'http://127.0.0.1:4002' }]);
         const { result } = renderHook(() => useResolveCloneBaseUrl());
         expect(result.current('w1')).toBe('http://127.0.0.1:4002');
         expect(result.current('local')).toBeUndefined();
+    });
+
+    it('resolves a workspace object directly from its remote marker (no registry needed)', () => {
+        const { result } = renderHook(() => useResolveCloneBaseUrl());
+        expect(result.current(remoteWs('w2', 'http://127.0.0.1:4005'))).toBe('http://127.0.0.1:4005');
+        expect(result.current(localWs('w3'))).toBeUndefined();
     });
 });
 
 describe('useCocClient', () => {
     it('returns the default singleton for a local / unknown clone', () => {
-        mockRepos = [repo(localWs('local'))];
         const { result } = renderHook(() => useCocClient('local'));
         expect(result.current).toBe(getSpaCocClient());
     });
@@ -113,25 +122,30 @@ describe('useCocClient', () => {
         expect(result.current).toBe(getSpaCocClient());
     });
 
-    it('returns a remote-routed client for a remote clone', () => {
-        mockRepos = [repo(remoteWs('w1', 'http://127.0.0.1:4003'))];
+    it('returns a remote-routed client for a remote clone (by id via the registry)', () => {
+        registerCloneBaseUrls([{ workspaceId: 'w1', baseUrl: 'http://127.0.0.1:4003' }]);
         const { result } = renderHook(() => useCocClient('w1'));
         expect(result.current).toBe(getCocClientFor('http://127.0.0.1:4003'));
         expect(result.current.options.baseUrl).toBe('http://127.0.0.1:4003');
+        expect(result.current).not.toBe(getSpaCocClient());
+    });
+
+    it('returns a remote-routed client for a remote workspace object', () => {
+        const { result } = renderHook(() => useCocClient(remoteWs('w1', 'http://127.0.0.1:4006')));
+        expect(result.current.options.baseUrl).toBe('http://127.0.0.1:4006');
         expect(result.current).not.toBe(getSpaCocClient());
     });
 });
 
 describe('useCloneWsUrl', () => {
     it('builds page-origin WS URLs for a local clone', () => {
-        mockRepos = [repo(localWs('local'))];
         const { result } = renderHook(() => useCloneWsUrl('local'));
         // jsdom default origin is http://localhost:3000 → ws://localhost:3000
         expect(result.current('/ws')).toMatch(/^ws:\/\/localhost(:\d+)?\/ws$/);
     });
 
-    it('builds remote WS URLs for a remote clone', () => {
-        mockRepos = [repo(remoteWs('w1', 'http://127.0.0.1:4004'))];
+    it('builds remote WS URLs for a remote clone (by id via the registry)', () => {
+        registerCloneBaseUrls([{ workspaceId: 'w1', baseUrl: 'http://127.0.0.1:4004' }]);
         const { result } = renderHook(() => useCloneWsUrl('w1'));
         expect(result.current('/ws')).toBe('ws://127.0.0.1:4004/ws');
         expect(result.current('/ws/terminal?workspaceId=w1')).toBe('ws://127.0.0.1:4004/ws/terminal?workspaceId=w1');

--- a/packages/coc/test/spa/react/repos/cloneRouting.test.tsx
+++ b/packages/coc/test/spa/react/repos/cloneRouting.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * AC-03 — clone→baseUrl resolver and the React routing hooks.
+ *
+ * resolveCloneBaseUrl is pure (workspace object or id + repos list → baseUrl).
+ * The hooks (useResolveCloneBaseUrl / useCocClient / useCloneWsUrl) read the live
+ * ReposContext repo list; ReposContext is mocked so no real fetching occurs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { WorkspaceInfo } from '@plusplusoneplusplus/coc-client';
+import { tagRemoteWorkspaces } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
+import type { RepoData } from '../../../../src/server/spa/client/react/repos/repoGrouping';
+
+// ── ReposContext mock (drives the hooks) ─────────────────────────────────────
+let mockRepos: RepoData[] = [];
+vi.mock('../../../../src/server/spa/client/react/contexts/ReposContext', () => ({
+    useRepos: () => ({ repos: mockRepos, loading: false, fetchRepos: vi.fn(), unseenCounts: {} }),
+}));
+
+import {
+    resolveCloneBaseUrl,
+    useResolveCloneBaseUrl,
+    useCocClient,
+    useCloneWsUrl,
+} from '../../../../src/server/spa/client/react/repos/cloneRouting';
+import { getCocClientFor, getSpaCocClient, resetSpaCocClientForTests } from '../../../../src/server/spa/client/react/api/cocClient';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function localWs(id: string, name = id): WorkspaceInfo {
+    return { id, name, rootPath: `/repos/${id}` };
+}
+
+/** Build a remote-tagged workspace via AC-01's tagger so the marker shape stays in sync. */
+function remoteWs(id: string, baseUrl: string, serverId = 'srv', serverLabel = 'Server') {
+    return tagRemoteWorkspaces({ id: serverId, label: serverLabel }, baseUrl, [localWs(id)], false)[0];
+}
+
+function repo(workspace: WorkspaceInfo | ReturnType<typeof remoteWs>): RepoData {
+    return { workspace };
+}
+
+beforeEach(() => {
+    mockRepos = [];
+    resetSpaCocClientForTests();
+});
+
+afterEach(() => {
+    resetSpaCocClientForTests();
+});
+
+// ── resolveCloneBaseUrl (pure) ───────────────────────────────────────────────
+
+describe('resolveCloneBaseUrl', () => {
+    it('returns the baseUrl when given a remote workspace object directly', () => {
+        const ws = remoteWs('w1', 'http://127.0.0.1:4000');
+        expect(resolveCloneBaseUrl(ws)).toBe('http://127.0.0.1:4000');
+    });
+
+    it('returns undefined for a local workspace object', () => {
+        expect(resolveCloneBaseUrl(localWs('w1'))).toBeUndefined();
+    });
+
+    it('resolves a remote baseUrl by workspace id via the repos list', () => {
+        mockRepos = [repo(localWs('local')), repo(remoteWs('w1', 'http://127.0.0.1:4001'))];
+        expect(resolveCloneBaseUrl('w1', mockRepos)).toBe('http://127.0.0.1:4001');
+    });
+
+    it('returns undefined for a local id found in the repos list', () => {
+        const repos = [repo(localWs('local')), repo(remoteWs('w1', 'http://127.0.0.1:4001'))];
+        expect(resolveCloneBaseUrl('local', repos)).toBeUndefined();
+    });
+
+    it('returns undefined for an unknown id', () => {
+        const repos = [repo(remoteWs('w1', 'http://127.0.0.1:4001'))];
+        expect(resolveCloneBaseUrl('nope', repos)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined / empty ref', () => {
+        expect(resolveCloneBaseUrl(undefined)).toBeUndefined();
+        expect(resolveCloneBaseUrl('')).toBeUndefined();
+    });
+
+    it('prefers the object marker over a repos lookup', () => {
+        // Object says :4000; the repos entry for the same id says :9999 — trust the object.
+        const ws = remoteWs('w1', 'http://127.0.0.1:4000');
+        const repos = [repo(remoteWs('w1', 'http://127.0.0.1:9999'))];
+        expect(resolveCloneBaseUrl(ws, repos)).toBe('http://127.0.0.1:4000');
+    });
+});
+
+// ── hooks ────────────────────────────────────────────────────────────────────
+
+describe('useResolveCloneBaseUrl', () => {
+    it('resolves ids against the live repos list', () => {
+        mockRepos = [repo(remoteWs('w1', 'http://127.0.0.1:4002'))];
+        const { result } = renderHook(() => useResolveCloneBaseUrl());
+        expect(result.current('w1')).toBe('http://127.0.0.1:4002');
+        expect(result.current('local')).toBeUndefined();
+    });
+});
+
+describe('useCocClient', () => {
+    it('returns the default singleton for a local / unknown clone', () => {
+        mockRepos = [repo(localWs('local'))];
+        const { result } = renderHook(() => useCocClient('local'));
+        expect(result.current).toBe(getSpaCocClient());
+    });
+
+    it('returns the default singleton when no ref is passed', () => {
+        const { result } = renderHook(() => useCocClient());
+        expect(result.current).toBe(getSpaCocClient());
+    });
+
+    it('returns a remote-routed client for a remote clone', () => {
+        mockRepos = [repo(remoteWs('w1', 'http://127.0.0.1:4003'))];
+        const { result } = renderHook(() => useCocClient('w1'));
+        expect(result.current).toBe(getCocClientFor('http://127.0.0.1:4003'));
+        expect(result.current.options.baseUrl).toBe('http://127.0.0.1:4003');
+        expect(result.current).not.toBe(getSpaCocClient());
+    });
+});
+
+describe('useCloneWsUrl', () => {
+    it('builds page-origin WS URLs for a local clone', () => {
+        mockRepos = [repo(localWs('local'))];
+        const { result } = renderHook(() => useCloneWsUrl('local'));
+        // jsdom default origin is http://localhost:3000 → ws://localhost:3000
+        expect(result.current('/ws')).toMatch(/^ws:\/\/localhost(:\d+)?\/ws$/);
+    });
+
+    it('builds remote WS URLs for a remote clone', () => {
+        mockRepos = [repo(remoteWs('w1', 'http://127.0.0.1:4004'))];
+        const { result } = renderHook(() => useCloneWsUrl('w1'));
+        expect(result.current('/ws')).toBe('ws://127.0.0.1:4004/ws');
+        expect(result.current('/ws/terminal?workspaceId=w1')).toBe('ws://127.0.0.1:4004/ws/terminal?workspaceId=w1');
+    });
+});

--- a/packages/coc/test/spa/react/repos/diffSource.test.ts
+++ b/packages/coc/test/spa/react/repos/diffSource.test.ts
@@ -9,13 +9,21 @@ import {
     extractFileDiffFromCombined,
 } from '../../../../src/server/spa/client/react/features/git/diff/diffSource';
 
-vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
-    fetchApi: vi.fn(),
-}));
+// diffSource fetches diffs via requestForWorkspace (clone-routed), so mock that
+// seam. The path-builder factories (createCommitDiffSource, …) resolve their
+// client through getCocClientForWorkspace, which with an empty registry returns
+// the default client whose path builders are pure — no mock needed for those.
+vi.mock('../../../../src/server/spa/client/react/repos/cloneRegistry', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../../src/server/spa/client/react/repos/cloneRegistry')>();
+    return {
+        ...actual,
+        requestForWorkspace: vi.fn(),
+    };
+});
 
-import { fetchApi } from '../../../../src/server/spa/client/react/hooks/useApi';
+import { requestForWorkspace } from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 
-const mockedFetchApi = vi.mocked(fetchApi);
+const mockedRequestForWorkspace = vi.mocked(requestForWorkspace);
 
 describe('createCommitDiffSource', () => {
     const ws = 'ws1';
@@ -186,18 +194,21 @@ describe('createBranchRangeDiffSource', () => {
 });
 
 describe('fetchDiffFromSource', () => {
+    const ws = 'ws1';
+
     beforeEach(() => {
-        mockedFetchApi.mockReset();
+        mockedRequestForWorkspace.mockReset();
     });
 
     it('normalizes standard response with all fields', async () => {
-        mockedFetchApi.mockResolvedValue({
+        mockedRequestForWorkspace.mockResolvedValue({
             diff: '--- a/file\n+++ b/file',
             truncated: true,
             totalLines: 8000,
         });
-        const result = await fetchDiffFromSource('/some/url');
-        expect(mockedFetchApi).toHaveBeenCalledWith('/some/url');
+        const result = await fetchDiffFromSource(ws, '/some/url');
+        // The relative url is routed to the workspace's clone (workspaceId, url).
+        expect(mockedRequestForWorkspace).toHaveBeenCalledWith(ws, '/some/url');
         expect(result).toEqual({
             diff: '--- a/file\n+++ b/file',
             truncated: true,
@@ -206,8 +217,8 @@ describe('fetchDiffFromSource', () => {
     });
 
     it('normalizes minimal response without truncation fields', async () => {
-        mockedFetchApi.mockResolvedValue({ diff: 'some diff' });
-        const result = await fetchDiffFromSource('/some/url');
+        mockedRequestForWorkspace.mockResolvedValue({ diff: 'some diff' });
+        const result = await fetchDiffFromSource(ws, '/some/url');
         expect(result).toEqual({
             diff: 'some diff',
             truncated: false,
@@ -216,8 +227,8 @@ describe('fetchDiffFromSource', () => {
     });
 
     it('handles missing diff field', async () => {
-        mockedFetchApi.mockResolvedValue({});
-        const result = await fetchDiffFromSource('/some/url');
+        mockedRequestForWorkspace.mockResolvedValue({});
+        const result = await fetchDiffFromSource(ws, '/some/url');
         expect(result).toEqual({
             diff: '',
             truncated: false,
@@ -225,9 +236,9 @@ describe('fetchDiffFromSource', () => {
         });
     });
 
-    it('propagates fetchApi errors', async () => {
-        mockedFetchApi.mockRejectedValue(new Error('API error: 500'));
-        await expect(fetchDiffFromSource('/some/url')).rejects.toThrow('API error: 500');
+    it('propagates request errors', async () => {
+        mockedRequestForWorkspace.mockRejectedValue(new Error('API error: 500'));
+        await expect(fetchDiffFromSource(ws, '/some/url')).rejects.toThrow('API error: 500');
     });
 });
 

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestUrls.test.ts
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestUrls.test.ts
@@ -27,8 +27,10 @@ describe('PullRequestsTab — URL construction', () => {
 
     it('uses the typed cocClient for pull requests (no raw getApiBase() URL construction)', () => {
         // After migrating to cocClient, URLs are built inside the client library.
-        // Check that cocClient is used and there are no manual /repos/ URL constructions with getApiBase().
-        expect(source).toMatch(/getSpaCocClient\(\)/);
+        // AC-07 routes the PR tab through the clone-aware useCocClient(workspaceId)
+        // so a remote clone targets its server; either typed client entry point
+        // satisfies "no raw URL building".
+        expect(source).toMatch(/getSpaCocClient\(\)|useCocClient\(/);
         expect(source).not.toMatch(/getApiBase\(\).*\/repos\//);
     });
 });

--- a/packages/coc/test/spa/react/repos/remoteSelectionPersistence.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteSelectionPersistence.test.ts
@@ -1,0 +1,124 @@
+/**
+ * AC-08 — remote-clone selection persistence (pure module).
+ *
+ * Persistence uses the STABLE { serverId, workspaceId } pair, resolved to the
+ * clone's CURRENT id on load by matching `remote.serverId` (not `baseUrl`). The
+ * port-reassignment variant is the load-bearing case: the persisted serverId is
+ * unchanged but the server's baseUrl differs on reload → still resolves.
+ *
+ * Local clones are never persisted here, so local-clone persistence is unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WorkspaceInfo } from '@plusplusoneplusplus/coc-client';
+import {
+    _resetRemoteSelectionForTests,
+    clearPersistedRemoteSelection,
+    loadPersistedRemoteSelection,
+    persistRemoteSelection,
+    resolvePersistedRemoteSelection,
+} from '../../../../src/server/spa/client/react/repos/remoteSelectionPersistence';
+import {
+    tagRemoteWorkspaces,
+    type RemoteWorkspaceInfo,
+} from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
+
+const STORAGE_KEY = 'coc-remote-clone-selection';
+
+function ws(id: string, name = id): WorkspaceInfo {
+    return { id, name, rootPath: `/repos/${id}` };
+}
+
+/** Tag one remote workspace via the real tagger so the marker shape stays authoritative. */
+function remoteWs(serverId: string, baseUrl: string, id: string): RemoteWorkspaceInfo {
+    return tagRemoteWorkspaces({ id: serverId, label: serverId }, baseUrl, [ws(id)], false)[0];
+}
+
+beforeEach(() => {
+    _resetRemoteSelectionForTests();
+});
+
+afterEach(() => {
+    _resetRemoteSelectionForTests();
+});
+
+describe('persist / load / clear', () => {
+    it('round-trips a { serverId, workspaceId } pair', () => {
+        persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' });
+        expect(loadPersistedRemoteSelection()).toEqual({ serverId: 'srv-1', workspaceId: 'ws-a' });
+    });
+
+    it('persists neither the baseUrl nor a composite id (only the stable pair)', () => {
+        persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' });
+        const raw = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+        expect(Object.keys(raw).sort()).toEqual(['serverId', 'workspaceId']);
+        expect(JSON.stringify(raw)).not.toContain('http');
+        expect(JSON.stringify(raw)).not.toContain('127.0.0.1');
+    });
+
+    it('returns null when nothing is persisted', () => {
+        expect(loadPersistedRemoteSelection()).toBeNull();
+    });
+
+    it('clears the persisted pair', () => {
+        persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' });
+        clearPersistedRemoteSelection();
+        expect(loadPersistedRemoteSelection()).toBeNull();
+    });
+
+    it('returns null for a malformed / partial persisted value', () => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ serverId: 'srv-1' })); // no workspaceId
+        expect(loadPersistedRemoteSelection()).toBeNull();
+        localStorage.setItem(STORAGE_KEY, 'not json');
+        expect(loadPersistedRemoteSelection()).toBeNull();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ serverId: '', workspaceId: 'ws-a' }));
+        expect(loadPersistedRemoteSelection()).toBeNull();
+    });
+});
+
+describe('resolvePersistedRemoteSelection', () => {
+    it('resolves the pair to the matching remote workspace id', () => {
+        const workspaces = [remoteWs('srv-1', 'http://127.0.0.1:4000', 'ws-a')];
+        const resolved = resolvePersistedRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' }, workspaces);
+        expect(resolved).toBe('ws-a');
+    });
+
+    it('returns null when no persisted pair is given', () => {
+        expect(resolvePersistedRemoteSelection(null, [remoteWs('srv-1', 'http://127.0.0.1:4000', 'ws-a')])).toBeNull();
+    });
+
+    it('returns null when the server is gone (no remote workspace matches)', () => {
+        const workspaces = [remoteWs('srv-2', 'http://127.0.0.1:4001', 'ws-b')];
+        expect(resolvePersistedRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' }, workspaces)).toBeNull();
+    });
+
+    it('ignores local workspaces with a colliding id (only remote rows match)', () => {
+        // A LOCAL workspace happens to share the persisted workspace id, but it has
+        // no remote marker, so it must not resolve as the remote selection.
+        const workspaces = [ws('ws-a') as RemoteWorkspaceInfo];
+        expect(resolvePersistedRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' }, workspaces)).toBeNull();
+    });
+
+    it('survives devtunnel PORT REASSIGNMENT — resolves by serverId though baseUrl changed', () => {
+        // Persisted at one port; on reload the SAME server has a NEW baseUrl/port.
+        persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' });
+        const reloadedWorkspaces = [remoteWs('srv-1', 'http://127.0.0.1:9999', 'ws-a')];
+        const resolved = resolvePersistedRemoteSelection(loadPersistedRemoteSelection(), reloadedWorkspaces);
+        expect(resolved).toBe('ws-a');
+        // And the matched workspace carries the CURRENT (reassigned) baseUrl.
+        expect(reloadedWorkspaces[0].baseUrl).toBe('http://127.0.0.1:9999');
+    });
+
+    it('disambiguates a workspace id that collides ACROSS two servers by serverId', () => {
+        // Two different servers each expose a workspace with id 'ws-shared'.
+        const workspaces = [
+            remoteWs('srv-1', 'http://127.0.0.1:4000', 'ws-shared'),
+            remoteWs('srv-2', 'http://127.0.0.1:4001', 'ws-shared'),
+        ];
+        // The persisted pair pins srv-2 → it must resolve to srv-2's row, routed at :4001.
+        const resolved = resolvePersistedRemoteSelection({ serverId: 'srv-2', workspaceId: 'ws-shared' }, workspaces);
+        expect(resolved).toBe('ws-shared');
+        const matched = workspaces.find(w => w.remote.serverId === 'srv-2')!;
+        expect(matched.baseUrl).toBe('http://127.0.0.1:4001');
+    });
+});

--- a/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
@@ -25,10 +25,22 @@ vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
 
 // Per-server remote CocClient: replace only the constructor, keep real exports/types.
 // Each base URL gets its own canned workspaces.list() + gitInfoBatch() response.
+interface QueueRepoEntry {
+    repoId: string;
+    rootPath?: string;
+    isPaused?: boolean;
+    taskCount?: number;
+    queuedCount?: number;
+    runningCount?: number;
+}
 interface RemoteResponse {
     workspaces?: WorkspaceInfo[];
     gitInfo?: Record<string, unknown>;
     listError?: Error;
+    /** Canned `/api/queue/repos` rows for this base URL (AC-05). */
+    queueRepos?: QueueRepoEntry[];
+    /** When set, queue.repos() rejects (queue fetch must stay resilient). */
+    queueError?: Error;
 }
 const remoteResponses = new Map<string, RemoteResponse>();
 const constructedBaseUrls: string[] = [];
@@ -41,6 +53,9 @@ vi.mock('@plusplusoneplusplus/coc-client', async (importOriginal) => {
             list: () => Promise<{ workspaces: WorkspaceInfo[] }>;
             gitInfoBatch: (ids: string[]) => Promise<{ results: Record<string, unknown> }>;
         };
+        readonly queue: {
+            repos: () => Promise<{ repos: QueueRepoEntry[] }>;
+        };
         constructor(options: { baseUrl?: string }) {
             this.baseUrl = options.baseUrl ?? '';
             constructedBaseUrls.push(this.baseUrl);
@@ -52,6 +67,12 @@ vi.mock('@plusplusoneplusplus/coc-client', async (importOriginal) => {
                 },
                 gitInfoBatch: async () => ({ results: resp.gitInfo ?? {} }),
             };
+            this.queue = {
+                repos: async () => {
+                    if (resp.queueError) throw resp.queueError;
+                    return { repos: resp.queueRepos ?? [] };
+                },
+            };
         }
     }
     return { ...actual, CocClient: MockCocClient };
@@ -61,8 +82,10 @@ vi.mock('@plusplusoneplusplus/coc-client', async (importOriginal) => {
 import {
     aggregateRemoteWorkspaces,
     isRemoteWorkspace,
+    remoteQueueStatusFromRepo,
     tagRemoteWorkspaces,
 } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
+import type { RemoteServerRuntimeStatus } from '@plusplusoneplusplus/coc-client';
 import {
     _resetRemoteWorkspaceCache,
     loadRemoteWorkspaceCache,
@@ -103,6 +126,21 @@ function offlineServer(id: string, label: string, effectiveUrl?: string): Remote
     } as RemoteServer;
 }
 
+/** A non-online server (e.g. 'connecting' | 'failed' | 'idle') for the status dot. */
+function serverWithStatus(id: string, label: string, status: RemoteServerRuntimeStatus, effectiveUrl?: string): RemoteServer {
+    return {
+        id,
+        label,
+        kind: 'ssh',
+        host: id,
+        localPort: 4000,
+        addedAt: 0,
+        updatedAt: 0,
+        status,
+        ...(effectiveUrl ? { effectiveUrl } : {}),
+    } as RemoteServer;
+}
+
 beforeEach(() => {
     remoteShellEnabled = true;
     serversList.mockReset();
@@ -133,15 +171,35 @@ describe('tagRemoteWorkspaces', () => {
                 serverId: 'srv-1',
                 serverLabel: 'Ubuntu ARM',
                 offline: false,
+                // AC-05: an online (offline=false) tag defaults to an online
+                // connection + idle queue when no explicit status is supplied.
+                connection: 'online',
+                queue: 'idle',
             });
             expect(isRemoteWorkspace(t)).toBe(true);
         }
     });
 
-    it('flags entries offline when offline=true and falls back to id when label missing', () => {
+    it('defaults connection to offline + idle queue when offline=true and no status given', () => {
         const tagged = tagRemoteWorkspaces({ id: 'srv-2', label: '' }, 'http://127.0.0.1:5000', [ws('a')], true);
         expect(tagged[0].remote.offline).toBe(true);
         expect(tagged[0].remote.serverLabel).toBe('srv-2');
+        expect(tagged[0].remote.connection).toBe('offline');
+        expect(tagged[0].remote.queue).toBe('idle');
+    });
+
+    it('applies an explicit connection + per-workspace queue status (AC-05)', () => {
+        const tagged = tagRemoteWorkspaces(
+            { id: 'srv-3', label: 'S3' },
+            'http://127.0.0.1:6000',
+            [ws('busy'), ws('calm')],
+            false,
+            { connection: 'online', queueByWorkspace: { busy: 'running' } },
+        );
+        const byId = new Map(tagged.map(t => [t.id, t]));
+        expect(byId.get('busy')!.remote.queue).toBe('running');
+        expect(byId.get('calm')!.remote.queue).toBe('idle'); // missing ⇒ idle
+        expect(byId.get('busy')!.remote.connection).toBe('online');
     });
 
     it('preserves original workspace fields', () => {
@@ -325,5 +383,87 @@ describe('aggregateRemoteWorkspaces — feature flag', () => {
         const result = await aggregateRemoteWorkspaces();
         expect(result.workspaces).toHaveLength(0);
         expect(result.sources).toHaveLength(0);
+    });
+});
+
+// ── AC-05: connection status + remote queue sourcing ──────────────────────────
+
+describe('remoteQueueStatusFromRepo', () => {
+    it('maps paused > running > queued > idle', () => {
+        expect(remoteQueueStatusFromRepo({ isPaused: true, runningCount: 3, queuedCount: 2 })).toBe('paused');
+        expect(remoteQueueStatusFromRepo({ runningCount: 1, queuedCount: 5 })).toBe('running');
+        expect(remoteQueueStatusFromRepo({ runningCount: 0, queuedCount: 2 })).toBe('queued');
+        expect(remoteQueueStatusFromRepo({ runningCount: 0, queuedCount: 0 })).toBe('idle');
+        expect(remoteQueueStatusFromRepo(undefined)).toBe('idle');
+    });
+});
+
+describe('aggregateRemoteWorkspaces — connection + remote queue (AC-05)', () => {
+    it('tags online workspaces with connection=online and their remote queue status', async () => {
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', {
+            workspaces: [ws('busy'), ws('calm')],
+            queueRepos: [
+                { repoId: 'busy', runningCount: 2, queuedCount: 0, isPaused: false },
+                { repoId: 'calm', runningCount: 0, queuedCount: 0, isPaused: false },
+            ],
+        });
+
+        const result = await aggregateRemoteWorkspaces();
+        const byId = new Map(result.workspaces.map(w => [w.id, w]));
+        expect(byId.get('busy')!.remote.connection).toBe('online');
+        expect(byId.get('busy')!.remote.queue).toBe('running');
+        expect(byId.get('calm')!.remote.queue).toBe('idle');
+    });
+
+    it('maps a paused remote repo to queue=paused', async () => {
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', {
+            workspaces: [ws('w1')],
+            queueRepos: [{ repoId: 'w1', isPaused: true, runningCount: 0, queuedCount: 0 }],
+        });
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces[0].remote.queue).toBe('paused');
+    });
+
+    it('stays resilient when the remote queue fetch fails — workspaces survive with idle queue', async () => {
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', {
+            workspaces: [ws('w1')],
+            queueError: new Error('queue 500'),
+        });
+        const result = await aggregateRemoteWorkspaces();
+        // Server is NOT dropped; queue defaults to idle.
+        expect(result.workspaces.map(w => w.id)).toEqual(['w1']);
+        expect(result.workspaces[0].remote.connection).toBe('online');
+        expect(result.workspaces[0].remote.queue).toBe('idle');
+    });
+
+    it('records connection=connecting for a connecting server (cached rows)', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-c', { baseUrl: 'http://127.0.0.1:4000', workspaces: [ws('w1')] });
+        serversList.mockResolvedValue([serverWithStatus('srv-c', 'Connecting', 'connecting')]);
+
+        const result = await aggregateRemoteWorkspaces();
+        // No live fetch for a non-online server.
+        expect(constructedBaseUrls).toHaveLength(0);
+        expect(result.workspaces[0].remote.connection).toBe('connecting');
+        expect(result.workspaces[0].remote.offline).toBe(true); // still cache-sourced
+        expect(result.workspaces[0].remote.queue).toBe('idle');
+    });
+
+    it('records connection=offline for an offline server (cached rows)', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-o', { baseUrl: 'http://127.0.0.1:4000', workspaces: [ws('w1')] });
+        serversList.mockResolvedValue([offlineServer('srv-o', 'Offline')]);
+
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces[0].remote.connection).toBe('offline');
+    });
+
+    it('records connection=failed for a failed server (cached rows)', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-f', { baseUrl: 'http://127.0.0.1:4000', workspaces: [ws('w1')] });
+        serversList.mockResolvedValue([serverWithStatus('srv-f', 'Failed', 'failed')]);
+
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces[0].remote.connection).toBe('failed');
     });
 });

--- a/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for remote workspace aggregation (AC-01):
+ *   • tag + merge logic (tagRemoteWorkspaces / aggregateRemoteWorkspaces)
+ *   • offline-cache fallback (offline server → cached entries flagged offline)
+ *
+ * All remote I/O is mocked — no live remote server is required.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RemoteServer, WorkspaceInfo } from '@plusplusoneplusplus/coc-client';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+// Feature flag — flipped per-test.
+let remoteShellEnabled = true;
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isRemoteShellEnabled: () => remoteShellEnabled,
+}));
+
+// Registry client: getSpaCocClient().servers.list()
+const serversList = vi.fn<[], Promise<RemoteServer[]>>();
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({ servers: { list: serversList } }),
+}));
+
+// Per-server remote CocClient: replace only the constructor, keep real exports/types.
+// Each base URL gets its own canned workspaces.list() + gitInfoBatch() response.
+interface RemoteResponse {
+    workspaces?: WorkspaceInfo[];
+    gitInfo?: Record<string, unknown>;
+    listError?: Error;
+}
+const remoteResponses = new Map<string, RemoteResponse>();
+const constructedBaseUrls: string[] = [];
+
+vi.mock('@plusplusoneplusplus/coc-client', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@plusplusoneplusplus/coc-client')>();
+    class MockCocClient {
+        private readonly baseUrl: string;
+        readonly workspaces: {
+            list: () => Promise<{ workspaces: WorkspaceInfo[] }>;
+            gitInfoBatch: (ids: string[]) => Promise<{ results: Record<string, unknown> }>;
+        };
+        constructor(options: { baseUrl?: string }) {
+            this.baseUrl = options.baseUrl ?? '';
+            constructedBaseUrls.push(this.baseUrl);
+            const resp = remoteResponses.get(this.baseUrl) ?? {};
+            this.workspaces = {
+                list: async () => {
+                    if (resp.listError) throw resp.listError;
+                    return { workspaces: resp.workspaces ?? [] };
+                },
+                gitInfoBatch: async () => ({ results: resp.gitInfo ?? {} }),
+            };
+        }
+    }
+    return { ...actual, CocClient: MockCocClient };
+});
+
+// Import after mocks are registered.
+import {
+    aggregateRemoteWorkspaces,
+    isRemoteWorkspace,
+    tagRemoteWorkspaces,
+} from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
+import {
+    _resetRemoteWorkspaceCache,
+    loadRemoteWorkspaceCache,
+    saveRemoteWorkspaceCacheEntry,
+} from '../../../../src/server/spa/client/react/repos/remoteWorkspaceCache';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function ws(id: string, name = id, extra: Partial<WorkspaceInfo> = {}): WorkspaceInfo {
+    return { id, name, rootPath: `/repos/${id}`, ...extra };
+}
+
+function onlineServer(id: string, label: string, effectiveUrl: string): RemoteServer {
+    return {
+        id,
+        label,
+        kind: 'ssh',
+        host: id,
+        localPort: 4000,
+        addedAt: 0,
+        updatedAt: 0,
+        status: 'online',
+        effectiveUrl,
+    } as RemoteServer;
+}
+
+function offlineServer(id: string, label: string, effectiveUrl?: string): RemoteServer {
+    return {
+        id,
+        label,
+        kind: 'ssh',
+        host: id,
+        localPort: 4000,
+        addedAt: 0,
+        updatedAt: 0,
+        status: 'offline',
+        ...(effectiveUrl ? { effectiveUrl } : {}),
+    } as RemoteServer;
+}
+
+beforeEach(() => {
+    remoteShellEnabled = true;
+    serversList.mockReset();
+    remoteResponses.clear();
+    constructedBaseUrls.length = 0;
+    _resetRemoteWorkspaceCache();
+});
+
+afterEach(() => {
+    _resetRemoteWorkspaceCache();
+});
+
+// ── tag logic ─────────────────────────────────────────────────────────────────
+
+describe('tagRemoteWorkspaces', () => {
+    it('tags each workspace with baseUrl + serverId + serverLabel and a remote marker', () => {
+        const tagged = tagRemoteWorkspaces(
+            { id: 'srv-1', label: 'Ubuntu ARM' },
+            'http://127.0.0.1:4000',
+            [ws('a'), ws('b')],
+            false,
+        );
+        expect(tagged).toHaveLength(2);
+        for (const t of tagged) {
+            expect(t.baseUrl).toBe('http://127.0.0.1:4000');
+            expect(t.remote).toEqual({
+                baseUrl: 'http://127.0.0.1:4000',
+                serverId: 'srv-1',
+                serverLabel: 'Ubuntu ARM',
+                offline: false,
+            });
+            expect(isRemoteWorkspace(t)).toBe(true);
+        }
+    });
+
+    it('flags entries offline when offline=true and falls back to id when label missing', () => {
+        const tagged = tagRemoteWorkspaces({ id: 'srv-2', label: '' }, 'http://127.0.0.1:5000', [ws('a')], true);
+        expect(tagged[0].remote.offline).toBe(true);
+        expect(tagged[0].remote.serverLabel).toBe('srv-2');
+    });
+
+    it('preserves original workspace fields', () => {
+        const tagged = tagRemoteWorkspaces(
+            { id: 's', label: 'L' },
+            'http://127.0.0.1:4000',
+            [ws('a', 'Repo A', { remoteUrl: 'git@github.com:org/repo.git', isGitRepo: true })],
+            false,
+        );
+        expect(tagged[0].name).toBe('Repo A');
+        expect(tagged[0].remoteUrl).toBe('git@github.com:org/repo.git');
+        expect(tagged[0].isGitRepo).toBe(true);
+    });
+});
+
+describe('isRemoteWorkspace', () => {
+    it('returns false for local workspaces (no baseUrl/remote)', () => {
+        expect(isRemoteWorkspace(ws('local'))).toBe(false);
+        expect(isRemoteWorkspace(null)).toBe(false);
+        expect(isRemoteWorkspace({ baseUrl: 'x' })).toBe(false); // missing remote marker
+    });
+});
+
+// ── merge (online) ──────────────────────────────────────────────────────────
+
+describe('aggregateRemoteWorkspaces — online merge', () => {
+    it('fetches each online server at its effectiveUrl and merges tagged workspaces + git-info', async () => {
+        serversList.mockResolvedValue([
+            onlineServer('srv-1', 'Server One', 'http://127.0.0.1:4000'),
+            onlineServer('srv-2', 'Server Two', 'http://127.0.0.1:4001'),
+        ]);
+        remoteResponses.set('http://127.0.0.1:4000', {
+            workspaces: [ws('w1'), ws('w2')],
+            gitInfo: { w1: { branch: 'main', dirty: false, isGitRepo: true, remoteUrl: null } },
+        });
+        remoteResponses.set('http://127.0.0.1:4001', {
+            workspaces: [ws('w3')],
+            gitInfo: { w3: { branch: 'dev', dirty: true, isGitRepo: true, remoteUrl: null } },
+        });
+
+        const result = await aggregateRemoteWorkspaces();
+
+        // Fetched directly at each effectiveUrl.
+        expect(constructedBaseUrls).toContain('http://127.0.0.1:4000');
+        expect(constructedBaseUrls).toContain('http://127.0.0.1:4001');
+
+        expect(result.sources).toHaveLength(2);
+        expect(result.workspaces.map(w => w.id).sort()).toEqual(['w1', 'w2', 'w3']);
+
+        // Tagging carries through the merge.
+        const w1 = result.workspaces.find(w => w.id === 'w1')!;
+        expect(w1.remote.serverId).toBe('srv-1');
+        expect(w1.remote.serverLabel).toBe('Server One');
+        expect(w1.remote.offline).toBe(false);
+        expect(w1.baseUrl).toBe('http://127.0.0.1:4000');
+
+        // git-info merged across sources, keyed by workspace id.
+        expect(result.gitInfo.w1).toMatchObject({ branch: 'main' });
+        expect(result.gitInfo.w3).toMatchObject({ branch: 'dev', dirty: true });
+        expect(result.warnings).toHaveLength(0);
+    });
+
+    it('excludes virtual workspaces from the remote source', async () => {
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', {
+            workspaces: [ws('real'), ws('global', 'Global', { virtual: true })],
+        });
+
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces.map(w => w.id)).toEqual(['real']);
+    });
+
+    it('caches the online list so a later offline load can reuse it', async () => {
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', { workspaces: [ws('w1'), ws('w2')] });
+
+        await aggregateRemoteWorkspaces();
+
+        const cache = loadRemoteWorkspaceCache();
+        expect(cache['srv-1'].baseUrl).toBe('http://127.0.0.1:4000');
+        expect(cache['srv-1'].workspaces.map(w => w.id)).toEqual(['w1', 'w2']);
+        // Cached list is untagged so it can be re-tagged offline.
+        expect((cache['srv-1'].workspaces[0] as { remote?: unknown }).remote).toBeUndefined();
+    });
+});
+
+// ── offline-cache fallback ──────────────────────────────────────────────────
+
+describe('aggregateRemoteWorkspaces — offline cache fallback', () => {
+    it('returns last-known cached entries flagged offline when the server is offline', async () => {
+        // Seed cache as if a prior online fetch happened.
+        saveRemoteWorkspaceCacheEntry('srv-1', {
+            baseUrl: 'http://127.0.0.1:4000',
+            workspaces: [ws('w1'), ws('w2')],
+        });
+        serversList.mockResolvedValue([offlineServer('srv-1', 'Server One')]);
+
+        const result = await aggregateRemoteWorkspaces();
+
+        // No live fetch attempted for an offline server.
+        expect(constructedBaseUrls).toHaveLength(0);
+
+        expect(result.sources).toHaveLength(1);
+        expect(result.sources[0].online).toBe(false);
+        expect(result.workspaces.map(w => w.id)).toEqual(['w1', 'w2']);
+        for (const w of result.workspaces) {
+            expect(w.remote.offline).toBe(true);
+            expect(w.remote.serverId).toBe('srv-1');
+            // Falls back to cached baseUrl when the offline server has none.
+            expect(w.baseUrl).toBe('http://127.0.0.1:4000');
+        }
+        // No git-info for cached (offline) sources.
+        expect(result.gitInfo).toEqual({});
+    });
+
+    it('uses the cached baseUrl as fallback but prefers a current effectiveUrl when present', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-1', {
+            baseUrl: 'http://127.0.0.1:4000',
+            workspaces: [ws('w1')],
+        });
+        // devtunnel port reassignment: server reports a new effectiveUrl while offline.
+        serversList.mockResolvedValue([offlineServer('srv-1', 'S1', 'http://127.0.0.1:9999')]);
+
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces[0].baseUrl).toBe('http://127.0.0.1:9999');
+    });
+
+    it('omits an offline server with no cached entries (no phantom rows)', async () => {
+        serversList.mockResolvedValue([offlineServer('srv-1', 'S1')]);
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.sources).toHaveLength(0);
+        expect(result.workspaces).toHaveLength(0);
+    });
+
+    it('falls back to cached offline entries when an online fetch throws', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-1', {
+            baseUrl: 'http://127.0.0.1:4000',
+            workspaces: [ws('w1')],
+        });
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', { listError: new Error('ECONNREFUSED') });
+
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces).toHaveLength(1);
+        expect(result.workspaces[0].remote.offline).toBe(true);
+        expect(result.warnings[0]).toContain('ECONNREFUSED');
+    });
+
+    it('mixes online and offline servers in one aggregate', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-off', {
+            baseUrl: 'http://127.0.0.1:5000',
+            workspaces: [ws('cached')],
+        });
+        serversList.mockResolvedValue([
+            onlineServer('srv-on', 'Online', 'http://127.0.0.1:4000'),
+            offlineServer('srv-off', 'Offline'),
+        ]);
+        remoteResponses.set('http://127.0.0.1:4000', { workspaces: [ws('live')] });
+
+        const result = await aggregateRemoteWorkspaces();
+        const byId = new Map(result.workspaces.map(w => [w.id, w]));
+        expect(byId.get('live')!.remote.offline).toBe(false);
+        expect(byId.get('cached')!.remote.offline).toBe(true);
+        expect(result.sources).toHaveLength(2);
+    });
+});
+
+// ── feature-flag gating ─────────────────────────────────────────────────────
+
+describe('aggregateRemoteWorkspaces — feature flag', () => {
+    it('returns an empty aggregate and performs NO server fetch when remoteShell is OFF', async () => {
+        remoteShellEnabled = false;
+        const result = await aggregateRemoteWorkspaces();
+        expect(serversList).not.toHaveBeenCalled();
+        expect(constructedBaseUrls).toHaveLength(0);
+        expect(result).toEqual({ sources: [], workspaces: [], gitInfo: {}, warnings: [] });
+    });
+
+    it('returns an empty aggregate when the registry list fails', async () => {
+        serversList.mockRejectedValue(new Error('registry down'));
+        const result = await aggregateRemoteWorkspaces();
+        expect(result.workspaces).toHaveLength(0);
+        expect(result.sources).toHaveLength(0);
+    });
+});

--- a/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
@@ -91,6 +91,10 @@ import {
     loadRemoteWorkspaceCache,
     saveRemoteWorkspaceCacheEntry,
 } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceCache';
+import {
+    lookupCloneBaseUrl,
+    resetCloneRegistryForTests,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -147,10 +151,12 @@ beforeEach(() => {
     remoteResponses.clear();
     constructedBaseUrls.length = 0;
     _resetRemoteWorkspaceCache();
+    resetCloneRegistryForTests();
 });
 
 afterEach(() => {
     _resetRemoteWorkspaceCache();
+    resetCloneRegistryForTests();
 });
 
 // ── tag logic ─────────────────────────────────────────────────────────────────
@@ -465,5 +471,57 @@ describe('aggregateRemoteWorkspaces — connection + remote queue (AC-05)', () =
 
         const result = await aggregateRemoteWorkspaces();
         expect(result.workspaces[0].remote.connection).toBe('failed');
+    });
+});
+
+// ── AC-07: populate the workspace→baseUrl LOOKUP registry ───────────────────
+describe('aggregateRemoteWorkspaces — clone lookup registry (AC-07)', () => {
+    it('registers every remote workspace id → its baseUrl for per-clone routing', async () => {
+        serversList.mockResolvedValue([
+            onlineServer('srv-1', 'Server One', 'http://127.0.0.1:4000'),
+            onlineServer('srv-2', 'Server Two', 'http://127.0.0.1:4001'),
+        ]);
+        remoteResponses.set('http://127.0.0.1:4000', { workspaces: [ws('w1'), ws('w2')] });
+        remoteResponses.set('http://127.0.0.1:4001', { workspaces: [ws('w3')] });
+
+        await aggregateRemoteWorkspaces();
+
+        expect(lookupCloneBaseUrl('w1')).toBe('http://127.0.0.1:4000');
+        expect(lookupCloneBaseUrl('w2')).toBe('http://127.0.0.1:4000');
+        expect(lookupCloneBaseUrl('w3')).toBe('http://127.0.0.1:4001');
+        // A local id is never registered → resolves to undefined (default client).
+        expect(lookupCloneBaseUrl('local-only')).toBeUndefined();
+    });
+
+    it('registers OFFLINE (cached) clones too, so an offline-selected clone still resolves to its server (not local)', async () => {
+        saveRemoteWorkspaceCacheEntry('srv-o', { baseUrl: 'http://127.0.0.1:4000', workspaces: [ws('w1')] });
+        serversList.mockResolvedValue([offlineServer('srv-o', 'Offline')]);
+
+        await aggregateRemoteWorkspaces();
+        expect(lookupCloneBaseUrl('w1')).toBe('http://127.0.0.1:4000');
+    });
+
+    it('clears the registry when the remote-shell flag is OFF (per-clone routing reverts to local)', async () => {
+        // First populate while ON.
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', { workspaces: [ws('w1')] });
+        await aggregateRemoteWorkspaces();
+        expect(lookupCloneBaseUrl('w1')).toBe('http://127.0.0.1:4000');
+
+        // Flip OFF and re-aggregate → registry cleared.
+        remoteShellEnabled = false;
+        await aggregateRemoteWorkspaces();
+        expect(lookupCloneBaseUrl('w1')).toBeUndefined();
+    });
+
+    it('clears the registry when the server registry is unavailable', async () => {
+        serversList.mockResolvedValue([onlineServer('srv-1', 'S1', 'http://127.0.0.1:4000')]);
+        remoteResponses.set('http://127.0.0.1:4000', { workspaces: [ws('w1')] });
+        await aggregateRemoteWorkspaces();
+        expect(lookupCloneBaseUrl('w1')).toBe('http://127.0.0.1:4000');
+
+        serversList.mockRejectedValue(new Error('registry down'));
+        await aggregateRemoteWorkspaces();
+        expect(lookupCloneBaseUrl('w1')).toBeUndefined();
     });
 });

--- a/packages/coc/test/spa/react/repos/repoGrouping.test.ts
+++ b/packages/coc/test/spa/react/repos/repoGrouping.test.ts
@@ -7,10 +7,40 @@ import {
     groupKey,
     applyGroupOrder,
     groupReposByRemote,
+    isRemoteRepo,
     normalizeRemoteUrl,
     remoteUrlLabel,
+    sortClonesLocalFirst,
 } from '../../../../src/server/spa/client/react/repos/repoGrouping';
 import type { RepoGroup, RepoData } from '../../../../src/server/spa/client/react/repos/repoGrouping';
+
+// ── Remote-repo fixtures (AC-04) ──────────────────────────────────────────────
+// A remote checkout aggregated by AC-01 carries `baseUrl` + a `remote` marker on
+// its workspace, plus `remoteUrl` (when the remote server reported one) so it can
+// fold into the matching local group by normalized git URL.
+
+function localRepo(id: string, remoteUrl: string): RepoData {
+    return {
+        workspace: { id, name: id, rootPath: `/local/${id}`, remoteUrl },
+        gitInfo: { branch: 'main', dirty: false, isGitRepo: true, remoteUrl },
+    };
+}
+
+function remoteRepo(id: string, remoteUrl: string | undefined, serverLabel = 'devbox'): RepoData {
+    return {
+        workspace: {
+            id,
+            name: id,
+            rootPath: `/remote/${id}`,
+            remoteUrl,
+            baseUrl: 'http://127.0.0.1:4000',
+            remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline: false },
+        },
+        gitInfo: remoteUrl
+            ? { branch: 'main', dirty: false, isGitRepo: true, remoteUrl }
+            : undefined,
+    };
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -253,5 +283,97 @@ describe('groupReposByRemote with Azure DevOps URLs', () => {
         expect(azureGroup).toBeDefined();
         const ungrouped = groups.find(g => g.normalizedUrl === null && g.repos[0].workspace.id === 'ws-bad');
         expect(ungrouped).toBeDefined();
+    });
+});
+
+// ── isRemoteRepo (AC-04) ──────────────────────────────────────────────────────
+
+describe('isRemoteRepo', () => {
+    it('is true for an aggregated remote checkout (carries baseUrl + remote marker)', () => {
+        expect(isRemoteRepo(remoteRepo('r1', 'https://github.com/acme/app.git'))).toBe(true);
+    });
+
+    it('is false for a local checkout', () => {
+        expect(isRemoteRepo(localRepo('l1', 'https://github.com/acme/app.git'))).toBe(false);
+    });
+
+    it('is false when only baseUrl is present without a remote marker', () => {
+        const repo: RepoData = { workspace: { id: 'x', name: 'x', rootPath: '/x', baseUrl: 'http://127.0.0.1:4000' } };
+        expect(isRemoteRepo(repo)).toBe(false);
+    });
+});
+
+// ── sortClonesLocalFirst (AC-04) ──────────────────────────────────────────────
+
+describe('sortClonesLocalFirst', () => {
+    const URL = 'https://github.com/acme/app.git';
+
+    it('moves remote clones after local clones, preserving relative order', () => {
+        const r1 = remoteRepo('r1', URL);
+        const l1 = localRepo('l1', URL);
+        const r2 = remoteRepo('r2', URL);
+        const l2 = localRepo('l2', URL);
+        const sorted = sortClonesLocalFirst([r1, l1, r2, l2]);
+        expect(sorted.map(r => r.workspace.id)).toEqual(['l1', 'l2', 'r1', 'r2']);
+    });
+
+    it('returns the same array reference (no-op) when there are no remote clones', () => {
+        const input = [localRepo('l1', URL), localRepo('l2', URL)];
+        expect(sortClonesLocalFirst(input)).toBe(input);
+    });
+
+    it('leaves a remote-only list untouched in order', () => {
+        const sorted = sortClonesLocalFirst([remoteRepo('r1', URL), remoteRepo('r2', URL)]);
+        expect(sorted.map(r => r.workspace.id)).toEqual(['r1', 'r2']);
+    });
+});
+
+// ── groupReposByRemote with remote checkouts (AC-04) ──────────────────────────
+
+describe('groupReposByRemote with remote checkouts', () => {
+    const URL = 'https://github.com/acme/app.git';
+    const OTHER = 'https://github.com/acme/other.git';
+
+    it('(a) folds a remote clone into the local group by normalized URL', () => {
+        // Local + remote checkout of the SAME origin → one group, two clones.
+        const groups = groupReposByRemote([localRepo('local', URL), remoteRepo('remote', URL)], {});
+        const group = groups.find(g => g.normalizedUrl === 'github.com/acme/app');
+        expect(group).toBeDefined();
+        expect(group!.repos).toHaveLength(2);
+        expect(group!.repos.map(r => r.workspace.id).sort()).toEqual(['local', 'remote']);
+    });
+
+    it('(b) surfaces a remote-only repo as its own group', () => {
+        // Remote checkout whose origin has NO local counterpart → standalone group.
+        const groups = groupReposByRemote([localRepo('local', URL), remoteRepo('remoteOnly', OTHER)], {});
+        const otherGroup = groups.find(g => g.normalizedUrl === 'github.com/acme/other');
+        expect(otherGroup).toBeDefined();
+        expect(otherGroup!.repos).toHaveLength(1);
+        expect(isRemoteRepo(otherGroup!.repos[0])).toBe(true);
+    });
+
+    it('(b) groups a remote-only repo that lacks gitInfo via its workspace.remoteUrl', () => {
+        const groups = groupReposByRemote([remoteRepo('remoteOnly', OTHER)], {});
+        expect(groups).toHaveLength(1);
+        expect(groups[0].normalizedUrl).toBe('github.com/acme/other');
+        expect(isRemoteRepo(groups[0].repos[0])).toBe(true);
+    });
+
+    it('(c) orders local clones before remote within a folded group (primary stays local)', () => {
+        // Remote listed FIRST in the input must still land after the local clone,
+        // so the i===0 PRIMARY marker points at a local checkout.
+        const groups = groupReposByRemote([remoteRepo('remote', URL), localRepo('local', URL)], {});
+        const group = groups.find(g => g.normalizedUrl === 'github.com/acme/app')!;
+        expect(group.repos.map(r => r.workspace.id)).toEqual(['local', 'remote']);
+        expect(isRemoteRepo(group.repos[0])).toBe(false); // primary = local
+    });
+
+    it('keeps multiple locals ahead of multiple remotes in a folded group', () => {
+        const groups = groupReposByRemote(
+            [remoteRepo('r1', URL), localRepo('l1', URL), remoteRepo('r2', URL), localRepo('l2', URL)],
+            {},
+        );
+        const group = groups.find(g => g.normalizedUrl === 'github.com/acme/app')!;
+        expect(group.repos.map(r => r.workspace.id)).toEqual(['l1', 'l2', 'r1', 'r2']);
     });
 });

--- a/packages/coc/test/spa/react/repos/useFileDiff.test.ts
+++ b/packages/coc/test/spa/react/repos/useFileDiff.test.ts
@@ -43,7 +43,23 @@ describe('useFileDiff', () => {
         expect(result.current.error).toBeNull();
         expect(result.current.truncated).toBe(false);
         expect(result.current.totalLines).toBe(0);
-        expect(mockFetchDiffFromSource).toHaveBeenCalledWith('/api/diff');
+        // No workspaceId passed → routes to the default origin ('' workspace id).
+        expect(mockFetchDiffFromSource).toHaveBeenCalledWith('', '/api/diff');
+    });
+
+    it('forwards the workspaceId so the fetch routes to that clone (AC-07)', async () => {
+        mockFetchDiffFromSource.mockResolvedValue({
+            diff: 'remote diff',
+            truncated: false,
+            totalLines: 0,
+        });
+
+        const { result } = renderHook(() => useFileDiff('/api/diff', null, 'remote-ws'));
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.diff).toBe('remote diff');
+        expect(mockFetchDiffFromSource).toHaveBeenCalledWith('remote-ws', '/api/diff');
     });
 
     it('handles truncated response', async () => {
@@ -89,7 +105,7 @@ describe('useFileDiff', () => {
         });
 
         await waitFor(() => expect(result.current.diff).toBe('full content'));
-        expect(mockFetchDiffFromSource).toHaveBeenCalledWith('/api/diff?full=true');
+        expect(mockFetchDiffFromSource).toHaveBeenCalledWith('', '/api/diff?full=true');
         expect(result.current.truncated).toBe(false);
     });
 

--- a/packages/coc/test/spa/react/useGitInfo.test.ts
+++ b/packages/coc/test/spa/react/useGitInfo.test.ts
@@ -24,9 +24,11 @@ describe('useGitInfo hook source', () => {
         expect(HOOK_SOURCE).toContain('workspaces.gitInfo(workspaceId)');
     });
 
-    it('imports typed CoC client', () => {
-        expect(HOOK_SOURCE).toContain("from '../../../api/cocClient'");
-        expect(HOOK_SOURCE).toContain('getSpaCocClient');
+    it('imports the clone-aware CoC client hook', () => {
+        // AC-07: useGitInfo routes via useCocClient(workspaceId) so a remote clone
+        // reads git-info from its own server.
+        expect(HOOK_SOURCE).toContain("from '../../../repos/cloneRouting'");
+        expect(HOOK_SOURCE).toContain('useCocClient');
     });
 
     it('exports GitInfo interface', () => {
@@ -61,6 +63,7 @@ describe('useGitInfo hook source', () => {
     });
 
     it('reacts to workspaceId changes via useEffect dependency', () => {
-        expect(HOOK_SOURCE).toContain('[workspaceId]');
+        // The clone-aware client is part of the dependency list (workspaceId drives it).
+        expect(HOOK_SOURCE).toContain('[workspaceId, client]');
     });
 });


### PR DESCRIPTION
## Summary

Behind the experimental `features.remoteShell` flag, repos/clones from **SSH/devtunnel-connected remote CoC servers** now fold into the per-repo **CLONE dropdown**, are selectable, and drive their full set of activity tabs — with every tab's REST + WebSocket traffic routed **directly to the clone's own server**. The goal is a single dashboard that sees and acts across all your connected machines.

Default behaviour is unchanged: with the flag off, no remote fetch happens and local clones are byte-for-byte identical to today.

## Why

The dashboard was local-filesystem only. SSH (`ssh -N`) and devtunnel already forward each remote CoC to `http://127.0.0.1:{localPort}`, so the SPA can talk to a remote clone's server directly over loopback — no new tunnel or relay needed. This surfaces those remotes' repos in the dropdown and makes their tabs fully interactive.

## What changed

Implemented as sliced ACs plus follow-up fixes (one commit each):

| Commit | What |
|---|---|
| AC-01 | Aggregate remote-server workspaces into the repo flow (tagged with `{ baseUrl, serverId, serverLabel }`, offline-cached) |
| AC-02 | CoC server allows **loopback-only** cross-origin REST + WS (never `*`) |
| AC-03 | Per-clone `baseUrl` routing primitives (`getCocClientFor`, `useCocClient`, `cloneWsUrl`) |
| AC-04 | Fold remote clones into the dropdown by git URL + remote-only repos + server-label badges |
| AC-05 | Blended status dot (connection state, else remote queue state) |
| AC-06 | Greyed/non-interactive offline-clone rows |
| AC-07 | Route every tab's data **and writes** to the selected clone's server |
| AC-08 | Persist remote-clone selection across reload via the stable `serverId` (survives devtunnel port reassignment) |
| fix | Report reachable `url`-kind remotes as `online` so their clones surface |
| fix | Route `POST /workspaces/active` to the clone (was 404-ing for remote clones) |
| fix | Route the git diff-viewing layer (working-tree, diffs, comments, classify) to the clone |

## Architecture

- **Direct, no relay.** A remote clone carries an optional `baseUrl` (= the server's forwarded `effectiveUrl`); the SPA routes that clone's REST + WS straight there. `baseUrl` is the routing key — **no composite workspace IDs**.
- **Loopback-only CORS.** The server reflects only `localhost`/`127.0.0.1`/`::1` origins (exact-hostname match, never `*`); WS upgrades from non-loopback origins get a 403.
- **No local fallthrough.** A `workspaceId → baseUrl` registry (populated by the aggregation each refresh) ensures a remote clone's clone-scoped calls always target its server; local/unknown ids resolve to the default origin.
- **Gated** behind `features.remoteShell` (experimental, off by default).

## Testing

- **Full test suite green: 29,607 passed, 0 failed** (1487 files).
- **Live browser verification** against a second CoC server registered as a remote: its repos fold into the dropdown badged with the server label; selecting a remote clone loads Activity, Git (history + diffs), work-items, etc. from that server (verified in DevTools that requests target the remote port, not the page origin); a chat write routes remotely; stopping the server greys its clones; local-clone routing is unregressed.

## Reviewer notes / known limitations

- **Experimental & flag-gated.** No impact on the default dashboard.
- A few **secondary per-process actions** that only have a `processId` (not a `workspaceId`) in scope — e.g. a conversation turn's image load, a skill-picker dialog — still read the local origin. Tracked as a follow-up; they degrade silently (swallowed `.catch`), they don't break the tabs.
- **Remote-browser access is out of scope.** The loopback forward terminates on the CoC host, so opening the dashboard from a different machine (over the CoC's own tunnel) wouldn't reach a remote clone's forwarded port — that would need a server-side relay, intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
