### PR TITLE
fix(coc): keep real sub-agent duration in agent canvas

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/agentToolCalls.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/agentToolCalls.ts
@@ -52,6 +52,37 @@ export function nonEmptyArgs(tc: ClientToolCall): Record<string, unknown> | unde
 // tool-call id appears in both `turn.toolCalls` and the timeline.
 const STATUS_RANK: Record<string, number> = { pending: 0, running: 1, completed: 2, failed: 2 };
 
+// A single tool call surfaces as several snapshots (live `tool-start` /
+// `tool-complete`, plus the persisted row), and each stamps its own *receipt*
+// time — so the terminal snapshot's `startTime` is actually the completion
+// moment. Merge a run's true span as the earliest observed start and the latest
+// observed end; otherwise a late snapshot's start wins and collapses the run to
+// a 0:00 duration in the canvas. Returns the original value to preserve its type
+// (ISO string or epoch ms).
+function earliestTime(a: unknown, b: unknown): unknown {
+    const ta = parseTime(a);
+    const tb = parseTime(b);
+    if (ta === undefined) {
+        return b;
+    }
+    if (tb === undefined) {
+        return a;
+    }
+    return ta <= tb ? a : b;
+}
+
+function latestTime(a: unknown, b: unknown): unknown {
+    const ta = parseTime(a);
+    const tb = parseTime(b);
+    if (ta === undefined) {
+        return b;
+    }
+    if (tb === undefined) {
+        return a;
+    }
+    return ta >= tb ? a : b;
+}
+
 /** Collect every tool call across turns, deduped by id, preferring terminal state. */
 export function collectToolCalls(turns: ClientConversationTurn[]): ClientToolCall[] {
     const byId = new Map<string, ClientToolCall>();
@@ -75,8 +106,8 @@ export function collectToolCalls(turns: ClientConversationTurn[]): ClientToolCal
             ...worse,
             ...better,
             ...(mergedArgs ? { args: mergedArgs } : {}),
-            startTime: better.startTime ?? worse.startTime,
-            endTime: better.endTime ?? worse.endTime,
+            startTime: earliestTime(better.startTime, worse.startTime) as ClientToolCall['startTime'],
+            endTime: latestTime(better.endTime, worse.endTime) as ClientToolCall['endTime'],
             result: better.result ?? worse.result,
             error: better.error ?? worse.error,
             // The terminal snapshot can also drop the parent linkage — keep

--- a/packages/coc/test/server/spa/client/agent-canvas-data.test.ts
+++ b/packages/coc/test/server/spa/client/agent-canvas-data.test.ts
@@ -172,6 +172,55 @@ describe('buildAgentRunTreeFromTurns', () => {
         });
     });
 
+    it('keeps the real start when the tool-complete snapshot re-stamps startTime to the finish time', () => {
+        // useChatSSE stamps `startTime: now` on EVERY tool snapshot, so a
+        // tool-complete carries a startTime equal to the *completion* moment.
+        // The merge must keep the earliest start (the tool-start snapshot),
+        // otherwise the sub-agent renders a bogus 0:00 duration in the canvas.
+        const turns = [assistantTurn(
+            [],
+            [
+                { type: 'tool-start', timestamp: '2026-06-13T10:00:00.000Z', toolCall: tc({ id: 't1', args: { description: 'work' }, status: 'running', startTime: '2026-06-13T10:00:00.000Z', endTime: undefined }) },
+                { type: 'tool-complete', timestamp: '2026-06-13T10:00:44.000Z', toolCall: tc({ id: 't1', args: { description: 'work' }, status: 'completed', startTime: '2026-06-13T10:00:44.000Z', endTime: '2026-06-13T10:00:44.000Z', result: 'ok' }) },
+            ],
+        )];
+        const child = buildAgentRunTreeFromTurns(turns).children[0];
+        expect(child.status).toBe('done');
+        expect(child.startedAt).toBe(Date.parse('2026-06-13T10:00:00.000Z'));
+        expect(child.completedAt).toBe(Date.parse('2026-06-13T10:00:44.000Z'));
+        // The whole point: a real, non-zero span survives the merge.
+        expect(child.completedAt! - child.startedAt!).toBe(44_000);
+    });
+
+    it('prefers the earliest start / latest end across persisted and timeline snapshots', () => {
+        // Persisted row has the true span; a later timeline snapshot re-stamps a
+        // start at finish time. Earliest-start / latest-end keeps the true span
+        // regardless of which snapshot the status-rank merge treats as "better".
+        const turns = [assistantTurn(
+            [tc({ id: 't1', args: { description: 'work' }, status: 'completed', startTime: '2026-06-13T10:00:00.000Z', endTime: '2026-06-13T10:00:30.000Z', result: 'ok' })],
+            [
+                { type: 'tool-complete', timestamp: '2026-06-13T10:00:44.000Z', toolCall: tc({ id: 't1', args: {}, status: 'completed', startTime: '2026-06-13T10:00:44.000Z', endTime: '2026-06-13T10:00:44.000Z', result: 'ok' }) },
+            ],
+        )];
+        const child = buildAgentRunTreeFromTurns(turns).children[0];
+        expect(child.startedAt).toBe(Date.parse('2026-06-13T10:00:00.000Z'));
+        expect(child.completedAt).toBe(Date.parse('2026-06-13T10:00:44.000Z'));
+    });
+
+    it('still resolves a start when only the terminal snapshot carries a time', () => {
+        // If the tool-start snapshot was missed, fall back to whatever time the
+        // terminal snapshot has rather than dropping it.
+        const turns = [assistantTurn(
+            [tc({ id: 't1', args: { description: 'work' }, status: 'running', startTime: undefined, endTime: undefined })],
+            [
+                { type: 'tool-complete', timestamp: '2026-06-13T10:00:44.000Z', toolCall: tc({ id: 't1', args: { description: 'work' }, status: 'completed', startTime: '2026-06-13T10:00:44.000Z', endTime: '2026-06-13T10:00:44.000Z', result: 'ok' }) },
+            ],
+        )];
+        const child = buildAgentRunTreeFromTurns(turns).children[0];
+        expect(child.startedAt).toBe(Date.parse('2026-06-13T10:00:44.000Z'));
+        expect(child.completedAt).toBe(Date.parse('2026-06-13T10:00:44.000Z'));
+    });
+
     it('derives root status from children when no explicit status is given', () => {
         const running = [assistantTurn([tc({ id: 't1', args: { description: 'x' }, status: 'running' })])];
         expect(buildAgentRunTreeFromTurns(running).status).toBe('running');


### PR DESCRIPTION
A tool call surfaces as several snapshots (live tool-start/tool-complete
plus the persisted row), and useChatSSE stamps startTime=now on EVERY
snapshot — so the tool-complete snapshot's startTime is actually the
completion moment. collectToolCalls merged with `better.startTime ??
worse.startTime`, letting that terminal snapshot's start win and clobber
the real start, collapsing every completed sub-agent to a 0:00 duration
in the canvas (running sub-agents were unaffected, hiding the bug).

Merge a run's span as earliest observed start / latest observed end so a
late snapshot can never shrink it. Add regression coverage for the
re-stamped tool-complete startTime, the persisted+timeline mix, and the
terminal-only fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
