### PR TITLE
fix(coc): route the Ralph session journal read to the clone

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -722,6 +722,13 @@ the input:
   ralph-start` POSTs — so a remote clone's goal file and Ralph session target the
   clone's server (the local server 403s a remote-only path as "outside trusted
   directories").
+- The Ralph workflow pane routes its whole data flow to the clone: the per-session
+  journal READ (`useRalphSessionView` -> `workspaces.ralphSession`) resolves its
+  client via `getCocClientForWorkspace(workspaceId)`, and the continue/new-loop/
+  resume mutations (`RalphWorkflowPaneContainer` / `RalphWorkflowPane`) go through
+  `useCocClient(workspaceId)` -- so a remote clone's Ralph session is read and
+  mutated on its own server (the bare local singleton 404s a remote-only session as
+  "Ralph session not found").
 - The Activity WRITE path `useSendMessage` routes `processes.sendMessage` /
   `promoteToRalph` through `getCocClientForWorkspace(workspaceId)`; the
   Activity events stream `useChatSSE` opens its `EventSource` at

--- a/packages/coc/src/server/spa/client/react/features/chat/useRalphSessionView.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/useRalphSessionView.ts
@@ -18,7 +18,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { getSpaCocClient } from '../../api/cocClient';
+import { getCocClientForWorkspace } from '../../repos/cloneRegistry';
 import type { RalphSessionView } from './RalphWorkflowPane';
 
 const DEFAULT_POLL_MS = 5000;
@@ -49,7 +49,11 @@ export function useRalphSessionView(
     useEffect(() => {
         if (!sessionId) return;
         let cancelled = false;
-        getSpaCocClient()
+        // Route the read to the clone that owns the workspace: a remote clone's
+        // Ralph session lives on its own server, so the bare local singleton
+        // would 404 ("Ralph session not found"). Local/unregistered ids resolve
+        // to the same default origin, so local behaviour is unchanged.
+        getCocClientForWorkspace(workspaceId)
             .workspaces.ralphSession(workspaceId, sessionId)
             .then((res) => {
                 if (cancelled) return;

--- a/packages/coc/test/spa/react/repos/remoteCloneRoutingSweep.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteCloneRoutingSweep.test.ts
@@ -56,4 +56,13 @@ describe('remote-clone routing sweep', () => {
         expect(workItemsTab).toContain('/git/commits/');
         expect(workItemsTab).not.toContain('fetchApi');
     });
+
+    it('useRalphSessionView routes the per-session journal read to the clone', () => {
+        const ralphView = read('features/chat/useRalphSessionView.ts');
+        expect(ralphView).toContain('getCocClientForWorkspace(workspaceId)');
+        expect(ralphView).toContain('.workspaces.ralphSession(workspaceId, sessionId)');
+        // The bare local singleton must not return — it 404s a remote clone's
+        // session ("Ralph session not found").
+        expect(ralphView).not.toContain('getSpaCocClient');
+    });
 });

--- a/packages/coc/test/spa/react/repos/useRalphSessionView.test.tsx
+++ b/packages/coc/test/spa/react/repos/useRalphSessionView.test.tsx
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  *
  * Tests for `useRalphSessionView` — the read-side hook for the per-session
- * Ralph journal. Mocks `getSpaCocClient().workspaces.ralphSession(...)` and
+ * Ralph journal. Mocks the local `getSpaCocClient()` and the remote
+ * `getCocClientFor(baseUrl)` clients' `workspaces.ralphSession(...)` and
  * verifies:
  *
  *   1. Initial fetch resolves into the `{record, sections}` shape.
@@ -12,12 +13,16 @@
  *   5. Once the session reaches a terminal phase, polling stops.
  *   6. Switching `sessionId` re-fetches.
  *   7. `sessionId === null` short-circuits without calling the client.
+ *   8. A registered remote workspace routes the read to the clone server.
+ *   9. An unregistered (local) workspace stays on the local singleton.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 
 const ralphSessionMock = vi.fn();
+const remoteRalphSessionMock = vi.fn();
+const getCocClientForMock = vi.fn();
 
 vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({
@@ -25,9 +30,19 @@ vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
             ralphSession: ralphSessionMock,
         },
     }),
+    // A remote clone resolves through getCocClientFor(baseUrl); return a DISTINCT
+    // client so a routed read is observably different from the local singleton.
+    getCocClientFor: (baseUrl: string) => {
+        getCocClientForMock(baseUrl);
+        return { workspaces: { ralphSession: remoteRalphSessionMock } };
+    },
 }));
 
 import { useRalphSessionView } from '../../../../src/server/spa/client/react/features/chat/useRalphSessionView';
+import {
+    registerCloneBaseUrls,
+    resetCloneRegistryForTests,
+} from '../../../../src/server/spa/client/react/repos/cloneRegistry';
 
 function makeRecord(overrides: any = {}) {
     return {
@@ -49,6 +64,12 @@ function sleep(ms: number): Promise<void> {
 
 beforeEach(() => {
     ralphSessionMock.mockReset();
+    remoteRalphSessionMock.mockReset();
+    getCocClientForMock.mockReset();
+});
+
+afterEach(() => {
+    resetCloneRegistryForTests();
 });
 
 describe('useRalphSessionView', () => {
@@ -164,5 +185,40 @@ describe('useRalphSessionView', () => {
         await sleep(20);
         expect(result.current.view).toBeUndefined();
         expect(ralphSessionMock).not.toHaveBeenCalled();
+    });
+
+    // ── Remote-clone routing (AC-07) ──────────────────────────────
+
+    it('routes the session read to the remote clone server when wsId is a registered remote workspace', async () => {
+        // Regression: a remote clone's Ralph session lives on its own server, so
+        // the read must hit the clone — not the local singleton, which 404s with
+        // "Ralph session not found".
+        registerCloneBaseUrls([{ workspaceId: 'remote-ws', baseUrl: 'http://127.0.0.1:9999' }]);
+        remoteRalphSessionMock.mockResolvedValueOnce({
+            record: makeRecord({ sessionId: 'sess-r', phase: 'complete' }),
+            sections: [],
+        });
+
+        const { result } = renderHook(() => useRalphSessionView('remote-ws', 'sess-r'));
+        await waitFor(() => expect(result.current.view).not.toBeUndefined());
+
+        expect(getCocClientForMock).toHaveBeenCalledWith('http://127.0.0.1:9999');
+        expect(remoteRalphSessionMock).toHaveBeenCalledWith('remote-ws', 'sess-r');
+        expect(ralphSessionMock).not.toHaveBeenCalled();
+        expect(result.current.view?.record.sessionId).toBe('sess-r');
+    });
+
+    it('keeps an unregistered (local) wsId on the local singleton — no remote leakage', async () => {
+        ralphSessionMock.mockResolvedValueOnce({
+            record: makeRecord({ sessionId: 'sess-l', phase: 'complete' }),
+            sections: [],
+        });
+
+        const { result } = renderHook(() => useRalphSessionView('local-ws', 'sess-l'));
+        await waitFor(() => expect(result.current.view).not.toBeUndefined());
+
+        expect(ralphSessionMock).toHaveBeenCalledWith('local-ws', 'sess-l');
+        expect(getCocClientForMock).not.toHaveBeenCalled();
+        expect(remoteRalphSessionMock).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

Another remote-clone routing gap (follow-up to #334 / #336 / #337). Opening a **Ralph session in the workflow pane** for a remote clone failed with:

> Ralph session not found.
> Session id: `ralph-1781621575712-myk717`

The pane reads the per-session journal via `useRalphSessionView`, which used the bare `getSpaCocClient()` singleton — always the **local** server. A remote clone's Ralph session only exists on the remote machine, so the read 404'd and the pane fell back to its "session not found" empty state.

Behind the experimental `features.remoteShell` flag; local behaviour unchanged.

## What changed

`useRalphSessionView` now resolves its client via `getCocClientForWorkspace(workspaceId)` — the remote clone's client for a registered remote workspace, or the unchanged local base for a local/unregistered id — mirroring `useRecentSkills`. `workspaceId` was already an effect dependency, so no dependency-array change.

The pane's continue / new-loop / resume **mutations** already routed through `useCocClient(workspaceId)`, so this read was the one remaining unrouted Ralph-session call. The whole workflow-pane data flow now targets the clone that owns the workspace.

## Testing

- Two routing regressions added to `useRalphSessionView.test.tsx`: a registered remote workspace reads from the clone client (asserts `getCocClientFor('http://127.0.0.1:9999')` is used, not the local singleton); an unregistered (local) id stays on the local singleton with no remote leakage.
- A source-grep assertion added to `remoteCloneRoutingSweep.test.ts` so a revert to `getSpaCocClient()` fails loudly.
- Adjacent suites green: 177 (Ralph pane / container / activity list + clone-routing / registry / sweep) and 399 integration (ChatDetail + RepoChatTab). esbuild bundle builds clean; eslint reports 0 errors on the changed files.
- Updated the dashboard-spa coc-knowledge reference's routed-surface list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
