### PR TITLE
fix(coc): Orchestrator breadcrumb returns to main thread, not the chart

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -386,8 +386,9 @@ same `handleSelectAgent` path as the cascade menu so the read-only
 `AgentCascadeMenu` lists the tree's depth levels (`flattenAgentLevels` → L0…Ln,
 only existing levels) in a left pane and that level's agents on the right;
 picking an agent opens its conversation **in-place, read-only**
-(`SubAgentDetailView`), picking the orchestrator (L0) returns to the
-thread/canvas. The selected sub-agent rides the hash as `?agent=<id>` alongside
+(`SubAgentDetailView`), picking the orchestrator (L0) returns to the main
+thread (`handleSelectAgent` derives the view via `viewForAgentSelection`: a
+sub-agent id → `agents` canvas, the orchestrator/null → `thread`). The selected sub-agent rides the hash as `?agent=<id>` alongside
 `?view=agents` (`chatAgentHash.ts`), composed into one `replaceState`; a
 stale/invalid id clears itself and resets on chat switch (parity with
 `effectiveView`). `buildSubAgentTurns(turns, id)` reconstructs the sub-agent's

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -47,7 +47,7 @@ import { buildEffortOptionsForModel } from './EffortPillSelector';
 import type { EffortLevel } from './EffortPillSelector';
 import type { RichTextInputHandle } from '../../shared/RichTextInput';
 import { ConversationMiniMap } from './conversation/ConversationMiniMap';
-import { AgentCanvas, AgentCascadeMenu, SubAgentDetailView, ChatViewToggle, buildAgentRunTreeFromTurns, buildSubAgentTurns, flattenAgentLevels, findAgentNode, pathToAgent, readChatViewFromHash, applyChatViewToHash, readAgentFromHash, applyAgentToHash } from './agent-canvas';
+import { AgentCanvas, AgentCascadeMenu, SubAgentDetailView, ChatViewToggle, viewForAgentSelection, buildAgentRunTreeFromTurns, buildSubAgentTurns, flattenAgentLevels, findAgentNode, pathToAgent, readChatViewFromHash, applyChatViewToHash, readAgentFromHash, applyAgentToHash } from './agent-canvas';
 import type { AgentRunNode, ChatView } from './agent-canvas';
 import { useConversationSelection } from './hooks/useConversationSelection';
 import { snapshotConversation } from '../../utils/snapshot-copy-utils';
@@ -393,12 +393,11 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         [agentRoot, selectedAgentNode, selectedAgentId],
     );
     // Open a sub-agent (forcing the agents context so closing returns to the
-    // canvas) or return to the orchestrator (null).
+    // canvas) or return to the orchestrator (null), which lands back on the
+    // main thread rather than the agents canvas.
     const handleSelectAgent = useCallback((agentId: string | null) => {
         setSelectedAgentId(agentId);
-        if (agentId) {
-            setView('agents');
-        }
+        setView(viewForAgentSelection(agentId));
     }, []);
 
     const openAgentDetail = useCallback((node: AgentRunNode) => {

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/ChatViewToggle.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/ChatViewToggle.tsx
@@ -7,6 +7,16 @@ import { AcIcons } from './icons';
 
 export type ChatView = 'thread' | 'agents';
 
+/**
+ * The view that should be shown after selecting an agent from the canvas,
+ * breadcrumb, or cascade menu: a sub-agent id opens the spatial 'agents'
+ * context, while the orchestrator root (null) returns to the linear 'thread'.
+ * Pure so the "Orchestrator → back to thread" navigation stays unit-testable.
+ */
+export function viewForAgentSelection(agentId: string | null): ChatView {
+    return agentId ? 'agents' : 'thread';
+}
+
 interface ChatViewToggleProps {
     view: ChatView;
     onChange: (view: ChatView) => void;

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/index.ts
@@ -1,6 +1,6 @@
 export { AgentCanvas } from './AgentCanvas';
 export type { AgentCanvasProps } from './AgentCanvas';
-export { ChatViewToggle } from './ChatViewToggle';
+export { ChatViewToggle, viewForAgentSelection } from './ChatViewToggle';
 export type { ChatView } from './ChatViewToggle';
 export { AgentCascadeMenu } from './AgentCascadeMenu';
 export { SubAgentDetailView } from './SubAgentDetailView';

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-sub-agent-view.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-sub-agent-view.test.ts
@@ -50,6 +50,15 @@ describe('ChatDetail sub-agent drill-in wiring', () => {
         expect(source).toMatch(/onSelectAgent=\{handleSelectAgent\}/);
     });
 
+    it('routes the view from the selection so the orchestrator returns to the thread', () => {
+        // handleSelectAgent(null) (Orchestrator breadcrumb / cascade item /
+        // canvas root) must switch the view back to the thread instead of
+        // leaving the user on the agents canvas — delegated to the pure
+        // viewForAgentSelection helper (covered directly in ChatViewToggle.test).
+        expect(source).toContain('viewForAgentSelection');
+        expect(source).toMatch(/setView\(viewForAgentSelection\(agentId\)\)/);
+    });
+
     it('wires the canvas inspector action through the same selected-agent detail path', () => {
         expect(source).toMatch(/const\s+openAgentDetail\s*=\s*useCallback/);
         expect(source).toContain('handleSelectAgent(node.isRoot ? null : node.id)');

--- a/packages/coc/test/spa/react/ChatViewToggle.test.tsx
+++ b/packages/coc/test/spa/react/ChatViewToggle.test.tsx
@@ -1,7 +1,23 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ChatViewToggle } from '../../../src/server/spa/client/react/features/chat/agent-canvas/ChatViewToggle';
+import { ChatViewToggle, viewForAgentSelection } from '../../../src/server/spa/client/react/features/chat/agent-canvas/ChatViewToggle';
+
+describe('viewForAgentSelection', () => {
+    it('opens the agents canvas for a selected sub-agent id', () => {
+        expect(viewForAgentSelection('agent-1')).toBe('agents');
+    });
+
+    it('returns to the main thread for the orchestrator root (null)', () => {
+        // Regression: clicking the "Orchestrator" breadcrumb / cascade item
+        // must land on the thread, not leave the user staring at the chart.
+        expect(viewForAgentSelection(null)).toBe('thread');
+    });
+
+    it('treats an empty id as the orchestrator (thread)', () => {
+        expect(viewForAgentSelection('')).toBe('thread');
+    });
+});
 
 describe('ChatViewToggle', () => {
     it('renders Thread and Agents segments', () => {


### PR DESCRIPTION
Clicking the "Orchestrator" crumb in the read-only sub-agent detail view
(and the cascade menu's "Orchestrator (back to thread)" item, and the canvas
root node) cleared the selected agent but never switched the view, leaving the
user on the Agents canvas/chart instead of the conversation. handleSelectAgent
now derives the view from the selection via a new pure viewForAgentSelection
helper: a sub-agent id -> agents canvas, the orchestrator/null -> thread.

Tests: unit-test viewForAgentSelection (agents for an id, thread for null/empty)
in ChatViewToggle.test, plus a wiring assertion in the ChatDetail sub-agent-view
source test. Update the dashboard-spa coc-knowledge reference.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
