### PR TITLE
fix(coc): right-anchor context-usage breakdown popover to prevent rig…

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ComposerMetaStrip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ComposerMetaStrip.tsx
@@ -206,7 +206,7 @@ export function ComposerMetaStrip({
                     {/* Breakdown popover — shown on hover/tap; full breakdown when available, simple total otherwise */}
                     {ctxPopoverOpen && (
                         <div
-                            className="absolute bottom-full left-0 mb-2 z-50 bg-white dark:bg-[#1e1e1e] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded-md shadow-lg p-3 min-w-[220px] text-xs pointer-events-auto"
+                            className="absolute bottom-full right-0 mb-2 z-50 bg-white dark:bg-[#1e1e1e] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded-md shadow-lg p-3 min-w-[220px] text-xs pointer-events-auto"
                             data-testid="composer-ctx-breakdown-popover"
                             onMouseEnter={() => setCtxPopoverOpen(true)}
                             onMouseLeave={() => setCtxPopoverOpen(false)}

--- a/packages/coc/src/server/spa/client/react/ui/ContextWindowIndicator.tsx
+++ b/packages/coc/src/server/spa/client/react/ui/ContextWindowIndicator.tsx
@@ -147,7 +147,7 @@ export function ContextWindowIndicator({
             {/* Breakdown popover — shown on hover/tap; full breakdown when available, simple total otherwise */}
             {popoverOpen && (
                 <div
-                    className="absolute bottom-full left-0 mb-2 z-50 bg-white dark:bg-[#1e1e1e] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded-md shadow-lg p-3 min-w-[220px] text-xs pointer-events-auto"
+                    className="absolute bottom-full right-0 mb-2 z-50 bg-white dark:bg-[#1e1e1e] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded-md shadow-lg p-3 min-w-[220px] text-xs pointer-events-auto"
                     data-testid="ctx-breakdown-popover"
                     onMouseEnter={() => setPopoverOpen(true)}
                     onMouseLeave={() => setPopoverOpen(false)}

--- a/packages/coc/test/spa/react/ContextWindowIndicator.test.tsx
+++ b/packages/coc/test/spa/react/ContextWindowIndicator.test.tsx
@@ -240,4 +240,15 @@ describe('ContextWindowIndicator', () => {
         expect(popover.textContent).toContain('Other');
         expect(popover.textContent).toContain('Total');
     });
+
+    it('right-anchors the breakdown popover so it is not clipped on the right edge', () => {
+        // The indicator sits on the right side of the chat header, so the popover
+        // must open leftward (right-0) rather than overflow past the panel boundary
+        // (which clipped the "% of limit" column). Regression test.
+        render(<ContextWindowIndicator tokenLimit={200000} currentTokens={70000} />);
+        fireEvent.mouseEnter(screen.getByTestId('context-window-indicator'));
+        const popover = screen.getByTestId('ctx-breakdown-popover');
+        expect(popover.className).toContain('right-0');
+        expect(popover.className).not.toContain('left-0');
+    });
 });

--- a/packages/coc/test/spa/react/repos/ComposerMetaStrip.test.tsx
+++ b/packages/coc/test/spa/react/repos/ComposerMetaStrip.test.tsx
@@ -263,4 +263,15 @@ describe('ComposerMetaStrip', () => {
         expect(popover.textContent).toContain('Other');
         expect(popover.textContent).toContain('Total');
     });
+
+    it('right-anchors the breakdown popover so it is not clipped on the right edge', () => {
+        // The ctx fuel gauge sits on the right side of the composer toolbar, so
+        // the popover must open leftward (right-0) rather than overflow past the
+        // panel boundary (which clipped the "% of limit" column). Regression test.
+        render(<ComposerMetaStrip sessionTokenLimit={200000} sessionCurrentTokens={70000} />);
+        fireEvent.mouseEnter(screen.getByTestId('composer-ctx-fuel'));
+        const popover = screen.getByTestId('composer-ctx-breakdown-popover');
+        expect(popover.className).toContain('right-0');
+        expect(popover.className).not.toContain('left-0');
+    });
 });


### PR DESCRIPTION
…ht-edge clipping

The ctx fuel gauge / context-window indicator sit on the right side of their toolbars, but the breakdown popover was anchored with left-0, so the 220px popover overflowed past the panel boundary and clipped the '% of limit' column. Anchor the popover with right-0 so it opens leftward into available space. Adds regression tests asserting the right-0 anchor.