### PR TITLE
pr/53e843d5c featcoc wrap tool guidance prompt fragme

### DIFF
--- a/.github/skills/coc-knowledge/references/llm-tools.md
+++ b/.github/skills/coc-knowledge/references/llm-tools.md
@@ -55,6 +55,8 @@ preferences are rewritten.
 - Applies `applyLlmToolPreferences()` filtering from `prompt-builder.ts`
 - Filters by the effective disabled tools list
 
+Each addon's prompt `suffix` is wrapped in a named XML-style tag via `tagGuidanceSuffix()` from `prompt-tags.ts` (e.g. `<follow_up_suggestions>`, `<ask_user_tool>`, `<work_item_tools>`, `<web_search_tool>`, `<canvas_tools>`, `<memory_tool>`), so the aggregated `toolGuidance` is self-delimiting. `tagGuidanceSuffix` includes the leading blank-line separator `applyLlmToolPreferences` relies on; the standalone `tagBlock()` helper wraps non-suffix blocks (e.g. the `<citing_rule>` source-location directive). When a tool is disabled its whole tagged block is dropped with it.
+
 ## Provider Parity (Copilot / Codex / Claude)
 
 The assembled `Tool<any>[]` bundle is passed to every provider via

--- a/packages/coc-agent-sdk/src/claude-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/claude-sdk-service.ts
@@ -28,20 +28,20 @@
  * themselves.
  */
 
-import type { SendMessageOptions, MCPServerConfig, MCPLocalServerConfig, ReasoningEffort, SystemMessageConfig, TokenUsage } from './types';
+import type { SendMessageOptions, MCPServerConfig, MCPLocalServerConfig, ReasoningEffort, SystemMessageConfig, TokenUsage, Attachment } from './types';
 import type { ToolEvent } from './types';
 import { denyAllPermissions } from './types';
 import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult, TransformOptions, TransformResult } from './sdk-service-interface';
 import type { IAccountQuotaResult, IAccountQuotaSnapshot } from './copilot-sdk-service';
 import type { ToolCall } from './tool-call';
-import type { ClaudeImageSource } from './image-converter';
+import type { ClaudeImageSource, ClaudeImageSkip } from './image-converter';
 import { sdkServiceRegistry, CLAUDE_PROVIDER } from './sdk-service-registry';
 import { dynamicImportModule } from './sdk-esm-loader';
 import { getSDKLogger } from './logger';
 import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
 import { cocToolBridgeServer } from './llm-tools/bridge-server';
 import { buildCocLlmToolsMcpConfig, COC_LLM_TOOLS_MCP_SERVER_NAME } from './llm-tools/mcp-config';
-import { tryReadImageAsBase64 } from './image-converter';
+import { evaluateClaudeImageFile } from './image-converter';
 import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import * as crypto from 'crypto';
