### PR TITLE
pr/d05c38e3a featcoc route markdown chat links to doc

### DIFF
--- a/packages/coc/src/server/spa/client/react/App.tsx
+++ b/packages/coc/src/server/spa/client/react/App.tsx
@@ -31,7 +31,11 @@ import { toForwardSlashes } from '@plusplusoneplusplus/forge/utils/path-utils';
 import { MarkdownReviewDialog } from './processes/MarkdownReviewDialog';
 import { EnqueueDialog } from './queue/EnqueueDialog';
 import { RunScriptDialog } from './queue/RunScriptDialog';
-import { isAbsolutePath, resolveRelativePath } from './utils/path-resolution';
+import {
+    resolveMarkdownReviewTarget,
+    resolveWorkspaceForPath,
+    type WorkspaceLike,
+} from './shared/markdown-review/resolveMarkdownReviewTarget';
 import { buildNotificationEntry } from './utils/build-notification-entry';
 import { WelcomeTour } from './welcome/WelcomeTour';
 import { SHOW_WELCOME_TUTORIAL } from './featureFlags';
@@ -51,12 +55,10 @@ interface MarkdownReviewDialogState {
     taskRootPath?: string | null;
 }
 
-/* @internal – exported for testing only */
-export interface WorkspaceLike {
-    id: string;
-    name?: string;
-    rootPath?: string;
-}
+// `resolveWorkspaceForPath` / `WorkspaceLike` live in the shared markdown-review
+// helper now; re-export here so existing test imports keep resolving.
+export { resolveWorkspaceForPath };
+export type { WorkspaceLike };
 
 const ACTIVE_WORKSPACE_CLIENT_ID_KEY = 'coc-dashboard-active-workspace-client-id';
 const ACTIVE_WORKSPACE_REPORT_INTERVAL_MS = 60 * 1000;
@@ -81,46 +83,9 @@ export function getDashboardClientId(): string {
 }
 
 
-function normalizePath(pathValue: string): string {
-    return toForwardSlashes(pathValue);
-}
-
 /* @internal – exported for testing only */
 export function getFileName(path: string): string {
     return toForwardSlashes(path).split('/').pop() || path;
-}
-
-
-/* @internal – exported for testing only */
-export function resolveWorkspaceForPath(filePath: string, workspaces: WorkspaceLike[]): WorkspaceLike | null {
-    const normalizedPath = normalizePath(filePath).toLowerCase();
-    let best: WorkspaceLike | null = null;
-
-    for (const ws of workspaces) {
-        if (!ws?.rootPath) continue;
-        const normalizedRoot = normalizePath(ws.rootPath).replace(/\/+$/, '').toLowerCase();
-        if (!normalizedRoot) continue;
-
-        if (normalizedPath === normalizedRoot || normalizedPath.startsWith(normalizedRoot + '/')) {
-            if (!best || normalizedRoot.length > normalizePath(best.rootPath || '').toLowerCase().length) {
-                best = ws;
-            }
-        }
-    }
-
-    return best;
-}
-
-function toTaskRelativePath(fullPath: string, workspaceRoot: string): string | null {
-    if (!workspaceRoot) return null;
-    const normalizedPath = normalizePath(fullPath);
-    const normalizedRoot = normalizePath(workspaceRoot).replace(/\/+$/, '');
-    const tasksRoot = `${normalizedRoot}/.vscode/tasks`;
-
-    if (normalizedPath === tasksRoot) return '';
-    if (!normalizedPath.startsWith(tasksRoot + '/')) return null;
-
-    return normalizedPath.slice(tasksRoot.length + 1);
 }
 
 
@@ -380,75 +345,26 @@ function AppInner() {
     useEffect(() => {
         const handleOpenMarkdownReview = (event: Event) => {
             const detail = (event as CustomEvent<{ filePath?: string; sourceFilePath?: string; wsId?: string; taskRootPath?: string }>).detail;
-            let filePath = typeof detail?.filePath === 'string' ? detail.filePath : '';
-            if (!filePath) return;
-
-            const wsIdHint = typeof detail?.wsId === 'string' ? detail.wsId : '';
-            const eventTaskRootPath = typeof detail?.taskRootPath === 'string' ? detail.taskRootPath : undefined;
-
-            // Fast path: wsId hint provided — use workspace directly without path resolution
-            if (wsIdHint) {
-                const hintedWorkspace = (appState.workspaces as WorkspaceLike[] || []).find(ws => ws.id === wsIdHint);
-                if (hintedWorkspace) {
-                    if (isAbsolutePath(filePath)) {
-                        // Absolute path from chat click — determine fetchMode by task membership
-                        const taskRelativePath = toTaskRelativePath(filePath, hintedWorkspace.rootPath || '');
-                        setReviewDialog({
-                            open: true,
-                            minimized: false,
-                            scrollTop: 0,
-                            wsId: hintedWorkspace.id,
-                            filePath: taskRelativePath ?? filePath,
-                            displayPath: filePath,
-                            fetchMode: taskRelativePath !== null ? 'tasks' : 'auto',
-                            taskRootPath: eventTaskRootPath,
-                        });
-                    } else {
-                        // Task-relative path from TaskTree
-                        const displayBase = eventTaskRootPath
-                            ? normalizePath(eventTaskRootPath).replace(/\/+$/, '')
-                            : (() => {
-                                const rootNormalized = normalizePath(hintedWorkspace.rootPath || '').replace(/\/+$/, '');
-                                return rootNormalized ? `${rootNormalized}/.vscode/tasks` : '';
-                            })();
-                        const displayPath = displayBase ? `${displayBase}/${filePath}` : filePath;
-                        setReviewDialog({
-                            open: true,
-                            minimized: false,
-                            scrollTop: 0,
-                            wsId: hintedWorkspace.id,
-                            filePath,
-                            displayPath,
-                            fetchMode: 'tasks',
-                            taskRootPath: eventTaskRootPath,
-                        });
-                    }
-                    return;
-                }
-            }
-
-            // Resolve relative paths against the source file's directory
-            const sourceFilePath = typeof detail?.sourceFilePath === 'string' ? detail.sourceFilePath : '';
-            if (sourceFilePath && !isAbsolutePath(filePath)) {
-                const sourceDir = normalizePath(sourceFilePath).replace(/\/[^/]*$/, '');
-                filePath = resolveRelativePath(sourceDir, filePath);
-            }
-
-            const fullPath = filePath;
-
-            const workspace = resolveWorkspaceForPath(fullPath, appState.workspaces || []);
-            if (!workspace?.id) return;
-
-            const taskRelativePath = toTaskRelativePath(fullPath, workspace.rootPath || '');
+            const target = resolveMarkdownReviewTarget(
+                {
+                    filePath: typeof detail?.filePath === 'string' ? detail.filePath : '',
+                    wsId: typeof detail?.wsId === 'string' ? detail.wsId : undefined,
+                    sourceFilePath: typeof detail?.sourceFilePath === 'string' ? detail.sourceFilePath : undefined,
+                    taskRootPath: typeof detail?.taskRootPath === 'string' ? detail.taskRootPath : undefined,
+                },
+                (appState.workspaces as WorkspaceLike[]) || [],
+            );
+            if (!target) return;
 
             setReviewDialog({
                 open: true,
                 minimized: false,
                 scrollTop: 0,
-                wsId: workspace.id,
-                filePath: taskRelativePath ?? fullPath,
-                displayPath: fullPath,
-                fetchMode: taskRelativePath !== null ? 'tasks' : 'auto',
+                wsId: target.wsId,
+                filePath: target.filePath,
+                displayPath: target.displayPath,
+                fetchMode: target.fetchMode,
+                taskRootPath: target.taskRootPath,
             });
         };
 

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -356,6 +356,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 line: typeof detail.line === 'number' ? detail.line : undefined,
                 endLine: typeof detail.endLine === 'number' ? detail.endLine : undefined,
                 sourceFilePath: typeof detail.sourceFilePath === 'string' ? detail.sourceFilePath : undefined,
+                kind: detail.kind === 'note' ? 'note' : 'code',
             });
         };
         window.addEventListener('coc-open-source-canvas', handler as EventListener);

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1105,7 +1105,11 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     // canvas above (only one of these columns is ever non-null at a time).
     const sourceCanvasFileRef = sourceCanvas.fileRef;
     const sourceCanvasWsId = sourceCanvasFileRef?.wsId ?? workspaceId ?? null;
