### PR TITLE
fix(coc): route RalphStartPanel goal-file read + ralph endpoints to the clone

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -716,6 +716,12 @@ the input:
   `recordSkillUsage`), `RepoSettingsTab` (mcp-config, skills, instructions, repo
   prefs, processes, description PATCH), `RepoDetail` (work-items badge preview),
   and `WorkItemsTab` (commit file list).
+- `RalphStartPanel` builds raw `fetch` URLs against `cloneApiBase(workspaceId)`
+  (absolute remote base, or local when unregistered) for its whole flow: the
+  goal-file read (`/fs/blob?path=...`) and the `ralph-launch` / `processes/:id/
+  ralph-start` POSTs — so a remote clone's goal file and Ralph session target the
+  clone's server (the local server 403s a remote-only path as "outside trusted
+  directories").
 - The Activity WRITE path `useSendMessage` routes `processes.sendMessage` /
   `promoteToRalph` through `getCocClientForWorkspace(workspaceId)`; the
   Activity events stream `useChatSSE` opens its `EventSource` at

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphStartPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphStartPanel.tsx
@@ -18,7 +18,7 @@
  *   completed grilling-phase process).
  */
 import { useState, useEffect } from 'react';
-import { getApiBase } from '../../utils/config';
+import { cloneApiBase } from '../../repos/cloneRegistry';
 import { cn } from '../../ui/cn';
 import type { ClientConversationTurn } from '../../types/dashboard';
 import { ModalJobAiControls, useModalJobAiSelection } from '../../shared/ModalJobAiControls';
@@ -68,7 +68,7 @@ export function RalphStartPanel({ processId, workspaceId, turns, onStarted, goal
             setLoadingFile(true);
             try {
                 const resp = await fetch(
-                    `${getApiBase()}/fs/blob?path=${encodeURIComponent(goalFilePath)}`,
+                    `${cloneApiBase(workspaceId)}/fs/blob?path=${encodeURIComponent(goalFilePath)}`,
                 );
                 if (!resp.ok) throw new Error(`Failed to read goal file (HTTP ${resp.status})`);
                 const data = await resp.json();
@@ -96,8 +96,8 @@ export function RalphStartPanel({ processId, workspaceId, turns, onStarted, goal
             // `goalFilePath` to load the file's content but keep the
             // ralph-start endpoint so the existing process/session is reused.
             const url = useLaunchEndpoint
-                ? `${getApiBase()}/ralph-launch`
-                : `${getApiBase()}/processes/${encodeURIComponent(processId)}/ralph-start`;
+                ? `${cloneApiBase(workspaceId)}/ralph-launch`
+                : `${cloneApiBase(workspaceId)}/processes/${encodeURIComponent(processId)}/ralph-start`;
             const resolvedAi = aiSelection.resolved;
             const config: Record<string, unknown> = {};
             if (resolvedAi.model) config.model = resolvedAi.model;

--- a/packages/coc/test/server/spa/client/repos/RalphStartPanel.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/RalphStartPanel.test.tsx
@@ -3,7 +3,7 @@
  *
  * Tests for RalphStartPanel component.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
@@ -33,6 +33,7 @@ vi.mock('../../../../../src/server/spa/client/react/shared/ModalJobAiControls', 
 
 import { RalphStartPanel } from '../../../../../src/server/spa/client/react/features/chat/RalphStartPanel';
 import type { ClientConversationTurn } from '../../../../../src/server/spa/client/react/types/dashboard';
+import { registerCloneBaseUrls, resetCloneRegistryForTests } from '../../../../../src/server/spa/client/react/repos/cloneRegistry';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,6 +60,45 @@ describe('RalphStartPanel', () => {
         mockModalSelection.mockReset();
         mockModalSelection.mockReturnValue({ resolved: { provider: 'copilot' } });
         vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        resetCloneRegistryForTests();
+    });
+
+    it('routes the goal-file blob fetch to the remote clone server, not the local origin', async () => {
+        // Regression: a remote clone's /fs/blob must target the clone's own server.
+        // Reading the path on the LOCAL server 403s ("Path is outside trusted
+        // directories") because that path only exists on the remote machine.
+        registerCloneBaseUrls([{ workspaceId: 'remote-ws', baseUrl: 'http://127.0.0.1:9999' }]);
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ content: '## Goal\nremote goal body' }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <RalphStartPanel
+                processId="queue_remote"
+                workspaceId="remote-ws"
+                turns={[]}
+                goalFilePath="/home/u/.coc/repos/remote-ws/notes/Plans/x.goal.md"
+                onStarted={mockOnStarted}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('ralph-start-btn'));
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        const url = String(fetchMock.mock.calls[0][0]);
+        expect(url).toContain('http://127.0.0.1:9999/api/fs/blob');
+        expect(url).not.toContain('localhost:4000');
+
+        // The remote file's content flows into the goal-spec editor.
+        await waitFor(() => {
+            const textarea = screen.getByTestId('ralph-goal-spec-input') as HTMLTextAreaElement;
+            expect(textarea.value).toContain('remote goal body');
+        });
     });
 
     it('shows "Start Ralph" button initially', () => {


### PR DESCRIPTION
## Summary

Another remote-clone routing gap (follow-up to #334 / #336). Opening the **Ralph start panel** on a remote clone failed: it read the goal-spec file via `GET /api/fs/blob?path=...` against the **local** server, which 403'd —

> `{"error":"Path is outside trusted directories"}`

— because the goal file (`/home/.../.coc/repos/<remote-ws>/notes/.../x.goal.md`) only exists on the remote machine, not in the local server's trusted dirs.

Behind the experimental `features.remoteShell` flag; local behaviour unchanged.

## What changed

`RalphStartPanel` built three raw `fetch` URLs against `getApiBase()` (the local origin):
- `GET /fs/blob?path=...` — reads the goal-spec file (the reported 403).
- `POST /ralph-launch` — mints a fresh Ralph session.
- `POST /processes/:id/ralph-start` — continues a grilling process as Ralph.

All three now use `cloneApiBase(workspaceId)` — the absolute remote base (`{baseUrl}/api`) for a remote clone, or the unchanged local base for a local/unregistered workspace. `workspaceId` is already threaded in from `ChatDetail`. So the goal-file read and the Ralph session both hit the clone that owns the workspace.

Routing the whole flow (not just the reported `/fs/blob`) avoids a half-routed dialog where the goal loads but starting Ralph then fails on the local origin.

## Testing

- New remote-routing regression: registers a clone `baseUrl`, renders the panel for that workspace, and asserts the `/fs/blob` fetch targets the remote server (`http://127.0.0.1:9999/api/fs/blob`, not localhost) and that the remote file's content loads into the goal editor.
- Existing RalphStartPanel suite (13) + ChatDetail (83, renders the panel) stay green.
- esbuild bundle builds clean; eslint reports 0 errors on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
