### PR TITLE
fix(coc): route chat PR-status fetches to the workspace's owning server

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/usePrChatStatusItems.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/usePrChatStatusItems.ts
@@ -12,13 +12,21 @@
  *   5. fetches PR detail per association, mapping it to a {@link PrStatusCardItem}
  *      with per-row loading / ready / error state and a retry.
  *
+ * Every REST call (binding list/upsert, detail, checks) is routed through
+ * {@link getCocClientForWorkspace} keyed by the chat's `workspaceId`, so a chat
+ * owned by a REMOTE workspace resolves the PR against the server that actually
+ * owns that workspace. Resolving a remote workspace id against the local server
+ * would 404 (`Repo <ws> not found`). Local workspaces fall through to the default
+ * page-origin client, unchanged.
+ *
  * All the union / detection / origin logic lives in the pure
  * {@link ./prChatAssociation} module (unit-tested independently); this hook is the
  * thin async/React layer over it.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ClientConversationTurn } from '../../../types/dashboard';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../../api/cocClient';
+import { getSpaCocClientErrorMessage } from '../../../api/cocClient';
+import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 import { resolveCanonicalOriginId } from '../../../repos/originScope';
 import { buildCheckRowsFromChecks } from '../../pull-requests/pr-derived-data';
 import type { PullRequestCheck } from '../../pull-requests/pr-utils';
@@ -179,7 +187,7 @@ export function usePrChatStatusItems(options: UsePrChatStatusItemsOptions): UseP
                     ),
                 );
             }
-            return getSpaCocClient()
+            return getCocClientForWorkspace(repoId)
                 .pullRequests.getForOrigin(association.originId, association.prId, {
                     workspaceId: repoId,
                     ...(force ? { force: true } : {}),
@@ -235,7 +243,7 @@ export function usePrChatStatusItems(options: UsePrChatStatusItemsOptions): UseP
                     ),
                 );
             }
-            getSpaCocClient()
+            getCocClientForWorkspace(repoId)
                 .pullRequests.getChecksForOrigin(association.originId, association.prId, {
                     workspaceId: repoId,
                     ...(force ? { force: true } : {}),
@@ -280,7 +288,7 @@ export function usePrChatStatusItems(options: UsePrChatStatusItemsOptions): UseP
             return;
         }
         const generation = ++generationRef.current;
-        const client = getSpaCocClient();
+        const client = getCocClientForWorkspace(workspaceId);
 
         (async () => {
             let bindings: PrChatBindingLike[] = [];

--- a/packages/coc/test/spa/react/ChatPrStatusCard.test.tsx
+++ b/packages/coc/test/spa/react/ChatPrStatusCard.test.tsx
@@ -28,12 +28,21 @@ const mocks = vi.hoisted(() => ({
         getForOrigin: vi.fn(),
         getChecksForOrigin: vi.fn(),
     },
+    getCocClientForWorkspace: vi.fn(),
 }));
 
 vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({ pullRequests: mocks.pullRequests }),
     getSpaCocClientErrorMessage: (err: unknown, fallback: string) =>
         (err instanceof Error && err.message) || fallback,
+}));
+
+// The hook routes every workspace-scoped REST call through getCocClientForWorkspace
+// so a remote-owned chat resolves the PR against the server that owns it. The
+// default maps any workspace to the shared local client; the remote-routing test
+// below overrides it to assert a remote workspace never hits the local client.
+vi.mock('../../../src/server/spa/client/react/repos/cloneRegistry', () => ({
+    getCocClientForWorkspace: mocks.getCocClientForWorkspace,
 }));
 
 import { ChatPrStatusCard } from '../../../src/server/spa/client/react/features/chat/conversation/ChatPrStatusCard';
@@ -70,6 +79,9 @@ describe('ChatPrStatusCard / usePrChatStatusItems', () => {
         mocks.pullRequests.getForOrigin.mockReset();
         mocks.pullRequests.getChecksForOrigin.mockReset();
         mocks.pullRequests.createChatBindingForOrigin.mockResolvedValue({ prId: '42', taskId: 't1' });
+        // Default: every workspace resolves to the shared local client.
+        mocks.getCocClientForWorkspace.mockReset();
+        mocks.getCocClientForWorkspace.mockReturnValue({ pullRequests: mocks.pullRequests });
     });
 
     afterEach(() => {
@@ -300,6 +312,43 @@ describe('ChatPrStatusCard / usePrChatStatusItems', () => {
         await waitFor(() => expect(mocks.pullRequests.listChatBindingsForOrigin).toHaveBeenCalled());
         expect(container.querySelector('[data-testid="pr-status-card"]')).toBeNull();
         expect(mocks.pullRequests.getForOrigin).not.toHaveBeenCalled();
+    });
+
+    it('regression: a remote workspace routes through getCocClientForWorkspace, never the local client', async () => {
+        // A remote-owned chat: the workspace id only resolves on its remote server.
+        // Resolving it against the local client 404s with "Repo <ws> not found".
+        const REMOTE_WS = 'ws-xjvuoc';
+        const remotePullRequests = {
+            listChatBindingsForOrigin: vi.fn().mockResolvedValue({ bindings: {} }),
+            createChatBindingForOrigin: vi.fn().mockResolvedValue({ prId: '42', taskId: 't1' }),
+            getForOrigin: vi.fn().mockResolvedValue({
+                number: 42,
+                title: 'Remote PR',
+                status: 'open',
+                sourceBranch: 'feature/card',
+                targetBranch: 'main',
+                createdAt: '2024-01-01T00:00:00Z',
+                url: GH_URL,
+            }),
+            getChecksForOrigin: vi.fn(),
+        };
+        mocks.getCocClientForWorkspace.mockImplementation((wsId: string) =>
+            wsId === REMOTE_WS ? { pullRequests: remotePullRequests } : { pullRequests: mocks.pullRequests },
+        );
+
+        const { findByText, findByTestId } = render(
+            <ChatPrStatusCard turns={[turnWithPrCreate(GH_URL)]} workspaceId={REMOTE_WS} remoteUrl={GH_REMOTE} taskId="t1" />,
+        );
+
+        fireEvent.click(await findByTestId('pr-status-card-toggle'));
+        await findByText('Remote PR');
+
+        // Routed to the workspace's owning (remote) server, keyed by its id.
+        expect(mocks.getCocClientForWorkspace).toHaveBeenCalledWith(REMOTE_WS);
+        expect(remotePullRequests.getForOrigin).toHaveBeenCalledWith(GH_ORIGIN, '42', { workspaceId: REMOTE_WS });
+        // The default local client is never used for a remote workspace.
+        expect(mocks.pullRequests.getForOrigin).not.toHaveBeenCalled();
+        expect(mocks.pullRequests.listChatBindingsForOrigin).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
The PR-status card (usePrChatStatusItems) fetched bindings, PR detail, and
CI checks through getSpaCocClient() — the page-origin client — keyed by the
chat's workspaceId. For a chat owned by a REMOTE workspace this resolved the
workspace id against the LOCAL server, whose RepoTreeService.resolveRepo has
no such row, returning 404 "Repo <ws> not found" (e.g. "Repo ws-xjvuoc not
found"). The PR itself opened fine; only its status row failed to load, and
Retry/Open-full-PR reused the same dead id.

Route every workspace-scoped REST call through getCocClientForWorkspace(
workspaceId) instead. A remote workspace resolves to its server's baseUrl
via the clone registry; a local workspace falls through to the default
client unchanged.

Test: add a regression test asserting a remote workspace id routes through
getCocClientForWorkspace and never hits the local client.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
