### PR TITLE
fix(coc): resolve files/preview relative paths against workspace root

### DIFF
--- a/packages/coc/src/server/tasks/tasks-read-handler.ts
+++ b/packages/coc/src/server/tasks/tasks-read-handler.ts
@@ -136,9 +136,12 @@ export function registerTaskRoutes(routes: Route[], store: ProcessStore, dataDir
                 return sendError(res, 400, 'Missing required query parameter: path');
             }
 
-            // Resolve and validate path is within workspace, a trusted read-only directory, or the task root
-            const resolvedPath = path.resolve(filePath);
+            // Resolve and validate path is within workspace, a trusted read-only directory, or the task root.
+            // Relative paths resolve against the workspace root (mirrors resolveAllowedHtmlPath), not process.cwd().
             const wsRoot = path.resolve(ws.rootPath);
+            const resolvedPath = path.isAbsolute(filePath)
+                ? path.resolve(filePath)
+                : path.resolve(wsRoot, filePath);
             const taskRoot = resolveTaskRoot({ dataDir, rootPath: ws.rootPath, workspaceId: ws.id });
             if (!isWithinDirectory(resolvedPath, wsRoot) && !isWithinTrustedReadOnlyDir(resolvedPath, dataDir) && !isWithinDirectory(resolvedPath, taskRoot.absolutePath)) {
                 return sendError(res, 403, 'Access denied: path is outside workspace');

--- a/packages/coc/test/server/file-preview-api.test.ts
+++ b/packages/coc/test/server/file-preview-api.test.ts
@@ -288,6 +288,45 @@ describe('File Preview API', () => {
     });
 
     // ========================================================================
+    // Relative paths (regression: path must resolve against workspace root,
+    // not the server process cwd)
+    // ========================================================================
+
+    describe('GET /api/workspaces/:id/files/preview — Relative paths', () => {
+        it('resolves a workspace-relative path against the workspace root', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+
+            const lines = Array.from({ length: 30 }, (_, i) => `Line ${i + 1}`);
+            createFile('src/server/main.ts', lines.join('\n'));
+
+            const relPath = path.join('src', 'server', 'main.ts');
+            const res = await request(
+                `${srv.url}/api/workspaces/${wsId}/files/preview?path=${encodeURIComponent(relPath)}&lines=0`
+            );
+            expect(res.status).toBe(200);
+            const body = JSON.parse(res.body);
+            expect(body.fileName).toBe('main.ts');
+            expect(body.lines).toHaveLength(30);
+            // Server echoes the absolute resolved path
+            expect(body.path).toBe(path.join(workspaceDir, 'src', 'server', 'main.ts'));
+        });
+
+        it('returns 403 for a relative path that escapes the workspace', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+
+            const relTraversal = path.join('..', '..', '..', '..', 'etc', 'passwd');
+            const res = await request(
+                `${srv.url}/api/workspaces/${wsId}/files/preview?path=${encodeURIComponent(relTraversal)}`
+            );
+            expect(res.status).toBe(403);
+            const body = JSON.parse(res.body);
+            expect(body.error).toContain('outside workspace');
+        });
+    });
+
+    // ========================================================================
     // Edge Cases
     // ========================================================================
 


### PR DESCRIPTION
The GET /api/workspaces/:id/files/preview handler called
path.resolve(filePath) with no base, so a workspace-relative `path`
query param resolved against the server process cwd instead of the
workspace — yielding a spurious 403/404. Mirror resolveAllowedHtmlPath
and the sibling /tasks/content route: absolute paths are unchanged,
relative paths now resolve against the workspace root. The existing
isWithinDirectory guard still rejects relative traversal escapes.

Add regression tests: a workspace-relative path resolves and returns
content, and a relative path escaping the workspace returns 403.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
