### PR TITLE
fix(coc): route commit changed-files fetch to the workspace's owning server

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/git/commits/CommitList.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/commits/CommitList.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { getSpaCocClient } from '../../../api/cocClient';
+import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 import { formatRelativeTime } from '../../../utils/format';
 import { CommitTooltip } from './CommitTooltip';
 import { buildFileTree, compactFolders, FileTreeView, FlatFileList } from '../diff/FileTree';
@@ -391,7 +391,7 @@ export function CommitList({ title, commits, selectedHash, selectedHashes, onMul
         setExpandedHash(initialExpandedHash);
         if (workspaceId) {
             setFilesLoading(initialExpandedHash);
-            getSpaCocClient().git.listCommitFiles(workspaceId, initialExpandedHash)
+            getCocClientForWorkspace(workspaceId).git.listCommitFiles(workspaceId, initialExpandedHash)
                 .then(data => {
                     setFileCache(prev => ({ ...prev, [initialExpandedHash]: data.files || [] }));
                 })
@@ -470,7 +470,7 @@ export function CommitList({ title, commits, selectedHash, selectedHashes, onMul
             setExpandedHash(commit.hash);
             if (!fileCache[commit.hash] && workspaceId) {
                 setFilesLoading(commit.hash);
-                getSpaCocClient().git.listCommitFiles(workspaceId, commit.hash)
+                getCocClientForWorkspace(workspaceId).git.listCommitFiles(workspaceId, commit.hash)
                     .then(data => {
                         setFileCache(prev => ({ ...prev, [commit.hash]: data.files || [] }));
                     })

--- a/packages/coc/test/spa/react/CommitList.remote-fetch.test.tsx
+++ b/packages/coc/test/spa/react/CommitList.remote-fetch.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for CommitList's per-commit changed-files fetch.
+ *
+ * Bug: the file list was fetched through getSpaCocClient() (the page-origin /
+ * LOCAL client) keyed by the commit's workspaceId. For a commit on a REMOTE
+ * workspace the id only resolves on its owning server; the local server has no
+ * clone at that path, so `git diff-tree` returned nothing and the UI showed
+ * "No files changed" for every unpushed commit.
+ *
+ * Fix: route both fetch sites (click-to-expand and deep-link auto-expand)
+ * through getCocClientForWorkspace(workspaceId) — the same routing the recent
+ * PR-status fix adopted. These tests assert a remote workspace resolves to its
+ * owning server and never hits the local client, and that the changed files
+ * actually render (no false "No files changed").
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { mockViewport } from '../helpers/viewport-mock';
+import type { GitCommitItem } from '../../../src/server/spa/client/react/features/git/commits/CommitList';
+
+const mocks = vi.hoisted(() => ({
+    getCocClientForWorkspace: vi.fn(),
+}));
+
+// The component must route every workspace-scoped call through this helper. The
+// remote-routing tests below override it to assert a remote workspace never
+// resolves to the shared local client.
+vi.mock('../../../src/server/spa/client/react/repos/cloneRegistry', () => ({
+    getCocClientForWorkspace: mocks.getCocClientForWorkspace,
+}));
+
+// Inert stubs for the comment-count / view-mode hooks: each makes its own
+// network + WebSocket calls we don't exercise here. The returns MUST be stable
+// singletons — the component feeds commentCounts into an effect's dependency
+// array, so a fresh Map per render would loop forever. flat view mode renders
+// FlatFileList so changed files surface as `commit-file-<path>` rows.
+const EMPTY_COUNTS = new Map<string, number>();
+const EMPTY_TOTALS = new Map();
+const FLAT_VIEW = { mode: 'flat' as const, setMode: () => {} };
+vi.mock('../../../src/server/spa/client/react/features/git/hooks/useFileCommentCounts', () => ({
+    useFileCommentCounts: () => EMPTY_COUNTS,
+}));
+vi.mock('../../../src/server/spa/client/react/features/git/hooks/useCommitCommentTotals', () => ({
+    useCommitCommentTotals: () => EMPTY_TOTALS,
+}));
+vi.mock('../../../src/server/spa/client/react/features/git/hooks/useFilesViewMode', () => ({
+    useFilesViewMode: () => FLAT_VIEW,
+}));
+
+import { CommitList } from '../../../src/server/spa/client/react/features/git/commits/CommitList';
+
+const HASH = 'abc1234deadbeef0000000000000000000000000';
+const SHORT = 'abc1234';
+const CHANGED_FILE = 'src/foo.ts';
+
+function commit(): GitCommitItem {
+    return {
+        hash: HASH,
+        shortHash: SHORT,
+        subject: 'fix(coc): route chat PR-status fetches',
+        author: 'Yiheng Tao',
+        date: '2026-06-21T02:04:21Z',
+        parentHashes: ['0000000000000000000000000000000000000000'],
+    };
+}
+
+function makeClient() {
+    return {
+        git: {
+            listCommitFiles: vi.fn().mockResolvedValue({
+                files: [{ status: 'M', path: CHANGED_FILE }],
+            }),
+        },
+    };
+}
+
+describe('CommitList — remote-aware changed-files fetch', () => {
+    let restoreViewport: () => void;
+
+    beforeEach(() => {
+        restoreViewport = mockViewport(1280);
+        mocks.getCocClientForWorkspace.mockReset();
+    });
+
+    afterEach(() => {
+        restoreViewport();
+        vi.restoreAllMocks();
+    });
+
+    it('regression: click-to-expand routes through the workspace owning server, never the local client', async () => {
+        const REMOTE_WS = 'ws-xjvuoc';
+        const remoteClient = makeClient();
+        const localClient = makeClient();
+        mocks.getCocClientForWorkspace.mockImplementation((wsId: string) =>
+            wsId === REMOTE_WS ? remoteClient : localClient,
+        );
+
+        const { getByTestId } = render(
+            <CommitList title="Unpushed" commits={[commit()]} workspaceId={REMOTE_WS} unpushedCount={1} />,
+        );
+
+        fireEvent.click(getByTestId(`commit-row-${SHORT}`));
+
+        // The changed file renders — the bug showed "No files changed" here.
+        await waitFor(() => getByTestId(`commit-file-${CHANGED_FILE}`));
+
+        // Routed to the workspace's owning server, keyed by its id.
+        expect(mocks.getCocClientForWorkspace).toHaveBeenCalledWith(REMOTE_WS);
+        expect(remoteClient.git.listCommitFiles).toHaveBeenCalledWith(REMOTE_WS, HASH);
+        // The default local client is never used for a remote workspace.
+        expect(localClient.git.listCommitFiles).not.toHaveBeenCalled();
+    });
+
+    it('regression: deep-link auto-expand also routes through the workspace owning server', async () => {
+        const REMOTE_WS = 'ws-xjvuoc';
+        const remoteClient = makeClient();
+        const localClient = makeClient();
+        mocks.getCocClientForWorkspace.mockImplementation((wsId: string) =>
+            wsId === REMOTE_WS ? remoteClient : localClient,
+        );
+
+        const { getByTestId } = render(
+            <CommitList
+                title="Unpushed"
+                commits={[commit()]}
+                workspaceId={REMOTE_WS}
+                initialExpandedHash={HASH}
+                unpushedCount={1}
+            />,
+        );
+
+        await waitFor(() => getByTestId(`commit-file-${CHANGED_FILE}`));
+
+        expect(mocks.getCocClientForWorkspace).toHaveBeenCalledWith(REMOTE_WS);
+        expect(remoteClient.git.listCommitFiles).toHaveBeenCalledWith(REMOTE_WS, HASH);
+        expect(localClient.git.listCommitFiles).not.toHaveBeenCalled();
+    });
+
+    it('a local workspace still resolves to the default client and renders files', async () => {
+        const LOCAL_WS = 'ws-local';
+        const localClient = makeClient();
+        mocks.getCocClientForWorkspace.mockReturnValue(localClient);
+
+        const { getByTestId } = render(
+            <CommitList title="Unpushed" commits={[commit()]} workspaceId={LOCAL_WS} unpushedCount={1} />,
+        );
+
+        fireEvent.click(getByTestId(`commit-row-${SHORT}`));
+
+        await waitFor(() => getByTestId(`commit-file-${CHANGED_FILE}`));
+        expect(mocks.getCocClientForWorkspace).toHaveBeenCalledWith(LOCAL_WS);
+        expect(localClient.git.listCommitFiles).toHaveBeenCalledWith(LOCAL_WS, HASH);
+    });
+});

--- a/packages/coc/test/spa/react/CommitList.test.ts
+++ b/packages/coc/test/spa/react/CommitList.test.ts
@@ -163,8 +163,12 @@ describe('CommitList', () => {
             expect(source).toContain('listCommitFiles(workspaceId');
         });
 
-        it('imports typed CoC client for file list fetching', () => {
-            expect(source).toContain("import { getSpaCocClient }");
+        it('fetches the file list through the workspace-routed client (remote-aware)', () => {
+            // Must route through getCocClientForWorkspace so a remote workspace's
+            // file list is fetched from its owning server, not the local one.
+            expect(source).toContain("import { getCocClientForWorkspace }");
+            expect(source).toContain('getCocClientForWorkspace(workspaceId).git.listCommitFiles');
+            expect(source).not.toContain('getSpaCocClient().git.listCommitFiles');
         });
 
         it('toggles expand/collapse on commit click via handleCommitClick', () => {


### PR DESCRIPTION
CommitList fetched a commit's changed-file list through getSpaCocClient()
(the page-origin / LOCAL client) keyed by the commit's workspaceId, at both
the click-to-expand and deep-link auto-expand sites. For a commit on a REMOTE
workspace the id only resolves on its owning server; the local server has no
clone at that path, so `git diff-tree` returned nothing and every unpushed
commit rendered "No files changed".

Route both fetches through getCocClientForWorkspace(workspaceId) instead — a
remote workspace resolves to its server's baseUrl via the clone registry; a
local workspace falls through to the default client unchanged. This is the
same routing fix applied to the PR-status card in 8269cb7cf.

Test: add CommitList.remote-fetch.test.tsx asserting a remote workspace routes
both fetch sites through getCocClientForWorkspace and never the local client,
and that changed files render; update the source-shape assertion in
CommitList.test.ts to lock the routed call.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