@@ -793,10 +793,21 @@ export class ClaudeSDKService implements ISDKService {
 
     private buildClaudePrompt(options: SendMessageOptions): string | AsyncIterable<ClaudeStreamingUserMessage> {
         const text = options.prompt ?? '';
-        const images = (options.attachments ?? [])
-            .filter(attachment => attachment.type === 'file')
-            .map(attachment => tryReadImageAsBase64(attachment.path))
-            .filter((image): image is ClaudeImageSource => image !== null);
+        const images: ClaudeImageSource[] = [];
+        for (const attachment of options.attachments ?? []) {
+            if (attachment.type !== 'file') continue;
+            // Explicit Claude image-size boundary: oversized/malformed supported
+            // images are dropped here (not forwarded) and recorded as sanitized
+            // skip diagnostics. Unsupported extensions (SVG, non-images) return
+            // null and are ignored silently so text-only behavior is preserved.
+            const evaluation = evaluateClaudeImageFile(attachment.path);
+            if (!evaluation) continue;
+            if (evaluation.ok) {
+                images.push(evaluation.source);
+            } else {
+                this.logClaudeImageSkipped(attachment, evaluation.skip);
+            }
+        }
 
         if (images.length === 0) return text;
 
@@ -820,6 +831,29 @@ export class ClaudeSDKService implements ISDKService {
         return (async function* () {
             yield message;
         })();
+    }
+
+    /**
+     * Record a sanitized diagnostic for a Claude image attachment that was not
+     * forwarded as an image block. Only safe metadata is logged — reason, byte
+     * size, applied limit, extension/media type, and the attachment display name
+     * or basename — never base64 payloads, prompt/system-prompt text,
+     * credentials, or transcript content (AC-04).
+     */
+    private logClaudeImageSkipped(attachment: Attachment, skip: ClaudeImageSkip): void {
+        getSDKLogger().warn(
+            {
+                provider: CLAUDE_PROVIDER,
+                event: 'claude_image_skipped',
+                reason: skip.reason,
+                limitBytes: skip.limit,
+                ...(typeof skip.byteSize === 'number' ? { byteSize: skip.byteSize } : {}),
+                extension: skip.extension,
+                mediaType: skip.mediaType,
+                attachmentName: claudeAttachmentDisplayName(attachment),
+            },
+            'Claude image attachment skipped',
+        );
     }
 
     /**
@@ -1547,6 +1581,17 @@ function inferClaudeMcpServerNamesFromOptions(options: SendMessageOptions): stri
         names.add(COC_LLM_TOOLS_MCP_SERVER_NAME);
     }
     return Array.from(names).sort();
+}
+
+/**
+ * Safe display label for a skipped-image diagnostic: the attachment's display
+ * name when present, else the path basename. Both are filename-level metadata
+ * (never image bytes or prompt content).
+ */
+function claudeAttachmentDisplayName(attachment: Attachment): string {
+    const displayName = attachment.displayName?.trim();
+    if (displayName) return displayName;
+    return path.basename(attachment.path);
 }
 
 function resolveClaudeSystemPromptOptions(

--- a/packages/coc-agent-sdk/src/image-converter.ts
+++ b/packages/coc-agent-sdk/src/image-converter.ts
@@ -17,10 +17,57 @@ const IMAGE_EXTENSIONS: Record<string, string> = {
 /** Max image file size we'll convert to a data URL (10 MB). */
 const MAX_IMAGE_FILE_SIZE = 10 * 1024 * 1024;
 
+/**
+ * Explicit Claude SDK image-size boundary.
+ *
+ * Claude image attachments must be size-checked at the Claude provider boundary
+ * before being converted into Claude base64 image blocks. The limit reuses the
+ * shared {@link MAX_IMAGE_FILE_SIZE} (10 MB) so all CoC image limits stay
+ * consistent (see `attachment-utils.MAX_ATTACHMENT_SIZE`, also 10 MB). It is
+ * exported (rather than left hidden inside the incidental shared read helper) so
+ * the Claude path makes the boundary clear and tests can reference it instead of
+ * hard-coding a magic number.
+ */
+export const MAX_CLAUDE_IMAGE_BYTES = MAX_IMAGE_FILE_SIZE;
+
 export interface ClaudeImageSource {
     media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
     data: string;
 }
+
+/** Why a candidate Claude image attachment was not forwarded as an image block. */
+export type ClaudeImageSkipReason =
+    /** The file is too large once its bytes are read/decoded. */
+    | 'too-large'
+    /** The path is not a regular file (e.g. a directory). */
+    | 'not-a-regular-file'
+    /** stat/read failed (missing file, permission error, etc.). */
+    | 'read-error';
+
+/**
+ * Safe, sanitized metadata describing a skipped Claude image. Carries only
+ * non-sensitive fields (reason, byte size, limit, extension, media type) — never
+ * image bytes, prompt text, or credentials.
+ */
+export interface ClaudeImageSkip {
+    reason: ClaudeImageSkipReason;
+    /** Decoded byte size when known (e.g. for oversized files). */
+    byteSize?: number;
+    /** The effective Claude image byte limit that was applied. */
+    limit: number;
+    extension: string;
+    mediaType: ClaudeImageSource['media_type'];
+}
+
+/**
+ * Result of evaluating a single file path for Claude image suitability: either a
+ * forwardable base64 image source plus its metadata, or a sanitized skip record.
+ * Unsupported extensions (SVG, non-images) return `null` so callers can ignore
+ * them silently — they are an expected, non-diagnostic case.
+ */
+export type ClaudeImageEvaluation =
+    | { ok: true; source: ClaudeImageSource; byteSize: number; extension: string; mediaType: ClaudeImageSource['media_type'] }
+    | { ok: false; skip: ClaudeImageSkip };
 
 const CLAUDE_IMAGE_MEDIA_TYPES: Record<string, ClaudeImageSource['media_type']> = {
     png: 'image/png',
@@ -69,15 +116,63 @@ export function tryConvertImageFileToDataUrl(filePath: string): string | null {
 }
 
 /**
+ * Evaluate a file path for use as a Claude base64 image block.
+ *
+ * This is the explicit Claude image-size boundary: the decoded byte length is
+ * enforced against {@link MAX_CLAUDE_IMAGE_BYTES} before the data is base64-
+ * encoded, so an oversized image is never forwarded to Claude. SVG and other
+ * non-Claude-raster extensions return `null` (an expected, silent skip rather
+ * than a diagnostic). Supported-extension files that are oversized, not regular
+ * files, or unreadable return a sanitized `{ ok: false, skip }` so the caller can
+ * record safe diagnostics without touching image bytes.
+ */
+export function evaluateClaudeImageFile(filePath: string): ClaudeImageEvaluation | null {
+    const extension = path.extname(filePath).replace(/^\./, '').toLowerCase();
+    const mediaType = CLAUDE_IMAGE_MEDIA_TYPES[extension];
+    if (!mediaType) return null;
+
+    let stat: fs.Stats;
+    try {
+        stat = fs.statSync(filePath);
+    } catch {
+        return { ok: false, skip: { reason: 'read-error', limit: MAX_CLAUDE_IMAGE_BYTES, extension, mediaType } };
+    }
+
+    if (!stat.isFile()) {
+        return { ok: false, skip: { reason: 'not-a-regular-file', limit: MAX_CLAUDE_IMAGE_BYTES, extension, mediaType } };
+    }
+    if (stat.size > MAX_CLAUDE_IMAGE_BYTES) {
+        return { ok: false, skip: { reason: 'too-large', byteSize: stat.size, limit: MAX_CLAUDE_IMAGE_BYTES, extension, mediaType } };
+    }
+
+    let data: Buffer;
+    try {
+        data = fs.readFileSync(filePath);
+    } catch {
+        return { ok: false, skip: { reason: 'read-error', limit: MAX_CLAUDE_IMAGE_BYTES, extension, mediaType } };
+    }
+    // Defensive: enforce the limit against the actual decoded byte length too,
+    // in case stat under-reported (e.g. a file that grew between stat and read).
+    if (data.length > MAX_CLAUDE_IMAGE_BYTES) {
+        return { ok: false, skip: { reason: 'too-large', byteSize: data.length, limit: MAX_CLAUDE_IMAGE_BYTES, extension, mediaType } };
+    }
+
+    return {
+        ok: true,
+        source: { media_type: mediaType, data: data.toString('base64') },
+        byteSize: data.length,
+        extension,
+        mediaType,
+    };
+}
+
+/**
  * Return a Claude-compatible base64 source for supported raster image files.
  * SVG is intentionally excluded because Claude's base64 image source does not
- * accept `image/svg+xml`.
+ * accept `image/svg+xml`. Delegates to {@link evaluateClaudeImageFile} so the
+ * size boundary is enforced in exactly one place.
  */
 export function tryReadImageAsBase64(filePath: string): ClaudeImageSource | null {
-    const image = readImageFile(filePath, CLAUDE_IMAGE_MEDIA_TYPES);
-    if (!image) return null;
-    return {
-        media_type: image.mime as ClaudeImageSource['media_type'],
-        data: image.data.toString('base64'),
-    };
+    const evaluation = evaluateClaudeImageFile(filePath);
+    return evaluation?.ok ? evaluation.source : null;
 }

--- a/packages/coc-agent-sdk/src/index.ts
+++ b/packages/coc-agent-sdk/src/index.ts
@@ -82,6 +82,15 @@ export {
 export {
     isImageFilePath,
     isSupportedCodexImagePath,
+    evaluateClaudeImageFile,
+    MAX_CLAUDE_IMAGE_BYTES,
+} from './image-converter';
+
+export type {
+    ClaudeImageSource,
+    ClaudeImageSkip,
+    ClaudeImageSkipReason,
+    ClaudeImageEvaluation,
 } from './image-converter';
 
 export type { BackgroundTasksInfo, IAccountQuotaSnapshot, IAccountQuotaResult } from './copilot-sdk-service';

--- a/packages/coc-agent-sdk/test/ai/claude-sdk-image.test.ts
+++ b/packages/coc-agent-sdk/test/ai/claude-sdk-image.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../src/sdk-esm-loader', () => ({
 
 import { ClaudeSDKService } from '../../src/claude-sdk-service';
 import { dynamicImportModule } from '../../src/sdk-esm-loader';
+import { MAX_CLAUDE_IMAGE_BYTES } from '../../src/image-converter';
+import { initSDKLogger, resetSDKLogger } from '../../src/logger';
 
 const mockDynamicImport = vi.mocked(dynamicImportModule);
 
@@ -30,6 +32,27 @@ async function drainAsyncIterable(iterable: AsyncIterable<unknown>): Promise<unk
     return values;
 }
 
+/** Minimal pino-shaped logger that records every call for assertions. */
+function createCapturingLogger() {
+    const logs: Array<{ level: string; fields: Record<string, unknown>; message: string }> = [];
+    const capture = (level: string) => (...args: unknown[]) => {
+        const [first, second] = args;
+        const fields = typeof first === 'object' && first !== null && !Array.isArray(first)
+            ? (first as Record<string, unknown>)
+            : {};
+        const message = typeof first === 'string' ? first : typeof second === 'string' ? second : '';
+        logs.push({ level, fields, message });
+    };
+    const logger: Record<string, unknown> = {
+        debug: capture('debug'),
+        info: capture('info'),
+        warn: capture('warn'),
+        error: capture('error'),
+    };
+    logger.child = () => logger;
+    return { logs, logger };
+}
+
 describe('ClaudeSDKService image attachments', () => {
     let svc: ClaudeSDKService;
     let tmpDir: string;
@@ -46,6 +69,7 @@ describe('ClaudeSDKService image attachments', () => {
 
     afterEach(() => {
         svc.dispose();
+        resetSDKLogger();
         fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
@@ -111,14 +135,80 @@ describe('ClaudeSDKService image attachments', () => {
         expect(queryFn.mock.calls[0][0].prompt).toBe('Skip unsupported');
     });
 
-    it('skips oversized image attachments', async () => {
+    it('forwards an image whose byte size is exactly at the limit', async () => {
+        // A buffer exactly at MAX_CLAUDE_IMAGE_BYTES must still be forwarded —
+        // the boundary check skips only strictly-greater sizes.
+        const exact = Buffer.alloc(MAX_CLAUDE_IMAGE_BYTES, 1);
+        const result = await svc.sendMessage({
+            prompt: 'Exactly at limit',
+            attachments: [{ type: 'file', path: writeFile('exact.png', exact), displayName: 'exact.png' }],
+        });
+
+        expect(result.success).toBe(true);
+        const prompt = queryFn.mock.calls[0][0].prompt;
+        expect(typeof prompt).not.toBe('string');
+        const messages = (await drainAsyncIterable(prompt)) as Array<{
+            message: { content: Array<{ type: string; source?: { media_type: string } }> };
+        }>;
+        const blocks = messages[0].message.content;
+        expect(blocks).toHaveLength(2);
+        expect(blocks[1].type).toBe('image');
+        expect(blocks[1].source?.media_type).toBe('image/png');
+    });
+
+    it('skips oversized image attachments and keeps the text prompt', async () => {
         await svc.sendMessage({
             prompt: 'Too large',
             attachments: [
-                { type: 'file', path: writeFile('large.png', Buffer.alloc((10 * 1024 * 1024) + 1)), displayName: 'large.png' },
+                { type: 'file', path: writeFile('large.png', Buffer.alloc(MAX_CLAUDE_IMAGE_BYTES + 1)), displayName: 'large.png' },
             ],
         });
 
+        // Oversized image dropped; request still runs as a plain text prompt.
         expect(queryFn.mock.calls[0][0].prompt).toBe('Too large');
+    });
+
+    it('records a sanitized skip diagnostic for an oversized image (no payload/prompt leak)', async () => {
+        const { logs, logger } = createCapturingLogger();
+        initSDKLogger(logger as never);
+
+        const oversizedBytes = MAX_CLAUDE_IMAGE_BYTES + 1024;
+        await svc.sendMessage({
+            prompt: 'Sensitive prompt text that must never be logged',
+            attachments: [
+                { type: 'file', path: writeFile('huge.png', Buffer.alloc(oversizedBytes, 7)), displayName: 'huge.png' },
+            ],
+        });
+
+        const skip = logs.find(l => l.fields.event === 'claude_image_skipped');
+        expect(skip).toBeDefined();
+        expect(skip!.level).toBe('warn');
+        expect(skip!.fields.reason).toBe('too-large');
+        expect(skip!.fields.byteSize).toBe(oversizedBytes);
+        expect(skip!.fields.limitBytes).toBe(MAX_CLAUDE_IMAGE_BYTES);
+        expect(skip!.fields.extension).toBe('png');
+        expect(skip!.fields.mediaType).toBe('image/png');
+        expect(skip!.fields.attachmentName).toBe('huge.png');
+
+        // The diagnostic must never carry image bytes or prompt text.
+        const serialized = JSON.stringify(skip);
+        expect(serialized).not.toContain('Sensitive prompt text');
+        expect(serialized).not.toContain(Buffer.alloc(8, 7).toString('base64'));
+    });
+
+    it('falls back to the path basename when an oversized image has no display name', async () => {
+        const { logs, logger } = createCapturingLogger();
+        initSDKLogger(logger as never);
+
+        await svc.sendMessage({
+            prompt: 'No display name',
+            attachments: [
+                { type: 'file', path: writeFile('unnamed.png', Buffer.alloc(MAX_CLAUDE_IMAGE_BYTES + 1)), displayName: '' },
+            ],
+        });
+
+        const skip = logs.find(l => l.fields.event === 'claude_image_skipped');
+        expect(skip).toBeDefined();
+        expect(skip!.fields.attachmentName).toBe('unnamed.png');
     });
 });

--- a/packages/coc-agent-sdk/test/ai/image-data-url.test.ts
+++ b/packages/coc-agent-sdk/test/ai/image-data-url.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { tryConvertImageFileToDataUrl, tryReadImageAsBase64 } from '../../src/copilot-sdk-service';
-import { isImageFilePath, isSupportedCodexImagePath } from '../../src/image-converter';
+import { isImageFilePath, isSupportedCodexImagePath, evaluateClaudeImageFile, MAX_CLAUDE_IMAGE_BYTES } from '../../src/image-converter';
 import { CopilotSDKService, resetCopilotSDKService } from '../../src/copilot-sdk-service';
 import { createStreamingMockSDKModule } from '../helpers/mock-sdk';
 
@@ -180,8 +180,90 @@ describe('tryReadImageAsBase64', () => {
     });
 
     it('returns null for images larger than the conversion limit', () => {
-        const filePath = writeTmpFile('large.png', Buffer.alloc((10 * 1024 * 1024) + 1));
+        const filePath = writeTmpFile('large.png', Buffer.alloc(MAX_CLAUDE_IMAGE_BYTES + 1));
         expect(tryReadImageAsBase64(filePath)).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateClaudeImageFile — explicit Claude image-size boundary
+// ---------------------------------------------------------------------------
+
+describe('evaluateClaudeImageFile', () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-eval-test-'));
+    });
+
+    afterAll(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeTmpFile(name: string, content: Buffer | string): string {
+        const p = path.join(tmpDir, name);
+        fs.writeFileSync(p, content);
+        return p;
+    }
+
+    it('returns null for unsupported extensions (SVG, text) — a silent, non-diagnostic skip', () => {
+        expect(evaluateClaudeImageFile(writeTmpFile('icon.svg', '<svg></svg>'))).toBeNull();
+        expect(evaluateClaudeImageFile(writeTmpFile('notes.txt', 'hello'))).toBeNull();
+    });
+
+    it('forwards an under-limit image with its metadata', () => {
+        const bytes = Buffer.alloc(1024, 3);
+        const result = evaluateClaudeImageFile(writeTmpFile('small.png', bytes));
+        expect(result).toEqual({
+            ok: true,
+            source: { media_type: 'image/png', data: bytes.toString('base64') },
+            byteSize: bytes.length,
+            extension: 'png',
+            mediaType: 'image/png',
+        });
+    });
+
+    it('forwards an image whose byte size is exactly at the limit', () => {
+        const bytes = Buffer.alloc(MAX_CLAUDE_IMAGE_BYTES, 5);
+        const result = evaluateClaudeImageFile(writeTmpFile('exact.webp', bytes));
+        expect(result?.ok).toBe(true);
+        if (result?.ok) {
+            expect(result.byteSize).toBe(MAX_CLAUDE_IMAGE_BYTES);
+            expect(result.mediaType).toBe('image/webp');
+        }
+    });
+
+    it('skips an over-limit image with a sanitized too-large diagnostic', () => {
+        const oversized = MAX_CLAUDE_IMAGE_BYTES + 1;
+        const result = evaluateClaudeImageFile(writeTmpFile('big.jpg', Buffer.alloc(oversized)));
+        expect(result).toEqual({
+            ok: false,
+            skip: {
+                reason: 'too-large',
+                byteSize: oversized,
+                limit: MAX_CLAUDE_IMAGE_BYTES,
+                extension: 'jpg',
+                mediaType: 'image/jpeg',
+            },
+        });
+    });
+
+    it('reports a read-error skip for a missing supported-extension file', () => {
+        const result = evaluateClaudeImageFile(path.join(tmpDir, 'missing.png'));
+        expect(result).toEqual({
+            ok: false,
+            skip: { reason: 'read-error', limit: MAX_CLAUDE_IMAGE_BYTES, extension: 'png', mediaType: 'image/png' },
+        });
+    });
+
+    it('reports a not-a-regular-file skip for a directory with an image extension', () => {
+        const dirPath = path.join(tmpDir, 'folder.png');
+        fs.mkdirSync(dirPath, { recursive: true });
+        const result = evaluateClaudeImageFile(dirPath);
+        expect(result).toEqual({
+            ok: false,
+            skip: { reason: 'not-a-regular-file', limit: MAX_CLAUDE_IMAGE_BYTES, extension: 'png', mediaType: 'image/png' },
+        });
     });
 });
 

--- a/packages/coc/src/server/core/attachment-utils.ts
+++ b/packages/coc/src/server/core/attachment-utils.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Attachment } from '@plusplusoneplusplus/forge';
-import { parseDataUrl, isImageDataUrl, saveImagesToTempFiles } from './image-utils';
+import { parseDataUrl, isImageDataUrl, saveImagesToTempFiles, MAX_IMAGE_BYTES } from './image-utils';
 
 /** Wire format for file attachments from the client */
 export interface AttachmentPayload {
@@ -78,8 +78,12 @@ export function parseGenericDataUrl(
     }
 }
 
-/** Max attachment size server-side (10 MB) */
-const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024;
+/**
+ * Max attachment size server-side (10 MB). Re-exported from the shared
+ * {@link MAX_IMAGE_BYTES} so the limit is defined exactly once and the boundary
+ * is referenceable by name (e.g. from tests) instead of being a magic number.
+ */
+export const MAX_ATTACHMENT_SIZE = MAX_IMAGE_BYTES;
 /** Max number of attachments per message */
 const MAX_ATTACHMENTS = 10;
 
@@ -143,6 +147,10 @@ export function saveAttachmentsToTempFiles(
         if (category === 'image') {
             const parsed = parseDataUrl(payload.dataUrl);
             if (parsed) {
+                // Decoded-byte enforcement: the client-reported `size` is not
+                // trusted, so drop images whose actual decoded bytes exceed the
+                // limit before writing them to disk or producing an SDK attachment.
+                if (parsed.buffer.length > MAX_ATTACHMENT_SIZE) continue;
                 const sanitizedName = sanitizeFileName(payload.name);
                 const safeName = sanitizedName.trim().length > 0 ? sanitizedName : `image-${i}.${parsed.extension}`;
                 const filePath = path.join(tempDir, safeName);
@@ -159,6 +167,10 @@ export function saveAttachmentsToTempFiles(
         // Generic data URL parsing
         const parsed = parseGenericDataUrl(payload.dataUrl);
         if (!parsed) continue;
+        // Decoded-byte enforcement (same rationale as the image path above):
+        // drop any payload whose decoded bytes exceed the limit, regardless of
+        // the client-reported `size`, before it is written to disk.
+        if (parsed.buffer.length > MAX_ATTACHMENT_SIZE) continue;
 
         const sanitizedName = sanitizeFileName(payload.name);
         const safeName = sanitizedName.trim().length > 0 ? sanitizedName : `file-${i}`;

--- a/packages/coc/src/server/core/image-utils.ts
+++ b/packages/coc/src/server/core/image-utils.ts
@@ -14,6 +14,20 @@ import * as path from 'path';
 import type { Attachment } from '@plusplusoneplusplus/forge';
 
 /**
+ * Maximum decoded byte size for a single image / attachment buffer (10 MB).
+ *
+ * Single source of truth for the server-side image/attachment byte limit.
+ * `attachment-utils` re-exports this as `MAX_ATTACHMENT_SIZE`, and it mirrors
+ * the SDK-side `MAX_CLAUDE_IMAGE_BYTES` (also 10 MB) so every CoC image limit
+ * stays intentionally consistent. It is enforced against the *decoded* buffer
+ * length — never the client-reported `size` — so a forged small `size` cannot
+ * smuggle an oversized payload onto disk. Defined here (the dependency leaf) so
+ * both `image-utils` and `attachment-utils` can reference it without a circular
+ * import.
+ */
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+/**
  * Parse a base64 data URL into its components.
  * Returns null for invalid or non-image data URLs.
  */
@@ -47,6 +61,9 @@ export function saveImagesToTempFiles(
     for (let i = 0; i < images.length; i++) {
         const parsed = parseDataUrl(images[i]);
         if (!parsed) { continue; }
+        // Decoded-byte enforcement: do not trust any client-reported size — drop
+        // oversized images here, before any temp file is written to disk.
+        if (parsed.buffer.length > MAX_IMAGE_BYTES) { continue; }
         const fileName = `image-${i}.${parsed.extension}`;
         const filePath = path.join(tempDir, fileName);
         fs.writeFileSync(filePath, parsed.buffer);

--- a/packages/coc/src/server/executors/memory-v2-addon.ts
+++ b/packages/coc/src/server/executors/memory-v2-addon.ts
@@ -28,6 +28,7 @@ import {
 } from '@plusplusoneplusplus/coc-memory';
 import { readGlobalPreferences, readRepoPreferences } from '../preferences-handler';
 import { createMemoryStoreFactTool, createMemoryRecallTool, type MemoryV2ToolDeps } from '../llm-tools/memory-v2-tools';
+import { tagGuidanceSuffix } from './prompt-tags';
 
 // ============================================================================
 // Types
@@ -61,8 +62,10 @@ const EMPTY_ADDON: MemoryV2Addon = Object.freeze({
     dispose: () => {},
 });
 
-const MEMORY_TOOL_SUFFIX =
-    '\n\nYou have a persistent `memory` tool. Actively capture facts, preferences, and patterns you discover during this session. When in doubt, save it — storage is cheap and forgetting is expensive.';
+const MEMORY_TOOL_SUFFIX = tagGuidanceSuffix(
+    'memory_tool',
+    'You have a persistent `memory` tool. Actively capture facts, preferences, and patterns you discover during this session. When in doubt, save it — storage is cheap and forgetting is expensive.',
+);
 
 // ============================================================================
 // Builder

--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -41,6 +41,7 @@ import { createCancelLoopTool, createCreateLoopTool, createListLoopsTool, create
 import { createSearchConversationsTool } from '../llm-tools/search-conversations-tool';
 import { createSuggestFollowUpsTool } from '../llm-tools/suggest-follow-ups-tool';
 import { createTavilyWebSearchTool } from '../llm-tools/tavily-web-search-tool';
+import { tagBlock, tagGuidanceSuffix } from './prompt-tags';
 import type { ChatMode, ChatPayload, ChatProvider, DreamRunPayload, ForEachGenerationContext, MapReduceGenerationContext, PrClassificationPayload, RunScriptPayload } from '../tasks/task-types';
 import {
     hasCommitChatContext,
@@ -85,12 +86,14 @@ export function buildModeSystemMessage(
     return { mode: 'append' as const, content: READ_ONLY_SYSTEM_MESSAGE };
 }
 
-export const SOURCE_LOCATION_MARKDOWN_LINK_SYSTEM_MESSAGE = `\
-When citing source code locations, format each location as a Markdown link.
+export const SOURCE_LOCATION_MARKDOWN_LINK_SYSTEM_MESSAGE = tagBlock(
+    'citing_rule',
+    `When citing source code locations, format each location as a Markdown link.
 
 Use:
 - [src/file.ts:42](src/file.ts:42)
-- [src/file.ts:42-58](src/file.ts:42-58)`;
+- [src/file.ts:42-58](src/file.ts:42-58)`,
+);
 
 export function buildSourceLocationMarkdownLinkSystemMessage(
     provider: ChatProvider | undefined,
@@ -456,7 +459,10 @@ export function buildFollowUpSuggestionsAddon(
     }
     return {
         tools: [createSuggestFollowUpsTool()],
-        suffix: `\n\nWhen suggesting follow-ups, provide exactly ${count} suggestions. Each suggestion must be a short imperative action phrase (not a question), for example: "Show me an example", "Explain the retry config", "Generate the fix".`,
+        suffix: tagGuidanceSuffix(
+            'follow_up_suggestions',
+            `When suggesting follow-ups, provide exactly ${count} suggestions. Each suggestion must be a short imperative action phrase (not a question), for example: "Show me an example", "Explain the retry config", "Generate the fix".`,
+        ),
     };
 }
 
@@ -533,11 +539,13 @@ export function buildAskUserAddon(
     }
 
     const { tool, answerQuestion, skipQuestion, answerQuestions, cancelAll, hasPending } = createAskUserTool(deps);
-    const suffix =
-        '\n\nYou have access to the `ask_user` tool. It takes `{ questions: [...] }`; put related clarification, ' +
+    const suffix = tagGuidanceSuffix(
+        'ask_user_tool',
+        'You have access to the `ask_user` tool. It takes `{ questions: [...] }`; put related clarification, ' +
         'confirmation, or choice questions in one call instead of calling the tool repeatedly. The user will see one interactive widget. ' +
         'Every question has Skip and Need more context options, so the user is never stuck. If the tool result includes `deferred: true` with `reason: "needs-context"`, provide the missing context and ask a revised version of that question again when the answer is still needed; if it is no longer needed, explain why. Do not treat it as permission to ignore the question. ' +
-        'Do NOT use ask_user for simple yes/no that can be inferred from context.';
+        'Do NOT use ask_user for simple yes/no that can be inferred from context.',
+    );
 
     return { tools: [tool], suffix, answerQuestion, skipQuestion, answerQuestions, cancelAll, hasPending };
 }
@@ -569,12 +577,14 @@ export function buildCreateWorkItemAddon(
     const { tool: getWorkItemTool } = createGetWorkItemTool(dataDir, repoId, deps);
     const { tool: workItemTool } = createCreateUpdateWorkItemTool(dataDir, repoId, broadcastFn, deps);
 
-    const suffix =
-        '\n\nYou have access to the `get_work_item` and `create_update_work_item` tools. ' +
+    const suffix = tagGuidanceSuffix(
+        'work_item_tools',
+        'You have access to the `get_work_item` and `create_update_work_item` tools. ' +
         'Use `get_work_item` to read an existing work item by UUID, WI-N, or work-item number when the user ' +
         'references an existing item or attached context supplies a work-item pointer — before drafting changes, ' +
         'unless the full detail is already in the prompt. It is read-only. ' +
-        'Use `create_update_work_item` only after presenting a draft and receiving user confirmation.';
+        'Use `create_update_work_item` only after presenting a draft and receiving user confirmation.',
+    );
 
     return { tools: [getWorkItemTool, workItemTool], suffix };
 }
@@ -623,10 +633,12 @@ export function buildTavilyWebSearchAddon(
     }
 
     const { tool } = createTavilyWebSearchTool({ dataDir });
-    const suffix =
-        '\n\nYou have access to the `tavily_web_search` tool. ' +
+    const suffix = tagGuidanceSuffix(
+        'web_search_tool',
+        'You have access to the `tavily_web_search` tool. ' +
         'Use it proactively when the user asks about recent events, version-specific behavior, ' +
-        'newly released libraries/APIs, ongoing incidents, or anything likely past your knowledge cutoff.';
+        'newly released libraries/APIs, ongoing incidents, or anything likely past your knowledge cutoff.',
+    );
 
     return { tools: [tool], suffix };
 }
@@ -709,12 +721,14 @@ export function buildCanvasToolsAddon(
         processStore: store,
     });
 
-    const suffix =
-        '\n\nCanvas tools (`write_canvas`, `read_canvas`, `extension_canvas`) maintain a live artifact in '
+    const suffix = tagGuidanceSuffix(
+        'canvas_tools',
+        'Canvas tools (`write_canvas`, `read_canvas`, `extension_canvas`) maintain a live artifact in '
         + 'a side panel beside this chat. Use one when the user wants a document, plan, spec, or code file '
         + 'they will iterate on — not for short answers — and keep replies brief, referencing the canvas '
         + 'rather than repeating it. For interactive artifacts (boards, checklists, dashboards) use '
-        + '`extension_canvas`.';
+        + '`extension_canvas`.',
+    );
 
     return { tools: [write, read, extension], suffix };
 }

--- a/packages/coc/src/server/executors/prompt-tags.ts
+++ b/packages/coc/src/server/executors/prompt-tags.ts
@@ -1,0 +1,28 @@
+/**
+ * Helpers for wrapping prompt sections in named XML-style tags.
+ *
+ * Tagging makes each block self-delimiting and individually addressable by the
+ * model, matching the convention already used elsewhere in the assembled system
+ * prompt (`<memory_snapshot>`, `<recalled_memory>`, `<selected_skills>`,
+ * `<admin-global-system-prompt>`). Tag names use `snake_case` to match those.
+ *
+ * This is a leaf module with no local imports so any prompt-assembly file can
+ * use it without risking a circular dependency (notably `prompt-builder.ts`
+ * re-exports from `memory-v2-addon.ts`, and both consume these helpers).
+ *
+ * No VS Code dependencies — pure string helpers. Cross-platform compatible.
+ */
+
+/** Wrap `body` in a `<tag>…</tag>` block on its own lines. */
+export function tagBlock(tag: string, body: string): string {
+    return `<${tag}>\n${body}\n</${tag}>`;
+}
+
+/**
+ * Build a tool-guidance `suffix`: a {@link tagBlock} prefixed with the
+ * blank-line separator that `applyLlmToolPreferences` relies on when
+ * concatenating each addon's `suffix` into the aggregated `toolGuidance` prose.
+ */
+export function tagGuidanceSuffix(tag: string, body: string): string {
+    return `\n\n${tagBlock(tag, body)}`;
+}

--- a/packages/coc/test/server/attachment-utils.test.ts
+++ b/packages/coc/test/server/attachment-utils.test.ts
@@ -17,6 +17,7 @@ import {
     hasAttachments,
     processMessageAttachments,
     TEXT_EXTERNALIZE_THRESHOLD,
+    MAX_ATTACHMENT_SIZE,
 } from '../../src/server/core/attachment-utils';
 import type { AttachmentPayload } from '../../src/server/core/attachment-utils';
 
@@ -58,6 +59,16 @@ function makePayload(overrides: Partial<AttachmentPayload> = {}): AttachmentPayl
         dataUrl: TEXT_DATA_URL,
         ...overrides,
     };
+}
+
+/**
+ * Build an image/png data URL whose *decoded* bytes exceed MAX_ATTACHMENT_SIZE.
+ * Used for forged-size tests: the declared `size` on the payload can be set
+ * arbitrarily small while the actual decoded image bytes are over the limit.
+ */
+function makeOversizedImageDataUrl(): string {
+    const oversized = Buffer.alloc(MAX_ATTACHMENT_SIZE + 1);
+    return `data:image/png;base64,${oversized.toString('base64')}`;
 }
 
 // ── parseGenericDataUrl ──────────────────────────────────────────────────
@@ -132,9 +143,9 @@ describe('validateAttachments', () => {
         expect(payloads[0].name).toBe('ok.txt');
     });
 
-    it('rejects files exceeding 10MB', () => {
+    it('rejects files whose declared size exceeds the limit', () => {
         const { payloads } = validateAttachments([
-            makePayload({ size: 11 * 1024 * 1024 }),
+            makePayload({ size: MAX_ATTACHMENT_SIZE + 1 }),
         ]);
         expect(payloads).toHaveLength(0);
     });
@@ -247,6 +258,48 @@ describe('saveAttachmentsToTempFiles', () => {
             tempDir,
         );
         expect(attachments).toHaveLength(0);
+    });
+
+    it('drops a forged-size image whose decoded bytes exceed the limit (never written to disk)', () => {
+        const tempDir = makeTempDir();
+        // Declared size is tiny, but the decoded image is over MAX_ATTACHMENT_SIZE.
+        const forged = makePayload({
+            name: 'forged.png',
+            mimeType: 'image/png',
+            size: 1024,
+            dataUrl: makeOversizedImageDataUrl(),
+        });
+        const { attachments, textContents } = saveAttachmentsToTempFiles([forged], tempDir);
+
+        expect(attachments).toHaveLength(0);
+        expect(textContents).toHaveLength(0);
+        // Nothing was written to disk for the oversized payload.
+        expect(fs.readdirSync(tempDir)).toHaveLength(0);
+    });
+
+    it('drops a forged-size generic attachment whose decoded bytes exceed the limit', () => {
+        const tempDir = makeTempDir();
+        const oversized = Buffer.alloc(MAX_ATTACHMENT_SIZE + 1);
+        const forged = makePayload({
+            name: 'forged.bin',
+            mimeType: 'application/octet-stream',
+            size: 512,
+            dataUrl: `data:application/octet-stream;base64,${oversized.toString('base64')}`,
+        });
+        const { attachments } = saveAttachmentsToTempFiles([forged], tempDir);
+
+        expect(attachments).toHaveLength(0);
+        expect(fs.readdirSync(tempDir)).toHaveLength(0);
+    });
+
+    it('still saves an image whose decoded bytes are within the limit', () => {
+        const tempDir = makeTempDir();
+        const { attachments } = saveAttachmentsToTempFiles(
+            [makePayload({ name: 'photo.png', mimeType: 'image/png', dataUrl: PNG_DATA_URL })],
+            tempDir,
+        );
+        expect(attachments).toHaveLength(1);
+        expect(fs.existsSync(attachments[0].path)).toBe(true);
     });
 });
 
@@ -432,6 +485,27 @@ describe('processMessageAttachments', () => {
         expect(result.textContext).toBe('');
         expect(result.validatedImages).toBeUndefined();
         expect(result.fileAttachmentMeta).toBeUndefined();
+    });
+
+    it('drops a forged-size oversized image attachment safely (no temp file, no SDK attachment)', () => {
+        const tempDir = makeTempDir();
+        const body = {
+            content: 'check this image',
+            // Declared size is small, but decoded bytes exceed MAX_ATTACHMENT_SIZE.
+            attachments: [makePayload({
+                name: 'forged.png',
+                mimeType: 'image/png',
+                size: 512,
+                dataUrl: makeOversizedImageDataUrl(),
+            })],
+        };
+
+        const result = processMessageAttachments(body, tempDir);
+        // The oversized image must not become an SDK attachment or a temp file…
+        expect(result.sdkAttachments).toHaveLength(0);
+        expect(fs.readdirSync(tempDir)).toHaveLength(0);
+        // …and the request does not throw — the text prompt path still proceeds.
+        expect(result.textContext).toBe('');
     });
 
     it('saves bitmap/image attachments to temp files (never inlined)', () => {

--- a/packages/coc/test/server/executors-prompt-builder.test.ts
+++ b/packages/coc/test/server/executors-prompt-builder.test.ts
@@ -140,6 +140,11 @@ describe('buildSourceLocationMarkdownLinkSystemMessage', () => {
         expect(result!.content).toContain('[src/file.ts:42-58](src/file.ts:42-58)');
     });
 
+    it('wraps the citation guidance in a <citing_rule> tag', () => {
+        expect(SOURCE_LOCATION_MARKDOWN_LINK_SYSTEM_MESSAGE.startsWith('<citing_rule>\n')).toBe(true);
+        expect(SOURCE_LOCATION_MARKDOWN_LINK_SYSTEM_MESSAGE.endsWith('\n</citing_rule>')).toBe(true);
+    });
+
     it.each(['codex', undefined] as const)('omits source-location instructions for %s', (provider) => {
         expect(buildSourceLocationMarkdownLinkSystemMessage(provider)).toBeUndefined();
     });
@@ -606,6 +611,12 @@ describe('buildFollowUpSuggestionsAddon', () => {
         const result = buildFollowUpSuggestionsAddon(true, 5);
         expect(result.suffix).toContain('5 suggestions');
     });
+
+    it('wraps the guidance in a <follow_up_suggestions> tag with the separator prefix', () => {
+        const result = buildFollowUpSuggestionsAddon(true, 3);
+        expect(result.suffix.startsWith('\n\n<follow_up_suggestions>\n')).toBe(true);
+        expect(result.suffix.endsWith('\n</follow_up_suggestions>')).toBe(true);
+    });
 });
 
 // ============================================================================
@@ -672,6 +683,12 @@ describe('buildCreateWorkItemAddon', () => {
         const result = buildCreateWorkItemAddon('/data', 'repo-1');
         expect(result.suffix).toContain('get_work_item');
         expect(result.suffix).toContain('create_update_work_item');
+    });
+
+    it('wraps the guidance in a <work_item_tools> tag with the separator prefix', () => {
+        const result = buildCreateWorkItemAddon('/data', 'repo-1');
+        expect(result.suffix.startsWith('\n\n<work_item_tools>\n')).toBe(true);
+        expect(result.suffix.endsWith('\n</work_item_tools>')).toBe(true);
     });
 
     it('passes dataDir, repoId, broadcastFn, and deps to factories', () => {

--- a/packages/coc/test/server/executors/chat-tool-builder.test.ts
+++ b/packages/coc/test/server/executors/chat-tool-builder.test.ts
@@ -60,6 +60,12 @@ describe('buildChatToolBundle', () => {
         // above); their prompt suffix was intentionally trimmed, so no guidance text.
         expect(result.toolGuidance).toContain('3 suggestions');
         expect(result.askUser).toBeDefined();
+        // Each enabled addon's guidance is wrapped in its named XML-style tag.
+        expect(result.toolGuidance).toContain('<follow_up_suggestions>');
+        expect(result.toolGuidance).toContain('</follow_up_suggestions>');
+        expect(result.toolGuidance).toContain('<ask_user_tool>');
+        expect(result.toolGuidance).toContain('<work_item_tools>');
+        expect(result.toolGuidance).toContain('<web_search_tool>');
     });
 
     it('filters tavily_web_search and its suffix when disabled by repo preferences', () => {
@@ -75,6 +81,8 @@ describe('buildChatToolBundle', () => {
 
         expect(result.tools.map(t => t.name)).not.toContain('tavily_web_search');
         expect(result.toolGuidance).not.toContain('tavily_web_search');
+        // Disabling the tool drops its whole tagged guidance block.
+        expect(result.toolGuidance).not.toContain('<web_search_tool>');
     });
 
     it('honors context-specific exclusions in addition to preferences', () => {

--- a/packages/coc/test/server/executors/memory-v2-addon.test.ts
+++ b/packages/coc/test/server/executors/memory-v2-addon.test.ts
@@ -111,6 +111,9 @@ describe('buildMemoryV2Addon', () => {
             expect(toolNames).toContain(MEMORY_V2_STORE_TOOL_NAME);
             expect(toolNames).toContain(MEMORY_V2_RECALL_TOOL_NAME);
             expect(addon.suffix).toContain('memory');
+            // Guidance is wrapped in a named tag with the separator prefix.
+            expect(addon.suffix.startsWith('\n\n<memory_tool>\n')).toBe(true);
+            expect(addon.suffix.endsWith('\n</memory_tool>')).toBe(true);
             expect(addon.excludedBuiltinTools).toEqual(['vote_memory', 'store_memory']);
         } finally {
             addon.dispose();

--- a/packages/coc/test/server/executors/prompt-tags.test.ts
+++ b/packages/coc/test/server/executors/prompt-tags.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { tagBlock, tagGuidanceSuffix } from '../../../src/server/executors/prompt-tags';
+
+describe('tagBlock', () => {
+    it('wraps body in an open/close tag on their own lines', () => {
+        expect(tagBlock('citing_rule', 'hello')).toBe('<citing_rule>\nhello\n</citing_rule>');
+    });
+
+    it('preserves multi-line bodies verbatim between the tags', () => {
+        const body = 'line one\nline two';
+        expect(tagBlock('demo', body)).toBe('<demo>\nline one\nline two\n</demo>');
+    });
+
+    it('does not add the blank-line separator (that is for guidance suffixes)', () => {
+        expect(tagBlock('demo', 'x').startsWith('\n')).toBe(false);
+    });
+
+    it('handles an empty body without collapsing the tags', () => {
+        expect(tagBlock('demo', '')).toBe('<demo>\n\n</demo>');
+    });
+});
+
+describe('tagGuidanceSuffix', () => {
+    it('prefixes the tagged block with the blank-line separator the assembler relies on', () => {
+        expect(tagGuidanceSuffix('canvas_tools', 'use canvases')).toBe(
+            '\n\n<canvas_tools>\nuse canvases\n</canvas_tools>',
+        );
+    });
+
+    it('is equivalent to a separator plus tagBlock', () => {
+        const tag = 'work_item_tools';
+        const body = 'guidance text';
+        expect(tagGuidanceSuffix(tag, body)).toBe(`\n\n${tagBlock(tag, body)}`);
+    });
+});

--- a/packages/coc/test/server/image-utils.test.ts
+++ b/packages/coc/test/server/image-utils.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { parseDataUrl, saveImagesToTempFiles, cleanupTempDir, isImageDataUrl } from '../../src/server/core/image-utils';
+import { parseDataUrl, saveImagesToTempFiles, cleanupTempDir, isImageDataUrl, MAX_IMAGE_BYTES } from '../../src/server/core/image-utils';
 
 // ============================================================================
 // Helpers
@@ -122,6 +122,20 @@ describe('saveImagesToTempFiles', () => {
         expect(result.attachments).toHaveLength(1);
         expect(result.attachments[0].type).toBe('file');
         expect(fs.existsSync(result.attachments[0].path)).toBe(true);
+    });
+
+    it('should drop an image whose decoded bytes exceed MAX_IMAGE_BYTES before writing a temp file', () => {
+        const oversized = Buffer.alloc(MAX_IMAGE_BYTES + 1);
+        const oversizedDataUrl = `data:image/png;base64,${oversized.toString('base64')}`;
+        const result = saveImagesToTempFiles([oversizedDataUrl, PNG_DATA_URL]);
+        tempDirs.push(result.tempDir);
+
+        // Only the in-limit image survives; the oversized one is dropped.
+        expect(result.attachments).toHaveLength(1);
+        // Index is preserved (the valid PNG is at index 1).
+        expect(path.basename(result.attachments[0].path)).toBe('image-1.png');
+        // The oversized image left nothing on disk.
+        expect(fs.readdirSync(result.tempDir)).toHaveLength(1);
     });
 });
 


### PR DESCRIPTION
- **feat(coc): wrap tool-guidance prompt fragments in named XML tags**
- **feat(coc-agent-sdk): explicit Claude image-size boundary + sanitized skip diagnostics**
- **feat(coc): decoded-byte validation for image/attachment data URLs (AC-03)**
