### PR TITLE
refactor(coc): extract GitHub work-item state mapping into static const tables

### DIFF
--- a/packages/coc/src/server/work-items/index.ts
+++ b/packages/coc/src/server/work-items/index.ts
@@ -68,6 +68,13 @@ export {
     type ParsedGitHubWorkItemIssue,
 } from './work-item-sync-github-issue';
 export {
+    COC_STATUS_TO_GITHUB_STATE,
+    GITHUB_STATE_TO_COC_STATUS,
+    mapGitHubStateToWorkItemStatus,
+    mapWorkItemStatusToGitHubState,
+    type GitHubIssueState,
+} from './work-item-sync-github-mapping';
+export {
     GhCliGitHubWorkItemIssueTransport,
     convertLocalEpicTreeToGitHubBacked,
     createGitHubWorkItemSyncProviderAdapter,

--- a/packages/coc/src/server/work-items/work-item-sync-conflict.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-conflict.ts
@@ -5,6 +5,7 @@ import type {
 } from '@plusplusoneplusplus/coc-client';
 import type { WorkItem } from './types';
 import { parseGitHubWorkItemIssue } from './work-item-sync-github-issue';
+import { mapGitHubStateToWorkItemStatus } from './work-item-sync-github-mapping';
 import type { AzureBoardsWorkItem } from './work-item-sync-azure-boards-provider';
 import type { GitHubWorkItemIssue } from './work-item-sync-github-provider';
 import {
@@ -114,7 +115,7 @@ export function buildGitHubWorkItemSyncConflict(
     const parsed = parseGitHubWorkItemIssue(options.remote);
     const remoteStatus = parsed.metadata?.status
         ?? parsed.status
-        ?? (options.remote.state === 'closed' ? 'done' : 'created');
+        ?? mapGitHubStateToWorkItemStatus(options.remote.state);
     const remote: ProviderOwnedFieldValues = {
         title: normalizeText(options.remote.title),
         description: normalizeText(parsed.bodyWithoutMetadata),

--- a/packages/coc/src/server/work-items/work-item-sync-github-mapping.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-github-mapping.ts
@@ -1,0 +1,46 @@
+import {
+    isKnownWorkItemStatus,
+    type KnownWorkItemStatus,
+    type WorkItemStatus,
+} from './types';
+
+/** The two states a GitHub issue can be in. */
+export type GitHubIssueState = 'open' | 'closed';
+
+/**
+ * CoC work-item status → GitHub issue state. GitHub issues only have two states,
+ * so every non-terminal CoC lifecycle status maps to `open` and the terminal
+ * states (`done`, `failed`) map to `closed`.
+ */
+export const COC_STATUS_TO_GITHUB_STATE: Record<KnownWorkItemStatus, GitHubIssueState> = {
+    created: 'open',
+    drafting: 'open',
+    planning: 'open',
+    readyToExecute: 'open',
+    executing: 'open',
+    aiDone: 'open',
+    aiFailed: 'open',
+    done: 'closed',
+    failed: 'closed',
+};
+
+/**
+ * GitHub issue state → CoC work-item status. A `closed` issue maps to `done`;
+ * an `open` issue maps to `created`. Used as the fallback when an issue body
+ * carries no explicit CoC status metadata.
+ */
+export const GITHUB_STATE_TO_COC_STATUS: Record<GitHubIssueState, WorkItemStatus> = {
+    open: 'created',
+    closed: 'done',
+};
+
+/** Map a CoC work-item status to a GitHub issue state. Unknown statuses stay `open`. */
+export function mapWorkItemStatusToGitHubState(status: WorkItemStatus | undefined): GitHubIssueState {
+    if (status && isKnownWorkItemStatus(status)) return COC_STATUS_TO_GITHUB_STATE[status];
+    return 'open';
+}
+
+/** Map a GitHub issue state to a CoC work-item status. Anything other than `closed` is treated as `open`. */
+export function mapGitHubStateToWorkItemStatus(state: string | undefined | null): WorkItemStatus {
+    return GITHUB_STATE_TO_COC_STATUS[state === 'closed' ? 'closed' : 'open'];
+}

--- a/packages/coc/src/server/work-items/work-item-sync-github-provider.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-github-provider.ts
@@ -26,9 +26,9 @@ import type {
 } from './types';
 import {
     getEffectiveType,
-    isTerminalStatus,
     isValidParentChildTypes,
 } from './types';
+import { mapWorkItemStatusToGitHubState } from './work-item-sync-github-mapping';
 import {
     WORK_ITEM_SYNC_MAX_ITEMS,
     type WorkItemSyncProviderAdapter,
@@ -499,11 +499,6 @@ export async function createGitHubIssueForLocalEpicRoot(
     };
 }
 
-/** Map a CoC work-item status to a GitHub issue open/closed state. */
-function githubStateForStatus(status: WorkItem['status']): 'open' | 'closed' {
-    return isTerminalStatus(status) ? 'closed' : 'open';
-}
-
 /**
  * Push provider-owned local edits of an already-mirrored item to its backing
  * GitHub issue, then return the refreshed mirror metadata. This is the GitHub
@@ -539,7 +534,7 @@ export async function updateGitHubIssueForLocalMirror(
         title: options.item.title,
         body: update.body,
         labels: update.labels,
-        state: githubStateForStatus(options.item.status),
+        state: mapWorkItemStatusToGitHubState(options.item.status),
     });
     return {
         issue: updated,

--- a/packages/coc/test/server/work-items/work-item-sync-github-mapping.test.ts
+++ b/packages/coc/test/server/work-items/work-item-sync-github-mapping.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+    COC_STATUS_TO_GITHUB_STATE,
+    GITHUB_STATE_TO_COC_STATUS,
+    mapGitHubStateToWorkItemStatus,
+    mapWorkItemStatusToGitHubState,
+    type GitHubIssueState,
+} from '../../../src/server/work-items/work-item-sync-github-mapping';
+import {
+    WORK_ITEM_STATUSES,
+    isTerminalStatus,
+    type KnownWorkItemStatus,
+} from '../../../src/server/work-items/types';
+
+describe('GitHub work item state mapping', () => {
+    it('maps every known CoC status to a GitHub state and matches the terminal-status rule', () => {
+        const cases: Array<[KnownWorkItemStatus, GitHubIssueState]> = [
+            ['created', 'open'],
+            ['drafting', 'open'],
+            ['planning', 'open'],
+            ['readyToExecute', 'open'],
+            ['executing', 'open'],
+            ['aiDone', 'open'],
+            ['aiFailed', 'open'],
+            ['done', 'closed'],
+            ['failed', 'closed'],
+        ];
+
+        for (const [status, expected] of cases) {
+            expect(mapWorkItemStatusToGitHubState(status)).toBe(expected);
+            expect(COC_STATUS_TO_GITHUB_STATE[status]).toBe(expected);
+        }
+    });
+
+    it('covers every known status in the forward table (exhaustive)', () => {
+        for (const status of WORK_ITEM_STATUSES) {
+            expect(COC_STATUS_TO_GITHUB_STATE[status]).toBeDefined();
+        }
+        expect(Object.keys(COC_STATUS_TO_GITHUB_STATE).sort()).toEqual([...WORK_ITEM_STATUSES].sort());
+    });
+
+    it('preserves the legacy terminal-status behavior for the forward mapping', () => {
+        // Regression: the forward map must keep agreeing with isTerminalStatus(...) ? 'closed' : 'open'.
+        for (const status of WORK_ITEM_STATUSES) {
+            const expected: GitHubIssueState = isTerminalStatus(status) ? 'closed' : 'open';
+            expect(mapWorkItemStatusToGitHubState(status)).toBe(expected);
+        }
+    });
+
+    it('treats unknown or missing statuses as open', () => {
+        expect(mapWorkItemStatusToGitHubState('weird-custom-status' as never)).toBe('open');
+        expect(mapWorkItemStatusToGitHubState(undefined)).toBe('open');
+        expect(mapWorkItemStatusToGitHubState('' as never)).toBe('open');
+    });
+
+    it('maps GitHub states back to CoC statuses', () => {
+        expect(mapGitHubStateToWorkItemStatus('open')).toBe('created');
+        expect(mapGitHubStateToWorkItemStatus('closed')).toBe('done');
+        expect(GITHUB_STATE_TO_COC_STATUS.open).toBe('created');
+        expect(GITHUB_STATE_TO_COC_STATUS.closed).toBe('done');
+    });
+
+    it('preserves the legacy reverse behavior: only "closed" maps to done', () => {
+        // Regression: anything other than 'closed' must resolve to 'created'.
+        for (const state of ['open', 'unknown', '', undefined, null]) {
+            const expected = state === 'closed' ? 'done' : 'created';
+            expect(mapGitHubStateToWorkItemStatus(state as never)).toBe(expected);
+        }
+        expect(mapGitHubStateToWorkItemStatus('closed')).toBe('done');
+    });
+});


### PR DESCRIPTION
Mirror the Azure Boards mapping module pattern for GitHub. The
CoC-status <-> GitHub-issue-state mapping was previously two scattered
inline ternaries: githubStateForStatus() in the provider and a
`state === 'closed' ? 'done' : 'created'` fallback in the conflict
builder. Both are now declarative lookup tables in a dedicated
work-item-sync-github-mapping module:

- COC_STATUS_TO_GITHUB_STATE (forward, exhaustive over KnownWorkItemStatus)
- GITHUB_STATE_TO_COC_STATUS (reverse)
- mapWorkItemStatusToGitHubState / mapGitHubStateToWorkItemStatus helpers

Behavior is unchanged: terminal statuses (done/failed) -> closed, all
else -> open; closed -> done, anything else -> created.

Adds regression tests asserting the new tables stay in agreement with
the legacy terminal-status rule and the closed->done fallback, plus
exhaustiveness over every known status.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
