### PR TITLE
fix(coc): live-sync remote clone task status (per-clone global WS bridge)

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -720,6 +720,15 @@ the input:
   `promoteToRalph` through `getCocClientForWorkspace(workspaceId)`; the
   Activity events stream `useChatSSE` opens its `EventSource` at
   `cloneApiBase(workspaceId)`.
+- The GLOBAL `/ws` event stream is mirrored per-clone by `RemoteCloneEventBridge`
+  (`features/remote-shell/`, rendered inside `ReposProvider`): it opens one
+  `getCocClientFor(baseUrl).events.connect(...)` socket per ONLINE remote clone
+  (deduped by `baseUrl`, reconciled as clones connect/disconnect) and feeds every
+  message into App's shared `onMessage`. Without it, `useWebSocket` only listens to
+  the LOCAL `/ws`, so a remote task's `process-updated` lifecycle event never
+  arrives and its sidebar row stays stuck "running" (the per-process SSE still
+  shows the open conversation completing). This is the global-events counterpart to
+  the per-process `useChatSSE` routing.
 - The terminal PTY socket (`useTerminalWebSocket`) resolves the clone baseUrl
   from the registry and passes it into `cloneWsUrl`, so a remote clone's terminal
   targets its server. The `/ws` comment subscriptions (`useTaskComments` +

--- a/.github/skills/coc-knowledge/references/streaming-architecture.md
+++ b/.github/skills/coc-knowledge/references/streaming-architecture.md
@@ -43,6 +43,8 @@ The dashboard SPA may talk directly to a *different* CoC server forwarded at `ht
 - WS: `attachWebSocketUpgradeHandler()` (`streaming/websocket.ts`) calls `isWebSocketOriginAllowed()` before dispatching `/ws` or `/ws/terminal`. A non-loopback `Origin` upgrade is answered `403 Forbidden` and the socket destroyed; a missing `Origin` (non-browser client) is allowed.
 - This is always-on for loopback origins (not gated by `features.remoteShell`, which is a client-side UI flag).
 
+**Per-clone global sockets (dashboard).** `useWebSocket` opens the global `/ws` to the LOCAL server only. When remote clones are shown, `RemoteCloneEventBridge` (`spa/client/react/features/remote-shell/`) opens one additional global `/ws` per ONLINE remote clone (`getCocClientFor(baseUrl).events.connect`, deduped by `baseUrl`) and feeds their messages into the same `onMessage` dispatcher — so remote processes' `process-added/updated/removed` lifecycle events reach the dashboard and remote task rows transition `running → completed` live, exactly like local ones. The per-process token SSE is already routed per-clone via `useChatSSE`/`cloneApiBase`.
+
 ## Internal Architecture (Single Node.js Process)
 
 Everything runs in one Node.js process. LLM API calls are async network I/O (not CPU-bound).

--- a/packages/coc/src/server/spa/client/react/App.tsx
+++ b/packages/coc/src/server/spa/client/react/App.tsx
@@ -25,6 +25,7 @@ import { useWebSocket } from './hooks/useWebSocket';
 import { fetchApi } from './hooks/useApi';
 import { getSpaCocClient } from './api/cocClient';
 import { getCocClientForWorkspace } from './repos/cloneRegistry';
+import { RemoteCloneEventBridge } from './features/remote-shell/RemoteCloneEventBridge';
 import { ToastContainer, useToast } from './ui';
 import { toForwardSlashes } from '@plusplusoneplusplus/forge/utils/path-utils';
 import { MarkdownReviewDialog } from './processes/MarkdownReviewDialog';
@@ -467,6 +468,9 @@ function AppInner() {
     return (
         <ToastProvider value={{ addToast, removeToast, toasts }}>
             <ReposProvider>
+                {/* Mirror the global /ws event stream to every online remote clone
+                    so their tasks transition RUNNING → COMPLETED live (renders null). */}
+                <RemoteCloneEventBridge onMessage={onMessage} />
                 <div className="flex flex-col h-full">
                     <SecurityBanner />
                     <TopBar onAdminOpen={handleAdminOpen} />

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteCloneEventBridge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteCloneEventBridge.tsx
@@ -1,0 +1,95 @@
+/**
+ * RemoteCloneEventBridge — extends the global `/ws` event subscription to every
+ * ONLINE remote clone.
+ *
+ * The dashboard moves a task RUNNING → COMPLETED in the sidebar from the global
+ * `/ws` `process-added`/`process-updated`/`process-removed` lifecycle events
+ * (dispatched in App.onMessage). `useWebSocket` only connects that socket to the
+ * LOCAL server, so a remote clone's task never receives its lifecycle events and
+ * the row stays stuck "running" even though the conversation pane (fed by the
+ * per-process SSE, which IS routed per-clone via useChatSSE) shows it completed.
+ *
+ * This opens one additional global socket per online remote clone (deduped by
+ * `baseUrl`) and feeds every message into the SAME `onMessage` handler, so remote
+ * tasks update in real time exactly like local ones. Server-side loopback WS CORS
+ * (AC-02) already permits the cross-origin upgrade to `127.0.0.1:{port}`.
+ *
+ * Gated implicitly by `features.remoteShell`: the aggregation only contributes
+ * remote workspaces when the flag is on, so this no-ops (zero sockets) otherwise.
+ */
+import { useEffect, useRef } from 'react';
+import type { ProcessWebSocketConnection } from '@plusplusoneplusplus/coc-client';
+import { getCocClientFor } from '../../api/cocClient';
+import { useRepos } from '../../contexts/ReposContext';
+import { isRemoteWorkspace } from '../../repos/remoteWorkspaceAggregation';
+import type { RepoData } from '../../repos/repoGrouping';
+
+/** Distinct baseUrls of currently-online remote clones (one socket per server). */
+function onlineRemoteBaseUrls(repos: RepoData[]): string[] {
+    const set = new Set<string>();
+    for (const repo of repos) {
+        const ws = repo.workspace;
+        if (isRemoteWorkspace(ws) && ws.remote.connection === 'online' && ws.baseUrl) {
+            set.add(ws.baseUrl);
+        }
+    }
+    return Array.from(set).sort();
+}
+
+/**
+ * Keep a live global event socket open to each online remote clone, routing every
+ * message into the shared dashboard `onMessage` handler.
+ */
+export function useRemoteCloneEvents(onMessage: (msg: any) => void): void {
+    const { repos } = useRepos();
+
+    // Ref the handler so a new onMessage identity doesn't churn the sockets.
+    const onMessageRef = useRef(onMessage);
+    useEffect(() => {
+        onMessageRef.current = onMessage;
+    }, [onMessage]);
+
+    // Stable key for the online-clone set — reconcile sockets only when it changes.
+    const key = onlineRemoteBaseUrls(repos).join('|');
+    const connectionsRef = useRef<Map<string, ProcessWebSocketConnection>>(new Map());
+
+    useEffect(() => {
+        const conns = connectionsRef.current;
+        const desired = new Set(key ? key.split('|') : []);
+        // Drop sockets for clones that went offline or disappeared.
+        for (const [baseUrl, conn] of conns) {
+            if (!desired.has(baseUrl)) {
+                conn.close();
+                conns.delete(baseUrl);
+            }
+        }
+        // Open a socket for each newly-online clone, feeding the shared handler.
+        for (const baseUrl of desired) {
+            if (!conns.has(baseUrl)) {
+                conns.set(
+                    baseUrl,
+                    getCocClientFor(baseUrl).events.connect({
+                        onMessage: (msg: any) => onMessageRef.current(msg),
+                    }),
+                );
+            }
+        }
+    }, [key]);
+
+    // Close every remote socket on unmount.
+    useEffect(() => {
+        const conns = connectionsRef.current;
+        return () => {
+            for (const conn of conns.values()) {
+                conn.close();
+            }
+            conns.clear();
+        };
+    }, []);
+}
+
+/** Null-rendering bridge that wires remote-clone events into `onMessage`. */
+export function RemoteCloneEventBridge({ onMessage }: { onMessage: (msg: any) => void }): null {
+    useRemoteCloneEvents(onMessage);
+    return null;
+}

--- a/packages/coc/test/spa/react/remote-shell/RemoteCloneEventBridge.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteCloneEventBridge.test.tsx
@@ -1,0 +1,157 @@
+/* @vitest-environment jsdom */
+/**
+ * Tests for useRemoteCloneEvents — the global-event socket fan-out to online
+ * remote clones that keeps remote task rows transitioning RUNNING → COMPLETED.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const { mockUseRepos, connectSpy, sockets } = vi.hoisted(() => ({
+    mockUseRepos: vi.fn(),
+    connectSpy: vi.fn(),
+    sockets: new Map<string, { close: ReturnType<typeof vi.fn>; opts: any }>(),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/ReposContext', () => ({
+    useRepos: () => mockUseRepos(),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: vi.fn(() => ({})),
+    getCocClientFor: (baseUrl: string) => ({
+        events: {
+            connect: (opts: any) => {
+                connectSpy(baseUrl, opts);
+                const close = vi.fn();
+                sockets.set(baseUrl, { close, opts });
+                return { close };
+            },
+        },
+    }),
+}));
+
+import { useRemoteCloneEvents } from '../../../../src/server/spa/client/react/features/remote-shell/RemoteCloneEventBridge';
+
+function remoteRepo(id: string, baseUrl: string, connection: string) {
+    return {
+        workspace: {
+            id,
+            baseUrl,
+            remote: {
+                baseUrl,
+                serverId: `srv-${baseUrl}`,
+                serverLabel: 'Server',
+                offline: connection !== 'online',
+                connection,
+                queue: 'idle',
+            },
+        },
+    } as any;
+}
+
+function localRepo(id: string) {
+    return { workspace: { id } } as any;
+}
+
+describe('useRemoteCloneEvents', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        sockets.clear();
+        mockUseRepos.mockReturnValue({ repos: [] });
+    });
+
+    it('opens one socket per online remote clone (local repos ignored)', () => {
+        mockUseRepos.mockReturnValue({
+            repos: [
+                remoteRepo('w1', 'http://127.0.0.1:4000', 'online'),
+                remoteRepo('w2', 'http://127.0.0.1:5000', 'online'),
+                localRepo('local'),
+            ],
+        });
+        renderHook(() => useRemoteCloneEvents(vi.fn()));
+        expect(connectSpy).toHaveBeenCalledTimes(2);
+        expect(connectSpy.mock.calls.map(c => c[0]).sort()).toEqual([
+            'http://127.0.0.1:4000',
+            'http://127.0.0.1:5000',
+        ]);
+    });
+
+    it('dedupes multiple workspaces on the same server to a single socket', () => {
+        mockUseRepos.mockReturnValue({
+            repos: [
+                remoteRepo('w1', 'http://127.0.0.1:4000', 'online'),
+                remoteRepo('w2', 'http://127.0.0.1:4000', 'online'),
+            ],
+        });
+        renderHook(() => useRemoteCloneEvents(vi.fn()));
+        expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips clones that are not online (offline / connecting)', () => {
+        mockUseRepos.mockReturnValue({
+            repos: [
+                remoteRepo('w1', 'http://127.0.0.1:4000', 'offline'),
+                remoteRepo('w2', 'http://127.0.0.1:5000', 'connecting'),
+            ],
+        });
+        renderHook(() => useRemoteCloneEvents(vi.fn()));
+        expect(connectSpy).not.toHaveBeenCalled();
+    });
+
+    it('routes socket messages into the shared onMessage handler', () => {
+        const onMessage = vi.fn();
+        mockUseRepos.mockReturnValue({ repos: [remoteRepo('w1', 'http://127.0.0.1:4000', 'online')] });
+        renderHook(() => useRemoteCloneEvents(onMessage));
+
+        const msg = { type: 'process-updated', process: { id: 'p1', status: 'completed' } };
+        sockets.get('http://127.0.0.1:4000')!.opts.onMessage(msg);
+        expect(onMessage).toHaveBeenCalledWith(msg);
+    });
+
+    it('closes the socket when a clone goes offline', () => {
+        mockUseRepos.mockReturnValue({ repos: [remoteRepo('w1', 'http://127.0.0.1:4000', 'online')] });
+        const { rerender } = renderHook(() => useRemoteCloneEvents(vi.fn()));
+        const close = sockets.get('http://127.0.0.1:4000')!.close;
+        expect(close).not.toHaveBeenCalled();
+
+        mockUseRepos.mockReturnValue({ repos: [remoteRepo('w1', 'http://127.0.0.1:4000', 'offline')] });
+        rerender();
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens a socket for a newly-online clone without tearing down stable ones', () => {
+        mockUseRepos.mockReturnValue({ repos: [remoteRepo('w1', 'http://127.0.0.1:4000', 'online')] });
+        const { rerender } = renderHook(() => useRemoteCloneEvents(vi.fn()));
+        expect(connectSpy).toHaveBeenCalledTimes(1);
+        const stableClose = sockets.get('http://127.0.0.1:4000')!.close;
+
+        mockUseRepos.mockReturnValue({
+            repos: [
+                remoteRepo('w1', 'http://127.0.0.1:4000', 'online'),
+                remoteRepo('w2', 'http://127.0.0.1:5000', 'online'),
+            ],
+        });
+        rerender();
+        expect(connectSpy).toHaveBeenCalledTimes(2); // only the new server
+        expect(stableClose).not.toHaveBeenCalled(); // existing socket preserved
+    });
+
+    it('closes every socket on unmount', () => {
+        mockUseRepos.mockReturnValue({
+            repos: [
+                remoteRepo('w1', 'http://127.0.0.1:4000', 'online'),
+                remoteRepo('w2', 'http://127.0.0.1:5000', 'online'),
+            ],
+        });
+        const { unmount } = renderHook(() => useRemoteCloneEvents(vi.fn()));
+        unmount();
+        expect(sockets.get('http://127.0.0.1:4000')!.close).toHaveBeenCalledTimes(1);
+        expect(sockets.get('http://127.0.0.1:5000')!.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-ops when there are no remote clones', () => {
+        mockUseRepos.mockReturnValue({ repos: [localRepo('a'), localRepo('b')] });
+        renderHook(() => useRemoteCloneEvents(vi.fn()));
+        expect(connectSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to #334 (merged). A remote clone's task stayed stuck **"running"** in the dashboard sidebar after it finished — even though the open conversation pane correctly showed "Completed". This wires up the missing live-update path so remote task rows transition **RUNNING → COMPLETED** in real time, exactly like local tasks.

Behind the experimental `features.remoteShell` flag (no-ops when off).

## Root cause

The dashboard uses two server→browser channels, and only one was routed to remote clones:

- **Per-process SSE** (the open conversation's token/status stream) — already routed per-clone (`useChatSSE` opens its `EventSource` at the clone's `baseUrl`). That's why the conversation pane shows "Completed".
- **The global `/ws` WebSocket** (the `process-added/updated/removed` lifecycle events that flip a sidebar row's status) — `useWebSocket` only ever connected this to the **local** server. So when a task finishes on the remote machine, the remote server emits `process-updated` on **its** `/ws`, which the dashboard never listened to → the row stayed "running".

## Fix

`RemoteCloneEventBridge` (`features/remote-shell/`, rendered inside `ReposProvider`) opens one global `/ws` socket per **online** remote clone — `getCocClientFor(baseUrl).events.connect(...)`, deduped by `baseUrl`, reconciled as clones connect/disconnect, closed on unmount — and feeds every message into App's shared `onMessage`. Remote `process-*` lifecycle events now reach the dashboard, so remote rows update live.

The server side already permitted this: loopback WS CORS landed earlier (AC-02), so the cross-origin upgrade to `127.0.0.1:{port}` is accepted.

## Testing

- `useRemoteCloneEvents` unit tests: one socket per online clone, dedup by server, online-only filtering, message routing into `onMessage`, open/close on connect/disconnect, and unmount cleanup (8 tests).
- App-level + remote-shell suites stay green; the bridge no-ops with no online remote clones.
- esbuild bundle builds clean; eslint reports 0 errors on the changed files.

## Notes

- Scope: this covers the App-level `onMessage` dispatcher (process lifecycle, queue, work-items, notes, etc.). ReposContext's own local-`/ws` git/pipeline refresh is not yet mirrored per-clone — a possible follow-up, not needed for the task-status symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
