### PR TITLE
fix(coc): route the rest of the remote-clone tab surface to the clone's server

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -709,6 +709,13 @@ the input:
 - Non-React services that take a `workspaceId` resolve via
   `getCocClientForWorkspace(workspaceId)`: `explorerApi.*`, `notesApi.*`, and the
   recent-skills hook `useRecentSkills` (per-workspace preferences get/patch).
+- Several React components route their workspace-scoped calls through the registry
+  seams inline (not the hook) — `requestForWorkspace(id, url, opts?)` for raw
+  fetches, `getCocClientForWorkspace(id)` for typed-client calls: `EnqueueDialog`
+  (`/summary` + `/skills/all` loads, the `queue.enqueue` mutation, and
+  `recordSkillUsage`), `RepoSettingsTab` (mcp-config, skills, instructions, repo
+  prefs, processes, description PATCH), `RepoDetail` (work-items badge preview),
+  and `WorkItemsTab` (commit file list).
 - The Activity WRITE path `useSendMessage` routes `processes.sendMessage` /
   `promoteToRalph` through `getCocClientForWorkspace(workspaceId)`; the
   Activity events stream `useChatSSE` opens its `EventSource` at

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -703,10 +703,12 @@ the input:
   client for all clone-scoped REST: `useGitInfo`, `TerminalView` (terminal
   list/pin), `ChatDetail` (every `processes`/`queue`/`notes`/`canvases`/`skills`
   call), `RepoSchedulesTab` (schedule CRUD + notes-git status),
-  `WorkItemSection` + `WorkItemHierarchyTree` (list/tree/mutations), and
+  `WorkItemSection` + `WorkItemHierarchyTree` (list/tree/mutations),
+  `WorkItemExecuteDialog` (skill-list load), and
   `PullRequestsTab` (list/suggestions/roster/classification).
 - Non-React services that take a `workspaceId` resolve via
-  `getCocClientForWorkspace(workspaceId)`: `explorerApi.*` and `notesApi.*`.
+  `getCocClientForWorkspace(workspaceId)`: `explorerApi.*`, `notesApi.*`, and the
+  recent-skills hook `useRecentSkills` (per-workspace preferences get/patch).
 - The Activity WRITE path `useSendMessage` routes `processes.sendMessage` /
   `promoteToRalph` through `getCocClientForWorkspace(workspaceId)`; the
   Activity events stream `useChatSSE` opens its `EventSource` at

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -32,6 +32,7 @@ import { GenerateTaskDialog } from '../../tasks/GenerateTaskDialog';
 import { TasksPanel } from '../../tasks/TasksPanel';
 import { fetchApi } from '../../hooks/useApi';
 import { getSpaCocClient } from '../../api/cocClient';
+import { requestForWorkspace } from '../../repos/cloneRegistry';
 import { useRepoQueueStats } from '../../queue/hooks/useRepoQueueStats';
 import { useGitInfo } from '../git/hooks/useGitInfo';
 import { useTerminalEnabled } from '../../hooks/feature-flags/useTerminalEnabled';
