### PR TITLE
fix(coc): detect Claude Code Write/Edit goal files for inline Ralph panel

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -514,10 +514,15 @@ parameters with a unified `args.diff`, expanded tool details and hover previews
 render that patch text instead of the short result summary.
 `utils/conversationScan.ts` powers chat References and goal-file detection by
 scanning completed file-writing tool calls for pinned document extensions
-(`.md`, `.txt`, `.yaml`, `.yml`, `.json`). It detects direct create/write/edit
-paths, `apply_patch` added files, and conservative shell `mv`/`move` command
-destinations from command arguments, including `bash -c`/`bash -lc` wrappers.
-It does not infer created files from arbitrary shell output.
+(`.md`, `.txt`, `.yaml`, `.yml`, `.json`). Tool names and args are run through
+`normalizeToolName`/`normalizeToolArgs` first, so provider-specific shapes are
+recognised — e.g. Claude Code's PascalCase `Write`/`Edit`/`MultiEdit` (with a
+`file_path` arg) map to the canonical create/edit tools, which is what lets a
+`.goal.md` written by a Claude session surface the inline Ralph launch panel.
+It detects direct create/write/edit paths, `apply_patch` added files, and
+conservative shell `mv`/`move` command destinations from command arguments,
+including `bash -c`/`bash -lc` wrappers. It does not infer created files from
+arbitrary shell output.
 
 ## Input Area
 

--- a/packages/coc/src/server/spa/client/react/utils/conversationScan.ts
+++ b/packages/coc/src/server/spa/client/react/utils/conversationScan.ts
@@ -1,6 +1,10 @@
 import type { ClientConversationTurn, ClientToolCall } from '../types/dashboard';
 import { getApplyPatchText, parseApplyPatchFileChanges } from './applyPatchParser';
 import { FILE_WRITE_TOOLS } from './fileWriteTools';
+import {
+    normalizeToolArgs,
+    normalizeToolName,
+} from '../features/chat/conversation/tool-calls/toolNormalization';
 
 /** File extensions considered "plan/doc" files worth pinning */
 export const PINNED_EXTENSIONS = ['.md', '.txt', '.yaml', '.yml', '.json'];