-    const sourceCanvasContent = useSourceCanvasContent(sourceCanvasFileRef);
+    // Notes (`kind: 'note'`) load/save through the embedded NoteEditor, so skip
+    // the read-only preview fetch for them — it would be unused.
+    const sourceCanvasContent = useSourceCanvasContent(
+        sourceCanvasFileRef?.kind === 'note' ? null : sourceCanvasFileRef,
+    );
     const sourceCanvasColumn = (sourceCanvas.isOpen && sourceCanvasFileRef) ? (
         isMobile ? (
             <BottomSheet

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -33,8 +33,7 @@ import type { QueuedMessage } from '../../utils/chatUtils';
 import { useChatSSE } from './hooks/useChatSSE';
 import type { RalphGrillPlanningProgress, CanvasUpdatedEvent } from './hooks/useChatSSE';
 import { CanvasPanel } from '../canvas/CanvasPanel';
-import { SourceCanvasPanel, useSourceCanvasState, useSourceCanvasContent } from './source-canvas';
-import { BottomSheet } from '../../ui/BottomSheet';
+import { SourceCanvasDock, useSourceCanvasState, useSourceCanvasContent } from './source-canvas';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { hydrateAskUserBatch } from './hooks/hydrateAskUserBatch';
 import { useSendMessage } from './hooks/useSendMessage';
@@ -1111,44 +1110,14 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         sourceCanvasFileRef?.kind === 'note' ? null : sourceCanvasFileRef,
     );
     const sourceCanvasColumn = (sourceCanvas.isOpen && sourceCanvasFileRef) ? (
-        isMobile ? (
-            <BottomSheet
-                isOpen
-                onClose={sourceCanvas.close}
-                title={(sourceCanvasFileRef.displayPath || sourceCanvasFileRef.fullPath).replace(/\\/g, '/').split('/').pop() || 'Source'}
-                height={90}
-            >
-                <SourceCanvasPanel
-                    fileRef={sourceCanvasFileRef}
-                    wsId={sourceCanvasWsId}
-                    content={sourceCanvasContent}
-                    onClose={sourceCanvas.close}
-                />
-            </BottomSheet>
-        ) : (
-            <>
-                <div
-                    className="hidden lg:flex items-center justify-center w-1 cursor-col-resize shrink-0 hover:bg-[#d0d0d0] dark:hover:bg-[#3a3a3c]"
-                    onMouseDown={sourceCanvasResize.handleMouseDown}
-                    onTouchStart={sourceCanvasResize.handleTouchStart}
-                    role="separator"
-                    aria-label="Resize source canvas panel"
-                    data-testid="source-canvas-resize-handle"
-                />
-                <div
-                    style={{ width: sourceCanvasResize.width }}
-                    className="hidden lg:block shrink-0 h-full border-l border-[#e0e0e0] dark:border-[#474749]"
-                    data-testid="source-canvas-column"
-                >
-                    <SourceCanvasPanel
-                        fileRef={sourceCanvasFileRef}
-                        wsId={sourceCanvasWsId}
-                        content={sourceCanvasContent}
-                        onClose={sourceCanvas.close}
-                    />
-                </div>
-            </>
-        )
+        <SourceCanvasDock
+            fileRef={sourceCanvasFileRef}
+            wsId={sourceCanvasWsId}
+            content={sourceCanvasContent}
+            isMobile={isMobile}
+            onClose={sourceCanvas.close}
+            resize={sourceCanvasResize}
+        />
     ) : null;
 
     const { handlePopOut, handleFloat } = useChatWindowActions({ task, taskId, workspaceId });

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasDock.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasDock.tsx
@@ -1,0 +1,83 @@
+/**
+ * SourceCanvasDock — host layout for the docked source-file canvas.
+ *
+ * Picks the surface for the single `SourceCanvasPanel` slot:
+ *  - mobile → a full-height `BottomSheet` (AC-05: notes render the editable
+ *    NoteEditor inside the same sheet the read-only viewer uses).
+ *  - desktop → a resizable, full-height sibling column with a drag handle.
+ *
+ * The panel chrome + body-mode switch (`kind: 'note'` editor vs `'code'`
+ * read-only viewer) live in `SourceCanvasPanel`; this component only owns the
+ * mobile-vs-desktop shell + resizing, mirroring the branch that used to live
+ * inline in `ChatDetail`.
+ */
+import { BottomSheet } from '../../../ui/BottomSheet';
+import { SourceCanvasPanel } from './SourceCanvasPanel';
+import type { SourceCanvasFileRef } from './types';
+import type { SourceCanvasContentState } from './useSourceCanvasContent';
+import type { UseResizablePanelReturn } from '../../../hooks/ui/useResizablePanel';
+
+function sheetTitle(fileRef: SourceCanvasFileRef): string {
+    const path = fileRef.displayPath || fileRef.fullPath;
+    return path.replace(/\\/g, '/').split('/').pop() || 'Source';
+}
+
+export interface SourceCanvasDockProps {
+    /** The file to display (markdown note or read-only code ref). */
+    fileRef: SourceCanvasFileRef;
+    /** Resolved workspace id, used for reveal-in-explorer. */
+    wsId?: string | null;
+    /** Loaded content for the read-only viewer (unused for notes). */
+    content?: SourceCanvasContentState;
+    /** Mobile breakpoint → render inside a BottomSheet instead of a column. */
+    isMobile: boolean;
+    /** Close the canvas. */
+    onClose: () => void;
+    /** Resize handlers/width for the desktop column. */
+    resize: Pick<UseResizablePanelReturn, 'width' | 'handleMouseDown' | 'handleTouchStart'>;
+}
+
+export function SourceCanvasDock({ fileRef, wsId, content, isMobile, onClose, resize }: SourceCanvasDockProps) {
+    if (isMobile) {
+        return (
+            <BottomSheet
+                isOpen
+                onClose={onClose}
+                title={sheetTitle(fileRef)}
+                height={90}
+            >
+                <SourceCanvasPanel
+                    fileRef={fileRef}
+                    wsId={wsId}
+                    content={content}
+                    onClose={onClose}
+                />
+            </BottomSheet>
+        );
+    }
+
+    return (
+        <>
+            <div
+                className="hidden lg:flex items-center justify-center w-1 cursor-col-resize shrink-0 hover:bg-[#d0d0d0] dark:hover:bg-[#3a3a3c]"
+                onMouseDown={resize.handleMouseDown}
+                onTouchStart={resize.handleTouchStart}
+                role="separator"
+                aria-label="Resize source canvas panel"
+                data-testid="source-canvas-resize-handle"
+            />
+            <div
+                style={{ width: resize.width }}
+                className="hidden lg:block shrink-0 h-full border-l border-[#e0e0e0] dark:border-[#474749]"
+                data-testid="source-canvas-column"
+            >
+                <SourceCanvasPanel
+                    fileRef={fileRef}
+                    wsId={wsId}
+                    content={content}
+                    onClose={onClose}
+                />
+            </div>
+        </>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor.tsx
@@ -72,6 +72,7 @@ export function SourceCanvasNoteEditor({ fileRef }: SourceCanvasNoteEditorProps)
                 io={editorIO}
                 commentBackend={noopCommentBackend}
                 notesRoot={target.taskRootPath ?? undefined}
+                scrollToLine={fileRef.line}
             />
         </div>
     );

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor.tsx
@@ -1,0 +1,78 @@
+/**
+ * SourceCanvasNoteEditor — editable markdown body for the docked source canvas
+ * (AC-02). When a chat-message markdown link opens the canvas (`kind: 'note'`),
+ * this renders the full editable `NoteEditor` (inline edit + auto-save) in the
+ * single canvas slot, in place of the read-only Rendered/Raw source viewer.
+ *
+ * Editor wiring matches the floating `MarkdownReviewDialog` exactly: the
+ * comment backend is `noopCommentBackend` (inert comments) and the IO adapter is
+ * chosen by `fetchMode` (`tasks` for files under `.vscode/tasks/`, otherwise the
+ * workspace-file adapter). Path/workspace/`taskRootPath` resolution is shared
+ * with the dialog via `resolveMarkdownReviewTarget`, so the two surfaces stay in
+ * sync.
+ */
+import { useMemo } from 'react';
+import { useApp } from '../../../contexts/AppContext';
+import { NoteEditor } from '../../notes/editor/NoteEditor';
+import { noopCommentBackend } from '../../notes/editor/NoteEditorCommentBackend';
+import { createTasksNoteEditorIO } from '../../../tasks/TasksNoteEditorIO';
+import { createWorkspaceFileNoteEditorIO } from '../../../tasks/WorkspaceFileNoteEditorIO';
+import {
+    resolveMarkdownReviewTarget,
+    type WorkspaceLike,
+} from '../../../shared/markdown-review/resolveMarkdownReviewTarget';
+import type { SourceCanvasFileRef } from './types';
+
+export interface SourceCanvasNoteEditorProps {
+    fileRef: SourceCanvasFileRef;
+}
+
+export function SourceCanvasNoteEditor({ fileRef }: SourceCanvasNoteEditorProps) {
+    const { state } = useApp();
+    const workspaces = state.workspaces as WorkspaceLike[] | undefined;
+
+    // Stateless adapters — create once per mount.
+    const tasksIO = useMemo(() => createTasksNoteEditorIO(), []);
+    const workspaceIO = useMemo(() => createWorkspaceFileNoteEditorIO(), []);
+
+    const target = useMemo(
+        () => resolveMarkdownReviewTarget(
+            {
+                filePath: fileRef.fullPath,
+                wsId: fileRef.wsId,
+                sourceFilePath: fileRef.sourceFilePath,
+            },
+            workspaces || [],
+        ),
+        [fileRef.fullPath, fileRef.wsId, fileRef.sourceFilePath, workspaces],
+    );
+
+    if (!target) {
+        return (
+            <div className="p-4 text-xs" data-testid="source-canvas-note-error">
+                <div className="font-medium text-[#cc4444] dark:text-[#f48771]">
+                    {`Couldn't open ${fileRef.displayPath || fileRef.fullPath}`}
+                </div>
+                <div className="mt-1 text-[#848484]">No matching workspace found.</div>
+            </div>
+        );
+    }
+
+    const editorIO = target.fetchMode === 'tasks' ? tasksIO : workspaceIO;
+
+    return (
+        <div
+            className="flex-1 min-h-0 overflow-hidden flex flex-col"
+            data-testid="source-canvas-note-editor"
+            data-ws-id={target.wsId}
+        >
+            <NoteEditor
+                workspaceId={target.wsId}
+                notePath={target.filePath}
+                io={editorIO}
+                commentBackend={noopCommentBackend}
+                notesRoot={target.taskRootPath ?? undefined}
+            />
+        </div>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNotePopOutButton.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNotePopOutButton.tsx
@@ -1,0 +1,93 @@
+/**
+ * SourceCanvasNotePopOutButton — the "Pop out" header action for the docked
+ * note editor (AC-03). Only shown in markdown/editable mode (`kind: 'note'`).
+ *
+ * Reuses the floating dialog's pop-out flow verbatim: it resolves the same
+ * workspace/path/fetchMode/taskRootPath via `resolveMarkdownReviewTarget`, opens
+ * the standalone `#popout/markdown` window (`PopOutMarkdownShell`), marks the
+ * file popped out (`mdPopOutKey`), and closes the canvas note — matching what
+ * `MarkdownReviewDialog.handlePopOut` does today.
+ */
+import { useCallback, useMemo } from 'react';
+import { useApp } from '../../../contexts/AppContext';
+import { useMarkdownPopOut } from '../../../contexts/MarkdownPopOutContext';
+import { useGlobalToast } from '../../../contexts/ToastContext';
+import { mdPopOutKey } from '../../../layout/PopOutMarkdownShell';
+import {
+    resolveMarkdownReviewTarget,
+    type WorkspaceLike,
+} from '../../../shared/markdown-review/resolveMarkdownReviewTarget';
+import type { SourceCanvasFileRef } from './types';
+
+function PopOutIcon() {
+    return (
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor"
+             aria-hidden="true" style={{ display: 'inline-block', verticalAlign: 'middle' }}>
+            <path d="M7 3h4v4h-1V4.7L6.35 8.35l-.7-.7L9.3 4H7V3z"/>
+            <path d="M3 5h2V4H2v8h8V9H9v2H3V5z"/>
+        </svg>
+    );
+}
+
+export interface SourceCanvasNotePopOutButtonProps {
+    /** The markdown note ref currently shown in the canvas. */
+    fileRef: SourceCanvasFileRef;
+    /** Close the canvas note after a successful pop-out (dialog parity). */
+    onClose: () => void;
+    /** Header button styling, shared with the other header actions. */
+    className?: string;
+}
+
+export function SourceCanvasNotePopOutButton({ fileRef, onClose, className }: SourceCanvasNotePopOutButtonProps) {
+    const { state } = useApp();
+    const workspaces = state.workspaces as WorkspaceLike[] | undefined;
+    const { markPoppedOut } = useMarkdownPopOut();
+    const { addToast } = useGlobalToast();
+
+    // Resolve the same target the editor (and the floating dialog) use, so the
+    // pop-out window loads/saves the identical file.
+    const target = useMemo(
+        () => resolveMarkdownReviewTarget(
+            {
+                filePath: fileRef.fullPath,
+                wsId: fileRef.wsId,
+                sourceFilePath: fileRef.sourceFilePath,
+            },
+            workspaces || [],
+        ),
+        [fileRef.fullPath, fileRef.wsId, fileRef.sourceFilePath, workspaces],
+    );
+
+    const handlePopOut = useCallback(() => {
+        if (!target) { return; }
+        const params = new URLSearchParams();
+        params.set('workspace', target.wsId);
+        params.set('filePath', target.filePath);
+        if (target.displayPath) { params.set('displayPath', target.displayPath); }
+        params.set('fetchMode', target.fetchMode);
+        if (target.taskRootPath) { params.set('taskRootPath', target.taskRootPath); }
+        const url = `${window.location.origin}${window.location.pathname}?${params.toString()}#popout/markdown`;
+        const windowName = `coc-md-popout-${mdPopOutKey(target.wsId, target.filePath).replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+        const popup = window.open(url, windowName, 'width=900,height=700');
+        if (!popup) {
+            addToast('Pop-out blocked. Allow popups for this site and try again.', 'error');
+        } else {
+            markPoppedOut(mdPopOutKey(target.wsId, target.filePath));
+            onClose();
+        }
+    }, [target, addToast, markPoppedOut, onClose]);
+
+    return (
+        <button
+            type="button"
+            data-testid="source-canvas-popout-btn"
+            onClick={handlePopOut}
+            disabled={!target}
+            className={className}
+            aria-label="Open in new window"
+            title="Open in new window"
+        >
+            <PopOutIcon />
+        </button>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasPanel.tsx
@@ -16,6 +16,7 @@ import { getSpaCocClient } from '../../../api/cocClient';
 import { Spinner } from '../../../ui/Spinner';
 import { SourceCanvasBody } from './SourceCanvasBody';
 import { SourceCanvasNoteEditor } from './SourceCanvasNoteEditor';
+import { SourceCanvasNotePopOutButton } from './SourceCanvasNotePopOutButton';
 import type { SourceCanvasFileRef } from './types';
 import type { SourceCanvasContentState } from './useSourceCanvasContent';
 
@@ -124,6 +125,13 @@ export function SourceCanvasPanel({ fileRef, wsId, content, onClose }: SourceCan
                     >
                         <RevealInExplorerIcon />
                     </button>
+                    {fileRef.kind === 'note' && (
+                        <SourceCanvasNotePopOutButton
+                            fileRef={fileRef}
+                            onClose={onClose}
+                            className={headerBtnClass}
+                        />
+                    )}
                     <button
                         type="button"
                         data-testid="source-canvas-close-btn"

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/SourceCanvasPanel.tsx
@@ -1,18 +1,21 @@
 /**
- * SourceCanvasPanel — docked, read-only viewer chrome for a single source file.
+ * SourceCanvasPanel — docked viewer chrome for a single source file, with two
+ * body modes in one slot:
+ *  - `kind: 'code'` (default) → read-only syntax-highlighted / rendered-markdown
+ *    viewer (`SourceCanvasBody`) over content loaded by `useSourceCanvasContent`.
+ *  - `kind: 'note'` (AC-02) → the editable `SourceCanvasNoteEditor` (full
+ *    `NoteEditor`, inline edit + auto-save), which loads/saves its own content.
  *
  * Renders the panel header (file name + full path, copy-path, reveal-in-explorer,
- * close) and a body region. The body is a placeholder here; later slices fill it
- * with markdown/syntax-highlighted rendering (AC-04), line jump + highlight
- * (AC-05), and loading/error states (AC-06).
- *
- * Layout (docked column vs mobile BottomSheet) and resizing are owned by the
- * host (`ChatDetail`); this component is the inner chrome only.
+ * close) and the body region. Layout (docked column vs mobile BottomSheet) and
+ * resizing are owned by the host (`ChatDetail`); this component is the inner
+ * chrome only.
  */
 import { useCallback, useState } from 'react';
 import { getSpaCocClient } from '../../../api/cocClient';
 import { Spinner } from '../../../ui/Spinner';
 import { SourceCanvasBody } from './SourceCanvasBody';
+import { SourceCanvasNoteEditor } from './SourceCanvasNoteEditor';
 import type { SourceCanvasFileRef } from './types';
 import type { SourceCanvasContentState } from './useSourceCanvasContent';
 
@@ -132,40 +135,51 @@ export function SourceCanvasPanel({ fileRef, wsId, content, onClose }: SourceCan
                     </button>
                 </div>
             </div>
-            <div className="flex-1 min-h-0 overflow-auto" data-testid="source-canvas-body">
-                {/* AC-06 loading / error states; AC-04 success rendering
-                    (formatted markdown vs syntax-highlighted source). */}
-                {(!content || content.status === 'loading') && (
-                    <div
-                        className="flex items-center gap-2 p-4 text-xs text-[#848484]"
-                        data-testid="source-canvas-loading"
-                    >
-                        <Spinner size="sm" /> Loading {fileName}…
-                    </div>
-                )}
-                {content && content.status === 'error' && (
-                    <div className="p-4 text-xs" data-testid="source-canvas-error">
+            {fileRef.kind === 'note' ? (
+                /* Editable markdown mode (AC-02): the NoteEditor loads + saves
+                   its own content, so the read-only fetch/states are skipped. */
+                <div
+                    className="flex-1 min-h-0 overflow-hidden flex flex-col"
+                    data-testid="source-canvas-body"
+                >
+                    <SourceCanvasNoteEditor fileRef={fileRef} />
+                </div>
+            ) : (
+                <div className="flex-1 min-h-0 overflow-auto" data-testid="source-canvas-body">
+                    {/* Read-only code mode: AC-06 loading / error states; AC-04
+                        success rendering (markdown vs syntax-highlighted source). */}
+                    {(!content || content.status === 'loading') && (
                         <div
-                            className="font-medium text-[#cc4444] dark:text-[#f48771]"
-                            data-testid="source-canvas-error-msg"
+                            className="flex items-center gap-2 p-4 text-xs text-[#848484]"
+                            data-testid="source-canvas-loading"
                         >
-                            {`Couldn't load ${content.resolvedPath || path}`}
+                            <Spinner size="sm" /> Loading {fileName}…
                         </div>
-                        {content.error && (
-                            <div className="mt-1 text-[#848484]">{content.error}</div>
-                        )}
-                    </div>
-                )}
-                {content && content.status === 'success' && (
-                    <SourceCanvasBody
-                        fileName={fileName}
-                        content={content.content}
-                        language={content.language}
-                        line={fileRef.line}
-                        endLine={fileRef.endLine}
-                    />
-                )}
-            </div>
+                    )}
+                    {content && content.status === 'error' && (
+                        <div className="p-4 text-xs" data-testid="source-canvas-error">
+                            <div
+                                className="font-medium text-[#cc4444] dark:text-[#f48771]"
+                                data-testid="source-canvas-error-msg"
+                            >
+                                {`Couldn't load ${content.resolvedPath || path}`}
+                            </div>
+                            {content.error && (
+                                <div className="mt-1 text-[#848484]">{content.error}</div>
+                            )}
+                        </div>
+                    )}
+                    {content && content.status === 'success' && (
+                        <SourceCanvasBody
+                            fileName={fileName}
+                            content={content.content}
+                            language={content.language}
+                            line={fileRef.line}
+                            endLine={fileRef.endLine}
+                        />
+                    )}
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/index.ts
@@ -5,6 +5,8 @@ export { SourceCanvasPanel } from './SourceCanvasPanel';
 export type { SourceCanvasPanelProps } from './SourceCanvasPanel';
 export { SourceCanvasBody } from './SourceCanvasBody';
 export type { SourceCanvasBodyProps } from './SourceCanvasBody';
+export { SourceCanvasNoteEditor } from './SourceCanvasNoteEditor';
+export type { SourceCanvasNoteEditorProps } from './SourceCanvasNoteEditor';
 export { useSourceCanvasState } from './useSourceCanvasState';
 export type {
     UseSourceCanvasStateOptions,

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/index.ts
@@ -7,6 +7,8 @@ export { SourceCanvasBody } from './SourceCanvasBody';
 export type { SourceCanvasBodyProps } from './SourceCanvasBody';
 export { SourceCanvasNoteEditor } from './SourceCanvasNoteEditor';
 export type { SourceCanvasNoteEditorProps } from './SourceCanvasNoteEditor';
+export { SourceCanvasNotePopOutButton } from './SourceCanvasNotePopOutButton';
+export type { SourceCanvasNotePopOutButtonProps } from './SourceCanvasNotePopOutButton';
 export { useSourceCanvasState } from './useSourceCanvasState';
 export type {
     UseSourceCanvasStateOptions,

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/index.ts
@@ -3,6 +3,8 @@
  */
 export { SourceCanvasPanel } from './SourceCanvasPanel';
 export type { SourceCanvasPanelProps } from './SourceCanvasPanel';
+export { SourceCanvasDock } from './SourceCanvasDock';
+export type { SourceCanvasDockProps } from './SourceCanvasDock';
 export { SourceCanvasBody } from './SourceCanvasBody';
 export type { SourceCanvasBodyProps } from './SourceCanvasBody';
 export { SourceCanvasNoteEditor } from './SourceCanvasNoteEditor';

--- a/packages/coc/src/server/spa/client/react/features/chat/source-canvas/types.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/source-canvas/types.ts
@@ -23,4 +23,9 @@ export interface SourceCanvasFileRef {
     sourceFilePath?: string;
     /** Workspace-id hint from the clicked container, if known. */
     wsId?: string;
+    /**
+     * Body mode for the docked panel: `'note'` renders the editable markdown
+     * NoteEditor; `'code'` (or omitted) renders the read-only source viewer.
+     */
+    kind?: 'note' | 'code';
 }

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
@@ -22,6 +22,7 @@ import { extractHeadings } from './noteTocUtils';
 import './noteEditor.css';
 
 import { NoteConflictBanner } from './NoteConflictBanner';
+import { computeBestEffortScrollTop } from './noteScrollToLine';
 import { resetEditorHistory } from './editorHistory';
 import { FilePreviewTooltip } from './FilePreviewTooltip';
 import { NoteVersionHistoryPanel } from './NoteVersionHistoryPanel';
@@ -80,6 +81,11 @@ export interface NoteEditorProps {
     isDefaultRoot?: boolean;
     /** Root identifier for multi-root notes support. When set, scopes content/image API calls. */
     root?: string;
+    /** Best-effort: 1-based source line to scroll near when the note opens. When
+     *  set, the editor proportionally scrolls toward this line once content has
+     *  loaded; it falls back to the top when a precise jump is not feasible.
+     *  No range highlight is applied. */
+    scrollToLine?: number | null;
 }
 
 type SaveState = 'idle' | 'saving' | 'saved' | 'error' | 'conflict';
@@ -181,6 +187,7 @@ export function NoteEditor({
     onAddNoteReference,
     isDefaultRoot = true,
     root,
+    scrollToLine,
 }: NoteEditorProps) {
     const [loading, setLoading] = useState(false);
     const [refreshCounter, setRefreshCounter] = useState(0);
@@ -1138,6 +1145,39 @@ export function NoteEditor({
     }, [dirty]);
 
     const isEmpty = notePath === null;
+
+    // ── Best-effort scroll to a referenced source line (AC-04) ──────────────
+    //
+    // Runs once content has loaded (loading flips false) for the current note.
+    // The rich editor has no exact line→position map, so we scroll the editor
+    // container proportionally; when nothing is scrollable (e.g. jsdom, or a
+    // short note) it simply stays at the top. No range is highlighted.
+    useEffect(() => {
+        if (!scrollToLine || scrollToLine <= 1) return;
+        if (isEmpty || loading || loadError) return;
+        let raf = 0;
+        const run = () => {
+            const container = editorScrollContainerRef.current;
+            if (!container) return;
+            const totalLines = Math.max(1, rawMarkdownRef.current.split('\n').length);
+            const top = computeBestEffortScrollTop({
+                line: scrollToLine,
+                totalLines,
+                scrollHeight: container.scrollHeight,
+                clientHeight: container.clientHeight,
+            });
+            if (top > 0) container.scrollTop = top;
+        };
+        if (typeof requestAnimationFrame === 'function') {
+            raf = requestAnimationFrame(run);
+        } else {
+            run();
+        }
+        return () => {
+            if (raf && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(raf);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [notePath, scrollToLine, loading, loadError]);
 
     // ── Render ────────────────────────────────────────────────────────────────
     //

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/noteScrollToLine.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/noteScrollToLine.ts
@@ -1,0 +1,40 @@
+/**
+ * Best-effort "scroll to a source line" for the rich NoteEditor (AC-04).
+ *
+ * The rich editor renders Markdown as a ProseMirror document, so a source
+ * line number does not map to an exact DOM offset. Rather than guess a precise
+ * position, we scroll the editor's scroll container *proportionally*: line N of
+ * a T-line document scrolls roughly `(N - 1) / T` of the way down. That lands
+ * the referenced region near the viewport without claiming pixel accuracy, and
+ * degrades to "stay at the top" whenever the inputs make any jump pointless —
+ * no/first line, a single-line document, or nothing scrollable yet (e.g. the
+ * jsdom test environment, where layout heights are 0).
+ */
+export interface BestEffortScrollInput {
+    /** 1-based source line the clicked link referenced, if any. */
+    line?: number | null;
+    /** Total number of lines in the loaded markdown. */
+    totalLines: number;
+    /** Scrollable content height of the editor container, in px. */
+    scrollHeight: number;
+    /** Visible height of the editor container, in px. */
+    clientHeight: number;
+}
+
+/**
+ * Compute the `scrollTop` (px) for a best-effort jump to `line`. Returns `0`
+ * (open at the top) whenever a meaningful jump is not feasible.
+ */
+export function computeBestEffortScrollTop({
+    line,
+    totalLines,
+    scrollHeight,
+    clientHeight,
+}: BestEffortScrollInput): number {
+    if (!line || !Number.isFinite(line) || line <= 1) return 0;
+    if (!Number.isFinite(totalLines) || totalLines <= 1) return 0;
+    const maxScroll = scrollHeight - clientHeight;
+    if (!Number.isFinite(maxScroll) || maxScroll <= 0) return 0;
+    const ratio = Math.min(1, Math.max(0, (line - 1) / totalLines));
+    return Math.round(ratio * maxScroll);
+}

--- a/packages/coc/src/server/spa/client/react/shared/file-path/file-path-preview.ts
+++ b/packages/coc/src/server/spa/client/react/shared/file-path/file-path-preview.ts
@@ -236,7 +236,21 @@ function readSourceFilePath(el: HTMLElement): string | undefined {
     return el.closest('[data-source-file]')?.getAttribute('data-source-file') || undefined;
 }
 
-function dispatchOpenSourceCanvas(ref: FileReference): void {
+const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdx']);
+
+/** A `.md`/`.markdown`/`.mdx` path (ignoring any `?query`/`#hash` suffix). */
+function isMarkdownPath(path: string): boolean {
+    const clean = path.split(/[?#]/)[0];
+    const ext = clean.split('.').pop()?.toLowerCase() || '';
+    return MARKDOWN_EXTENSIONS.has(ext);
+}
+
+/**
+ * Open the docked source canvas. `kind` discriminates the body mode the host
+ * renders: `'note'` → the editable markdown NoteEditor, otherwise → the
+ * read-only syntax-highlighted source viewer.
+ */
+function dispatchOpenSourceCanvas(ref: FileReference, kind?: 'note'): void {
     window.dispatchEvent(new CustomEvent('coc-open-source-canvas', {
         detail: {
             filePath: ref.filePath,
@@ -244,6 +258,7 @@ function dispatchOpenSourceCanvas(ref: FileReference): void {
             line: ref.line,
             endLine: ref.endLine,
             sourceFilePath: ref.sourceFilePath,
+            ...(kind ? { kind } : {}),
         },
     }));
 }
@@ -264,20 +279,29 @@ function dispatchOpenMarkdownReview(ref: FileReference): void {
 /**
  * Open a clicked local file reference.
  *
- * Inside a chat AI response (`.chat-message.assistant`) — and when the
- * source-canvas feature flag is ON — this routes to the docked, read-only
- * source-file canvas via `coc-open-source-canvas`, carrying any `:line` /
- * `:start-end` info separately from the bare path. Everywhere else (flag OFF,
- * or non-chat surfaces like the tasks tree / notes) it falls back to the
- * floating `MarkdownReviewDialog`.
+ * When the source-canvas feature flag is ON, chat-message links route to the
+ * docked canvas via `coc-open-source-canvas` (carrying any `:line`/`:start-end`
+ * info separately from the bare path):
+ *  - **markdown** (`.md`/`.markdown`/`.mdx`) opens the editable NoteEditor from
+ *    ANY `.chat-message` (user or assistant), tagged `kind: 'note'`;
+ *  - **code** opens the read-only source viewer from a `.chat-message.assistant`
+ *    only (user-message code keeps the floating dialog).
+ *
+ * Everywhere else (flag OFF, or non-chat surfaces like the tasks tree / notes)
+ * it falls back to the floating `MarkdownReviewDialog`.
  */
 function openFileReference(sourceEl: HTMLElement, ref: FileReference): void {
     hideTooltip();
 
-    const inChatResponse = !!sourceEl.closest('.chat-message.assistant');
-    if (SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS && inChatResponse) {
-        dispatchOpenSourceCanvas(ref);
-        return;
+    if (SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS) {
+        if (isMarkdownPath(ref.filePath) && sourceEl.closest('.chat-message')) {
+            dispatchOpenSourceCanvas(ref, 'note');
+            return;
+        }
+        if (!isMarkdownPath(ref.filePath) && sourceEl.closest('.chat-message.assistant')) {
+            dispatchOpenSourceCanvas(ref);
+            return;
+        }
     }
 
     dispatchOpenMarkdownReview(ref);

--- a/packages/coc/src/server/spa/client/react/shared/markdown-review/resolveMarkdownReviewTarget.ts
+++ b/packages/coc/src/server/spa/client/react/shared/markdown-review/resolveMarkdownReviewTarget.ts
@@ -1,0 +1,170 @@
+/**
+ * Shared resolution for opening a markdown file in an editable NoteEditor —
+ * used by BOTH the floating `MarkdownReviewDialog` (via `App.tsx`'s
+ * `coc-open-markdown-review` handler) and the docked source canvas (AC-02).
+ *
+ * Given a clicked file reference (absolute or relative path, optional workspace
+ * hint, optional source file for relative resolution) and the known workspaces,
+ * it decides:
+ *  - which workspace to edit in (`wsId`),
+ *  - the path to load/save (`filePath`) — task-relative when the file lives
+ *    under `.vscode/tasks/`, otherwise the full path,
+ *  - the path to show in the header (`displayPath`),
+ *  - which NoteEditor IO adapter to use (`fetchMode`: `'tasks'` vs `'auto'`),
+ *  - the absolute task-root path when known (`taskRootPath`).
+ *
+ * Returns `null` when no workspace can be resolved, so callers can bail without
+ * opening an editor on an unresolvable path.
+ *
+ * This mirrors what `App.tsx`'s handler used to compute inline; keeping it in
+ * one place keeps the floating dialog and the canvas editor in sync.
+ */
+import { toForwardSlashes } from '@plusplusoneplusplus/forge/utils/path-utils';
+import { isAbsolutePath, resolveRelativePath } from '../../utils/path-resolution';
+
+/* @internal – exported for testing only */
+export interface WorkspaceLike {
+    id: string;
+    name?: string;
+    rootPath?: string;
+}
+
+export type MarkdownReviewFetchMode = 'tasks' | 'auto';
+
+export interface MarkdownReviewTarget {
+    /** Workspace id to edit in. */
+    wsId: string;
+    /** Path to load/save — task-relative under `.vscode/tasks/`, else the full path. */
+    filePath: string;
+    /** Path shown in the header (the absolute/full path). */
+    displayPath: string;
+    /** Which NoteEditor IO adapter to use. */
+    fetchMode: MarkdownReviewFetchMode;
+    /** Absolute task-root path, when known (fast-path event hint or TaskTree). */
+    taskRootPath?: string;
+}
+
+export interface MarkdownReviewInput {
+    /** The clicked file path (absolute, workspace-relative, or task-relative). */
+    filePath: string;
+    /** Explicit workspace-id hint from the clicked container, if any. */
+    wsId?: string;
+    /** The file the (possibly relative) reference appeared in — for resolution. */
+    sourceFilePath?: string;
+    /** Absolute task-root path hint carried by the event, if any. */
+    taskRootPath?: string;
+}
+
+function normalizePath(pathValue: string): string {
+    return toForwardSlashes(pathValue);
+}
+
+/**
+ * Pick the workspace whose `rootPath` is the longest prefix of `filePath`
+ * (case-insensitive), or `null` when none contains it.
+ */
+/* @internal – exported for testing only */
+export function resolveWorkspaceForPath(
+    filePath: string,
+    workspaces: WorkspaceLike[],
+): WorkspaceLike | null {
+    const normalizedPath = normalizePath(filePath).toLowerCase();
+    let best: WorkspaceLike | null = null;
+
+    for (const ws of workspaces) {
+        if (!ws?.rootPath) continue;
+        const normalizedRoot = normalizePath(ws.rootPath).replace(/\/+$/, '').toLowerCase();
+        if (!normalizedRoot) continue;
+
+        if (normalizedPath === normalizedRoot || normalizedPath.startsWith(normalizedRoot + '/')) {
+            if (!best || normalizedRoot.length > normalizePath(best.rootPath || '').toLowerCase().length) {
+                best = ws;
+            }
+        }
+    }
+
+    return best;
+}
+
+/**
+ * Path of `fullPath` relative to the workspace's `.vscode/tasks` directory, or
+ * `null` when it does not live under it. `''` means it IS the tasks root.
+ */
+function toTaskRelativePath(fullPath: string, workspaceRoot: string): string | null {
+    if (!workspaceRoot) return null;
+    const normalizedPath = normalizePath(fullPath);
+    const normalizedRoot = normalizePath(workspaceRoot).replace(/\/+$/, '');
+    const tasksRoot = `${normalizedRoot}/.vscode/tasks`;
+
+    if (normalizedPath === tasksRoot) return '';
+    if (!normalizedPath.startsWith(tasksRoot + '/')) return null;
+
+    return normalizedPath.slice(tasksRoot.length + 1);
+}
+
+/**
+ * Resolve a clicked markdown reference into the inputs an editable NoteEditor
+ * needs, or `null` when no workspace can be determined.
+ */
+export function resolveMarkdownReviewTarget(
+    input: MarkdownReviewInput,
+    workspaces: WorkspaceLike[],
+): MarkdownReviewTarget | null {
+    let filePath = typeof input.filePath === 'string' ? input.filePath : '';
+    if (!filePath) return null;
+
+    const wsIdHint = typeof input.wsId === 'string' ? input.wsId : '';
+    const eventTaskRootPath = typeof input.taskRootPath === 'string' ? input.taskRootPath : undefined;
+
+    // Fast path: wsId hint provided — use that workspace directly.
+    if (wsIdHint) {
+        const hintedWorkspace = (workspaces || []).find((ws) => ws.id === wsIdHint);
+        if (hintedWorkspace) {
+            if (isAbsolutePath(filePath)) {
+                // Absolute path from a chat click — fetchMode by task membership.
+                const taskRelativePath = toTaskRelativePath(filePath, hintedWorkspace.rootPath || '');
+                return {
+                    wsId: hintedWorkspace.id,
+                    filePath: taskRelativePath ?? filePath,
+                    displayPath: filePath,
+                    fetchMode: taskRelativePath !== null ? 'tasks' : 'auto',
+                    taskRootPath: eventTaskRootPath,
+                };
+            }
+            // Task-relative path (e.g. from the TaskTree).
+            const displayBase = eventTaskRootPath
+                ? normalizePath(eventTaskRootPath).replace(/\/+$/, '')
+                : (() => {
+                    const rootNormalized = normalizePath(hintedWorkspace.rootPath || '').replace(/\/+$/, '');
+                    return rootNormalized ? `${rootNormalized}/.vscode/tasks` : '';
+                })();
+            const displayPath = displayBase ? `${displayBase}/${filePath}` : filePath;
+            return {
+                wsId: hintedWorkspace.id,
+                filePath,
+                displayPath,
+                fetchMode: 'tasks',
+                taskRootPath: eventTaskRootPath,
+            };
+        }
+    }
+
+    // Resolve relative paths against the source file's directory.
+    const sourceFilePath = typeof input.sourceFilePath === 'string' ? input.sourceFilePath : '';
+    if (sourceFilePath && !isAbsolutePath(filePath)) {
+        const sourceDir = normalizePath(sourceFilePath).replace(/\/[^/]*$/, '');
+        filePath = resolveRelativePath(sourceDir, filePath);
+    }
+
+    const fullPath = filePath;
+    const workspace = resolveWorkspaceForPath(fullPath, workspaces || []);
+    if (!workspace?.id) return null;
+
+    const taskRelativePath = toTaskRelativePath(fullPath, workspace.rootPath || '');
+    return {
+        wsId: workspace.id,
+        filePath: taskRelativePath ?? fullPath,
+        displayPath: fullPath,
+        fetchMode: taskRelativePath !== null ? 'tasks' : 'auto',
+    };
+}

--- a/packages/coc/test/e2e/markdown-review-dialog.spec.ts
+++ b/packages/coc/test/e2e/markdown-review-dialog.spec.ts
@@ -2,8 +2,13 @@
  * MarkdownReviewDialog E2E Tests
  *
  * Tests the full lifecycle of the MarkdownReviewDialog opened by clicking
- * a `.file-path-link` outside an assistant response: open → display →
- * minimize → chip (pill) → restore → close.
+ * a `.file-path-link` in a user message for a non-markdown file: open →
+ * display → minimize → chip (pill) → restore → close.
+ *
+ * NOTE: Markdown file links inside any `.chat-message` are intercepted by the
+ * SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS feature flag and routed to the docked
+ * canvas. To keep the MarkdownReviewDialog reachable we use a non-markdown
+ * file path (`.ts`), which falls through to the floating dialog.
  */
 
 import { test, expect } from './fixtures/server-fixture';
@@ -13,7 +18,9 @@ import type { Page } from '@playwright/test';
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
 const WORKSPACE_ROOT = '/tmp/review-ws';
-const FILE_PATH = '/tmp/review-ws/docs/README.md';
+// Use a non-markdown extension so the click falls through to MarkdownReviewDialog.
+// Markdown links inside .chat-message are intercepted by SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS.
+const FILE_PATH = '/tmp/review-ws/src/main.ts';
 
 async function waitForTaskStatus(
     serverUrl: string,
@@ -156,7 +163,7 @@ test.describe('MarkdownReviewDialog', () => {
         await expect(pill).toBeVisible({ timeout: 3_000 });
 
         // Pill text should contain the filename
-        await expect(pill).toContainText('README.md');
+        await expect(pill).toContainText('main.ts');
     });
 
     test('restore from chip reopens the dialog', async ({

--- a/packages/coc/test/spa/react/EditableNoteCanvasFallbackGuard.test.ts
+++ b/packages/coc/test/spa/react/EditableNoteCanvasFallbackGuard.test.ts
@@ -1,0 +1,129 @@
+/**
+ * AC-06 guard — floating dialog fallback preserved; read-only code path unchanged.
+ *
+ * The editable-note-canvas feature only diverts the *in-chat markdown* branch to
+ * the docked canvas. Every other surface keeps the floating `MarkdownReviewDialog`,
+ * and code references keep the read-only syntax-highlighted source viewer. The
+ * spec explicitly notes the read-only `MarkdownCanvasView` "may be cleaned up in a
+ * later pass" — this static guard fails loudly if a future change silently removes
+ * any of the fallback artifacts, so the divert can never become a one-way door.
+ *
+ * Behavioural routing (flag on/off × markdown/code × chat/non-chat) is exercised in
+ * FilePathPreview.test.ts. This file is purely structural — it reads source and
+ * asserts the fallback wiring still exists.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const REACT_ROOT = join(__dirname, '../../../src/server/spa/client/react');
+
+function read(relativePath: string): string {
+    return readFileSync(join(REACT_ROOT, relativePath), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// 1. The floating MarkdownReviewDialog component still exists and is mounted.
+// ---------------------------------------------------------------------------
+describe('AC-06 — floating MarkdownReviewDialog preserved', () => {
+    const dialog = read('processes/MarkdownReviewDialog.tsx');
+    const app = read('App.tsx');
+
+    it('MarkdownReviewDialog component is still exported', () => {
+        expect(dialog).toContain('export function MarkdownReviewDialog');
+    });
+
+    it('App.tsx still imports and renders <MarkdownReviewDialog />', () => {
+        expect(app).toContain("import { MarkdownReviewDialog } from './processes/MarkdownReviewDialog'");
+        expect(app).toContain('<MarkdownReviewDialog');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The coc-open-markdown-review event channel is still wired end-to-end.
+// ---------------------------------------------------------------------------
+describe('AC-06 — coc-open-markdown-review event channel intact', () => {
+    const preview = read('shared/file-path/file-path-preview.ts');
+    const app = read('App.tsx');
+
+    it('file-path-preview still dispatches coc-open-markdown-review (the fallback)', () => {
+        expect(preview).toContain("new CustomEvent('coc-open-markdown-review'");
+    });
+
+    it('App.tsx still registers a coc-open-markdown-review listener', () => {
+        expect(app).toContain("window.addEventListener('coc-open-markdown-review'");
+        expect(app).toContain("window.removeEventListener('coc-open-markdown-review'");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The floating dialog is the UNCONDITIONAL fallback in openFileReference:
+//    the canvas branches are gated by SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS, and
+//    control falls through to dispatchOpenMarkdownReview when none match.
+// ---------------------------------------------------------------------------
+describe('AC-06 — floating dialog is the fallback after the flag-gated canvas branches', () => {
+    const preview = read('shared/file-path/file-path-preview.ts');
+
+    it('the only gate is SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS (no new flag added)', () => {
+        expect(preview).toContain('if (SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS)');
+    });
+
+    it('openFileReference falls through to dispatchOpenMarkdownReview', () => {
+        const fn = preview.slice(
+            preview.indexOf('function openFileReference('),
+            preview.indexOf('function openFilePathLink('),
+        );
+        expect(fn).toBeTruthy();
+        // The canvas dispatches sit inside the flag guard...
+        expect(fn).toContain('dispatchOpenSourceCanvas(ref');
+        // ...and the final, un-guarded statement is the floating-dialog fallback.
+        const lastDispatch = fn.lastIndexOf('dispatchOpenMarkdownReview(ref)');
+        const lastCanvas = fn.lastIndexOf('dispatchOpenSourceCanvas(ref');
+        expect(lastDispatch).toBeGreaterThan(lastCanvas);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Code references keep the READ-ONLY source viewer behaviour:
+//    markdown chat links carry kind 'note', code chat links do NOT, and the
+//    code branch stays assistant-only.
+// ---------------------------------------------------------------------------
+describe('AC-06 — code references stay read-only and assistant-only', () => {
+    const preview = read('shared/file-path/file-path-preview.ts');
+
+    it('markdown chat links open as an editable note (kind: note)', () => {
+        expect(preview).toContain("dispatchOpenSourceCanvas(ref, 'note')");
+    });
+
+    it('code chat links open the read-only viewer (no note kind) from assistant messages only', () => {
+        expect(preview).toContain("sourceEl.closest('.chat-message.assistant')");
+        // The non-markdown branch dispatches WITHOUT a kind argument.
+        expect(preview).toMatch(/!isMarkdownPath\(ref\.filePath\)[\s\S]*?dispatchOpenSourceCanvas\(ref\);/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 5. The read-only MarkdownCanvasView still exists inside SourceCanvasBody and
+//    is still the renderer for markdown refs — it must NOT have become editable.
+// ---------------------------------------------------------------------------
+describe('AC-06 — read-only MarkdownCanvasView preserved', () => {
+    const body = read('features/chat/source-canvas/SourceCanvasBody.tsx');
+
+    it('MarkdownCanvasView is still defined', () => {
+        expect(body).toContain('function MarkdownCanvasView(');
+    });
+
+    it('markdown files in the read-only body still render MarkdownCanvasView', () => {
+        expect(body).toContain('isMarkdownFile(fileName, language)');
+        expect(body).toContain('<MarkdownCanvasView content={content} range={range} />');
+    });
+
+    it('it keeps its read-only Rendered ⇄ Raw toggle (no inline editing)', () => {
+        expect(body).toContain("{raw ? 'Rendered' : 'Raw'}");
+    });
+
+    it('the read-only body never mounts the editable NoteEditor', () => {
+        expect(body).not.toContain('NoteEditor');
+    });
+});

--- a/packages/coc/test/spa/react/FilePathPreview.test.ts
+++ b/packages/coc/test/spa/react/FilePathPreview.test.ts
@@ -718,6 +718,239 @@ describe('source-canvas routing for chat AI-response file-path links (AC-03)', (
     });
 });
 
+describe('editable-note canvas routing for markdown chat links (AC-01)', () => {
+    const PREVIEW_MODULE = '../../../src/server/spa/client/react/shared/file-path/file-path-preview';
+    const FLAGS_MODULE = '../../../src/server/spa/client/react/featureFlags';
+
+    function freshBody(): void {
+        document.body = document.createElement('body');
+    }
+
+    beforeEach(() => {
+        freshBody();
+        vi.resetModules();
+        vi.doUnmock(FLAGS_MODULE);
+        delete (window as any).__COC_FILE_PATH_PREVIEW_DELEGATION__;
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ workspaces: [] }),
+        }) as any);
+    });
+
+    afterEach(() => {
+        vi.doUnmock(FLAGS_MODULE);
+        vi.resetModules();
+        vi.restoreAllMocks();
+        delete (window as any).__COC_FILE_PATH_PREVIEW_DELEGATION__;
+        freshBody();
+    });
+
+    function mockFlagOff(): void {
+        vi.doMock(FLAGS_MODULE, () => ({
+            SHOW_WELCOME_TUTORIAL: true,
+            SHOW_FOCUSED_DIFF: true,
+            SHOW_EXCALIDRAW_DIAGRAMS: true,
+            SHOW_SOURCE_CANVAS_FOR_CHAT_LINKS: false,
+            RALPH_MULTI_LOOP: false,
+        }));
+    }
+
+    function clickLink(selector = '.file-path-link'): ReturnType<typeof vi.spyOn> {
+        const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+        const link = document.querySelector(selector) as HTMLElement;
+        link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        return dispatchSpy as any;
+    }
+
+    function eventCalls(dispatchSpy: ReturnType<typeof vi.spyOn>, eventType: string): any[] {
+        return (dispatchSpy.mock.calls as any[]).filter(
+            ([e]) => (e as Event)?.type === eventType
+        );
+    }
+
+    // ── Flag ON ─────────────────────────────────────────────────────────────
+
+    it('markdown + assistant message → source canvas as an editable note (kind: note)', async () => {
+        const fullPath = '/repo/docs/plan.md';
+        document.body.innerHTML = `
+            <div class="chat-message assistant" data-ws-id="ws-1">
+                <span class="file-path-link" data-full-path="${fullPath}" data-line="40">plan.md:40</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        const call = eventCalls(dispatchSpy, 'coc-open-source-canvas')[0];
+        expect(call).toBeTruthy();
+        expect(call[0].detail).toEqual(expect.objectContaining({
+            filePath: fullPath,
+            wsId: 'ws-1',
+            line: 40,
+            kind: 'note',
+        }));
+        expect(eventCalls(dispatchSpy, 'coc-open-markdown-review')).toHaveLength(0);
+    });
+
+    it('markdown + USER message → source canvas as an editable note (widened beyond assistant)', async () => {
+        const fullPath = '/repo/docs/note.markdown';
+        document.body.innerHTML = `
+            <div class="chat-message user" data-ws-id="ws-1">
+                <span class="file-path-link" data-full-path="${fullPath}">note.markdown</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        const call = eventCalls(dispatchSpy, 'coc-open-source-canvas')[0];
+        expect(call).toBeTruthy();
+        expect(call[0].detail).toEqual(expect.objectContaining({
+            filePath: fullPath,
+            kind: 'note',
+        }));
+        expect(eventCalls(dispatchSpy, 'coc-open-markdown-review')).toHaveLength(0);
+    });
+
+    it('markdown md-link anchor in a chat message → editable note from data-href', async () => {
+        const fullPath = '/repo/docs/spec.mdx';
+        document.body.innerHTML = `
+            <div class="chat-message assistant" data-ws-id="ws-1" data-source-file="/repo/docs/current.md">
+                <span class="md-link" data-href="${fullPath}:12">
+                    <span class="md-link-text">[open spec]</span>
+                </span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink('.md-link-text');
+
+        const call = eventCalls(dispatchSpy, 'coc-open-source-canvas')[0];
+        expect(call).toBeTruthy();
+        expect(call[0].detail).toEqual(expect.objectContaining({
+            filePath: fullPath,
+            wsId: 'ws-1',
+            line: 12,
+            sourceFilePath: '/repo/docs/current.md',
+            kind: 'note',
+        }));
+        expect(eventCalls(dispatchSpy, 'coc-open-markdown-review')).toHaveLength(0);
+    });
+
+    it('markdown + non-chat surface (tasks tree) → keeps floating dialog', async () => {
+        const fullPath = '/repo/tasks/plan.md';
+        document.body.innerHTML = `
+            <div class="task-tree">
+                <span class="file-path-link" data-full-path="${fullPath}">plan.md</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'coc-open-markdown-review',
+                detail: { filePath: fullPath },
+            })
+        );
+        expect(eventCalls(dispatchSpy, 'coc-open-source-canvas')).toHaveLength(0);
+    });
+
+    it('code + assistant message → read-only source canvas (no note kind)', async () => {
+        const fullPath = '/repo/src/foo.ts';
+        document.body.innerHTML = `
+            <div class="chat-message assistant" data-ws-id="ws-1">
+                <span class="file-path-link" data-full-path="${fullPath}" data-line="42">foo.ts:42</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        const call = eventCalls(dispatchSpy, 'coc-open-source-canvas')[0];
+        expect(call).toBeTruthy();
+        expect(call[0].detail.filePath).toBe(fullPath);
+        expect(call[0].detail.kind).toBeUndefined();
+        expect(eventCalls(dispatchSpy, 'coc-open-markdown-review')).toHaveLength(0);
+    });
+
+    it('code + USER message → keeps floating dialog (code stays assistant-only)', async () => {
+        const fullPath = '/repo/src/foo.ts';
+        document.body.innerHTML = `
+            <div class="chat-message user">
+                <span class="file-path-link" data-full-path="${fullPath}">foo.ts</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'coc-open-markdown-review' })
+        );
+        expect(eventCalls(dispatchSpy, 'coc-open-source-canvas')).toHaveLength(0);
+    });
+
+    it('code + non-chat surface → keeps floating dialog', async () => {
+        const fullPath = '/repo/src/foo.ts';
+        document.body.innerHTML = `
+            <div class="task-tree">
+                <span class="file-path-link" data-full-path="${fullPath}">foo.ts</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'coc-open-markdown-review' })
+        );
+        expect(eventCalls(dispatchSpy, 'coc-open-source-canvas')).toHaveLength(0);
+    });
+
+    // ── Flag OFF → every chat link falls back to the floating dialog ─────────
+
+    it('flag OFF + markdown + assistant message → floating dialog', async () => {
+        mockFlagOff();
+        const fullPath = '/repo/docs/plan.md';
+        document.body.innerHTML = `
+            <div class="chat-message assistant" data-ws-id="ws-1">
+                <span class="file-path-link" data-full-path="${fullPath}">plan.md</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'coc-open-markdown-review',
+                detail: { filePath: fullPath, wsId: 'ws-1' },
+            })
+        );
+        expect(eventCalls(dispatchSpy, 'coc-open-source-canvas')).toHaveLength(0);
+    });
+
+    it('flag OFF + markdown + USER message → floating dialog', async () => {
+        mockFlagOff();
+        const fullPath = '/repo/docs/plan.md';
+        document.body.innerHTML = `
+            <div class="chat-message user">
+                <span class="file-path-link" data-full-path="${fullPath}">plan.md</span>
+            </div>
+        `;
+
+        await import(PREVIEW_MODULE);
+        const dispatchSpy = clickLink();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'coc-open-markdown-review' })
+        );
+        expect(eventCalls(dispatchSpy, 'coc-open-source-canvas')).toHaveLength(0);
+    });
+});
+
 function mockWorkspaceAndDirectoryPreview(fetchMock: ReturnType<typeof vi.fn>, overrides?: {
     dirName?: string;
     entries?: { name: string; isDirectory: boolean }[];

--- a/packages/coc/test/spa/react/SourceCanvasDock.test.tsx
+++ b/packages/coc/test/spa/react/SourceCanvasDock.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for SourceCanvasDock — the mobile-vs-desktop host shell for the docked
+ * source-file canvas (AC-05).
+ *
+ * Mobile (`isMobile`) → the panel renders inside a `BottomSheet`; the editable
+ * NoteEditor for a markdown note must live inside that sheet (not a desktop
+ * column, not the floating dialog). Desktop → a resizable sibling column.
+ *
+ * The real `SourceCanvasPanel` is rendered so the test exercises the actual
+ * Dock → BottomSheet → Panel composition; only the heavy NoteEditor / pop-out
+ * leaves are stubbed (same approach as SourceCanvasPanel.test.tsx).
+ */
+/* @vitest-environment jsdom */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({ explorer: { reveal: vi.fn(() => Promise.resolve()) } }),
+}));
+
+// Stub the editable note body so the dock test stays focused on the shell
+// (BottomSheet vs column) without pulling in the full NoteEditor / TipTap stack.
+vi.mock('../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor', () => ({
+    SourceCanvasNoteEditor: ({ fileRef }: any) => (
+        <div data-testid="source-canvas-note-editor-stub" data-full-path={fileRef.fullPath} />
+    ),
+}));
+
+// Stub the pop-out button — it pulls in App/Toast/MarkdownPopOut contexts.
+vi.mock('../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNotePopOutButton', () => ({
+    SourceCanvasNotePopOutButton: ({ onClose }: any) => (
+        <button type="button" data-testid="source-canvas-popout-btn" onClick={onClose} />
+    ),
+}));
+
+import { SourceCanvasDock } from '../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasDock';
+
+const resize = { width: 560, handleMouseDown: vi.fn(), handleTouchStart: vi.fn() };
+const noteRef = { fullPath: '/home/u/proj/notes/x.md', kind: 'note' as const };
+const codeRef = { fullPath: '/home/u/proj/src/foo.ts', kind: 'code' as const };
+
+describe('SourceCanvasDock', () => {
+    it('hosts the editable note editor inside a BottomSheet at the mobile breakpoint (AC-05)', () => {
+        render(
+            <SourceCanvasDock
+                fileRef={noteRef}
+                wsId="ws1"
+                isMobile
+                onClose={() => {}}
+                resize={resize}
+            />,
+        );
+        const sheet = screen.getByTestId('bottomsheet-panel');
+        expect(sheet).toBeTruthy();
+        // The editable NoteEditor renders *inside* the BottomSheet shell…
+        const editor = screen.getByTestId('source-canvas-note-editor-stub');
+        expect(sheet.contains(editor)).toBe(true);
+        expect(editor.getAttribute('data-full-path')).toBe('/home/u/proj/notes/x.md');
+        // …and the desktop column is NOT rendered on mobile.
+        expect(screen.queryByTestId('source-canvas-column')).toBeNull();
+        expect(screen.queryByTestId('source-canvas-resize-handle')).toBeNull();
+    });
+
+    it('uses the resizable desktop column (not a BottomSheet) when not mobile', () => {
+        render(
+            <SourceCanvasDock
+                fileRef={noteRef}
+                wsId="ws1"
+                isMobile={false}
+                onClose={() => {}}
+                resize={resize}
+            />,
+        );
+        const column = screen.getByTestId('source-canvas-column');
+        expect(column).toBeTruthy();
+        expect((column as HTMLElement).style.width).toBe('560px');
+        expect(screen.getByTestId('source-canvas-resize-handle')).toBeTruthy();
+        // The note editor renders in the column, and there is no BottomSheet.
+        expect(column.contains(screen.getByTestId('source-canvas-note-editor-stub'))).toBe(true);
+        expect(screen.queryByTestId('bottomsheet-panel')).toBeNull();
+    });
+
+    it('hosts the read-only code viewer inside the BottomSheet for a code ref on mobile', () => {
+        render(
+            <SourceCanvasDock
+                fileRef={codeRef}
+                wsId="ws1"
+                content={{
+                    status: 'success',
+                    content: 'const x = 1;\n',
+                    language: 'typescript',
+                    resolvedPath: '/home/u/proj/src/foo.ts',
+                    error: '',
+                }}
+                isMobile
+                onClose={() => {}}
+                resize={resize}
+            />,
+        );
+        const sheet = screen.getByTestId('bottomsheet-panel');
+        // Read-only source viewer inside the sheet; no editable note editor.
+        expect(sheet.contains(screen.getByTestId('source-canvas-source'))).toBe(true);
+        expect(screen.queryByTestId('source-canvas-note-editor-stub')).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/SourceCanvasNoteEditor.test.tsx
+++ b/packages/coc/test/spa/react/SourceCanvasNoteEditor.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for SourceCanvasNoteEditor — the editable markdown body of the docked
+ * source canvas (AC-02). Verifies the embedded NoteEditor is wired with the
+ * shared resolver's workspace/path/IO and the inert `noopCommentBackend`
+ * (parity with the floating dialog), and that an unresolvable ref shows an
+ * error instead of mounting the editor.
+ */
+/* @vitest-environment jsdom */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+/* ── Capture the props the NoteEditor is mounted with ───────────────────── */
+
+const noteEditorProps = vi.fn();
+
+vi.mock('../../../src/server/spa/client/react/features/notes/editor/NoteEditor', () => ({
+    NoteEditor: (props: any) => {
+        noteEditorProps(props);
+        return <div data-testid="note-editor-mock" data-note-path={props.notePath} />;
+    },
+}));
+
+vi.mock('../../../src/server/spa/client/react/tasks/TasksNoteEditorIO', () => ({
+    createTasksNoteEditorIO: () => ({ __kind: 'tasks' }),
+}));
+
+vi.mock('../../../src/server/spa/client/react/tasks/WorkspaceFileNoteEditorIO', () => ({
+    createWorkspaceFileNoteEditorIO: () => ({ __kind: 'workspace' }),
+}));
+
+const workspacesRef: { current: any[] } = { current: [{ id: 'ws1', rootPath: '/home/u/proj' }] };
+vi.mock('../../../src/server/spa/client/react/contexts/AppContext', () => ({
+    useApp: () => ({ state: { workspaces: workspacesRef.current }, dispatch: vi.fn() }),
+}));
+
+import { SourceCanvasNoteEditor } from '../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor';
+import { noopCommentBackend } from '../../../src/server/spa/client/react/features/notes/editor/NoteEditorCommentBackend';
+
+beforeEach(() => {
+    noteEditorProps.mockClear();
+    workspacesRef.current = [{ id: 'ws1', rootPath: '/home/u/proj' }];
+});
+
+describe('SourceCanvasNoteEditor', () => {
+    it('mounts NoteEditor with the inert noopCommentBackend (dialog parity)', () => {
+        const { getByTestId } = render(
+            <SourceCanvasNoteEditor
+                fileRef={{ fullPath: '/home/u/proj/.vscode/tasks/plan.md', kind: 'note' }}
+            />,
+        );
+        expect(getByTestId('source-canvas-note-editor')).toBeTruthy();
+        expect(getByTestId('note-editor-mock')).toBeTruthy();
+        const props = noteEditorProps.mock.calls[0][0];
+        expect(props.commentBackend).toBe(noopCommentBackend);
+    });
+
+    it('uses the tasks IO + task-relative path + taskRootPath for a .vscode/tasks file', () => {
+        render(
+            <SourceCanvasNoteEditor
+                fileRef={{
+                    fullPath: '/home/u/proj/.vscode/tasks/plan.md',
+                    wsId: 'ws1',
+                    kind: 'note',
+                }}
+            />,
+        );
+        const props = noteEditorProps.mock.calls[0][0];
+        expect(props.workspaceId).toBe('ws1');
+        expect(props.notePath).toBe('plan.md');
+        expect(props.io).toEqual({ __kind: 'tasks' });
+    });
+
+    it('uses the workspace-file IO + full path for a markdown file outside tasks', () => {
+        render(
+            <SourceCanvasNoteEditor
+                fileRef={{ fullPath: '/home/u/proj/docs/readme.md', kind: 'note' }}
+            />,
+        );
+        const props = noteEditorProps.mock.calls[0][0];
+        expect(props.workspaceId).toBe('ws1');
+        expect(props.notePath).toBe('/home/u/proj/docs/readme.md');
+        expect(props.io).toEqual({ __kind: 'workspace' });
+    });
+
+    it('shows an error and does not mount the editor when no workspace resolves', () => {
+        workspacesRef.current = [];
+        const { getByTestId, queryByTestId } = render(
+            <SourceCanvasNoteEditor
+                fileRef={{ fullPath: '/elsewhere/x.md', kind: 'note' }}
+            />,
+        );
+        expect(getByTestId('source-canvas-note-error')).toBeTruthy();
+        expect(queryByTestId('note-editor-mock')).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/SourceCanvasNoteEditor.test.tsx
+++ b/packages/coc/test/spa/react/SourceCanvasNoteEditor.test.tsx
@@ -83,6 +83,26 @@ describe('SourceCanvasNoteEditor', () => {
         expect(props.io).toEqual({ __kind: 'workspace' });
     });
 
+    it('forwards the ref line to the editor as scrollToLine (AC-04 best-effort scroll)', () => {
+        render(
+            <SourceCanvasNoteEditor
+                fileRef={{ fullPath: '/home/u/proj/docs/readme.md', kind: 'note', line: 40 }}
+            />,
+        );
+        const props = noteEditorProps.mock.calls[0][0];
+        expect(props.scrollToLine).toBe(40);
+    });
+
+    it('passes no scrollToLine when the ref carried no line (opens at top)', () => {
+        render(
+            <SourceCanvasNoteEditor
+                fileRef={{ fullPath: '/home/u/proj/docs/readme.md', kind: 'note' }}
+            />,
+        );
+        const props = noteEditorProps.mock.calls[0][0];
+        expect(props.scrollToLine).toBeUndefined();
+    });
+
     it('shows an error and does not mount the editor when no workspace resolves', () => {
         workspacesRef.current = [];
         const { getByTestId, queryByTestId } = render(

--- a/packages/coc/test/spa/react/SourceCanvasNotePopOutButton.test.tsx
+++ b/packages/coc/test/spa/react/SourceCanvasNotePopOutButton.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for SourceCanvasNotePopOutButton — the docked note editor's "Pop out"
+ * header action (AC-03). Verifies it builds the same `#popout/markdown` URL the
+ * floating dialog uses (workspace/filePath/displayPath/fetchMode/taskRootPath),
+ * marks the file popped out, closes the canvas note on success, and surfaces a
+ * toast (without closing) when the popup is blocked.
+ */
+/* @vitest-environment jsdom */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+const { markPoppedOutMock, addToastMock } = vi.hoisted(() => ({
+    markPoppedOutMock: vi.fn(),
+    addToastMock: vi.fn(),
+}));
+
+const workspacesRef: { current: any[] } = { current: [{ id: 'ws1', rootPath: '/home/u/proj' }] };
+vi.mock('../../../src/server/spa/client/react/contexts/AppContext', () => ({
+    useApp: () => ({ state: { workspaces: workspacesRef.current }, dispatch: vi.fn() }),
+}));
+
+vi.mock('../../../src/server/spa/client/react/contexts/MarkdownPopOutContext', () => ({
+    useMarkdownPopOut: () => ({ markPoppedOut: markPoppedOutMock }),
+}));
+
+vi.mock('../../../src/server/spa/client/react/contexts/ToastContext', () => ({
+    useGlobalToast: () => ({ addToast: addToastMock }),
+}));
+
+import { SourceCanvasNotePopOutButton } from '../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNotePopOutButton';
+
+beforeEach(() => {
+    markPoppedOutMock.mockClear();
+    addToastMock.mockClear();
+    workspacesRef.current = [{ id: 'ws1', rootPath: '/home/u/proj' }];
+});
+
+describe('SourceCanvasNotePopOutButton', () => {
+    it('opens the #popout/markdown window with the auto fetchMode params for a non-task file', () => {
+        const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+        const onClose = vi.fn();
+        const { getByTestId } = render(
+            <SourceCanvasNotePopOutButton
+                fileRef={{ fullPath: '/home/u/proj/docs/readme.md', kind: 'note' }}
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.click(getByTestId('source-canvas-popout-btn'));
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        const calledUrl = String(openSpy.mock.calls[0][0]);
+        expect(calledUrl).toContain('#popout/markdown');
+        const url = new URL(calledUrl);
+        expect(url.searchParams.get('workspace')).toBe('ws1');
+        expect(url.searchParams.get('filePath')).toBe('/home/u/proj/docs/readme.md');
+        expect(url.searchParams.get('displayPath')).toBe('/home/u/proj/docs/readme.md');
+        expect(url.searchParams.get('fetchMode')).toBe('auto');
+        expect(url.searchParams.get('taskRootPath')).toBeNull();
+
+        // Success path: mark popped out + close the canvas note (dialog parity).
+        expect(markPoppedOutMock).toHaveBeenCalledWith('ws1::/home/u/proj/docs/readme.md');
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(addToastMock).not.toHaveBeenCalled();
+        openSpy.mockRestore();
+    });
+
+    it('uses the tasks fetchMode + task-relative filePath for a .vscode/tasks note', () => {
+        const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+        const { getByTestId } = render(
+            <SourceCanvasNotePopOutButton
+                fileRef={{ fullPath: '/home/u/proj/.vscode/tasks/plan.md', wsId: 'ws1', kind: 'note' }}
+                onClose={() => {}}
+            />,
+        );
+
+        fireEvent.click(getByTestId('source-canvas-popout-btn'));
+
+        const url = new URL(String(openSpy.mock.calls[0][0]));
+        expect(url.searchParams.get('workspace')).toBe('ws1');
+        expect(url.searchParams.get('filePath')).toBe('plan.md');
+        expect(url.searchParams.get('fetchMode')).toBe('tasks');
+        openSpy.mockRestore();
+    });
+
+    it('shows a toast and does NOT close when the popup is blocked', () => {
+        const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+        const onClose = vi.fn();
+        const { getByTestId } = render(
+            <SourceCanvasNotePopOutButton
+                fileRef={{ fullPath: '/home/u/proj/docs/readme.md', kind: 'note' }}
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.click(getByTestId('source-canvas-popout-btn'));
+
+        expect(addToastMock).toHaveBeenCalledWith(
+            'Pop-out blocked. Allow popups for this site and try again.',
+            'error',
+        );
+        expect(markPoppedOutMock).not.toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
+        openSpy.mockRestore();
+    });
+
+    it('is disabled and no-ops when no workspace resolves', () => {
+        workspacesRef.current = [];
+        const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+        const { getByTestId } = render(
+            <SourceCanvasNotePopOutButton
+                fileRef={{ fullPath: '/elsewhere/x.md', kind: 'note' }}
+                onClose={() => {}}
+            />,
+        );
+
+        const btn = getByTestId('source-canvas-popout-btn') as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+        fireEvent.click(btn);
+        expect(openSpy).not.toHaveBeenCalled();
+        openSpy.mockRestore();
+    });
+});

--- a/packages/coc/test/spa/react/SourceCanvasPanel.test.tsx
+++ b/packages/coc/test/spa/react/SourceCanvasPanel.test.tsx
@@ -26,6 +26,14 @@ vi.mock('../../../src/server/spa/client/react/features/chat/source-canvas/Source
     ),
 }));
 
+// Stub the pop-out button (AC-03) — it pulls in App/Toast/MarkdownPopOut
+// contexts; its own behavior is covered in SourceCanvasNotePopOutButton.test.tsx.
+vi.mock('../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNotePopOutButton', () => ({
+    SourceCanvasNotePopOutButton: ({ onClose }: any) => (
+        <button type="button" data-testid="source-canvas-popout-btn" onClick={onClose} />
+    ),
+}));
+
 import { SourceCanvasPanel } from '../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasPanel';
 
 beforeEach(() => {
@@ -178,6 +186,34 @@ describe('SourceCanvasPanel', () => {
         // …and the read-only loading/source viewer is NOT mounted for notes.
         expect(queryByTestId('source-canvas-loading')).toBeNull();
         expect(queryByTestId('source-canvas-source')).toBeNull();
+    });
+
+    it('shows all four header actions (incl. Pop out) only in note/editable mode (AC-03)', () => {
+        const { getByTestId, queryByTestId, rerender } = render(
+            <SourceCanvasPanel
+                fileRef={{ fullPath: '/home/u/proj/notes/x.md', kind: 'note' }}
+                wsId="ws1"
+                onClose={() => {}}
+            />,
+        );
+        // Copy path, Reveal, Pop out, Close — and no minimize/maximize.
+        expect(getByTestId('source-canvas-copy-btn')).toBeTruthy();
+        expect(getByTestId('source-canvas-reveal-btn')).toBeTruthy();
+        expect(getByTestId('source-canvas-popout-btn')).toBeTruthy();
+        expect(getByTestId('source-canvas-close-btn')).toBeTruthy();
+        expect(queryByTestId('source-canvas-minimize-btn')).toBeNull();
+        expect(queryByTestId('source-canvas-maximize-btn')).toBeNull();
+
+        // Code mode keeps the original three actions (no Pop out).
+        rerender(
+            <SourceCanvasPanel
+                fileRef={{ fullPath: '/home/u/proj/src/foo.ts', kind: 'code' }}
+                wsId="ws1"
+                content={{ status: 'loading', content: '', language: '', resolvedPath: '', error: '' }}
+                onClose={() => {}}
+            />,
+        );
+        expect(queryByTestId('source-canvas-popout-btn')).toBeNull();
     });
 
     it('renders the read-only source viewer (not the note editor) for a code ref', () => {

--- a/packages/coc/test/spa/react/SourceCanvasPanel.test.tsx
+++ b/packages/coc/test/spa/react/SourceCanvasPanel.test.tsx
@@ -17,6 +17,15 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({ explorer: { reveal: revealMock } }),
 }));
 
+// Stub the editable note body so the panel test stays focused on the body-mode
+// branch (kind: 'note' → editable editor; code → read-only viewer) without
+// pulling in the full NoteEditor / TipTap stack.
+vi.mock('../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasNoteEditor', () => ({
+    SourceCanvasNoteEditor: ({ fileRef }: any) => (
+        <div data-testid="source-canvas-note-editor-stub" data-full-path={fileRef.fullPath} />
+    ),
+}));
+
 import { SourceCanvasPanel } from '../../../src/server/spa/client/react/features/chat/source-canvas/SourceCanvasPanel';
 
 beforeEach(() => {
@@ -152,5 +161,41 @@ describe('SourceCanvasPanel', () => {
         expect(source.querySelector('.source-canvas-line-number')?.textContent).toBe('1');
         expect(queryByTestId('source-canvas-loading')).toBeNull();
         expect(queryByTestId('source-canvas-error')).toBeNull();
+    });
+
+    // --- AC-02: single slot, two body modes (note vs code) ---
+
+    it('renders the editable note editor (not the read-only viewer) for a markdown note ref', () => {
+        const { getByTestId, queryByTestId } = render(
+            <SourceCanvasPanel
+                fileRef={{ fullPath: '/home/u/proj/notes/x.md', kind: 'note' }}
+                wsId="ws1"
+                onClose={() => {}}
+            />,
+        );
+        // Editable body present…
+        expect(getByTestId('source-canvas-note-editor-stub')).toBeTruthy();
+        // …and the read-only loading/source viewer is NOT mounted for notes.
+        expect(queryByTestId('source-canvas-loading')).toBeNull();
+        expect(queryByTestId('source-canvas-source')).toBeNull();
+    });
+
+    it('renders the read-only source viewer (not the note editor) for a code ref', () => {
+        const { getByTestId, queryByTestId } = render(
+            <SourceCanvasPanel
+                fileRef={{ fullPath: '/home/u/proj/src/foo.ts', kind: 'code' }}
+                wsId="ws1"
+                content={{
+                    status: 'success',
+                    content: 'const x = 1;\n',
+                    language: 'typescript',
+                    resolvedPath: '/home/u/proj/src/foo.ts',
+                    error: '',
+                }}
+                onClose={() => {}}
+            />,
+        );
+        expect(getByTestId('source-canvas-source')).toBeTruthy();
+        expect(queryByTestId('source-canvas-note-editor-stub')).toBeNull();
     });
 });

--- a/packages/coc/test/spa/react/noteScrollToLine.test.ts
+++ b/packages/coc/test/spa/react/noteScrollToLine.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for computeBestEffortScrollTop — the proportional "scroll to source
+ * line" math backing AC-04. Pure function, so the cases below pin every branch
+ * (no line / first line / single-line doc / nothing scrollable / mid / clamp).
+ */
+import { describe, it, expect } from 'vitest';
+import { computeBestEffortScrollTop } from '../../../src/server/spa/client/react/features/notes/editor/noteScrollToLine';
+
+describe('computeBestEffortScrollTop', () => {
+    const tall = { totalLines: 100, scrollHeight: 2000, clientHeight: 1000 };
+
+    it('opens at the top when no line is given', () => {
+        expect(computeBestEffortScrollTop({ line: undefined, ...tall })).toBe(0);
+        expect(computeBestEffortScrollTop({ line: null, ...tall })).toBe(0);
+    });
+
+    it('opens at the top for the first line', () => {
+        expect(computeBestEffortScrollTop({ line: 1, ...tall })).toBe(0);
+        expect(computeBestEffortScrollTop({ line: 0, ...tall })).toBe(0);
+    });
+
+    it('opens at the top for a single-line document', () => {
+        expect(computeBestEffortScrollTop({ line: 5, totalLines: 1, scrollHeight: 2000, clientHeight: 1000 })).toBe(0);
+    });
+
+    it('opens at the top when nothing is scrollable (jsdom / short note)', () => {
+        // scrollHeight <= clientHeight → maxScroll <= 0
+        expect(computeBestEffortScrollTop({ line: 50, totalLines: 100, scrollHeight: 0, clientHeight: 0 })).toBe(0);
+        expect(computeBestEffortScrollTop({ line: 50, totalLines: 100, scrollHeight: 800, clientHeight: 1000 })).toBe(0);
+    });
+
+    it('scrolls proportionally for a mid-document line', () => {
+        // ratio = (50 - 1) / 100 = 0.49 ; maxScroll = 1000 → 490
+        expect(computeBestEffortScrollTop({ line: 50, ...tall })).toBe(490);
+    });
+
+    it('clamps to the bottom when the line is past the end of the document', () => {
+        // ratio clamps to 1 → full maxScroll (1000)
+        expect(computeBestEffortScrollTop({ line: 500, ...tall })).toBe(1000);
+    });
+
+    it('returns 0 for non-finite inputs instead of NaN', () => {
+        expect(computeBestEffortScrollTop({ line: Number.NaN, ...tall })).toBe(0);
+        expect(computeBestEffortScrollTop({ line: 50, totalLines: Number.NaN, scrollHeight: 2000, clientHeight: 1000 })).toBe(0);
+        expect(computeBestEffortScrollTop({ line: 50, totalLines: 100, scrollHeight: Number.NaN, clientHeight: 1000 })).toBe(0);
+    });
+});

--- a/packages/coc/test/spa/react/notes/NoteEditor.test.tsx
+++ b/packages/coc/test/spa/react/notes/NoteEditor.test.tsx
@@ -239,6 +239,28 @@ describe('NoteEditor', () => {
         });
     });
 
+    // ── Best-effort scroll to line (AC-04) ──────────────────────────────
+
+    it('loads content without throwing when a scrollToLine is provided', async () => {
+        mockLoadContent.mockResolvedValue({ content: '# Hello\n\nline two\nline three', path: 'page.md' });
+        await act(async () => {
+            render(<NoteEditor workspaceId="ws1" notePath="page.md" io={mockIo} scrollToLine={40} />);
+        });
+        // The best-effort scroll must not break the normal load path.
+        await waitFor(() => {
+            expect(mockLoadContent).toHaveBeenCalledTimes(1);
+            expect(mockSetContent).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('loads content normally (opens at top) when no scrollToLine is provided', async () => {
+        mockLoadContent.mockResolvedValue({ content: '# Hello', path: 'page.md' });
+        await act(async () => {
+            render(<NoteEditor workspaceId="ws1" notePath="page.md" io={mockIo} />);
+        });
+        await waitFor(() => expect(mockSetContent).toHaveBeenCalledTimes(1));
+    });
+
     // ── Load error ──────────────────────────────────────────────────────
 
     it('shows error banner when load fails', async () => {

--- a/packages/coc/test/spa/react/resolveMarkdownReviewTarget.test.ts
+++ b/packages/coc/test/spa/react/resolveMarkdownReviewTarget.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for resolveMarkdownReviewTarget — the shared path/workspace/fetchMode
+ * resolution used by BOTH the floating MarkdownReviewDialog (via App.tsx) and
+ * the docked source canvas's editable note body (AC-02).
+ *
+ * Guards the extraction of this logic out of App.tsx: the two surfaces must
+ * compute identical {wsId, filePath, displayPath, fetchMode, taskRootPath}.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    resolveMarkdownReviewTarget,
+    type WorkspaceLike,
+} from '../../../src/server/spa/client/react/shared/markdown-review/resolveMarkdownReviewTarget';
+
+const WS: WorkspaceLike[] = [{ id: 'ws1', rootPath: '/home/u/proj' }];
+
+describe('resolveMarkdownReviewTarget', () => {
+    it('returns null for an empty file path', () => {
+        expect(resolveMarkdownReviewTarget({ filePath: '' }, WS)).toBeNull();
+    });
+
+    it('returns null when no workspace contains the path', () => {
+        expect(
+            resolveMarkdownReviewTarget({ filePath: '/elsewhere/x.md' }, WS),
+        ).toBeNull();
+    });
+
+    it('resolves an absolute path under .vscode/tasks to tasks mode + task-relative filePath', () => {
+        const target = resolveMarkdownReviewTarget(
+            { filePath: '/home/u/proj/.vscode/tasks/plan.md' },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: 'plan.md',
+            displayPath: '/home/u/proj/.vscode/tasks/plan.md',
+            fetchMode: 'tasks',
+        });
+    });
+
+    it('resolves an absolute path outside tasks to auto mode + full filePath', () => {
+        const target = resolveMarkdownReviewTarget(
+            { filePath: '/home/u/proj/docs/readme.md' },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: '/home/u/proj/docs/readme.md',
+            displayPath: '/home/u/proj/docs/readme.md',
+            fetchMode: 'auto',
+        });
+    });
+
+    it('uses the wsId hint fast-path for an absolute tasks path (carries taskRootPath)', () => {
+        const target = resolveMarkdownReviewTarget(
+            {
+                filePath: '/home/u/proj/.vscode/tasks/plan.md',
+                wsId: 'ws1',
+                taskRootPath: '/home/u/proj/.vscode/tasks',
+            },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: 'plan.md',
+            displayPath: '/home/u/proj/.vscode/tasks/plan.md',
+            fetchMode: 'tasks',
+            taskRootPath: '/home/u/proj/.vscode/tasks',
+        });
+    });
+
+    it('uses the wsId hint fast-path for a task-relative path (builds displayPath from taskRootPath)', () => {
+        const target = resolveMarkdownReviewTarget(
+            { filePath: 'plan.md', wsId: 'ws1', taskRootPath: '/home/u/proj/.vscode/tasks' },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: 'plan.md',
+            displayPath: '/home/u/proj/.vscode/tasks/plan.md',
+            fetchMode: 'tasks',
+            taskRootPath: '/home/u/proj/.vscode/tasks',
+        });
+    });
+
+    it('derives the tasks displayPath from the workspace root when no taskRootPath is given', () => {
+        const target = resolveMarkdownReviewTarget(
+            { filePath: 'plan.md', wsId: 'ws1' },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: 'plan.md',
+            displayPath: '/home/u/proj/.vscode/tasks/plan.md',
+            fetchMode: 'tasks',
+            taskRootPath: undefined,
+        });
+    });
+
+    it('falls through to prefix matching when the wsId hint is unknown', () => {
+        const target = resolveMarkdownReviewTarget(
+            { filePath: '/home/u/proj/docs/x.md', wsId: 'nope' },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: '/home/u/proj/docs/x.md',
+            displayPath: '/home/u/proj/docs/x.md',
+            fetchMode: 'auto',
+        });
+    });
+
+    it('resolves a relative path against the source file directory', () => {
+        const target = resolveMarkdownReviewTarget(
+            { filePath: '../notes/x.md', sourceFilePath: '/home/u/proj/src/a.ts' },
+            WS,
+        );
+        expect(target).toEqual({
+            wsId: 'ws1',
+            filePath: '/home/u/proj/notes/x.md',
+            displayPath: '/home/u/proj/notes/x.md',
+            fetchMode: 'auto',
+        });
+    });
+
+    it('picks the longest-prefix (most specific) workspace root', () => {
+        const nested: WorkspaceLike[] = [
+            { id: 'parent', rootPath: '/home/u/proj' },
+            { id: 'child', rootPath: '/home/u/proj/sub' },
+        ];
+        const target = resolveMarkdownReviewTarget(
+            { filePath: '/home/u/proj/sub/docs/x.md' },
+            nested,
+        );
+        expect(target?.wsId).toBe('child');
+    });
+});


### PR DESCRIPTION
- **feat(coc): route markdown chat links to docked canvas as editable note (AC-01)**
- **feat(coc): render editable NoteEditor in docked canvas for markdown notes (AC-02)**
- **feat(coc): add Pop out action to docked note editor header (AC-03)**
- **feat(coc): best-effort scroll to referenced line in docked note editor (AC-04)**
- **feat(coc): mobile BottomSheet hosts editable note canvas via SourceCanvasDock (AC-05)**
- **test(coc): guard floating-dialog + read-only code fallbacks intact (AC-06)**
