### PR TITLE
fix(work-items): add createWorkItemStore factory to fix LLM tool scope resolution

### DIFF
--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -41,6 +41,7 @@ import { createCancelLoopTool, createCreateLoopTool, createListLoopsTool, create
 import { createSearchConversationsTool } from '../llm-tools/search-conversations-tool';
 import { createSuggestFollowUpsTool } from '../llm-tools/suggest-follow-ups-tool';
 import { createTavilyWebSearchTool } from '../llm-tools/tavily-web-search-tool';
+import { createWorkItemStore } from '../work-items/work-item-store';
 import { tagBlock, tagGuidanceSuffix } from './prompt-tags';
 import type { ChatMode, ChatPayload, ChatProvider, DreamRunPayload, ForEachGenerationContext, MapReduceGenerationContext, PrClassificationPayload, RunScriptPayload } from '../tasks/task-types';
 import {
@@ -574,8 +575,14 @@ export function buildCreateWorkItemAddon(
         return { tools: [], suffix: '' };
     }
 
-    const { tool: getWorkItemTool } = createGetWorkItemTool(dataDir, repoId, deps);
-    const { tool: workItemTool } = createCreateUpdateWorkItemTool(dataDir, repoId, broadcastFn, deps);
+    // Build one correctly-scoped store and inject it into both tools so they
+    // share a single instance and cannot diverge on which directory they use.
+    const workItemStore = deps?.workItemStore
+        ?? createWorkItemStore({ dataDir, processStore: deps?.processStore });
+    const scopedDeps: CreateUpdateWorkItemToolDeps = { ...deps, workItemStore };
+
+    const { tool: getWorkItemTool } = createGetWorkItemTool(dataDir, repoId, scopedDeps);
+    const { tool: workItemTool } = createCreateUpdateWorkItemTool(dataDir, repoId, broadcastFn, scopedDeps);
 
     const suffix = tagGuidanceSuffix(
         'work_item_tools',

--- a/packages/coc/src/server/llm-tools/create-update-work-item-tool.ts
+++ b/packages/coc/src/server/llm-tools/create-update-work-item-tool.ts
@@ -19,7 +19,7 @@ import { defineTool } from '@plusplusoneplusplus/coc-agent-sdk';
 import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import { resolveConfig, CONFIG_FILE_NAME } from '../../config';
 import { APIError } from '../errors';
-import { FileWorkItemStore } from '../work-items/work-item-store';
+import { createWorkItemStore } from '../work-items/work-item-store';
 import type { WorkItem, WorkItemPriority, WorkItemStatus, WorkItemStore, WorkItemType } from '../work-items/types';
 import { WORK_ITEM_TYPES } from '../work-items/types';
 import { WORK_ITEM_PLAN_TEMPLATE } from '../work-items/plan-template';
@@ -280,7 +280,7 @@ export function createCreateUpdateWorkItemTool(
     broadcastFn?: BroadcastWorkItemFn,
     deps?: CreateUpdateWorkItemToolDeps,
 ) {
-    const store: WorkItemStore = deps?.workItemStore ?? new FileWorkItemStore({ dataDir });
+    const store: WorkItemStore = deps?.workItemStore ?? createWorkItemStore({ dataDir, processStore: deps?.processStore });
     const configPath = path.join(dataDir, CONFIG_FILE_NAME);
     const commandCtx: WorkItemCommandContext = {
         workItemStore: store,

--- a/packages/coc/src/server/llm-tools/get-work-item-tool.ts
+++ b/packages/coc/src/server/llm-tools/get-work-item-tool.ts
@@ -12,7 +12,8 @@
  */
 
 import { defineTool } from '@plusplusoneplusplus/coc-agent-sdk';
-import { FileWorkItemStore } from '../work-items/work-item-store';
+import type { ProcessStore } from '@plusplusoneplusplus/forge';
+import { createWorkItemStore } from '../work-items/work-item-store';
 import type { WorkItem, WorkItemStore } from '../work-items/types';
 
 // ============================================================================
@@ -35,6 +36,8 @@ export interface GetWorkItemArgs {
 export interface GetWorkItemToolDeps {
     /** Workspace-scoped store. Defaults to a `FileWorkItemStore` rooted at `dataDir`. */
     workItemStore?: WorkItemStore;
+    /** When provided alongside `workItemStore` being absent, wires scope resolution. */
+    processStore?: ProcessStore;
 }
 
 export interface GetWorkItemSuccess {
@@ -118,7 +121,7 @@ export function createGetWorkItemTool(
     repoId: string,
     deps?: GetWorkItemToolDeps,
 ) {
-    const store: WorkItemStore = deps?.workItemStore ?? new FileWorkItemStore({ dataDir });
+    const store: WorkItemStore = deps?.workItemStore ?? createWorkItemStore({ dataDir, processStore: deps?.processStore });
 
     const tool = defineTool<GetWorkItemArgs>('get_work_item', {
         description:

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -75,7 +75,7 @@ import { registerWorkItemChangesRoutes } from './work-item-changes-routes';
 import { registerWorkItemAiRoutes } from './work-item-ai-routes';
 import { warmWorkItemWorkspaceCache } from './work-item-cache-warming';
 import { createWorkItemAiGenerators } from '../work-items/work-item-ai-generator';
-import { FileWorkItemStore, createWorkItemStorageScopeResolver } from '../work-items/work-item-store';
+import { createWorkItemStore } from '../work-items/work-item-store';
 import { createAzureBoardsWorkItemSyncProviderAdapter } from '../work-items/work-item-sync-azure-boards-provider';
 import { createGitHubWorkItemSyncProviderAdapter } from '../work-items/work-item-sync-github-provider';
 import { WorkItemAzureBoardsPullPoller } from '../work-items/work-item-azure-boards-pull-poller';
@@ -746,10 +746,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         providers: nativeCliSessionProviders,
     });
 
-    const workItemStore = new FileWorkItemStore({
-        dataDir,
-        scopeResolver: createWorkItemStorageScopeResolver(store),
-    });
+    const workItemStore = createWorkItemStore({ dataDir, processStore: store });
 
     // Dreams routes: reviewable, workspace-scoped cards plus manual run trigger.
     // Route registration is always present; the live config guard controls availability.

--- a/packages/coc/src/server/work-items/index.ts
+++ b/packages/coc/src/server/work-items/index.ts
@@ -39,7 +39,7 @@ export {
     toIndexEntry,
 } from './types';
 
-export { FileWorkItemStore, type FileWorkItemStoreOptions } from './work-item-store';
+export { FileWorkItemStore, type FileWorkItemStoreOptions, createWorkItemStore } from './work-item-store';
 export {
     DEFAULT_WORK_ITEM_SYNC_PROVIDER,
     SUPPORTED_WORK_ITEM_SYNC_PROVIDERS,

--- a/packages/coc/src/server/work-items/work-item-store.ts
+++ b/packages/coc/src/server/work-items/work-item-store.ts
@@ -110,6 +110,27 @@ export function createWorkItemStorageScopeResolver(
     };
 }
 
+/**
+ * Create a correctly workspace-scoped `FileWorkItemStore`.
+ *
+ * When `processStore` is provided, the store resolves workspace IDs to their
+ * canonical git-origin IDs (e.g. `ws-xyz` → `gh_owner_repo`) before reading or
+ * writing, matching the behavior of the REST routes.  When omitted, the store
+ * uses an identity scope and is appropriate for callers that already operate on
+ * canonical origin IDs directly.
+ */
+export function createWorkItemStore(opts: {
+    dataDir: string;
+    processStore?: Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'>;
+}): FileWorkItemStore {
+    return new FileWorkItemStore({
+        dataDir: opts.dataDir,
+        scopeResolver: opts.processStore
+            ? createWorkItemStorageScopeResolver(opts.processStore)
+            : undefined,
+    });
+}
+
 interface LegacyWorkItemSyncLink {
     provider: WorkItemSyncProvider;
     remote: WorkItemSyncRemoteIdentity;

--- a/packages/coc/test/server/create-update-work-item-tool.test.ts
+++ b/packages/coc/test/server/create-update-work-item-tool.test.ts
@@ -24,6 +24,14 @@ vi.mock('../../src/server/work-items/work-item-store', function () { return ({
         savePlanVersion: mockSavePlanVersion,
         addChange: mockAddChange,
     }); }),
+    createWorkItemStore: vi.fn(() => ({
+        addWorkItem: mockAddWorkItem,
+        getWorkItem: mockGetWorkItem,
+        listWorkItems: mockListWorkItems,
+        updateWorkItem: mockUpdateWorkItem,
+        savePlanVersion: mockSavePlanVersion,
+        addChange: mockAddChange,
+    })),
 }); });
 
 import { createCreateUpdateWorkItemTool } from '../../src/server/llm-tools/create-update-work-item-tool';

--- a/packages/coc/test/server/executors-prompt-builder.test.ts
+++ b/packages/coc/test/server/executors-prompt-builder.test.ts
@@ -65,6 +65,12 @@ vi.mock('../../src/server/llm-tools/get-work-item-tool', () => ({
     createGetWorkItemTool: (...args: any[]) => mockCreateGetWorkItemTool(...args),
 }));
 
+const mockScopedStore = { _isScopedStore: true };
+const mockCreateWorkItemStore = vi.fn(() => mockScopedStore);
+vi.mock('../../src/server/work-items/work-item-store', () => ({
+    createWorkItemStore: (...args: any[]) => mockCreateWorkItemStore(...args),
+}));
+
 import {
     buildForEachGenerationSystemMessage,
     buildModeSystemMessage,
@@ -691,12 +697,17 @@ describe('buildCreateWorkItemAddon', () => {
         expect(result.suffix.endsWith('\n</work_item_tools>')).toBe(true);
     });
 
-    it('passes dataDir, repoId, broadcastFn, and deps to factories', () => {
+    it('passes dataDir, repoId, broadcastFn, and a scoped workItemStore to factories', () => {
         const broadcast = vi.fn();
-        const deps = { processStore: {} as any };
+        const processStore = {} as any;
+        const deps = { processStore };
         buildCreateWorkItemAddon('/data', 'repo-1', broadcast, deps);
-        expect(mockCreateUpdateWorkItemTool).toHaveBeenCalledWith('/data', 'repo-1', broadcast, deps);
-        expect(mockCreateGetWorkItemTool).toHaveBeenCalledWith('/data', 'repo-1', deps);
+
+        // The addon builds one scoped store and injects it into both tools.
+        expect(mockCreateWorkItemStore).toHaveBeenCalledWith({ dataDir: '/data', processStore });
+        const scopedDeps = { processStore, workItemStore: mockScopedStore };
+        expect(mockCreateUpdateWorkItemTool).toHaveBeenCalledWith('/data', 'repo-1', broadcast, scopedDeps);
+        expect(mockCreateGetWorkItemTool).toHaveBeenCalledWith('/data', 'repo-1', scopedDeps);
     });
 
 });

--- a/packages/coc/test/server/get-work-item-tool.test.ts
+++ b/packages/coc/test/server/get-work-item-tool.test.ts
@@ -25,6 +25,14 @@ vi.mock('../../src/server/work-items/work-item-store', function () { return ({
         savePlanVersion: mockSavePlanVersion,
         addChange: mockAddChange,
     }); }),
+    createWorkItemStore: vi.fn(() => ({
+        getWorkItem: mockGetWorkItem,
+        listWorkItems: mockListWorkItems,
+        updateWorkItem: mockUpdateWorkItem,
+        addWorkItem: mockAddWorkItem,
+        savePlanVersion: mockSavePlanVersion,
+        addChange: mockAddChange,
+    })),
 }); });
 
 import { createGetWorkItemTool } from '../../src/server/llm-tools/get-work-item-tool';

--- a/packages/coc/test/server/work-items/work-item-store-scope-factory.test.ts
+++ b/packages/coc/test/server/work-items/work-item-store-scope-factory.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Regression tests for the createWorkItemStore factory and scope resolution.
+ *
+ * Proves that the chat-path tools (get_work_item, create_update_work_item) resolve
+ * workspace IDs (e.g. `ws-abc`) to canonical git-origin IDs (e.g. `gh_owner_repo`)
+ * when a processStore is available, matching the behavior of the REST routes.
+ *
+ * Before this fix, the tools used an identity scope so a lookup for workspace
+ * `ws-xyz` missed items stored under `gh_owner_repo`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { ProcessStore, WorkspaceInfo } from '@plusplusoneplusplus/forge';
+import {
+    FileWorkItemStore,
+    createWorkItemStore,
+} from '../../../src/server/work-items/work-item-store';
+import type { WorkItem } from '../../../src/server/work-items/types';
+import { createGetWorkItemTool } from '../../../src/server/llm-tools/get-work-item-tool';
+import { createCreateUpdateWorkItemTool } from '../../../src/server/llm-tools/create-update-work-item-tool';
+import { buildCreateWorkItemAddon } from '../../../src/server/executors/prompt-builder';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeWorkItem(overrides: Partial<WorkItem> & { repoId: string }): WorkItem {
+    return {
+        id: overrides.id ?? `wi-${Date.now()}`,
+        repoId: overrides.repoId,
+        title: overrides.title ?? 'Test item',
+        description: overrides.description ?? '',
+        status: overrides.status ?? 'created',
+        source: overrides.source ?? 'manual',
+        createdAt: overrides.createdAt ?? '2026-01-01T00:00:00.000Z',
+        updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function makeProcessStore(workspaces: WorkspaceInfo[]): Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'> {
+    return {
+        getWorkspaces: async () => workspaces,
+        updateWorkspace: vi.fn(),
+    };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('createWorkItemStore factory', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'coc-factory-test-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('with processStore (workspace-scoped)', () => {
+        it('resolves ws-x to gh_o_r and finds an item stored under the canonical origin', async () => {
+            const processStore = makeProcessStore([
+                { id: 'ws-x', remoteUrl: 'https://github.com/o/r.git', rootPath: '/tmp/x' } as WorkspaceInfo,
+            ]);
+
+            // Write an item directly under the canonical origin directory.
+            const canonicalStore = new FileWorkItemStore({ dataDir: tmpDir });
+            const item = makeWorkItem({ id: 'item-uuid-1', repoId: 'gh_o_r' });
+            await canonicalStore.addWorkItem(item);
+
+            // The factory-built store should resolve ws-x → gh_o_r and find the item.
+            const store = createWorkItemStore({ dataDir: tmpDir, processStore });
+
+            const byId = await store.getWorkItem(item.id, 'ws-x');
+            expect(byId).toBeDefined();
+            expect(byId!.id).toBe(item.id);
+        });
+
+        it('resolves by work item number through ws-x scope via listWorkItems', async () => {
+            const processStore = makeProcessStore([
+                { id: 'ws-abc', remoteUrl: 'https://github.com/myorg/myrepo.git', rootPath: '/tmp/abc' } as WorkspaceInfo,
+            ]);
+
+            const canonicalStore = new FileWorkItemStore({ dataDir: tmpDir });
+            const item = makeWorkItem({ id: 'item-uuid-2', repoId: 'gh_myorg_myrepo' });
+            await canonicalStore.addWorkItem(item);
+
+            // Re-read through canonical store to get the assigned workItemNumber.
+            const stored = await canonicalStore.getWorkItem(item.id, 'gh_myorg_myrepo');
+            expect(stored).toBeDefined();
+            const itemNumber = stored!.workItemNumber;
+            expect(itemNumber).toBeGreaterThan(0);
+
+            // The scoped store should find the item under gh_myorg_myrepo when queried via ws-abc.
+            const store = createWorkItemStore({ dataDir: tmpDir, processStore });
+            const { items } = await store.listWorkItems({ repoId: 'ws-abc' });
+            const found = items.find(i => i.workItemNumber === itemNumber);
+            expect(found).toBeDefined();
+            expect(found!.id).toBe(item.id);
+        });
+    });
+
+    describe('without processStore (identity scope)', () => {
+        it('reads from repos/<repoId>/work-items verbatim', async () => {
+            const identityStore = createWorkItemStore({ dataDir: tmpDir });
+            const item = makeWorkItem({ id: 'item-uuid-id', repoId: 'gh_direct' });
+            await identityStore.addWorkItem(item);
+
+            const found = await identityStore.getWorkItem(item.id, 'gh_direct');
+            expect(found).toBeDefined();
+            expect(found!.id).toBe(item.id);
+        });
+
+        it('does NOT cross workspace boundaries', async () => {
+            const identityStore = createWorkItemStore({ dataDir: tmpDir });
+            const item = makeWorkItem({ id: 'item-no-cross', repoId: 'gh_direct' });
+            await identityStore.addWorkItem(item);
+
+            // Without scope resolution, 'ws-x' does not map to 'gh_direct'.
+            const notFound = await identityStore.getWorkItem(item.id, 'ws-x');
+            expect(notFound).toBeUndefined();
+        });
+    });
+});
+
+describe('get_work_item tool — scope resolution regression', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'coc-factory-get-test-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves WI-N, UUID, and number via ws-x when workItemStore is injected with resolver', async () => {
+        const processStore = makeProcessStore([
+            { id: 'ws-x', remoteUrl: 'https://github.com/o/r.git', rootPath: '/tmp/x' } as WorkspaceInfo,
+        ]);
+
+        const canonicalStore = new FileWorkItemStore({ dataDir: tmpDir });
+        const item = makeWorkItem({ id: 'fixed-uuid-9', repoId: 'gh_o_r' });
+        await canonicalStore.addWorkItem(item);
+
+        const stored = await canonicalStore.getWorkItem(item.id, 'gh_o_r');
+        const itemNumber = stored!.workItemNumber!;
+
+        const scopedStore = createWorkItemStore({ dataDir: tmpDir, processStore });
+        const { tool: getTool } = createGetWorkItemTool(tmpDir, 'ws-x', { workItemStore: scopedStore });
+
+        // By UUID
+        const r1 = await getTool.handler({ workItemId: item.id });
+        expect(r1.found).toBe(true);
+        if (r1.found) expect(r1.item.id).toBe(item.id);
+
+        // By number
+        const r2 = await getTool.handler({ workItemNumber: itemNumber });
+        expect(r2.found).toBe(true);
+
+        // By WI-N target
+        const r3 = await getTool.handler({ target: `WI-${itemNumber}` });
+        expect(r3.found).toBe(true);
+    });
+});
+
+describe('buildCreateWorkItemAddon — scope resolution', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'coc-factory-addon-test-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('get_work_item from the addon resolves gh_o_r items via ws-x workspace id', async () => {
+        const processStore = makeProcessStore([
+            { id: 'ws-x', remoteUrl: 'https://github.com/o/r.git', rootPath: '/tmp/x' } as WorkspaceInfo,
+        ]);
+
+        const canonicalStore = new FileWorkItemStore({ dataDir: tmpDir });
+        const item = makeWorkItem({ id: 'addon-item-uuid', repoId: 'gh_o_r' });
+        await canonicalStore.addWorkItem(item);
+
+        const { tools } = buildCreateWorkItemAddon(tmpDir, 'ws-x', undefined, {
+            processStore: processStore as unknown as ProcessStore,
+        });
+
+        const getTool = tools.find(t => t.name === 'get_work_item');
+        expect(getTool).toBeDefined();
+
+        const result = await getTool!.handler({ workItemId: item.id });
+        expect(result.found).toBe(true);
+        if (result.found) expect(result.item.id).toBe(item.id);
+    });
+
+    it('round-trip: create_update_work_item writes under canonical origin, get_work_item reads it back', async () => {
+        const processStore = makeProcessStore([
+            { id: 'ws-rt', remoteUrl: 'https://github.com/rt/repo.git', rootPath: '/tmp/rt' } as WorkspaceInfo,
+        ]);
+
+        const broadcasts: unknown[] = [];
+        const broadcast = (evt: unknown) => broadcasts.push(evt);
+
+        const { tools } = buildCreateWorkItemAddon(tmpDir, 'ws-rt', broadcast, {
+            processStore: processStore as unknown as ProcessStore,
+            getHierarchyEnabled: () => false,
+            getSyncEnabled: () => false,
+        });
+
+        const createTool = tools.find(t => t.name === 'create_update_work_item');
+        const getTool = tools.find(t => t.name === 'get_work_item');
+        expect(createTool).toBeDefined();
+        expect(getTool).toBeDefined();
+
+        // Create a new work item via the addon (writes under canonical origin dir).
+        const createResult = await createTool!.handler({
+            title: 'Round-trip item',
+            description: 'Created via addon',
+        });
+        expect(createResult.created).toBe(true);
+        const createdId: string = createResult.id;
+
+        // Confirm it was written under the canonical origin directory, not ws-rt.
+        const canonicalDir = path.join(tmpDir, 'repos', 'gh_rt_repo', 'work-items');
+        const canonicalFiles = await fs.readdir(canonicalDir);
+        expect(canonicalFiles.some(f => f.includes(createdId))).toBe(true);
+
+        // The get_work_item tool from the same addon should find it via ws-rt.
+        const getResult = await getTool!.handler({ workItemId: createdId });
+        expect(getResult.found).toBe(true);
+        if (getResult.found) {
+            expect(getResult.item.title).toBe('Round-trip item');
+        }
+    });
+});


