### PR TITLE
pr/06c410083 featcoc add post api servers id restart

### DIFF
--- a/packages/coc-client/src/contracts/servers.ts
+++ b/packages/coc-client/src/contracts/servers.ts
@@ -79,6 +79,11 @@ export interface RemoteServerRuntime {
   lastError?: string;
 }
 
+export interface RemoteServerRestartResponse {
+  ok: boolean;
+  message?: string;
+}
+
 export interface CherryPickTransferEndpoint {
   serverId?: string | null;
   workspaceId: string;

--- a/packages/coc-client/src/domains/servers.ts
+++ b/packages/coc-client/src/domains/servers.ts
@@ -5,6 +5,7 @@ import type {
   RemoteServerHealth,
   RemoteServerInput,
   RemoteServerPatch,
+  RemoteServerRestartResponse,
   RemoteServerRuntime,
 } from '../contracts';
 import type { RequestAdapter } from '../types';
@@ -49,6 +50,12 @@ export class ServersClient {
 
   reconnect(id: string): Promise<RemoteServerRuntime> {
     return this.transport.request<RemoteServerRuntime>(serverPath(id, '/reconnect'), {
+      method: 'POST',
+    });
+  }
+
+  restart(id: string): Promise<RemoteServerRestartResponse> {
+    return this.transport.request<RemoteServerRestartResponse>(serverPath(id, '/restart'), {
       method: 'POST',
     });
   }

--- a/packages/coc-client/test/domains/servers.test.ts
+++ b/packages/coc-client/test/domains/servers.test.ts
@@ -13,6 +13,7 @@ describe('ServersClient', () => {
     await client.remove('s1');
     await client.test({ kind: 'url', label: 'Test', url: 'http://localhost:4000' });
     await client.reconnect('s1');
+    await client.restart('s1');
     await client.getHealth('s1');
     await client.cherryPickTransfer({
       source: { serverId: 'source/server', workspaceId: 'source/ws', commitHash: 'abc123' },
@@ -42,6 +43,10 @@ describe('ServersClient', () => {
         options: { method: 'POST' },
       },
       {
+        path: '/servers/s1/restart',
+        options: { method: 'POST' },
+      },
+      {
         path: '/servers/s1/health',
       },
       {
@@ -64,6 +69,7 @@ describe('ServersClient', () => {
     await client.update('id/with spaces', { label: 'x' });
     await client.remove('id/with spaces');
     await client.reconnect('id/with spaces');
+    await client.restart('id/with spaces');
     await client.getHealth('id/with spaces');
 
     const paths = adapter.calls.map(c => c.path);
@@ -72,6 +78,7 @@ describe('ServersClient', () => {
       `/servers/${encoded}`,
       `/servers/${encoded}`,
       `/servers/${encoded}/reconnect`,
+      `/servers/${encoded}/restart`,
       `/servers/${encoded}/health`,
     ]);
   });

--- a/packages/coc/src/server/servers/remote-server-health.ts
+++ b/packages/coc/src/server/servers/remote-server-health.ts
@@ -26,6 +26,46 @@ async function fetchOptionalServerName(baseUrl: string): Promise<string | undefi
     }
 }
 
+/** Outcome of a remote restart request. */
+export interface RemoteRestartResult {
+    /** True when the remote accepted the restart (replied 2xx before exiting). */
+    ok: boolean;
+    /** HTTP status returned by the remote, when a response was received. */
+    status?: number;
+    /** Error detail when the request failed, timed out, or returned non-2xx. */
+    error?: string;
+}
+
+/**
+ * Ask a remote coc server to restart itself by POSTing to its
+ * `/api/admin/restart` endpoint. The remote replies `200` *before* `process.exit`,
+ * so a `2xx` here means the restart was accepted. Reaches the remote the same way
+ * {@link checkRemoteServerHealth} does — a direct `fetch` against the resolved base
+ * URL with the same bounded timeout — and never throws: transport errors,
+ * timeouts, and non-2xx responses all come back as `{ ok: false, error }`.
+ */
+export async function requestRemoteServerRestart(
+    baseUrl: string,
+    timeoutMs = FETCH_TIMEOUT_MS,
+): Promise<RemoteRestartResult> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(`${baseUrl}/api/admin/restart`, {
+            method: 'POST',
+            signal: controller.signal,
+        });
+        clearTimeout(timer);
+        if (!res.ok) {
+            return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+        }
+        return { ok: true, status: res.status };
+    } catch (error) {
+        clearTimeout(timer);
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+}
+
 export async function checkRemoteServerHealth(target: HealthTarget): Promise<RemoteServerHealth> {
     const lastChecked = Date.now();
     if (!target.baseUrl) {

--- a/packages/coc/src/server/servers/remote-server-routes.ts
+++ b/packages/coc/src/server/servers/remote-server-routes.ts
@@ -11,7 +11,7 @@ import type {
 import { readJsonBody, send400, send404, send500, sendError, sendJson } from '../shared/router';
 import type { DevTunnelConnector } from './devtunnel-connector';
 import type { SshConnector, SshConnectionState } from './ssh-connector';
-import { checkRemoteServerHealth } from './remote-server-health';
+import { checkRemoteServerHealth, requestRemoteServerRestart } from './remote-server-health';
 import type {
     DevTunnelRemoteServer,
     RemoteServer,
@@ -643,6 +643,36 @@ export function registerRemoteServerRoutes(
                 // The failed state is stored on the connector and returned below.
             }
             sendJson(res, toRuntime(server, connector, sshConnector, urlHealthCache));
+        },
+    });
+
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/servers\/([^/]+)\/restart$/,
+        handler: async (_req, res, match) => {
+            const id = decodeURIComponent(match![1]);
+            const server = store.get(id);
+            if (!server) {
+                send404(res, `Remote server not found: ${id}`);
+                return;
+            }
+            // Restart the *remote process*, distinct from /reconnect (which only
+            // re-spawns the local tunnel). Reach the remote the same way the health
+            // checker does: build the target from the server's resolved effectiveUrl
+            // (tunnel servers via their local forwarded port, url servers directly).
+            // Stateless proxy — nothing is persisted.
+            const { effectiveUrl } = toRuntime(server, connector, sshConnector, urlHealthCache);
+            if (!effectiveUrl) {
+                sendError(res, 502, `Remote server "${server.label}" has no reachable endpoint to restart`);
+                return;
+            }
+            const result = await requestRemoteServerRestart(effectiveUrl);
+            if (!result.ok) {
+                sendError(res, 502, `Failed to restart remote server "${server.label}": ${result.error ?? 'unknown error'}`);
+                return;
+            }
+            // The remote replied 2xx before exiting → restart accepted.
+            sendJson(res, { ok: true, message: 'Server is restarting...' }, 202);
         },
     });
 

--- a/packages/coc/src/server/spa/client/react/features/servers/ServerCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/servers/ServerCard.tsx
@@ -26,6 +26,9 @@ export interface ServerCardProps {
     onEdit?: (id: string) => void;
     onReconnect?: (id: string) => void | Promise<void>;
     reconnecting?: boolean;
+    /** Restart the remote process itself (distinct from Reconnect). */
+    onRestart?: (id: string) => void | Promise<void>;
+    restarting?: boolean;
 }
 
 function isRemoteServer(server: CardServer): server is RemoteServer {
@@ -65,7 +68,7 @@ export function timeAgo(ts: number, now: number = Date.now()): string {
     return `${Math.floor(diff / 3600)}h ago`;
 }
 
-export function ServerCard({ health, isLocal, onRemove, onEdit, onReconnect, reconnecting }: ServerCardProps) {
+export function ServerCard({ health, isLocal, onRemove, onEdit, onReconnect, reconnecting, onRestart, restarting }: ServerCardProps) {
     const [menuOpen, setMenuOpen] = useState(false);
     const menuWrapRef = useRef<HTMLDivElement | null>(null);
     const endpoint = isRemoteServer(health.server)
@@ -165,6 +168,18 @@ export function ServerCard({ health, isLocal, onRemove, onEdit, onReconnect, rec
                                         onClick={() => { setMenuOpen(false); void onReconnect(health.server.id); }}
                                     >
                                         {reconnecting ? 'Reconnecting…' : 'Reconnect'}
+                                    </button>
+                                )}
+                                {isRemoteServer(health.server) && onRestart && (
+                                    <button
+                                        type="button"
+                                        data-testid="server-card-menu-restart"
+                                        className="w-full text-left px-3 py-2 hover:bg-black/[0.04] dark:hover:bg-white/[0.04] text-[#1e1e1e] dark:text-[#cccccc] disabled:opacity-40 disabled:cursor-not-allowed"
+                                        disabled={health.status !== 'online' || restarting}
+                                        title={health.status !== 'online' ? 'Restart is available only when the server is online' : undefined}
+                                        onClick={() => { setMenuOpen(false); void onRestart(health.server.id); }}
+                                    >
+                                        {restarting ? 'Restarting…' : 'Restart'}
                                     </button>
                                 )}
                                 <button

--- a/packages/coc/src/server/spa/client/react/features/servers/ServerCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/servers/ServerCard.tsx
@@ -197,6 +197,11 @@ export function ServerCard({ health, isLocal, onRemove, onEdit, onReconnect, rec
             </div>
 
             <div className="px-4 py-3 flex flex-col gap-1.5 text-xs text-[#848484] dark:text-[#999] flex-1">
+                {restarting && (
+                    <div className="text-[#e5a92b] font-medium" data-testid="server-card-restarting">
+                        ↻ Restarting…
+                    </div>
+                )}
                 {health.serverName && (
                     <div className="text-[#1e1e1e] dark:text-[#cccccc] font-medium text-xs truncate" data-testid="server-card-hostname">
                         CoC @ {health.serverName}

--- a/packages/coc/src/server/spa/client/react/features/servers/ServersView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/servers/ServersView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     addRemoteServer,
     listRemoteServers,
@@ -30,6 +30,10 @@ interface UnifiedHealth extends ServerCardHealth {
 
 const LOCAL_POLL_INTERVAL_MS = 30_000;
 const FETCH_TIMEOUT_MS = 5_000;
+// Upper bound on the optimistic "Restarting…" indicator. Normally it clears once
+// polling observes the server go offline and come back online; this backstop
+// guarantees it never sticks if the restart blip is missed between poll cycles.
+const RESTART_OPTIMISTIC_MAX_MS = 90_000;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -347,6 +351,9 @@ function ServerRow({
                     )}
                 </div>
                 <div className="flex items-center gap-1.5 text-[11.5px] text-[#848484] dark:text-[#9d9d9d] font-mono min-w-0 overflow-hidden">
+                    {restarting && (
+                        <span className="text-[#e5a92b] flex-shrink-0" data-testid="server-row-restarting">restarting…</span>
+                    )}
                     {health.serverName && (
                         <span className="text-[#424242] dark:text-[#cccccc] truncate shrink">{health.serverName}</span>
                     )}
@@ -650,6 +657,14 @@ export function ServersView() {
     const [restartConfirmId, setRestartConfirmId] = useState<string | undefined>();
     const [restartPending, setRestartPending] = useState(false);
     const [restartError, setRestartError] = useState<string | undefined>();
+    // Servers showing the optimistic "Restarting…" indicator. Outlives the in-flight
+    // request: set on confirm, cleared once polling settles the offline→online cycle
+    // (or by the RESTART_OPTIMISTIC_MAX_MS backstop).
+    const [restartingIds, setRestartingIds] = useState<Set<string>>(() => new Set());
+    // Per-id record of whether polling has observed the restart blip (offline/checking)
+    // since the restart began, so we only clear once it is genuinely back online.
+    const sawOfflineRef = useRef<Set<string>>(new Set());
+    const restartTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
     const [loadError, setLoadError] = useState<string | undefined>();
     const [view, setView] = useState<ViewMode>('split');
     const [filter, setFilter] = useState<FilterMode>('all');
@@ -664,7 +679,7 @@ export function ServersView() {
         return () => { cancelled = true; };
     }, []);
 
-    const remoteHealthStates = useRemoteServerHealth(servers);
+    const { healthStates: remoteHealthStates, refetch: refetchHealth } = useRemoteServerHealth(servers);
     const editServer = editServerId ? servers.find(s => s.id === editServerId) : undefined;
 
     const [localHealth, setLocalHealth] = useState<ServerCardHealth>(() => ({
@@ -792,6 +807,30 @@ export function ServersView() {
         setRestartError(undefined);
     };
 
+    const clearRestarting = useCallback((id: string) => {
+        sawOfflineRef.current.delete(id);
+        const timer = restartTimersRef.current.get(id);
+        if (timer) { clearTimeout(timer); restartTimersRef.current.delete(id); }
+        setRestartingIds(prev => {
+            if (!prev.has(id)) { return prev; }
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+        });
+    }, []);
+
+    const beginRestarting = useCallback((id: string) => {
+        sawOfflineRef.current.delete(id);
+        const existing = restartTimersRef.current.get(id);
+        if (existing) { clearTimeout(existing); }
+        restartTimersRef.current.set(id, setTimeout(() => clearRestarting(id), RESTART_OPTIMISTIC_MAX_MS));
+        setRestartingIds(prev => {
+            const next = new Set(prev);
+            next.add(id);
+            return next;
+        });
+    }, [clearRestarting]);
+
     const confirmRestart = async () => {
         const id = restartConfirmId;
         if (!id) { return; }
@@ -800,12 +839,43 @@ export function ServersView() {
         try {
             await restartServer(id);
             setRestartConfirmId(undefined);
+            // Optimistic transient that outlives the request, plus an immediate
+            // re-poll so the offline→online cycle surfaces without the 30s wait.
+            beginRestarting(id);
+            refetchHealth();
         } catch (e) {
+            // Restart never fired: clear any transient and surface the error inline.
+            clearRestarting(id);
             setRestartError(e instanceof Error ? e.message : 'Restart request failed');
         } finally {
             setRestartPending(false);
         }
     };
+
+    // Clear the optimistic "Restarting…" indicator once polling settles: a server
+    // must be observed offline/checking (the restart blip) and then back online.
+    useEffect(() => {
+        if (restartingIds.size === 0) { return; }
+        for (const h of remoteHealthStates) {
+            if (!restartingIds.has(h.server.id)) { continue; }
+            if (h.status === 'offline' || h.status === 'checking') {
+                sawOfflineRef.current.add(h.server.id);
+            } else if (h.status === 'online' && sawOfflineRef.current.has(h.server.id)) {
+                clearRestarting(h.server.id);
+            }
+        }
+    }, [remoteHealthStates, restartingIds, clearRestarting]);
+
+    // Drop pending restart timers on unmount.
+    useEffect(() => {
+        const timers = restartTimersRef.current;
+        return () => {
+            for (const timer of timers.values()) { clearTimeout(timer); }
+            timers.clear();
+        };
+    }, []);
+
+    const isRestarting = (id: string) => restartingIds.has(id) || (restartPending && restartConfirmId === id);
 
     const handleEdit = async (fields: RemoteServerInput) => {
         if (!editServer) { throw new Error('Remote server is no longer available'); }
@@ -836,7 +906,7 @@ export function ServersView() {
         onRemove: !h.isLocal ? () => { void handleRemove(h.server.id); } : undefined,
         onRestart: !h.isLocal ? () => requestRestart(h.server.id) : undefined,
         reconnecting: reconnectingId === h.server.id,
-        restarting: restartPending && restartConfirmId === h.server.id,
+        restarting: isRestarting(h.server.id),
     });
 
     return (
@@ -886,7 +956,7 @@ export function ServersView() {
                                 onReconnect={h.isLocal ? undefined : handleReconnect}
                                 reconnecting={reconnectingId === h.server.id}
                                 onRestart={h.isLocal ? undefined : requestRestart}
-                                restarting={restartPending && restartConfirmId === h.server.id}
+                                restarting={isRestarting(h.server.id)}
                             />
                         ))}
                     </div>
@@ -919,7 +989,7 @@ export function ServersView() {
                                     onRemove={!selectedHealth.isLocal ? () => { void handleRemove(selectedHealth.server.id); } : undefined}
                                     onRestart={!selectedHealth.isLocal ? () => requestRestart(selectedHealth.server.id) : undefined}
                                     reconnecting={reconnectingId === selectedHealth.server.id}
-                                    restarting={restartPending && restartConfirmId === selectedHealth.server.id}
+                                    restarting={isRestarting(selectedHealth.server.id)}
                                 />
                             ) : (
                                 <div className="h-full flex items-center justify-center text-xs text-[#999] dark:text-[#6e6e6e]">

--- a/packages/coc/src/server/spa/client/react/features/servers/ServersView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/servers/ServersView.tsx
@@ -4,6 +4,7 @@ import {
     listRemoteServers,
     reconnectServer,
     removeRemoteServer,
+    restartServer,
     updateRemoteServer,
     type RemoteServer,
     type RemoteServerInput,
@@ -12,6 +13,7 @@ import {
 import { useRemoteServerHealth } from '../../hooks/useRemoteServerHealth';
 import { getHostname } from '../../utils/config';
 import { getSpaCocClient } from '../../api/cocClient';
+import { Button, Dialog } from '../../ui';
 import { ServerCard, formatUptime, timeAgo, type ServerCardHealth } from './ServerCard';
 import { AddServerDialog, EditServerDialog } from './AddServerDialog';
 
@@ -73,6 +75,7 @@ const ICON = {
     external:  'M14 3h7v7M10 14L21 3M19 14v6H4V5h6',
     copy:      'M9 9h10v10H9zM5 5h10v4M5 5v10h4',
     reconnect: 'M3 12a9 9 0 0114-7.5L21 7M21 3v4h-4M21 12a9 9 0 01-14 7.5L3 17M3 21v-4h4',
+    restart:   'M12 3v8M5.6 7.6a9 9 0 1012.8 0',
     edit:      'M4 20h4l11-11-4-4L4 16zM14 5l4 4',
     remove:    'M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13',
 };
@@ -275,10 +278,12 @@ function SummaryStrip({ online, offline, total, procs, tunnels, sshTunnels }: {
 
 // ─── Server Row (split + list views) ─────────────────────────────────────────
 
-function QuickAction({ title, onClick, danger, children }: {
+function QuickAction({ title, onClick, danger, disabled, testId, children }: {
     title: string;
     onClick: React.MouseEventHandler<HTMLButtonElement>;
     danger?: boolean;
+    disabled?: boolean;
+    testId?: string;
     children: React.ReactNode;
 }) {
     return (
@@ -286,7 +291,9 @@ function QuickAction({ title, onClick, danger, children }: {
             type="button"
             title={title}
             onClick={onClick}
-            className={`w-6 h-6 flex items-center justify-center rounded transition-colors ${
+            disabled={disabled}
+            data-testid={testId}
+            className={`w-6 h-6 flex items-center justify-center rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
                 danger
                     ? 'text-[#848484] dark:text-[#9d9d9d] hover:text-[#f14c4c] dark:hover:text-[#f48771] hover:bg-[#f14c4c]/10'
                     : 'text-[#848484] dark:text-[#9d9d9d] hover:text-[#1e1e1e] dark:hover:text-[#cccccc] hover:bg-black/[0.06] dark:hover:bg-white/[0.06]'
@@ -299,7 +306,7 @@ function QuickAction({ title, onClick, danger, children }: {
 
 function ServerRow({
     health, selected, onClick,
-    onOpen, onReconnect, onCopy, onEdit, onRemove, reconnecting,
+    onOpen, onReconnect, onCopy, onEdit, onRemove, onRestart, reconnecting, restarting,
 }: {
     health: UnifiedHealth;
     selected?: boolean;
@@ -309,7 +316,9 @@ function ServerRow({
     onCopy: () => void;
     onEdit?: () => void;
     onRemove?: () => void;
+    onRestart?: () => void;
     reconnecting?: boolean;
+    restarting?: boolean;
 }) {
     const { server, status, uptime, processCount, kind, isLocal } = health;
     return (
@@ -378,6 +387,20 @@ function ServerRow({
                         onClick={e => { e.stopPropagation(); onReconnect(); }}
                     >
                         <Svg d={ICON.reconnect} size={13} />
+                    </QuickAction>
+                )}
+                {!isLocal && onRestart && (
+                    <QuickAction
+                        testId="server-row-restart"
+                        title={
+                            restarting ? 'Restarting…'
+                                : status !== 'online' ? 'Restart is available only when the server is online'
+                                : 'Restart remote server'
+                        }
+                        disabled={status !== 'online' || restarting}
+                        onClick={e => { e.stopPropagation(); onRestart(); }}
+                    >
+                        <Svg d={ICON.restart} size={13} />
                     </QuickAction>
                 )}
                 <QuickAction title="Copy URL" onClick={e => { e.stopPropagation(); onCopy(); }}>
@@ -463,7 +486,7 @@ function ConnectionRows({ health }: { health: UnifiedHealth }) {
 
 function DetailPanel({
     health,
-    onOpen, onReconnect, onCopy, onEdit, onRemove, reconnecting,
+    onOpen, onReconnect, onCopy, onEdit, onRemove, onRestart, reconnecting, restarting,
 }: {
     health: UnifiedHealth;
     onOpen: () => void;
@@ -471,7 +494,9 @@ function DetailPanel({
     onCopy: () => void;
     onEdit?: () => void;
     onRemove?: () => void;
+    onRestart?: () => void;
     reconnecting?: boolean;
+    restarting?: boolean;
 }) {
     const { server, status, version, uptime, processCount, kind, isLocal, error, lastChecked } = health;
     const endpoint = getEndpoint(health);
@@ -517,6 +542,15 @@ function DetailPanel({
                             <ActionBtn onClick={onReconnect} disabled={reconnecting}>
                                 <Svg d={ICON.reconnect} size={12} />
                                 {reconnecting ? 'Reconnecting…' : 'Reconnect'}
+                            </ActionBtn>
+                        )}
+                        {!isLocal && onRestart && (
+                            <ActionBtn
+                                onClick={onRestart}
+                                disabled={status !== 'online' || restarting}
+                            >
+                                <Svg d={ICON.restart} size={12} />
+                                {restarting ? 'Restarting…' : 'Restart'}
                             </ActionBtn>
                         )}
                         <ActionBtn onClick={onCopy}>
@@ -613,6 +647,9 @@ export function ServersView() {
     const [addOpen, setAddOpen] = useState(false);
     const [editServerId, setEditServerId] = useState<string | undefined>();
     const [reconnectingId, setReconnectingId] = useState<string | undefined>();
+    const [restartConfirmId, setRestartConfirmId] = useState<string | undefined>();
+    const [restartPending, setRestartPending] = useState(false);
+    const [restartError, setRestartError] = useState<string | undefined>();
     const [loadError, setLoadError] = useState<string | undefined>();
     const [view, setView] = useState<ViewMode>('split');
     const [filter, setFilter] = useState<FilterMode>('all');
@@ -718,6 +755,9 @@ export function ServersView() {
     }), [allHealthStates, filter, search]);
 
     const selectedHealth = allHealthStates.find(h => h.server.id === selectedId) ?? allHealthStates[0];
+    const restartTarget = restartConfirmId
+        ? allHealthStates.find(h => h.server.id === restartConfirmId)
+        : undefined;
 
     const handleAdd = async (fields: RemoteServerInput) => {
         await addRemoteServer(fields);
@@ -736,6 +776,34 @@ export function ServersView() {
             setServers(await listRemoteServers());
         } finally {
             setReconnectingId(undefined);
+        }
+    };
+
+    // Restart targets the *remote* process (POST /api/servers/:id/restart). Distinct
+    // from Reconnect, which only re-spawns the local tunnel. Always gated by an
+    // explicit confirmation dialog before any request fires.
+    const requestRestart = (id: string) => {
+        setRestartError(undefined);
+        setRestartConfirmId(id);
+    };
+
+    const cancelRestart = () => {
+        setRestartConfirmId(undefined);
+        setRestartError(undefined);
+    };
+
+    const confirmRestart = async () => {
+        const id = restartConfirmId;
+        if (!id) { return; }
+        setRestartPending(true);
+        setRestartError(undefined);
+        try {
+            await restartServer(id);
+            setRestartConfirmId(undefined);
+        } catch (e) {
+            setRestartError(e instanceof Error ? e.message : 'Restart request failed');
+        } finally {
+            setRestartPending(false);
         }
     };
 
@@ -766,7 +834,9 @@ export function ServersView() {
         onCopy: () => handleCopy(h),
         onEdit:   !h.isLocal ? () => setEditServerId(h.server.id) : undefined,
         onRemove: !h.isLocal ? () => { void handleRemove(h.server.id); } : undefined,
+        onRestart: !h.isLocal ? () => requestRestart(h.server.id) : undefined,
         reconnecting: reconnectingId === h.server.id,
+        restarting: restartPending && restartConfirmId === h.server.id,
     });
 
     return (
@@ -815,6 +885,8 @@ export function ServersView() {
                                 onEdit={h.isLocal ? undefined : setEditServerId}
                                 onReconnect={h.isLocal ? undefined : handleReconnect}
                                 reconnecting={reconnectingId === h.server.id}
+                                onRestart={h.isLocal ? undefined : requestRestart}
+                                restarting={restartPending && restartConfirmId === h.server.id}
                             />
                         ))}
                     </div>
@@ -845,7 +917,9 @@ export function ServersView() {
                                     onCopy={() => handleCopy(selectedHealth)}
                                     onEdit={!selectedHealth.isLocal ? () => setEditServerId(selectedHealth.server.id) : undefined}
                                     onRemove={!selectedHealth.isLocal ? () => { void handleRemove(selectedHealth.server.id); } : undefined}
+                                    onRestart={!selectedHealth.isLocal ? () => requestRestart(selectedHealth.server.id) : undefined}
                                     reconnecting={reconnectingId === selectedHealth.server.id}
+                                    restarting={restartPending && restartConfirmId === selectedHealth.server.id}
                                 />
                             ) : (
                                 <div className="h-full flex items-center justify-center text-xs text-[#999] dark:text-[#6e6e6e]">
@@ -879,6 +953,55 @@ export function ServersView() {
                 onClose={() => setEditServerId(undefined)}
                 onSave={handleEdit}
             />
+
+            <Dialog
+                open={!!restartConfirmId}
+                onClose={cancelRestart}
+                title="Restart server"
+                id="restart-confirm-dialog"
+                footer={
+                    <>
+                        <Button
+                            variant="secondary"
+                            data-testid="restart-confirm-cancel"
+                            onClick={cancelRestart}
+                            disabled={restartPending}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="danger"
+                            data-testid="restart-confirm-submit"
+                            onClick={() => { void confirmRestart(); }}
+                            loading={restartPending}
+                        >
+                            Restart server
+                        </Button>
+                    </>
+                }
+            >
+                <div className="flex flex-col gap-3" data-testid="restart-confirm-body">
+                    <p>
+                        Restart{' '}
+                        <strong>{restartTarget?.server.label ?? 'this server'}</strong>?
+                    </p>
+                    <p className="text-[#848484] dark:text-[#9d9d9d]">
+                        This restarts the remote server process. Any tasks or processes
+                        currently running on it will be interrupted. The server only comes
+                        back if it runs under a process manager (pm2, systemd, or a wrapper
+                        that relaunches it) — otherwise it stays offline until you start it
+                        again manually.
+                    </p>
+                    {restartError && (
+                        <div
+                            data-testid="restart-confirm-error"
+                            className="px-3 py-2 rounded border border-[#f14c4c]/40 bg-[#f14c4c]/10 text-xs text-[#f14c4c]"
+                        >
+                            {restartError}
+                        </div>
+                    )}
+                </div>
+            </Dialog>
         </div>
     );
 }

--- a/packages/coc/src/server/spa/client/react/hooks/useRemoteServerHealth.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useRemoteServerHealth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import type { RemoteServer, RemoteServerHealth } from '../utils/serverRegistry';
 import { getSpaCocClient } from '../api/cocClient';
 
@@ -7,6 +7,18 @@ const POLL_INTERVAL_MS = 30_000;
 export interface ServerHealthState extends Omit<RemoteServerHealth, 'serverId' | 'kind'> {
     server: RemoteServer;
     kind: RemoteServer['kind'];
+}
+
+export interface UseRemoteServerHealthResult {
+    /** Latest health snapshot, one entry per server. */
+    healthStates: ServerHealthState[];
+    /**
+     * Re-poll every server immediately, without waiting for the next
+     * {@link POLL_INTERVAL_MS} cycle. Used after a Restart so the offline→online
+     * transition surfaces promptly instead of up to 30s later. Safe to call any
+     * time; a no-op while there are no servers.
+     */
+    refetch: () => void;
 }
 
 async function checkServer(server: RemoteServer): Promise<ServerHealthState> {
@@ -39,17 +51,22 @@ async function checkServer(server: RemoteServer): Promise<ServerHealthState> {
     }
 }
 
-export function useRemoteServerHealth(servers: RemoteServer[]): ServerHealthState[] {
+export function useRemoteServerHealth(servers: RemoteServer[]): UseRemoteServerHealthResult {
     const [healthStates, setHealthStates] = useState<ServerHealthState[]>(
         () => servers.map(s => ({ server: s, kind: s.kind, status: 'checking' as const })),
     );
     const cancelledRef = useRef(false);
+    // Holds the current effect's poll closure so refetch() can fire an extra poll
+    // without re-running the effect (which would reset every row to "checking" and
+    // restart the interval timer).
+    const pollRef = useRef<(() => void) | undefined>(undefined);
 
     useEffect(() => {
         cancelledRef.current = false;
         setHealthStates(servers.map(s => ({ server: s, kind: s.kind, status: 'checking' as const })));
 
         if (servers.length === 0) {
+            pollRef.current = undefined;
             return () => { cancelledRef.current = true; };
         }
 
@@ -58,14 +75,18 @@ export function useRemoteServerHealth(servers: RemoteServer[]): ServerHealthStat
             if (cancelledRef.current) { return; }
             setHealthStates(results);
         };
+        pollRef.current = () => { void poll(); };
 
         void poll();
         const id = setInterval(() => { void poll(); }, POLL_INTERVAL_MS);
         return () => {
             cancelledRef.current = true;
             clearInterval(id);
+            pollRef.current = undefined;
         };
     }, [servers]);
 
-    return healthStates;
+    const refetch = useCallback(() => { pollRef.current?.(); }, []);
+
+    return { healthStates, refetch };
 }

--- a/packages/coc/src/server/spa/client/react/utils/serverRegistry.ts
+++ b/packages/coc/src/server/spa/client/react/utils/serverRegistry.ts
@@ -11,9 +11,10 @@ export type {
     RemoteServerPatch,
     RemoteServerHealth,
     RemoteServerRuntime,
+    RemoteServerRestartResponse,
 } from '@plusplusoneplusplus/coc-client';
 
-import type { RemoteServer, RemoteServerHealth, RemoteServerInput, RemoteServerPatch, RemoteServerRuntime, UrlRemoteServer } from '@plusplusoneplusplus/coc-client';
+import type { RemoteServer, RemoteServerHealth, RemoteServerInput, RemoteServerPatch, RemoteServerRestartResponse, RemoteServerRuntime, UrlRemoteServer } from '@plusplusoneplusplus/coc-client';
 
 const LEGACY_REGISTRY_KEY = 'coc-remote-servers';
 const MIGRATION_DONE_KEY = 'coc-remote-servers-api-migrated';
@@ -134,6 +135,10 @@ export async function testRemoteServer(input: RemoteServerInput): Promise<Remote
 
 export async function reconnectServer(id: string): Promise<RemoteServerRuntime> {
     return getSpaCocClient().servers.reconnect(id);
+}
+
+export async function restartServer(id: string): Promise<RemoteServerRestartResponse> {
+    return getSpaCocClient().servers.restart(id);
 }
 
 export function getServerEndpoint(server: RemoteServer): string | undefined {

--- a/packages/coc/test/server/remote-server-routes.test.ts
+++ b/packages/coc/test/server/remote-server-routes.test.ts
@@ -548,6 +548,84 @@ describe('remote server routes', () => {
         });
     });
 
+    describe('restart route', () => {
+        let restartServer: http.Server | undefined;
+
+        afterEach(async () => {
+            if (restartServer?.listening) await stop(restartServer);
+            restartServer = undefined;
+        });
+
+        async function startRestartableRemote(options?: { restartStatus?: number }): Promise<{ baseUrl: string; restartCalls: MockCocRequest[] }> {
+            const restartCalls: MockCocRequest[] = [];
+            restartServer = http.createServer(async (req, res) => {
+                if (req.method === 'POST' && req.url === '/api/admin/restart') {
+                    restartCalls.push({ method: req.method, url: req.url, body: await readBody(req) });
+                    // Remote replies *before* it would exit, mirroring admin-handler.
+                    send(res, options?.restartStatus ?? 200, { message: 'Server is restarting...' });
+                    return;
+                }
+                // Health-checker probes so the server can be created as a url-kind remote.
+                if (req.url === '/api/health') {
+                    send(res, 200, { status: 'ok', uptime: 1, processCount: 1 });
+                    return;
+                }
+                if (req.url === '/api/admin/version') {
+                    send(res, 200, { version: '1.0.0', commit: 'abc123' });
+                    return;
+                }
+                if (req.url === '/api/admin/config') {
+                    send(res, 200, { hostname: 'remote-box' });
+                    return;
+                }
+                send(res, 404, { error: `Not found: ${req.method} ${req.url}` });
+            });
+            return { baseUrl: (await start(restartServer)).baseUrl, restartCalls };
+        }
+
+        it('proxies a POST to the remote /api/admin/restart and returns 2xx on success', async () => {
+            const remote = await startRestartableRemote();
+            const baseUrl = await startApi(new DevTunnelConnector());
+            const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Remote', url: remote.baseUrl });
+
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/restart`);
+            expect(res.status).toBeGreaterThanOrEqual(200);
+            expect(res.status).toBeLessThan(300);
+            expect(remote.restartCalls).toHaveLength(1);
+            expect(remote.restartCalls[0]).toMatchObject({ method: 'POST', url: '/api/admin/restart' });
+        });
+
+        it('returns 404 for an unknown server id', async () => {
+            const baseUrl = await startApi(new DevTunnelConnector());
+            const res = await request(baseUrl, 'POST', '/api/servers/does-not-exist/restart');
+            expect(res.status).toBe(404);
+        });
+
+        it('returns an error status when the remote responds non-2xx', async () => {
+            const remote = await startRestartableRemote({ restartStatus: 500 });
+            const baseUrl = await startApi(new DevTunnelConnector());
+            const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Remote', url: remote.baseUrl });
+
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/restart`);
+            expect(res.status).toBe(502);
+            expect(res.body).toHaveProperty('error');
+            expect(remote.restartCalls).toHaveLength(1);
+        });
+
+        it('returns an error status when the remote is unreachable', async () => {
+            // Start then immediately stop a server to obtain a guaranteed-refused endpoint.
+            const deadServer = http.createServer(() => {});
+            const dead = await start(deadServer);
+            await stop(deadServer);
+            const baseUrl = await startApi(new DevTunnelConnector());
+            const created = await request(baseUrl, 'POST', '/api/servers', { kind: 'url', label: 'Dead', url: dead.baseUrl });
+
+            const res = await request(baseUrl, 'POST', `/api/servers/${created.body.id}/restart`);
+            expect(res.status).toBe(502);
+            expect(res.body).toHaveProperty('error');
+        });
+    });
+
     it('reconnect returns 404 for missing server', async () => {
         const baseUrl = await startApi(new DevTunnelConnector());
         const res = await request(baseUrl, 'POST', '/api/servers/nonexistent/reconnect');

--- a/packages/coc/test/spa/react/features/servers/ServerCard.test.tsx
+++ b/packages/coc/test/spa/react/features/servers/ServerCard.test.tsx
@@ -328,6 +328,7 @@ describe('ServerCard — restart menu item', () => {
 
     it('shows "Restarting…" and disables the item while restarting', () => {
         render(<ServerCard health={REMOTE_BASE} isLocal={false} onRestart={vi.fn()} restarting />);
+        expect(screen.getByTestId('server-card-restarting').textContent).toContain('Restarting');
         fireEvent.click(screen.getByTestId('server-card-menu-btn'));
         const btn = screen.getByTestId('server-card-menu-restart') as HTMLButtonElement;
         expect(btn.disabled).toBe(true);

--- a/packages/coc/test/spa/react/features/servers/ServerCard.test.tsx
+++ b/packages/coc/test/spa/react/features/servers/ServerCard.test.tsx
@@ -300,6 +300,53 @@ describe('ServerCard — menu actions', () => {
     });
 });
 
+describe('ServerCard — restart menu item', () => {
+    it.each([
+        ['URL', REMOTE_BASE, 'r1'],
+        ['DevTunnel', DEVTUNNEL_BASE, 'd1'],
+        ['SSH', SSH_BASE, 's1'],
+    ] as const)('shows an enabled Restart item for online %s servers and calls onRestart', (_label, health, id) => {
+        const onRestart = vi.fn();
+        render(<ServerCard health={health} isLocal={false} onRestart={onRestart} />);
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        const btn = screen.getByTestId('server-card-menu-restart') as HTMLButtonElement;
+        expect(btn.disabled).toBe(false);
+        fireEvent.click(btn);
+        expect(onRestart).toHaveBeenCalledWith(id);
+        expect(screen.queryByTestId('server-card-menu')).toBeNull();
+    });
+
+    it('disables Restart and does not fire onRestart when the server is offline', () => {
+        const onRestart = vi.fn();
+        render(<ServerCard health={{ ...REMOTE_BASE, status: 'offline' }} isLocal={false} onRestart={onRestart} />);
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        const btn = screen.getByTestId('server-card-menu-restart') as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+        fireEvent.click(btn);
+        expect(onRestart).not.toHaveBeenCalled();
+    });
+
+    it('shows "Restarting…" and disables the item while restarting', () => {
+        render(<ServerCard health={REMOTE_BASE} isLocal={false} onRestart={vi.fn()} restarting />);
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        const btn = screen.getByTestId('server-card-menu-restart') as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+        expect(btn.textContent).toContain('Restarting');
+    });
+
+    it('does not render a Restart item when onRestart is not provided', () => {
+        render(<ServerCard health={REMOTE_BASE} isLocal={false} />);
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        expect(screen.queryByTestId('server-card-menu-restart')).toBeNull();
+    });
+
+    it('never renders a Restart item for the local server (no menu at all)', () => {
+        render(<ServerCard health={LOCAL_BASE} isLocal onRestart={vi.fn()} />);
+        expect(screen.queryByTestId('server-card-menu-btn')).toBeNull();
+        expect(screen.queryByTestId('server-card-menu-restart')).toBeNull();
+    });
+});
+
 describe('ServerCard — stats rendering', () => {
     it('renders process count, uptime, and version when defined', () => {
         render(<ServerCard health={REMOTE_BASE} isLocal={false} />);

--- a/packages/coc/test/spa/react/features/servers/ServersView.test.tsx
+++ b/packages/coc/test/spa/react/features/servers/ServersView.test.tsx
@@ -11,6 +11,7 @@ const registryMocks = vi.hoisted(() => ({
     removeRemoteServer: vi.fn(),
     testRemoteServer: vi.fn(),
     reconnectServer: vi.fn(),
+    restartServer: vi.fn(),
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/serverRegistry', async (importOriginal) => {
@@ -23,6 +24,7 @@ vi.mock('../../../../../src/server/spa/client/react/utils/serverRegistry', async
         removeRemoteServer: registryMocks.removeRemoteServer,
         testRemoteServer: registryMocks.testRemoteServer,
         reconnectServer: registryMocks.reconnectServer,
+        restartServer: registryMocks.restartServer,
     };
 });
 
@@ -94,6 +96,7 @@ beforeEach(() => {
     registryMocks.removeRemoteServer.mockResolvedValue(undefined);
     registryMocks.testRemoteServer.mockResolvedValue({ serverId: 'test', kind: 'url', status: 'online', lastChecked: 1 });
     registryMocks.reconnectServer.mockResolvedValue({ serverId: 'c', kind: 'ssh', status: 'online' });
+    registryMocks.restartServer.mockResolvedValue({ ok: true, message: 'Server is restarting...' });
     const fetchMock = vi.fn().mockImplementation((url: string) => {
         if (url.endsWith('/health') || url.endsWith('/api/health')) {
             return Promise.resolve(jsonResponse({ uptime: 100, processCount: 2 }));
@@ -227,6 +230,106 @@ describe('ServersView', () => {
 
         expect(registryMocks.reconnectServer).toHaveBeenCalledWith('c');
         await waitFor(() => expect(registryMocks.listRemoteServers).toHaveBeenCalledTimes(2));
+    });
+
+    it('clicking Restart opens a confirmation dialog with a disruption warning and sends nothing yet', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+
+        render(<ServersView />);
+        switchToGrid();
+        await waitFor(() => expect(screen.getAllByTestId('server-card')).toHaveLength(2));
+
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        fireEvent.click(screen.getByTestId('server-card-menu-restart'));
+
+        const body = screen.getByTestId('restart-confirm-body');
+        expect(body.textContent).toContain('Box A');
+        expect(body.textContent?.toLowerCase()).toContain('interrupt');
+        expect(body.textContent?.toLowerCase()).toContain('process manager');
+        expect(registryMocks.restartServer).not.toHaveBeenCalled();
+    });
+
+    it('cancelling the restart dialog sends no request and closes it', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+
+        render(<ServersView />);
+        switchToGrid();
+        await waitFor(() => expect(screen.getAllByTestId('server-card')).toHaveLength(2));
+
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        fireEvent.click(screen.getByTestId('server-card-menu-restart'));
+        fireEvent.click(screen.getByTestId('restart-confirm-cancel'));
+
+        expect(registryMocks.restartServer).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('restart-confirm-body')).toBeNull();
+    });
+
+    it('confirming the restart dialog calls backend restart with the server id and closes', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+
+        render(<ServersView />);
+        switchToGrid();
+        await waitFor(() => expect(screen.getAllByTestId('server-card')).toHaveLength(2));
+
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        fireEvent.click(screen.getByTestId('server-card-menu-restart'));
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('restart-confirm-submit'));
+        });
+
+        expect(registryMocks.restartServer).toHaveBeenCalledWith('a');
+        await waitFor(() => expect(screen.queryByTestId('restart-confirm-body')).toBeNull());
+    });
+
+    it('surfaces an inline error and keeps the dialog open when restart fails', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+        registryMocks.restartServer.mockRejectedValueOnce(new Error('remote unreachable'));
+
+        render(<ServersView />);
+        switchToGrid();
+        await waitFor(() => expect(screen.getAllByTestId('server-card')).toHaveLength(2));
+
+        fireEvent.click(screen.getByTestId('server-card-menu-btn'));
+        fireEvent.click(screen.getByTestId('server-card-menu-restart'));
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('restart-confirm-submit'));
+        });
+
+        expect(registryMocks.restartServer).toHaveBeenCalledWith('a');
+        await waitFor(() => expect(screen.getByTestId('restart-confirm-error').textContent).toContain('remote unreachable'));
+        expect(screen.getByTestId('restart-confirm-body')).toBeTruthy();
+    });
+
+    it('row Restart action is enabled for an online remote server', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+
+        render(<ServersView />);
+        await waitFor(() => expect(screen.getByTestId('server-row-restart')).toBeTruthy());
+        expect((screen.getByTestId('server-row-restart') as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('row Restart action is disabled when the server is offline', async () => {
+        vi.mocked(useRemoteServerHealth).mockImplementation(servers =>
+            servers.map(s => ({
+                server: s,
+                kind: s.kind,
+                status: 'offline' as const,
+                effectiveUrl: s.kind === 'url' ? (s as typeof URL_REMOTE).url : undefined,
+            }))
+        );
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+
+        render(<ServersView />);
+        await waitFor(() => expect(screen.getByTestId('server-row-restart')).toBeTruthy());
+        expect((screen.getByTestId('server-row-restart') as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('never offers a Restart action for the local-only server list', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([]);
+
+        render(<ServersView />);
+        await waitFor(() => expect(registryMocks.listRemoteServers).toHaveBeenCalled());
+        expect(screen.queryByTestId('server-row-restart')).toBeNull();
     });
 
     it('clicking Edit server opens a prefilled edit dialog for a Direct URL server', async () => {

--- a/packages/coc/test/spa/react/features/servers/ServersView.test.tsx
+++ b/packages/coc/test/spa/react/features/servers/ServersView.test.tsx
@@ -14,6 +14,10 @@ const registryMocks = vi.hoisted(() => ({
     restartServer: vi.fn(),
 }));
 
+// Stable refetch spy shared by every useRemoteServerHealth mock so tests can assert
+// the immediate re-poll fires after a restart (AC-05).
+const healthMocks = vi.hoisted(() => ({ refetch: vi.fn() }));
+
 vi.mock('../../../../../src/server/spa/client/react/utils/serverRegistry', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../../../../src/server/spa/client/react/utils/serverRegistry')>();
     return {
@@ -38,8 +42,8 @@ vi.mock('../../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () 
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/hooks/useRemoteServerHealth', () => ({
-    useRemoteServerHealth: vi.fn((servers: RemoteServer[]) =>
-        servers.map(s => ({
+    useRemoteServerHealth: vi.fn((servers: RemoteServer[]) => ({
+        healthStates: servers.map(s => ({
             server: s,
             kind: s.kind,
             status: 'online' as const,
@@ -47,8 +51,9 @@ vi.mock('../../../../../src/server/spa/client/react/hooks/useRemoteServerHealth'
             effectiveUrl: s.kind === 'devtunnel' ? s.effectiveUrl : s.url,
             localPort: s.kind === 'devtunnel' ? s.localPort : undefined,
             tunnelId: s.kind === 'devtunnel' ? s.tunnelId : undefined,
-        }))
-    ),
+        })),
+        refetch: healthMocks.refetch,
+    })),
 }));
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -112,8 +117,8 @@ beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
 });
 
-const defaultHealthImpl = (servers: RemoteServer[]) =>
-    servers.map(s => ({
+const defaultHealthImpl = (servers: RemoteServer[]) => ({
+    healthStates: servers.map(s => ({
         server: s,
         kind: s.kind,
         status: 'online' as const,
@@ -121,7 +126,9 @@ const defaultHealthImpl = (servers: RemoteServer[]) =>
         effectiveUrl: s.kind === 'devtunnel' ? s.effectiveUrl : s.url,
         localPort: s.kind === 'devtunnel' ? s.localPort : undefined,
         tunnelId: s.kind === 'devtunnel' ? s.tunnelId : undefined,
-    }));
+    })),
+    refetch: healthMocks.refetch,
+});
 
 afterEach(() => {
     cleanup();
@@ -129,6 +136,7 @@ afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     Object.values(registryMocks).forEach(mock => mock.mockReset());
+    healthMocks.refetch.mockReset();
     vi.mocked(useRemoteServerHealth).mockReset().mockImplementation(defaultHealthImpl);
 });
 
@@ -300,6 +308,40 @@ describe('ServersView', () => {
         expect(screen.getByTestId('restart-confirm-body')).toBeTruthy();
     });
 
+    it('confirming a restart shows an optimistic "Restarting…" indicator and re-polls health immediately', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+
+        render(<ServersView />);
+        await waitFor(() => expect(screen.getByTestId('server-row-restart')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('server-row-restart'));
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('restart-confirm-submit'));
+        });
+
+        // Optimistic transient surfaces on the row and outlives the request.
+        await waitFor(() => expect(screen.getByTestId('server-row-restarting')).toBeTruthy());
+        // Immediate re-poll instead of waiting for the 30s POLL_INTERVAL_MS cycle.
+        expect(healthMocks.refetch).toHaveBeenCalled();
+    });
+
+    it('a failed restart neither re-polls nor leaves an optimistic "Restarting…" indicator', async () => {
+        registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
+        registryMocks.restartServer.mockRejectedValueOnce(new Error('remote unreachable'));
+
+        render(<ServersView />);
+        await waitFor(() => expect(screen.getByTestId('server-row-restart')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('server-row-restart'));
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('restart-confirm-submit'));
+        });
+
+        await waitFor(() => expect(screen.getByTestId('restart-confirm-error').textContent).toContain('remote unreachable'));
+        expect(healthMocks.refetch).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('server-row-restarting')).toBeNull();
+    });
+
     it('row Restart action is enabled for an online remote server', async () => {
         registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
 
@@ -309,14 +351,15 @@ describe('ServersView', () => {
     });
 
     it('row Restart action is disabled when the server is offline', async () => {
-        vi.mocked(useRemoteServerHealth).mockImplementation(servers =>
-            servers.map(s => ({
+        vi.mocked(useRemoteServerHealth).mockImplementation(servers => ({
+            healthStates: servers.map(s => ({
                 server: s,
                 kind: s.kind,
                 status: 'offline' as const,
                 effectiveUrl: s.kind === 'url' ? (s as typeof URL_REMOTE).url : undefined,
-            }))
-        );
+            })),
+            refetch: healthMocks.refetch,
+        }));
         registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
 
         render(<ServersView />);
@@ -543,8 +586,8 @@ describe('ServersView', () => {
     });
 
     it('filter "Offline" shows only offline-status servers', async () => {
-        vi.mocked(useRemoteServerHealth).mockImplementation(servers =>
-            servers.map(s => ({
+        vi.mocked(useRemoteServerHealth).mockImplementation(servers => ({
+            healthStates: servers.map(s => ({
                 server: s,
                 kind: s.kind,
                 status: 'offline' as const,
@@ -553,8 +596,9 @@ describe('ServersView', () => {
                     : (s as typeof URL_REMOTE).url,
                 localPort: s.kind === 'devtunnel' ? (s as typeof TUNNEL_REMOTE).localPort : undefined,
                 tunnelId: s.kind === 'devtunnel' ? (s as typeof TUNNEL_REMOTE).tunnelId : undefined,
-            }))
-        );
+            })),
+            refetch: healthMocks.refetch,
+        }));
         registryMocks.listRemoteServers.mockResolvedValue([URL_REMOTE]);
         render(<ServersView />);
         switchToGrid();

--- a/packages/coc/test/spa/react/hooks/useRemoteServerHealth.test.ts
+++ b/packages/coc/test/spa/react/hooks/useRemoteServerHealth.test.ts
@@ -53,7 +53,7 @@ describe('useRemoteServerHealth', () => {
     it('returns an empty array when given no servers', () => {
         const { result, unmount } = renderHook(() => useRemoteServerHealth(EMPTY_SERVERS));
         try {
-            expect(result.current).toEqual([]);
+            expect(result.current.healthStates).toEqual([]);
         } finally {
             unmount();
         }
@@ -64,9 +64,9 @@ describe('useRemoteServerHealth', () => {
         fetchMock.mockReturnValue(new Promise<Response>(r => { resolveFetch = r; }));
         const { result, unmount } = renderHook(() => useRemoteServerHealth(ONE_SERVER));
         try {
-            expect(result.current).toHaveLength(1);
-            expect(result.current[0].status).toBe('checking');
-            expect(result.current[0].server).toEqual(SERVER_A);
+            expect(result.current.healthStates).toHaveLength(1);
+            expect(result.current.healthStates[0].status).toBe('checking');
+            expect(result.current.healthStates[0].server).toEqual(SERVER_A);
         } finally {
             unmount();
             resolveFetch(jsonResponse({}, 500));
@@ -89,8 +89,8 @@ describe('useRemoteServerHealth', () => {
 
         const { result, unmount } = renderHook(() => useRemoteServerHealth(ONE_SERVER));
         try {
-            await waitFor(() => expect(result.current[0].status).toBe('online'));
-            const state = result.current[0];
+            await waitFor(() => expect(result.current.healthStates[0].status).toBe('online'));
+            const state = result.current.healthStates[0];
             expect(fetchMock).toHaveBeenCalledWith('/api/servers/a/health', expect.any(Object));
             expect(state.uptime).toBe(1234);
             expect(state.processCount).toBe(7);
@@ -108,9 +108,9 @@ describe('useRemoteServerHealth', () => {
         fetchMock.mockRejectedValue(new Error('network down'));
         const { result, unmount } = renderHook(() => useRemoteServerHealth(ONE_SERVER));
         try {
-            await waitFor(() => expect(result.current[0].status).toBe('offline'));
-            expect(result.current[0].error).toBe('CoC API request failed before receiving a response');
-            expect(result.current[0].lastChecked).toBeTypeOf('number');
+            await waitFor(() => expect(result.current.healthStates[0].status).toBe('offline'));
+            expect(result.current.healthStates[0].error).toBe('CoC API request failed before receiving a response');
+            expect(result.current.healthStates[0].lastChecked).toBeTypeOf('number');
         } finally {
             unmount();
         }
@@ -120,8 +120,8 @@ describe('useRemoteServerHealth', () => {
         fetchMock.mockResolvedValue(jsonResponse({ error: 'bad' }, 503));
         const { result, unmount } = renderHook(() => useRemoteServerHealth(ONE_SERVER));
         try {
-            await waitFor(() => expect(result.current[0].status).toBe('offline'));
-            expect(result.current[0].error).toBe('bad');
+            await waitFor(() => expect(result.current.healthStates[0].status).toBe('offline'));
+            expect(result.current.healthStates[0].error).toBe('bad');
         } finally {
             unmount();
         }
@@ -153,15 +153,15 @@ describe('useRemoteServerHealth', () => {
         const { result, unmount } = renderHook(() => useRemoteServerHealth(TWO_SERVERS));
         try {
             await waitFor(() => {
-                expect(result.current).toHaveLength(2);
-                const a = result.current.find(s => s.server.id === 'a');
-                const b = result.current.find(s => s.server.id === 'b');
+                expect(result.current.healthStates).toHaveLength(2);
+                const a = result.current.healthStates.find(s => s.server.id === 'a');
+                const b = result.current.healthStates.find(s => s.server.id === 'b');
                 expect(a?.status).toBe('online');
                 expect(b?.status).toBe('offline');
             });
-            expect(result.current.find(s => s.server.id === 'a')?.version).toBe('v-a');
-            expect(result.current.find(s => s.server.id === 'b')?.error).toBe('B is down');
-            expect(result.current.find(s => s.server.id === 'b')?.localPort).toBe(4000);
+            expect(result.current.healthStates.find(s => s.server.id === 'a')?.version).toBe('v-a');
+            expect(result.current.healthStates.find(s => s.server.id === 'b')?.error).toBe('B is down');
+            expect(result.current.healthStates.find(s => s.server.id === 'b')?.localPort).toBe(4000);
         } finally {
             unmount();
         }
@@ -175,6 +175,45 @@ describe('useRemoteServerHealth', () => {
         unmount();
         expect(clearSpy).toHaveBeenCalled();
         resolveFetch(jsonResponse({}, 500));
+    });
+
+    it('refetch() triggers an immediate re-poll without waiting for the interval', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(jsonResponse({
+            serverId: 'a',
+            kind: 'url',
+            status: 'online',
+            lastChecked: 1,
+        }));
+
+        const { result, unmount } = renderHook(() => useRemoteServerHealth(ONE_SERVER));
+        try {
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(result.current.healthStates[0].status).toBe('online');
+            const callsAfterFirstPoll = fetchMock.mock.calls.length;
+
+            // No interval advance — refetch alone should fire another poll.
+            await act(async () => {
+                result.current.refetch();
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirstPoll);
+        } finally {
+            unmount();
+            vi.useRealTimers();
+        }
+    });
+
+    it('refetch() is a no-op when there are no servers', () => {
+        const { result, unmount } = renderHook(() => useRemoteServerHealth(EMPTY_SERVERS));
+        try {
+            expect(() => result.current.refetch()).not.toThrow();
+            expect(fetchMock).not.toHaveBeenCalled();
+        } finally {
+            unmount();
+        }
     });
 
     it('re-polls after the 30s interval', async () => {
@@ -191,7 +230,7 @@ describe('useRemoteServerHealth', () => {
             await act(async () => {
                 await vi.advanceTimersByTimeAsync(0);
             });
-            expect(result.current[0].status).toBe('online');
+            expect(result.current.healthStates[0].status).toBe('online');
             const callsAfterFirstPoll = fetchMock.mock.calls.length;
 
             await act(async () => {


### PR DESCRIPTION
- **feat(coc): add POST /api/servers/{id}/restart backend route (AC-01)**
- **feat(coc-client): add servers.restart(id) client method + contract (AC-02)**
- **feat(coc): add Restart action + confirm dialog to servers admin page (AC-03/AC-04)**
- **feat(coc): optimistic Restarting state + immediate health re-poll (AC-05)**