@@ -120,7 +121,8 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
     const { state: workItemState, dispatch: workItemDispatch } = useWorkItems();
     useEffect(() => {
         if (workItemState.workItemsByRepo[ws.id] !== undefined) return;
-        fetchApi(`/workspaces/${encodeURIComponent(ws.id)}/work-items?limit=20`)
+        // Route the work-items badge preview to the repo's clone server.
+        requestForWorkspace<any>(ws.id, `/workspaces/${encodeURIComponent(ws.id)}/work-items?limit=20`)
             .then(data => {
                 if (data) {
                     workItemDispatch({ type: 'SET_WORK_ITEMS', repoId: ws.id, items: data.items || [], total: data.total ?? 0, hasMore: data.hasMore ?? false });

--- a/packages/coc/src/server/spa/client/react/features/repo-settings/RepoSettingsTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-settings/RepoSettingsTab.tsx
@@ -8,8 +8,8 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { fetchApi } from '../../hooks/useApi';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getCocClientForWorkspace, requestForWorkspace } from '../../repos/cloneRegistry';
 import { CocApiError } from '@plusplusoneplusplus/coc-client';
 import { useGlobalToast } from '../../contexts/ToastContext';
 import { useApp } from '../../contexts/AppContext';
@@ -304,7 +304,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         setLoading(true);
         setError(null);
         setMcpSources(undefined);
-        fetchApi(`/workspaces/${workspaceId}/mcp-config${forceReload ? '?forceReload=true' : ''}`)
+        requestForWorkspace<any>(workspaceId, `/workspaces/${workspaceId}/mcp-config${forceReload ? '?forceReload=true' : ''}`)
             .then((data) => {
                 setAvailableServers(data.availableServers ?? []);
                 setMcpSources(data.sources);
@@ -332,7 +332,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         setEnabledMcpServers(nextValue);
         setSaving(true);
         try {
-            await fetchApi(`/workspaces/${workspaceId}/mcp-config`, {
+            await requestForWorkspace(workspaceId, `/workspaces/${workspaceId}/mcp-config`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ enabledMcpServers: nextValue }),
@@ -360,7 +360,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
     const fetchSkills = useCallback(async () => {
         setSkillsLoading(true);
         try {
-            const skills = await getSpaCocClient().skills.listWorkspace(workspaceId);
+            const skills = await getCocClientForWorkspace(workspaceId).skills.listWorkspace(workspaceId);
             setSkills(skills);
         } catch {
             // ignore
@@ -372,13 +372,13 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
     useEffect(() => { fetchSkills(); }, [fetchSkills]);
 
     useEffect(() => {
-        getSpaCocClient().skills.getWorkspaceConfig(workspaceId)
+        getCocClientForWorkspace(workspaceId).skills.getWorkspaceConfig(workspaceId)
             .then((data) => {
                 setDisabledSkills(data.disabledSkills ?? []);
                 setExtraSkillFolders(data.extraSkillFolders ?? []);
             })
             .catch(() => {});
-        getSpaCocClient().preferences.getRepo(workspaceId)
+        getCocClientForWorkspace(workspaceId).preferences.getRepo(workspaceId)
             .then((data) => {
                 setLinkedRepoIds(data.linkedRepoIds ?? []);
             })
@@ -395,7 +395,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         setSkillDetail(null);
         setDetailLoading(true);
         try {
-            const data = await getSpaCocClient().skills.detailWorkspace(workspaceId, name);
+            const data = await getCocClientForWorkspace(workspaceId).skills.detailWorkspace(workspaceId, name);
             setSkillDetail(data.skill || null);
         } catch {
             // ignore
@@ -406,7 +406,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
 
     const handleDeleteSkill = async (name: string) => {
         try {
-            await getSpaCocClient().skills.deleteWorkspace(workspaceId, name);
+            await getCocClientForWorkspace(workspaceId).skills.deleteWorkspace(workspaceId, name);
             addToast(`Deleted skill: ${name}`, 'success');
             fetchSkills();
         } catch (err: any) {
@@ -423,7 +423,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         setDisabledSkills(nextDisabled);
         setSkillToggleSaving(true);
         try {
-            await getSpaCocClient().skills.updateWorkspaceConfig(workspaceId, { disabledSkills: nextDisabled });
+            await getCocClientForWorkspace(workspaceId).skills.updateWorkspaceConfig(workspaceId, { disabledSkills: nextDisabled });
         } catch (e: any) {
             setDisabledSkills(prevDisabled);
             addToast(e?.message ?? 'Failed to save skill config', 'error');
@@ -436,7 +436,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         const prevFolders = extraSkillFolders;
         setExtraSkillFolders(nextFolders);
         try {
-            await getSpaCocClient().skills.updateWorkspaceConfig(workspaceId, { disabledSkills, extraSkillFolders: nextFolders });
+            await getCocClientForWorkspace(workspaceId).skills.updateWorkspaceConfig(workspaceId, { disabledSkills, extraSkillFolders: nextFolders });
             fetchSkills();
         } catch (e: any) {
             setExtraSkillFolders(prevFolders);
@@ -448,7 +448,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         const prevIds = linkedRepoIds;
         setLinkedRepoIds(nextIds);
         try {
-            await getSpaCocClient().preferences.patchRepo(workspaceId, { linkedRepoIds: nextIds });
+            await getCocClientForWorkspace(workspaceId).preferences.patchRepo(workspaceId, { linkedRepoIds: nextIds });
         } catch (e: any) {
             setLinkedRepoIds(prevIds);
             addToast(e?.message ?? 'Failed to save linked repos', 'error');
@@ -468,7 +468,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
     const fetchInstructions = useCallback(async () => {
         setInstrLoading(true);
         try {
-            const data = await getSpaCocClient().workspaces.getInstructions(workspaceId) as Record<InstructionMode, string | null>;
+            const data = await getCocClientForWorkspace(workspaceId).workspaces.getInstructions(workspaceId) as Record<InstructionMode, string | null>;
             setInstrContents(data);
             setInstrDraft({
                 base: data.base ?? '',
@@ -488,7 +488,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         setInstrSaving(true);
         try {
             const content = instrDraft[mode];
-            await getSpaCocClient().workspaces.updateInstruction(workspaceId, mode, { content });
+            await getCocClientForWorkspace(workspaceId).workspaces.updateInstruction(workspaceId, mode, { content });
             setInstrContents(prev => ({ ...prev, [mode]: content || null }));
             addToast('Instructions saved', 'success');
         } catch (e: any) {
@@ -502,7 +502,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         setInstrSaving(true);
         try {
             try {
-                await getSpaCocClient().workspaces.deleteInstruction(workspaceId, mode);
+                await getCocClientForWorkspace(workspaceId).workspaces.deleteInstruction(workspaceId, mode);
             } catch (e) {
                 if (!(e instanceof CocApiError && e.status === 404)) throw e;
             }
@@ -535,7 +535,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
 
     const fetchProcesses = useCallback(() => {
         setLoadingProcesses(true);
-        return fetchApi(`/processes?workspace=${encodeURIComponent(ws.id)}&limit=10`)
+        return requestForWorkspace<any>(ws.id, `/processes?workspace=${encodeURIComponent(ws.id)}&limit=10`)
             .then(res => setProcesses(res?.processes || []))
             .catch(() => setProcesses([]))
             .finally(() => setLoadingProcesses(false));
@@ -544,7 +544,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
     useEffect(() => { void fetchProcesses(); }, [fetchProcesses]);
 
     useEffect(() => {
-        getSpaCocClient().preferences.getTaskSettings(ws.id)
+        getCocClientForWorkspace(workspaceId).preferences.getTaskSettings(ws.id)
             .then(res => setTasksFolder(res?.taskRootPath || res?.folderPath || null))
             .catch(() => setTasksFolder(null));
     }, [ws.id]);
@@ -570,7 +570,7 @@ export function RepoSettingsTab({ workspaceId, repo }: RepoSettingsTabProps) {
         if (desc === (ws.description ?? '')) return;
         setSavingDesc(true);
         try {
-            await fetchApi(`/workspaces/${encodeURIComponent(ws.id)}`, {
+            await requestForWorkspace(ws.id, `/workspaces/${encodeURIComponent(ws.id)}`, {
                 method: 'PATCH',
                 body: JSON.stringify({ description: desc }),
             });

--- a/packages/coc/src/server/spa/client/react/features/skills/hooks/useRecentSkills.ts
+++ b/packages/coc/src/server/spa/client/react/features/skills/hooks/useRecentSkills.ts
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 
 export interface RecentSkillEntry {
     type: 'prompt' | 'skill';
@@ -38,7 +38,7 @@ export function useRecentSkills(wsId?: string): UseRecentSkillsResult {
         let cancelled = false;
         (async () => {
             try {
-                const client = getSpaCocClient();
+                const client = getCocClientForWorkspace(wsId);
                 const prefs = wsId
                     ? await client.preferences.getRepo(wsId)
                     : await client.preferences.getGlobal();
@@ -75,7 +75,7 @@ export function useRecentSkills(wsId?: string): UseRecentSkillsResult {
             const updated = [entry, ...filtered].slice(0, MAX_RECENT);
 
             // Fire-and-forget persistence (uses legacy key for backwards compat)
-            const client = getSpaCocClient();
+            const client = getCocClientForWorkspace(wsId);
             const patchData = { recentFollowPrompts: updated } as any;
             (wsId
                 ? client.preferences.patchRepo(wsId, patchData)

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecuteDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemExecuteDialog.tsx
@@ -6,7 +6,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Dialog, Button } from '../../ui';
 import { useRecentSkills } from '../../features/skills/hooks/useRecentSkills';
-import { fetchApi } from '../../hooks/useApi';
 import { useCocClient } from '../../repos/cloneRouting';
 import { RunSkillPanel } from '../../shared/RunSkillPanel';
 import type { SkillItem } from '../../shared/RunSkillPanel';
@@ -54,7 +53,9 @@ export function WorkItemExecuteDialog({
         setLoading(true);
         (async () => {
             try {
-                const data = await fetchApi(
+                // AC-07: skills load from the selected clone's server (remote clones
+                // route to their own host; local clones hit the default origin).
+                const data = await cloneClient.request<{ skills?: SkillItem[] }>(
                     '/workspaces/' + encodeURIComponent(workspaceId) + '/skills',
                 );
                 if (cancelled) return;
@@ -66,7 +67,7 @@ export function WorkItemExecuteDialog({
             }
         })();
         return () => { cancelled = true; };
-    }, [open, workspaceId]);
+    }, [open, workspaceId, cloneClient]);
 
     const toggleSkill = useCallback((name: string) => {
         setSelectedSkills(prev =>

--- a/packages/coc/src/server/spa/client/react/features/work-items/WorkItemsTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/work-items/WorkItemsTab.tsx
@@ -16,7 +16,7 @@ import { CreateWorkItemDialog } from './CreateWorkItemDialog';
 import { ImportFromGitHubDialog } from './ImportFromGitHubDialog';
 import { useWorkItems } from '../../contexts/WorkItemContext';
 import { useApp } from '../../contexts/AppContext';
-import { fetchApi } from '../../hooks/useApi';
+import { requestForWorkspace } from '../../repos/cloneRegistry';
 import { useFileCommentCounts } from '../git/hooks/useFileCommentCounts';
 import { computeDiffCommentKey } from '../../../comments/diff-comment-utils';
 import { buildWorkItemHash, buildWorkItemSessionHash, buildWorkItemCommitHash } from '../../layout/Router';
@@ -109,8 +109,9 @@ export function WorkItemsTab({ workspaceId, onNavigateToTasksTab }: WorkItemsTab
             return;
         }
         setCommitFilesLoading(true);
-        fetchApi(`/workspaces/${encodeURIComponent(workspaceId)}/git/commits/${selectedCommitHash}/files`)
-            .then((data: { files?: { status: string; path: string }[] }) => {
+        // Route to the selected clone's server (remote clones hit their own host).
+        requestForWorkspace<{ files?: { status: string; path: string }[] }>(workspaceId, `/workspaces/${encodeURIComponent(workspaceId)}/git/commits/${selectedCommitHash}/files`)
+            .then((data) => {
                 const files = data.files ?? [];
                 setCommitFiles(files);
                 if (files.length > 0) {

--- a/packages/coc/src/server/spa/client/react/queue/EnqueueDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/queue/EnqueueDialog.tsx
@@ -7,8 +7,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useQueue } from '../contexts/QueueContext';
 import { useApp } from '../contexts/AppContext';
 import { Dialog, FloatingDialog, Button } from '../ui';
-import { fetchApi } from '../hooks/useApi';
-import { getSpaCocClient } from '../api/cocClient';
+import { getCocClientForWorkspace, requestForWorkspace } from '../repos/cloneRegistry';
 import { usePreferences } from '../hooks/preferences/usePreferences';
 import { useFileAttachments } from '../features/chat/hooks/useFileAttachments';
 import { useBreakpoint } from '../hooks/ui/useBreakpoint';
@@ -194,7 +193,7 @@ export function EnqueueDialog() {
     useEffect(() => {
         setFolders([]);
         if (!workspaceId) return;
-        fetchApi('/workspaces/' + encodeURIComponent(workspaceId) + '/summary')
+        requestForWorkspace<any>(workspaceId, '/workspaces/' + encodeURIComponent(workspaceId) + '/summary')
             .then((resp: any) => {
                 const data = resp?.tasks;
                 if (data && typeof data === 'object') {
@@ -209,7 +208,7 @@ export function EnqueueDialog() {
         setSkills([]);
         setSelectedSkills([]);
         if (!workspaceId) return;
-        fetchApi('/workspaces/' + encodeURIComponent(workspaceId) + '/skills/all')
+        requestForWorkspace<any>(workspaceId, '/workspaces/' + encodeURIComponent(workspaceId) + '/skills/all')
             .then((data: any) => {
                 if (data?.merged && Array.isArray(data.merged)) {
                     setSkills(data.merged);
@@ -437,7 +436,7 @@ export function EnqueueDialog() {
                     const taskNameFromFile = file.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, '') ?? '';
                     const body = buildBody([file], taskNameFromFile);
                     try {
-                        await getSpaCocClient().queue.enqueue(body);
+                        await getCocClientForWorkspace(workspaceId).queue.enqueue(body);
                         succeeded++;
                     } catch {
                         failed++;
@@ -452,7 +451,7 @@ export function EnqueueDialog() {
                 const body = buildBody(
                     contextFiles.length > 0 ? contextFiles : undefined,
                 );
-                const created = await getSpaCocClient().queue.enqueue(body);
+                const created = await getCocClientForWorkspace(workspaceId).queue.enqueue(body);
                 if (queueState.dialogLaunchMode === 'floating-chat') {
                     const createdId = created?.task?.id;
                     if (createdId) {
@@ -475,7 +474,7 @@ export function EnqueueDialog() {
             // Record skill usage for ordering
             for (const sk of effectiveSkills) {
                 if (sk && workspaceId) {
-                    getSpaCocClient().preferences.recordSkillUsage(workspaceId, sk).catch(() => { /* ignore */ });
+                    getCocClientForWorkspace(workspaceId).preferences.recordSkillUsage(workspaceId, sk).catch(() => { /* ignore */ });
                 }
             }
             clearAttachments();

--- a/packages/coc/test/server/spa/client/work-items/WorkItemExecuteDialog.execution-mode.test.tsx
+++ b/packages/coc/test/server/spa/client/work-items/WorkItemExecuteDialog.execution-mode.test.tsx
@@ -7,6 +7,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 const mocks = vi.hoisted(() => ({
     execute: vi.fn(),
     recordSkillUsage: vi.fn(),
+    request: vi.fn(),
     fetchApi: vi.fn(),
     trackUsage: vi.fn(),
 }));
@@ -24,6 +25,7 @@ vi.mock('../../../../../src/server/spa/client/react/features/skills/hooks/useRec
 
 vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({
+        request: mocks.request,
         workItems: {
             execute: mocks.execute,
         },
@@ -45,7 +47,9 @@ import { WorkItemExecuteDialog } from '../../../../../src/server/spa/client/reac
 describe('WorkItemExecuteDialog execution modes', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.fetchApi.mockResolvedValue({
+        // Skills load through the clone-aware cloneClient.request (AC-07); for the
+        // unregistered ws-1 that resolves to this getSpaCocClient() mock.
+        mocks.request.mockResolvedValue({
             skills: [{ name: 'impl', description: 'Implement changes' }],
         });
         mocks.execute.mockResolvedValue({ taskId: 'task-1' });

--- a/packages/coc/test/spa/react/WorkItemExecuteDialog.test.tsx
+++ b/packages/coc/test/spa/react/WorkItemExecuteDialog.test.tsx
@@ -5,6 +5,7 @@ import { WorkItemExecuteDialog } from '../../../src/server/spa/client/react/feat
 const mocks = vi.hoisted(() => ({
     execute: vi.fn(),
     recordSkillUsage: vi.fn(),
+    request: vi.fn(),
     fetchApi: vi.fn(),
     trackUsage: vi.fn(),
     modalSelection: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock('../../../src/server/spa/client/react/hooks/useApi', () => ({
 
 vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({
+        request: mocks.request,
         workItems: {
             execute: mocks.execute,
         },
@@ -44,7 +46,9 @@ describe('WorkItemExecuteDialog', () => {
         vi.clearAllMocks();
         mocks.execute.mockResolvedValue({ taskId: 'task-1' });
         mocks.recordSkillUsage.mockResolvedValue({});
-        mocks.fetchApi.mockResolvedValue({
+        // Skills now load via the clone-aware cloneClient.request (AC-07), which for the
+        // unregistered ws-1 resolves to this getSpaCocClient() mock.
+        mocks.request.mockResolvedValue({
             skills: [
                 { name: 'impl', description: 'Implement changes' },
                 { name: 'code-review', description: 'Review changes' },

--- a/packages/coc/test/spa/react/hooks/useRecentSkills.test.ts
+++ b/packages/coc/test/spa/react/hooks/useRecentSkills.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useRecentSkills } from '../../../../src/server/spa/client/react/features/skills/hooks/useRecentSkills';
+import { registerCloneBaseUrls, resetCloneRegistryForTests } from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 
 // Mock fetch globally
 const fetchMock = vi.fn();
@@ -35,6 +36,7 @@ describe('useRecentSkills', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+        resetCloneRegistryForTests();
     });
 
     // ── Initial load ──────────────────────────────────────────────
@@ -127,6 +129,32 @@ describe('useRecentSkills', () => {
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
         expect(fetchMock.mock.calls[0][0]).toContain(encodeURIComponent('my repo/path'));
+    });
+
+    // ── Remote-clone routing (AC-07) ──────────────────────────────
+
+    it('routes preferences to the remote clone server when wsId is a registered remote workspace', async () => {
+        // Regression: recent-skills preferences for a remote clone must hit the
+        // clone's own server, not the page origin (which 404s "Workspace not found").
+        registerCloneBaseUrls([{ workspaceId: 'remote-ws', baseUrl: 'http://127.0.0.1:9999' }]);
+        fetchMock.mockResolvedValue(makePrefsResponse());
+
+        renderHook(() => useRecentSkills('remote-ws'));
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        const url = String(fetchMock.mock.calls[0][0]);
+        expect(url).toContain('http://127.0.0.1:9999');
+        expect(url).toContain('/workspaces/remote-ws/preferences');
+    });
+
+    it('keeps an unregistered (local) wsId on the page origin — no remote leakage', async () => {
+        fetchMock.mockResolvedValue(makePrefsResponse());
+
+        renderHook(() => useRecentSkills('local-ws'));
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        const url = String(fetchMock.mock.calls[0][0]);
+        expect(url.startsWith('/workspaces/local-ws/preferences')).toBe(true);
     });
 
     // ── trackUsage ────────────────────────────────────────────────

--- a/packages/coc/test/spa/react/repos/RepoSettingsTab.skills.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoSettingsTab.skills.test.tsx
@@ -35,6 +35,14 @@ vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
         error instanceof Error ? error.message : fallback,
 }));
 
+// RepoSettingsTab routes through the clone registry: typed calls via
+// getCocClientForWorkspace, raw fetches via requestForWorkspace. Delegate both to
+// the existing mocks so all assertions keep working for the unregistered ws-1.
+vi.mock('../../../../src/server/spa/client/react/repos/cloneRegistry', () => ({
+    getCocClientForWorkspace: () => mockClient,
+    requestForWorkspace: (_wsId: string, path: string, options?: RequestInit) => mockFetchApi(path, options),
+}));
+
 vi.mock('../../../../src/server/spa/client/react/contexts/ToastContext', () => ({
     useGlobalToast: () => ({ addToast: vi.fn() }),
 }));

--- a/packages/coc/test/spa/react/repos/WorkItemsClientMigration.test.ts
+++ b/packages/coc/test/spa/react/repos/WorkItemsClientMigration.test.ts
@@ -73,6 +73,15 @@ describe('work items SPA client migration', () => {
         expect(executeDialog).toContain("'/workspaces/' + encodeURIComponent(workspaceId) + '/skills'");
     });
 
+    it('loads the execute-dialog skill list through the clone-aware client, not the local-origin fetchApi', () => {
+        // Regression: for a remote clone, GET /workspaces/:id/skills must target the
+        // clone's own server. Routing it through the local-origin fetchApi 404s with
+        // "Workspace not found" because the local server has no such workspace.
+        expect(executeDialog).toContain('cloneClient.request');
+        expect(executeDialog).toContain("'/workspaces/' + encodeURIComponent(workspaceId) + '/skills'");
+        expect(executeDialog).not.toContain('fetchApi');
+    });
+
     it('loads execution session data through typed process and queue clients', () => {
         expect(executionSession).toContain('queue.getTask(taskId)');
         expect(executionSession).toContain('processes.get(pid)');

--- a/packages/coc/test/spa/react/repos/WorkItemsTab.commit-review.test.tsx
+++ b/packages/coc/test/spa/react/repos/WorkItemsTab.commit-review.test.tsx
@@ -14,6 +14,15 @@ vi.mock('../../../../src/server/spa/client/react/hooks/useApi', () => ({
     fetchApi: (path: string, options?: RequestInit) => mockFetchApi(path, options),
 }));
 
+// WorkItemsTab routes the commit-files load to the clone via requestForWorkspace;
+// delegate to the same mockFetchApi so the existing path-based setup keeps working.
+// Spread the real module so other consumers (e.g. WorkItemAiComposer's useCocClient
+// → lookupCloneBaseUrl) keep their real implementations.
+vi.mock('../../../../src/server/spa/client/react/repos/cloneRegistry', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../../../src/server/spa/client/react/repos/cloneRegistry')>()),
+    requestForWorkspace: (_wsId: string, path: string, options?: RequestInit) => mockFetchApi(path, options),
+}));
+
 vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
     useBreakpoint: () => ({ isMobile: false, isTablet: false }),
 }));

--- a/packages/coc/test/spa/react/repos/remoteCloneRoutingSweep.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteCloneRoutingSweep.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression: the remaining workspace-scoped SPA call sites route to the selected
+ * clone's server via the clone registry (remote clones hit their own host) instead
+ * of the local-origin fetchApi / default getSpaCocClient(). Before this, each of
+ * these 404'd ("Workspace not found") when the selected clone was remote.
+ *
+ * Source-grep style (mirrors WorkItemsClientMigration) so a revert to the
+ * local-origin client fails loudly.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REACT_SRC = path.join(__dirname, '..', '..', '..', '..', 'src', 'server', 'spa', 'client', 'react');
+const read = (rel: string) => fs.readFileSync(path.join(REACT_SRC, rel), 'utf-8');
+
+describe('remote-clone routing sweep', () => {
+    let enqueue: string;
+    let settings: string;
+    let repoDetail: string;
+    let workItemsTab: string;
+
+    beforeAll(() => {
+        enqueue = read('queue/EnqueueDialog.tsx');
+        settings = read('features/repo-settings/RepoSettingsTab.tsx');
+        repoDetail = read('features/repo-detail/RepoDetail.tsx');
+        workItemsTab = read('features/work-items/WorkItemsTab.tsx');
+    });
+
+    it('EnqueueDialog routes loads, the enqueue mutation, and skill-usage to the clone', () => {
+        expect(enqueue).toContain("requestForWorkspace<any>(workspaceId, '/workspaces/' + encodeURIComponent(workspaceId) + '/summary')");
+        expect(enqueue).toContain("requestForWorkspace<any>(workspaceId, '/workspaces/' + encodeURIComponent(workspaceId) + '/skills/all')");
+        expect(enqueue).toContain('getCocClientForWorkspace(workspaceId).queue.enqueue(body)');
+        expect(enqueue).toContain('getCocClientForWorkspace(workspaceId).preferences.recordSkillUsage(workspaceId');
+        // No local-origin fallthrough remains.
+        expect(enqueue).not.toContain('fetchApi');
+        expect(enqueue).not.toContain('getSpaCocClient()');
+    });
+
+    it('RepoSettingsTab routes its whole workspace-scoped surface to the clone', () => {
+        expect(settings).toContain('requestForWorkspace');
+        expect(settings).toContain('getCocClientForWorkspace(workspaceId)');
+        expect(settings).not.toContain('fetchApi');
+        // getSpaCocClientErrorMessage is still allowed; the bare client is not.
+        expect(settings).not.toContain('getSpaCocClient()');
+    });
+
+    it('RepoDetail routes the work-items badge preview to the clone', () => {
+        expect(repoDetail).toContain('requestForWorkspace');
+        expect(repoDetail).toContain('/work-items?limit=20');
+        expect(repoDetail).not.toContain('fetchApi(`/workspaces/${encodeURIComponent(ws.id)}/work-items');
+    });
+
+    it('WorkItemsTab routes the commit file list to the clone', () => {
+        expect(workItemsTab).toContain('requestForWorkspace');
+        expect(workItemsTab).toContain('/git/commits/');
+        expect(workItemsTab).not.toContain('fetchApi');
+    });
+});


### PR DESCRIPTION
## Summary

Follow-ups to #333. After that PR landed, several **workspace-scoped SPA call sites** still talked to the *local* CoC server, so they 404'd (`"Workspace not found"`) whenever the selected clone in the CLONE dropdown was a remote SSH/devtunnel server. This routes those remaining call sites to the clone's own server, so the remote-clone tabs work end-to-end.

Behind the experimental `features.remoteShell` flag. Local/unregistered workspace ids resolve to the default origin, so local behaviour is byte-for-byte unchanged.

## Why

#333 wired most tabs through the clone registry, but a handful of call sites were missed and kept using the local-origin `fetchApi` / default `getSpaCocClient()`. Each 404s for a remote clone because the local server has no such workspace.

## What changed

Two commits:

**`f8a00c56f` — work-item execute dialog + recent skills**
- `WorkItemExecuteDialog`: the skill-list load (the reported 404).
- `useRecentSkills`: per-workspace preferences get/patch (was silently failing for remote clones).

**`ce588fb4d` — the remaining sweep**
- `EnqueueDialog`: `/summary` + `/skills/all` loads, **the `queue.enqueue` mutation**, and `recordSkillUsage` — so a task enqueued against a remote repo runs on its own machine, not yours.
- `RepoSettingsTab`: the **entire** workspace-scoped surface (mcp-config GET/PUT, skills list/config/detail/delete, instructions, repo prefs, processes, description PATCH). Routing only part would half-break the tab on a remote clone.
- `RepoDetail`: the work-items badge preview.
- `WorkItemsTab`: the commit file list.

## How

All call sites go through the existing clone-registry seams:
- `requestForWorkspace(id, url, opts?)` for raw fetches (preserves `fetchApi`'s error translation).
- `getCocClientForWorkspace(id)` for typed-client calls (1:1 swap for `getSpaCocClient()`).

A local or unregistered id resolves to the default page origin, so these are no-ops for local clones.

## Testing

- ~1,250 tests green across the impacted components, their server-side duplicate suites, and full-app integration.
- New `remoteCloneRoutingSweep` source-grep regression locks the routing so a revert to the local-origin client fails loudly.
- `RepoSettingsTab` + `WorkItemsTab` behavioural tests updated to mock the clone registry (delegating to their existing mocks).
- esbuild client bundle builds clean; eslint reports 0 errors on the changed files.

## Reviewer notes / known limitations

- **Experimental & flag-gated** (`features.remoteShell`, off by default) — no impact on the default dashboard.
- **`RepoDetail` deliberately leaves a few calls on the local origin**: `/queue/resume`, launch-terminal, `/queue?repoId=`, and `workspaces.delete`. Their remote semantics are genuinely ambiguous (e.g. should "launch terminal" on a remote repo open a shell on your machine or the remote's?) and deserve a deliberate decision rather than a reflexive route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
