### PR TITLE
feat(coc): show remote server label + status on repo dropdown cards (…

### DIFF
--- a/packages/coc/src/server/spa/client/react/repos/RepoCard.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/RepoCard.tsx
@@ -4,9 +4,11 @@
  */
 
 import type { RepoData } from './repoGrouping';
-import { truncatePath } from './repoGrouping';
+import { truncatePath, isRemoteRepo } from './repoGrouping';
+import { blendRemoteCloneStatus, cloneStatusColor } from '../features/remote-shell/shellModel';
 import { Card, cn } from '../ui';
 import { useRepoQueueStats } from '../queue/hooks/useRepoQueueStats';
+import type { RemoteWorkspaceMarker } from './remoteWorkspaceAggregation';
 
 interface RepoCardProps {
     repo: RepoData;
@@ -25,6 +27,21 @@ export function RepoCard({ repo, isSelected, inGroup, onClick }: RepoCardProps) 
     const truncPath = truncatePath(ws.rootPath || '', 24);
     const taskCount = repo.taskCount || 0;
     const queueStats = useRepoQueueStats(ws.id);
+
+    // Remote-workspace distinction (AC-03): aggregated remote checkouts carry a
+    // `remote` marker (server label + connection/queue, set by AC-01). Surface a
+    // compact, truncated server-label badge with an inline status dot whose color
+    // is the connection-first blended status (shellModel) — so a remote row is
+    // scannable and an offline server reads as offline rather than disappearing
+    // silently (AC-01 DoD). Local cards take none of this branch and are unchanged.
+    const isRemote = isRemoteRepo(repo);
+    const remote: RemoteWorkspaceMarker | null = isRemote
+        ? (ws as { remote: RemoteWorkspaceMarker }).remote
+        : null;
+    const remoteStatus = remote ? blendRemoteCloneStatus(remote) : null;
+    const isOffline = remoteStatus === 'offline';
+    const serverLabel = remote?.serverLabel ? String(remote.serverLabel) : null;
+    const remoteDotColor = cloneStatusColor(remoteStatus ?? undefined, color);
 
     return (
         <Card
@@ -59,6 +76,30 @@ export function RepoCard({ repo, isSelected, inGroup, onClick }: RepoCardProps) 
                 )}
                 {taskCount > 0 && (
                     <span className="text-[10px] text-[#848484] flex-shrink-0">· {taskCount}</span>
+                )}
+                {isRemote && serverLabel && (
+                    <span
+                        data-testid="repo-card-remote-badge"
+                        data-offline={isOffline ? 'true' : 'false'}
+                        data-remote-status={remoteStatus ?? 'idle'}
+                        title={isOffline
+                            ? `Remote · ${serverLabel} · offline (server unreachable)`
+                            : `Remote · ${serverLabel}`}
+                        className={cn(
+                            'ml-auto inline-flex items-center gap-1 max-w-[96px] min-w-0 text-[9px] font-bold uppercase tracking-[0.04em] px-1 py-px rounded',
+                            isOffline
+                                ? 'bg-[#8c959f]/15 text-[#6e7781] dark:text-[#8c959f]'
+                                : 'bg-[#8250df]/12 text-[#8250df] dark:bg-[#a371f7]/15 dark:text-[#a371f7]'
+                        )}
+                    >
+                        <span
+                            data-testid="repo-card-remote-status-dot"
+                            className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                            style={{ background: remoteDotColor }}
+                            aria-hidden
+                        />
+                        <span className="truncate">{serverLabel}</span>
+                    </span>
                 )}
             </div>
 

--- a/packages/coc/test/spa/react/repos/RepoCard.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoCard.test.tsx
@@ -2,7 +2,7 @@
  * Tests for RepoCard — 2-line compact layout.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
@@ -161,5 +161,80 @@ describe('inGroup indent', () => {
         renderCard({ inGroup: false });
         const card = document.querySelector('.repo-item');
         expect(card?.className).not.toContain('ml-4');
+    });
+});
+
+// ── Remote-workspace distinction (AC-03) ───────────────────────────────────────
+
+function makeRemoteRepo(opts: {
+    serverLabel?: string;
+    connection?: string;
+    queue?: string;
+    offline?: boolean;
+    name?: string;
+} = {}): RepoData {
+    const { serverLabel = 'devbox', connection = 'online', queue = 'idle', offline = false, name = 'shortcuts' } = opts;
+    return makeRepo({
+        workspace: {
+            id: 'remote-1', name, color: '#0078d4', rootPath: '/remote/shortcuts', isGitRepo: true,
+            baseUrl: 'http://127.0.0.1:4000',
+            remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline, connection, queue },
+        } as any,
+        gitInfo: { branch: 'main', dirty: false, isGitRepo: true } as any,
+    });
+}
+
+describe('remote distinction (AC-03)', () => {
+    beforeEach(() => {
+        mockQueueStats.mockReturnValue({ running: 0, queued: 0 });
+    });
+
+    it('renders no remote badge for a local workspace (local layout unchanged)', () => {
+        renderCard();
+        expect(screen.queryByTestId('repo-card-remote-badge')).toBeNull();
+        // Local card keeps its exact 2-row structure (identity + metadata).
+        const card = document.querySelector('.repo-item');
+        expect(Array.from(card?.children || []).length).toBe(2);
+    });
+
+    it('shows a compact server-label badge with a status dot for an online remote workspace', () => {
+        renderCard({ repo: makeRemoteRepo({ serverLabel: 'devbox' }) });
+        const badge = screen.getByTestId('repo-card-remote-badge');
+        expect(badge.getAttribute('data-offline')).toBe('false');
+        expect(badge.getAttribute('data-remote-status')).toBe('idle');
+        expect(badge.textContent).toContain('devbox');
+        expect(badge.getAttribute('title')).toContain('devbox');
+        expect(screen.getByTestId('repo-card-remote-status-dot')).toBeTruthy();
+    });
+
+    it('reflects a running remote queue as a running status', () => {
+        renderCard({ repo: makeRemoteRepo({ connection: 'online', queue: 'running' }) });
+        const badge = screen.getByTestId('repo-card-remote-badge');
+        expect(badge.getAttribute('data-offline')).toBe('false');
+        expect(badge.getAttribute('data-remote-status')).toBe('running');
+    });
+
+    it('marks an offline remote workspace as offline rather than dropping it (AC-01 DoD)', () => {
+        renderCard({ repo: makeRemoteRepo({ connection: 'offline', offline: true }) });
+        const badge = screen.getByTestId('repo-card-remote-badge');
+        expect(badge.getAttribute('data-offline')).toBe('true');
+        expect(badge.getAttribute('data-remote-status')).toBe('offline');
+        expect(badge.getAttribute('title')).toContain('offline');
+        // The workspace still renders — it did not disappear silently.
+        expect(screen.getByText('shortcuts')).toBeTruthy();
+    });
+
+    it('keeps the badge inside row 1 so the card structure is still 2 rows', () => {
+        renderCard({ repo: makeRemoteRepo() });
+        const card = document.querySelector('.repo-item');
+        expect(Array.from(card?.children || []).length).toBe(2);
+    });
+
+    it('truncates a long server label so it cannot overflow the narrow dropdown', () => {
+        renderCard({ repo: makeRemoteRepo({ serverLabel: 'a-very-long-remote-server-label-that-would-overflow' }) });
+        const badge = screen.getByTestId('repo-card-remote-badge');
+        expect(badge.className).toContain('max-w-[96px]');
+        const labelSpan = badge.querySelector('span.truncate');
+        expect(labelSpan?.textContent).toContain('a-very-long-remote-server-label');
     });
 });


### PR DESCRIPTION
…AC-03)

Remote CoC workspaces already aggregate into the hamburger "Repositories" dropdown (AC-01) and group under their normalized Git remote alongside local clones (AC-02), but RepoCard rendered them identically to local repos. Give each remote card a compact, truncated server-label badge with an inline status dot whose color is the connection-first blended status (reusing shellModel.blendRemoteCloneStatus / cloneStatusColor), so:

- remote rows are visually distinguishable and scannable at the dropdown's narrow width (label truncates, badge width-capped) — AC-03;
- an offline/unreachable server's cached workspaces read as offline rather than disappearing silently — AC-01 DoD.

Local cards take none of this branch and are byte-for-byte unchanged.