### PR TITLE
Add monotonic seq counter to break updatedAt ties in canvas ordering

### DIFF
--- a/packages/coc/src/server/canvas/canvas-store.ts
+++ b/packages/coc/src/server/canvas/canvas-store.ts
@@ -48,6 +48,14 @@ export interface CanvasDescriptor {
     revision: number;
     createdAt: string;
     updatedAt: string;
+    /**
+     * Strictly-monotonic per-store ordering counter, bumped on every
+     * create/update. Breaks `updatedAt` ties in `listCanvases` so the most
+     * recently touched canvas sorts first even when several writes land in the
+     * same millisecond. Optional: descriptors written before this field existed
+     * fall back to `updatedAt` ordering.
+     */
+    seq?: number;
     /** Process that created the canvas (links the canvas to a chat). */
     processId?: string;
     lastEditor: CanvasEditor;
@@ -194,7 +202,21 @@ function writeFileAtomic(filePath: string, data: string): void {
 // ============================================================================
 
 export class CanvasStore {
+    /**
+     * Monotonic counter assigned to each create/update as `CanvasDescriptor.seq`.
+     * Breaks `updatedAt` ties in `listCanvases` so the most recently touched
+     * canvas sorts first even when several writes share a millisecond timestamp.
+     * Per store instance and in-memory only; cross-timestamp ordering still
+     * relies on `updatedAt`, so a fresh process (counter reset to 0) keeps older
+     * canvases correctly ordered by their persisted timestamps.
+     */
+    private seqCounter = 0;
+
     constructor(private readonly dataDir: string) {}
+
+    private nextSeq(): number {
+        return ++this.seqCounter;
+    }
 
     private getWorkspaceRoot(workspaceId: string): string {
         return getRepoDataPath(this.dataDir, workspaceId, CANVASES_DIR_NAME);
@@ -218,6 +240,7 @@ export class CanvasStore {
             revision: 1,
             createdAt: now,
             updatedAt: now,
+            seq: this.nextSeq(),
             ...(input.processId ? { processId: input.processId } : {}),
             lastEditor: input.editor ?? 'ai',
             content: input.content,
@@ -267,7 +290,15 @@ export class CanvasStore {
             }
         }
 
-        descriptors.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0));
+        // Newest first by wall-clock timestamp, with the monotonic seq breaking
+        // ties when writes share a millisecond so the most recently touched
+        // canvas is always first.
+        descriptors.sort((a, b) => {
+            if (a.updatedAt !== b.updatedAt) {
+                return a.updatedAt < b.updatedAt ? 1 : -1;
+            }
+            return (b.seq ?? 0) - (a.seq ?? 0);
+        });
         return descriptors;
     }
 
@@ -308,6 +339,7 @@ export class CanvasStore {
             content,
             revision: existing.revision + 1,
             updatedAt: new Date().toISOString(),
+            seq: this.nextSeq(),
             lastEditor: input.editor,
         };
         this.persist(updated);
@@ -396,6 +428,7 @@ export class CanvasStore {
             ...existing,
             revision: existing.revision + 1,
             updatedAt: new Date().toISOString(),
+            seq: this.nextSeq(),
             lastEditor: editor,
         };
         this.persist(updated);

--- a/packages/coc/test/server/canvas/canvas-store.test.ts
+++ b/packages/coc/test/server/canvas/canvas-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -96,6 +96,30 @@ describe('CanvasStore', () => {
             expect(list.map(c => c.id)).toContain(a.id);
             expect(list[0].id).toBe(b.id);
             expect((list[0] as Record<string, unknown>).content).toBeUndefined();
+        });
+
+        it('orders the most recently touched canvas first when updatedAt timestamps collide', () => {
+            // Freeze the clock so every createdAt/updatedAt is byte-identical — the
+            // millisecond collision that made ordering flaky when it relied on the
+            // timestamp string alone. The monotonic per-store seq must still place
+            // the most recently touched canvas first.
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+            try {
+                const a = store.createCanvas({ workspaceId: WS, title: 'A', content: 'aaa' });
+                const b = store.createCanvas({ workspaceId: WS, title: 'B', content: 'bbb' });
+                // Touch A last; it must sort ahead of the more recently created B
+                // even though both carry the same updatedAt timestamp.
+                const updated = store.updateCanvas(WS, a.id, { content: 'aaa2', editor: 'ai' });
+
+                expect(updated.ok).toBe(true);
+                expect(a.updatedAt).toBe(b.updatedAt); // the tie is real
+
+                const list = store.listCanvases(WS);
+                expect(list.map(c => c.id)).toEqual([a.id, b.id]);
+            } finally {
+                vi.useRealTimers();
+            }
         });
 
         it('filters by processId', () => {


### PR DESCRIPTION
## Summary
This PR adds a monotonic sequence counter (`seq`) to canvas descriptors to ensure deterministic ordering when multiple canvases are updated within the same millisecond. Previously, canvases with identical `updatedAt` timestamps could be ordered non-deterministically, causing flaky list ordering.

## Key Changes
- **Added `seq` field to `CanvasDescriptor`**: An optional monotonic counter that increments on every create/update operation, providing a tiebreaker for canvases with identical `updatedAt` timestamps
- **Implemented `seqCounter` in `CanvasStore`**: A per-instance in-memory counter that tracks the sequence number for each operation
- **Updated sorting logic in `listCanvases`**: Modified the sort comparator to first compare by `updatedAt`, then by `seq` (descending) when timestamps are equal, ensuring the most recently touched canvas always sorts first
- **Assigned `seq` on create and update**: Both `createCanvas` and `updateCanvas` operations now assign the next sequence number via `nextSeq()`
- **Added test coverage**: New test verifies that when `updatedAt` timestamps collide, the most recently touched canvas (highest `seq`) sorts first

## Implementation Details
- The `seq` field is optional on `CanvasDescriptor` to maintain backward compatibility with descriptors written before this field existed
- The counter is in-memory only and resets per process instance; cross-timestamp ordering still relies on persisted `updatedAt` values, so fresh processes maintain correct ordering of older canvases
- The sort comparator uses `?? 0` fallback for missing `seq` values to handle legacy descriptors gracefully

https://claude.ai/code/session_01C2VBcqwEQYPgkAcCAsLvVR