### PR DESCRIPTION
The get_work_item and create_update_work_item LLM tools were constructing
FileWorkItemStore without a scopeResolver, so they used an identity scope
(storageRepoId = workspaceId). Items stored under the canonical git-origin
ID (e.g. gh_plusplusoneplusplus_shortcuts) were invisible to these tools when
queried via the workspace ID (e.g. ws-hcv3mg).

Changes:
- Add createWorkItemStore({ dataDir, processStore? }) factory to
  work-item-store.ts. When processStore is provided, wires the
  workspace→canonical-origin resolver. When omitted, preserves identity
  scope for callers already using canonical IDs.
- Export createWorkItemStore from work-items/index.ts.
- get-work-item-tool: add processStore? to GetWorkItemToolDeps, switch
  fallback to createWorkItemStore factory, import ProcessStore type.
- create-update-work-item-tool: switch fallback to createWorkItemStore
  factory (deps already carried processStore).
- prompt-builder buildCreateWorkItemAddon: build one scoped store once and
  inject it into both tools via scopedDeps, ensuring read/write use the
  same canonical directory.
- routes/index.ts: converge onto createWorkItemStore factory (replaces
  inline new FileWorkItemStore + createWorkItemStorageScopeResolver).
- Update test mocks in get-work-item-tool.test.ts and
  create-update-work-item-tool.test.ts to export createWorkItemStore.
- Update executors-prompt-builder.test.ts to mock createWorkItemStore and
  assert the scoped store is injected into both tool factories.
- Add work-item-store-scope-factory.test.ts: regression tests proving
  ws-x → gh_o_r resolution end-to-end for factory, get_work_item tool,
  buildCreateWorkItemAddon, and create/read round-trip.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