@@ -250,6 +254,11 @@ function extractApplyPatchPaths(
  * 2. Persisted: name (not toolName) field, args may be empty
  * 3. Live SSE: toolName='unknown', args={} — resolved via tool-start or result parsing
  * 4. apply_patch: string args with "*** Add File:" lines, result "Added N file(s): ..."
+ *
+ * Tool names and args are run through normalizeToolName/normalizeToolArgs so
+ * provider-specific shapes are recognised — e.g. Claude Code's PascalCase
+ * Write/Edit/MultiEdit (with a `file_path` arg) map to the canonical
+ * create/edit tools used by FILE_WRITE_TOOLS.
  */
 export function scanTurnsForCreatedFiles(
     turns: ClientConversationTurn[]
@@ -289,9 +298,14 @@ export function scanTurnsForCreatedFiles(
 
         for (const tc of toolCalls) {
             // Resolve tool name: tc.toolName > tc.name > matching tool-start name
-            const effectiveName = resolveToolName(tc) !== 'unknown'
+            const rawName = resolveToolName(tc) !== 'unknown'
                 ? resolveToolName(tc)
                 : (tc.id && toolStartNames.get(tc.id)) || resolveToolName(tc);
+
+            // Normalize provider-specific names to canonical ones so detection
+            // works across providers — e.g. Claude Code's PascalCase
+            // Write/Edit/MultiEdit map to create/edit and Bash maps to bash.
+            const effectiveName = normalizeToolName(rawName);
 
             if (SHELL_MOVE_TOOLS.has(effectiveName)) {
                 const args = typeof tc.args === 'object' ? tc.args ?? {} : {};
@@ -324,11 +338,14 @@ export function scanTurnsForCreatedFiles(
             }
 
             // Resolve args: tc.args > tool-start args (by toolCallId)
-            let args = typeof tc.args === 'object' ? tc.args ?? {} : {};
-            const hasPath = args.path || args.filePath;
+            let rawArgs = typeof tc.args === 'object' ? tc.args ?? {} : {};
+            const hasPath = rawArgs.path || rawArgs.filePath || rawArgs.file_path;
             if (!hasPath && tc.id && toolStartArgs.has(tc.id)) {
-                args = toolStartArgs.get(tc.id)!;
+                rawArgs = toolStartArgs.get(tc.id)!;
             }
+
+            // Normalize args (e.g. Claude's `file_path` → `path`) before reading.
+            const args = normalizeToolArgs(effectiveName, rawArgs) as Record<string, any>;
 
             let filePath: string = args.path || args.filePath || '';
 

--- a/packages/coc/test/conversationScan.test.ts
+++ b/packages/coc/test/conversationScan.test.ts
@@ -783,4 +783,80 @@ describe('scanTurnsForCreatedFiles', () => {
             expect(scanTurnsForCreatedFiles(turns)).toHaveLength(0);
         });
     });
+
+    // ==================================================================
+    // Claude Code provider tools: PascalCase names + `file_path` arg.
+    // Regression: these were silently dropped, so a `.goal.md` written
+    // by a Claude session never surfaced the inline Ralph launch panel.
+    // ==================================================================
+    describe('Claude Code tool names (Write / Edit / MultiEdit, file_path arg)', () => {
+        it('detects a Write tool call with a file_path arg', () => {
+            const turns = [
+                makeTurn([{ toolName: 'Write', args: { file_path: '/tmp/plan.md' } }]),
+            ];
+            const results = scanTurnsForCreatedFiles(turns);
+            expect(results).toHaveLength(1);
+            expect(results[0].filePath).toBe('/tmp/plan.md');
+        });
+
+        it('detects a .goal.md written via the Write tool (the reported bug)', () => {
+            const turns = [
+                makeTurn([{
+                    toolName: 'Write',
+                    args: { file_path: '/repos/myrepo/Plans/feature/warm-indicator.goal.md' },
+                }]),
+            ];
+            const results = scanTurnsForCreatedFiles(turns);
+            expect(results).toHaveLength(1);
+            expect(results[0].filePath).toBe('/repos/myrepo/Plans/feature/warm-indicator.goal.md');
+            expect(results[0].filePath.toLowerCase().endsWith('.goal.md')).toBe(true);
+        });
+
+        it('detects an Edit tool call with a file_path arg', () => {
+            const turns = [
+                makeTurn([{ toolName: 'Edit', args: { file_path: '/tmp/spec.md' } }]),
+            ];
+            const results = scanTurnsForCreatedFiles(turns);
+            expect(results).toHaveLength(1);
+            expect(results[0].filePath).toBe('/tmp/spec.md');
+        });
+
+        it('detects a MultiEdit tool call with a file_path arg', () => {
+            const turns = [
+                makeTurn([{ toolName: 'MultiEdit', args: { file_path: '/tmp/design.md' } }]),
+            ];
+            const results = scanTurnsForCreatedFiles(turns);
+            expect(results).toHaveLength(1);
+            expect(results[0].filePath).toBe('/tmp/design.md');
+        });
+
+        it('detects a Write call from persisted data (name field, file_path arg)', () => {
+            const turns = [
+                makePersistedTurn([{ name: 'Write', args: { file_path: '/tmp/persisted.goal.md' } }]),
+            ];
+            const results = scanTurnsForCreatedFiles(turns);
+            expect(results).toHaveLength(1);
+            expect(results[0].filePath).toBe('/tmp/persisted.goal.md');
+        });
+
+        it('resolves a Write call from tool-start for live SSE completions', () => {
+            const turns = [
+                makeLiveSSETurn([{
+                    id: 'tc0',
+                    toolName: 'Write',
+                    args: { file_path: '/tmp/live.goal.md' },
+                }]),
+            ];
+            const results = scanTurnsForCreatedFiles(turns);
+            expect(results).toHaveLength(1);
+            expect(results[0].filePath).toBe('/tmp/live.goal.md');
+        });
+
+        it('still ignores the Read tool (normalizes to a non-write tool)', () => {
+            const turns = [
+                makeTurn([{ toolName: 'Read', args: { file_path: '/tmp/notes.md' } }]),
+            ];
+            expect(scanTurnsForCreatedFiles(turns)).toHaveLength(0);
+        });
+    });
 });


### PR DESCRIPTION
scanTurnsForCreatedFiles matched raw tool names against a lowercase
FILE_WRITE_TOOLS set and read args.path/args.filePath, so Claude Code's
PascalCase Write/Edit/MultiEdit calls (with a file_path arg) were silently
dropped. A `.goal.md` written by a Claude session therefore never surfaced
the inline Ralph launch panel in chat.

Run tool names through normalizeToolName and args through normalizeToolArgs
before matching, so provider-specific shapes canonicalize to create/edit
(and file_path -> path). The normalization already backed the display layer;
this reuses it in the scan.

Adds regression tests for Write/Edit/MultiEdit + file_path across timeline,
persisted, and live-SSE shapes (incl. the .goal.md scenario), and confirms
Read still normalizes to a non-write tool and is ignored.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
