### PR TITLE
pr/ffbf6e1ce featwork items ac 02 honor explicit targ

### DIFF
--- a/packages/coc/src/server/llm-tools/create-update-work-item-tool.ts
+++ b/packages/coc/src/server/llm-tools/create-update-work-item-tool.ts
@@ -60,6 +60,14 @@ export interface CreateUpdateWorkItemArgs {
     parentTarget?: string;
     /** Parent sequential work item number, e.g. 12 or "WI-12". */
     parentWorkItemNumber?: number | string;
+    /**
+     * Explicit target workspace or canonical origin id (e.g. a per-clone `ws-*`
+     * workspace id or a `gh_<owner>_<repo>` mirror). When provided, the operation
+     * is scoped to that workspace's canonical origin instead of the active one,
+     * so an item can be created directly under a mirrored parent. Omit to use the
+     * active workspace.
+     */
+    targetWorkspaceId?: string;
 }
 
 export type BroadcastWorkItemFn = (event: {
@@ -262,6 +270,31 @@ function commandErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Resolve the effective repoId for an operation, honoring an explicit
+ * `targetWorkspaceId` when supplied. A target is normalized to its canonical
+ * origin scope via the store's `resolveOriginId` (reusing the same scope
+ * resolution + `legacyRepoIds` machinery as the REST routes), so an item can be
+ * created under, or linked to, a mirrored parent of the same upstream repo.
+ *
+ * When no target is given the baked-in `repoId` is returned unchanged, keeping
+ * the active-workspace behavior byte-for-byte identical to today.
+ */
+async function resolveEffectiveRepoId(
+    store: WorkItemStore,
+    repoId: string,
+    target: string | undefined,
+): Promise<string> {
+    const trimmed = target?.trim();
+    if (!trimmed) {
+        return repoId;
+    }
+    if (store.resolveOriginId) {
+        return store.resolveOriginId(trimmed);
+    }
+    return trimmed;
+}
+
 // ============================================================================
 // Factory
 // ============================================================================
@@ -313,6 +346,9 @@ export function createCreateUpdateWorkItemTool(
             'the item under a new valid parent, or `parentId: null` to unlink it from its current parent. Link updates can ' +
             'be combined with field or plan updates and are validated against the allowed parent/child type hierarchy. ' +
             '`type` cannot be changed in update mode; when supplied it must match the existing item type. ' +
+            'Pass `targetWorkspaceId` (a "ws-*" workspace id or "gh_<owner>_<repo>" mirror) to scope the create/update ' +
+            'to a different workspace of the same upstream repo — e.g. to file an item directly under a mirrored parent; ' +
+            'omit it to use the active workspace. ' +
             'Do not append raw text or submit a partial diff for `plan`; always send the full revised plan. ' +
             'IMPORTANT: Before calling this tool, you MUST first present a draft summary to the user ' +
             'and only call this tool once the user confirms. ' +
@@ -382,16 +418,26 @@ export function createCreateUpdateWorkItemTool(
                     oneOf: [{ type: 'number' }, { type: 'string' }],
                     description: 'Parent sequential work item number, e.g. 12 or "WI-12". Alternative to parentId.',
                 },
+                targetWorkspaceId: {
+                    type: 'string',
+                    description:
+                        'Explicit target workspace or canonical origin id (e.g. a per-clone "ws-*" workspace id or a ' +
+                        '"gh_<owner>_<repo>" mirror). When provided, the create/update is scoped to that workspace\'s ' +
+                        'canonical origin instead of the active one — use it to create an item directly under a ' +
+                        'mirrored parent that lives in a different workspace of the same upstream repo. Omit to use ' +
+                        'the active workspace.',
+                },
             },
             required: [],
         },
         handler: async (rawArgs: CreateUpdateWorkItemArgs) => {
             const args = normalizePlanFromDescription(rawArgs);
+            const effectiveRepoId = await resolveEffectiveRepoId(store, repoId, args.targetWorkspaceId);
             const existingTarget = getExistingTarget(args);
             if (existingTarget !== undefined && String(existingTarget).trim() !== '') {
-                return updateExistingWorkItem(commandCtx, repoId, args);
+                return updateExistingWorkItem(commandCtx, effectiveRepoId, args);
             }
-            return createNewWorkItem(commandCtx, repoId, args);
+            return createNewWorkItem(commandCtx, effectiveRepoId, args);
         },
     });
 

--- a/packages/coc/src/server/work-items/index.ts
+++ b/packages/coc/src/server/work-items/index.ts
@@ -90,6 +90,7 @@ export {
     type CreateGitHubIssueForLocalChildResult,
     type CreateGitHubIssueForLocalEpicRootOptions,
     type CreateGitHubWorkItemSyncProviderOptions,
+    type GitHubSyncWarning,
     type GitHubWorkItemIssue,
     type GitHubWorkItemIssueListFilters,
     type GitHubWorkItemIssueTransport,

--- a/packages/coc/src/server/work-items/index.ts
+++ b/packages/coc/src/server/work-items/index.ts
@@ -55,6 +55,7 @@ export {
     buildGitHubWorkItemLabels,
     buildGitHubWorkItemSyncMetadata,
     formatGitHubWorkItemSyncMetadataBlock,
+    githubIssueContentRevision,
     hasExactlyOneGitHubWorkItemSyncMetadataBlock,
     parseGitHubWorkItemIssue,
     parseGitHubWorkItemSyncMetadataBlocks,

--- a/packages/coc/src/server/work-items/types.ts
+++ b/packages/coc/src/server/work-items/types.ts
@@ -130,6 +130,12 @@ export interface WorkItemGitHubMirrorMetadata {
     updatedAt?: string;
     /** Last successful GitHub→local pull timestamp for this item. */
     lastPulledAt?: string;
+    /**
+     * Per-field hashes of GitHub-owned local fields (title, description, status,
+     * tags) after the last successful pull. The next pull uses these as the merge
+     * base so a locally-dirty/unpushed edit survives instead of being clobbered.
+     */
+    lastSyncedFieldHashes?: Record<string, string>;
 }
 
 /** Azure Boards-backed Epic root metadata. Organization/project identity is workspace-scoped config. */

--- a/packages/coc/src/server/work-items/types.ts
+++ b/packages/coc/src/server/work-items/types.ts
@@ -200,6 +200,17 @@ export interface WorkItemSyncRemoteIdentity {
     issueUrl?: string;
 }
 
+/**
+ * Provider that owns the canonical origin scope a work item is stored under.
+ *
+ * Derived once from the item's resolved origin id (e.g. `gh_*` → `github`) and
+ * persisted on the item so "is this GitHub-mirrored?" no longer has to be
+ * recomputed from the remote URL host on demand. This is the *git host* of the
+ * scope the item physically lives in — distinct from `WorkItemSyncProvider`,
+ * which describes the external tracker an Epic tree syncs with.
+ */
+export type WorkItemOriginProvider = 'local' | 'github' | 'azure-devops' | 'git';
+
 /** Parent reference captured in provider-owned metadata for hierarchy reconstruction. */
 export interface WorkItemSyncParentReference {
     /** CoC parent work item ID when known. */
@@ -393,8 +404,21 @@ export interface WorkItem {
     id: string;
     /** Sequential human-readable number (e.g. 1 → displayed as WI-1). Per-repo, never reused. */
     workItemNumber?: number;
-    /** Workspace/repo this work item belongs to. */
+    /**
+     * Caller-facing workspace/repo id the item was stamped with at create time
+     * (e.g. a per-clone `ws-*` id or a `gh_*` origin id). Kept for provenance and
+     * backward compatibility; scope comparisons should use `originId` instead.
+     */
     repoId: string;
+    /**
+     * Stable canonical origin scope id this item is stored under
+     * (e.g. `gh_<owner>_<repo>`, `local_<workspaceId>`). Independent of which
+     * caller URL family stamped `repoId`, so same-origin clones resolve equal.
+     * Stamped on create and backfilled on read for pre-existing items.
+     */
+    originId?: string;
+    /** Git host that owns `originId`. Distinguishes local from github-mirrored items without re-parsing the remote URL. */
+    originProvider?: WorkItemOriginProvider;
     /** Short title. */
     title: string;
     /** Markdown description of what needs to be done. */
@@ -499,6 +523,10 @@ export interface WorkItemIndexEntry {
     /** Sequential human-readable number (e.g. 1 → displayed as WI-1). */
     workItemNumber?: number;
     repoId: string;
+    /** Stable canonical origin scope id (mirrors {@link WorkItem.originId}). */
+    originId?: string;
+    /** Git host that owns `originId` (mirrors {@link WorkItem.originProvider}). */
+    originProvider?: WorkItemOriginProvider;
     title: string;
     /** Description excerpt for search (may be truncated). */
     description?: string;
@@ -575,7 +603,7 @@ export interface WorkItemStore {
     // CRUD
     addWorkItem(item: WorkItem): Promise<void>;
     getWorkItem(id: string, repoId?: string): Promise<WorkItem | undefined>;
-    updateWorkItem(id: string, updates: Partial<Omit<WorkItem, 'id' | 'repoId' | 'createdAt'>>, repoId?: string): Promise<WorkItem | undefined>;
+    updateWorkItem(id: string, updates: Partial<Omit<WorkItem, 'id' | 'repoId' | 'originId' | 'originProvider' | 'createdAt'>>, repoId?: string): Promise<WorkItem | undefined>;
     removeWorkItem(id: string, repoId?: string): Promise<boolean>;
     listWorkItems(filter?: WorkItemFilter): Promise<WorkItemListResult>;
     /** List work items grouped by status with per-group pagination. */
@@ -667,12 +695,28 @@ export function getOwnWorkItemTrackerKind(item: { tracker?: WorkItemTrackerMetad
     return item.tracker?.kind ?? 'local-only';
 }
 
+/**
+ * Derive the origin provider from a canonical origin/scope id by its prefix.
+ *
+ * Mirrors forge's `resolveCanonicalOrigin` provider mapping
+ * (`gh_*` → github, `ado_*` → azure-devops, `git_*` → git) and defaults to
+ * `local` for `local_*` ids and any non-canonical caller stamp (e.g. `ws-*`).
+ */
+export function deriveWorkItemOriginProvider(originId: string | undefined): WorkItemOriginProvider {
+    if (originId?.startsWith('gh_')) return 'github';
+    if (originId?.startsWith('ado_')) return 'azure-devops';
+    if (originId?.startsWith('git_')) return 'git';
+    return 'local';
+}
+
 /** Extract an index entry from a full work item. */
 export function toIndexEntry(item: WorkItem): WorkItemIndexEntry {
     return {
         id: item.id,
         workItemNumber: item.workItemNumber,
         repoId: item.repoId,
+        originId: item.originId,
+        originProvider: item.originProvider,
         title: item.title,
         description: item.description || undefined,
         status: item.status,

--- a/packages/coc/src/server/work-items/types.ts
+++ b/packages/coc/src/server/work-items/types.ts
@@ -136,6 +136,15 @@ export interface WorkItemGitHubMirrorMetadata {
      * base so a locally-dirty/unpushed edit survives instead of being clobbered.
      */
     lastSyncedFieldHashes?: Record<string, string>;
+    /**
+     * Content revision of the remote GitHub issue (a hash of its CoC-owned
+     * content — title, metadata-stripped body, state, labels) recorded at the
+     * last successful pull/push. The push gate compares this against the current
+     * remote revision so a "changed remotely" conflict reflects a real edit to
+     * CoC-owned content, not a benign `updated_at` bump (a reaction, comment,
+     * cross-reference, or unrelated label) or a timestamp reformat.
+     */
+    lastSyncedRemoteRevision?: string;
 }
 
 /** Azure Boards-backed Epic root metadata. Organization/project identity is workspace-scoped config. */

--- a/packages/coc/src/server/work-items/work-item-commands.ts
+++ b/packages/coc/src/server/work-items/work-item-commands.ts
@@ -37,6 +37,7 @@ import {
     getEffectiveType,
 } from './types';
 import { resolveGitHubWorkItemSyncRepo, type GitHubWorkItemSyncRepo } from './work-item-sync-github-repo';
+import { githubIssueContentRevision } from './work-item-sync-github-issue';
 import {
     GhCliGitHubWorkItemIssueTransport,
     createGitHubIssueForLocalChild,
@@ -387,9 +388,42 @@ function githubOperationFailedError(action: string, error: unknown, code: string
     return githubProviderError(`GitHub ${action} failed: ${detail}`, code);
 }
 
+/**
+ * True when the remote GitHub issue changed since the local mirror last synced.
+ *
+ * Prefers a real content-revision check: a hash of the remote's CoC-owned
+ * content (title, metadata-stripped body, state, labels) is recorded at every
+ * pull/push as `lastSyncedRemoteRevision`. Comparing the current remote revision
+ * against that base detects a genuine edit to CoC-owned content while ignoring a
+ * benign `updated_at` bump (a reaction, comment, cross-reference, lock, or
+ * unrelated label) that the old timestamp-string-equality check flagged as a
+ * false conflict. Legacy mirrors without a recorded revision fall back to a
+ * parsed-instant `updatedAt` comparison so a timestamp reformat alone is not a
+ * conflict either.
+ */
 function githubMirrorIsStale(local: WorkItem, remote: GitHubWorkItemIssue): boolean {
-    const localUpdatedAt = local.githubMirror?.updatedAt;
-    return Boolean(localUpdatedAt && remote.updatedAt && localUpdatedAt !== remote.updatedAt);
+    const baseRevision = local.githubMirror?.lastSyncedRemoteRevision;
+    if (baseRevision !== undefined) {
+        return githubIssueContentRevision(remote) !== baseRevision;
+    }
+    return githubUpdatedAtChanged(local.githubMirror?.updatedAt, remote.updatedAt);
+}
+
+/**
+ * Compare two GitHub `updated_at` timestamps as instants rather than raw
+ * strings, so an ISO reformat (millisecond precision, timezone offset form)
+ * does not register as a change. Falls back to string inequality when either
+ * value is non-parseable, and treats a missing value on either side as "no
+ * detectable change" (matching the prior short-circuit behavior).
+ */
+function githubUpdatedAtChanged(local: string | undefined, remote: string | undefined): boolean {
+    if (!local || !remote) return false;
+    const localTime = Date.parse(local);
+    const remoteTime = Date.parse(remote);
+    if (Number.isNaN(localTime) || Number.isNaN(remoteTime)) {
+        return local !== remote;
+    }
+    return localTime !== remoteTime;
 }
 
 function azureBoardsMirrorIsStale(local: WorkItem, remote: AzureBoardsWorkItem): boolean {

--- a/packages/coc/src/server/work-items/work-item-github-pull-poller.ts
+++ b/packages/coc/src/server/work-items/work-item-github-pull-poller.ts
@@ -51,6 +51,15 @@ export interface WorkItemGitHubPullWorkspaceResult {
     deleted: number;
     deletedItemIds: string[];
     errors: WorkItemGitHubPullPollError[];
+    /** Number of remote candidate issues fetched for this poll (after the cap). */
+    candidatesConsidered: number;
+    /**
+     * True when the candidate fetch reached {@link WORK_ITEM_SYNC_MAX_ITEMS} and
+     * the remote issue list may have been truncated, so some descendants could be
+     * missing from the mirror. Surfaced in the structured result and logged so the
+     * truncation is observable rather than silent.
+     */
+    truncated: boolean;
 }
 
 interface WorkspaceTimer {
@@ -107,6 +116,8 @@ function blankResult(workspaceId: string): WorkItemGitHubPullWorkspaceResult {
         deleted: 0,
         deletedItemIds: [],
         errors: [],
+        candidatesConsidered: 0,
+        truncated: false,
     };
 }
 
@@ -190,6 +201,18 @@ export class WorkItemGitHubPullPoller {
         const workspace = await this.getWorkspace(workspaceId);
         const repo = this.resolveRepo(workspaceId, workspace);
         const candidateIssues = await this.transport.listIssues(repo, { limit: WORK_ITEM_SYNC_MAX_ITEMS });
+        result.candidatesConsidered = candidateIssues.length;
+        // The transport caps the candidate list at WORK_ITEM_SYNC_MAX_ITEMS, so a
+        // count at the cap means the remote list was (or may have been) truncated
+        // and some descendants could be missing from this pull. Log it so the
+        // truncation is observable instead of silently dropping issues.
+        if (candidateIssues.length >= WORK_ITEM_SYNC_MAX_ITEMS) {
+            result.truncated = true;
+            this.logError(
+                `[work-items/github-poll] ${workspaceId}: reached the ${WORK_ITEM_SYNC_MAX_ITEMS}-issue cap; `
+                + 'the GitHub issue list may be truncated and some descendants could be missing from the mirror.',
+            );
+        }
 
         for (const rootEntry of roots) {
             const root = await this.options.workItemStore.getWorkItem(rootEntry.id, workspaceId);

--- a/packages/coc/src/server/work-items/work-item-github-pull-poller.ts
+++ b/packages/coc/src/server/work-items/work-item-github-pull-poller.ts
@@ -9,6 +9,7 @@ import {
     deleteGitHubEpicMirrorTree,
     importGitHubEpicTreeAsWorkItems,
     type AvailableGitHubWorkItemSyncRepo,
+    type GitHubSyncWarning,
     type GitHubWorkItemIssue,
     type GitHubWorkItemIssueTransport,
     type ImportGitHubEpicTreeResult,
@@ -51,6 +52,11 @@ export interface WorkItemGitHubPullWorkspaceResult {
     deleted: number;
     deletedItemIds: string[];
     errors: WorkItemGitHubPullPollError[];
+    /**
+     * Conflicts where a locally-dirty/unpushed field was preserved over a
+     * competing remote change. Surfaced so the divergence is observable in logs.
+     */
+    warnings: GitHubSyncWarning[];
     /** Number of remote candidate issues fetched for this poll (after the cap). */
     candidatesConsidered: number;
     /**
@@ -116,6 +122,7 @@ function blankResult(workspaceId: string): WorkItemGitHubPullWorkspaceResult {
         deleted: 0,
         deletedItemIds: [],
         errors: [],
+        warnings: [],
         candidatesConsidered: 0,
         truncated: false,
     };
@@ -225,6 +232,7 @@ export class WorkItemGitHubPullPoller {
                 result.updated += syncResult.updated;
                 result.deleted += syncResult.deleted;
                 result.deletedItemIds.push(...syncResult.deletedItemIds);
+                result.warnings.push(...syncResult.warnings);
             } catch (error) {
                 result.errors.push({
                     workItemId: root.id,
@@ -245,6 +253,9 @@ export class WorkItemGitHubPullPoller {
     private async pollWorkspaceSafely(workspaceId: string): Promise<void> {
         try {
             const result = await this.pollWorkspace(workspaceId);
+            for (const warning of result.warnings) {
+                this.logError(`[work-items/github-poll] ${workspaceId}: ${warning.message}`);
+            }
             for (const error of result.errors) {
                 this.logError(`[work-items/github-poll] ${workspaceId}: ${error.message}`);
             }
@@ -307,6 +318,7 @@ export class WorkItemGitHubPullPoller {
                 items: [],
                 created: 0,
                 updated: 0,
+                warnings: [],
                 ...deleteResult,
             };
         }

--- a/packages/coc/src/server/work-items/work-item-store.ts
+++ b/packages/coc/src/server/work-items/work-item-store.ts
@@ -38,7 +38,7 @@ import type {
     WorkItemSyncProvider,
     WorkItemSyncRemoteIdentity,
 } from './types';
-import { getOwnWorkItemTrackerKind, toIndexEntry, WORK_ITEM_STATUSES } from './types';
+import { deriveWorkItemOriginProvider, getOwnWorkItemTrackerKind, toIndexEntry, WORK_ITEM_STATUSES } from './types';
 
 // ============================================================================
 // Store Implementation
@@ -413,7 +413,43 @@ export class FileWorkItemStore implements WorkItemStore {
             }
         }
 
-        return this.migrateLegacySyncLinks(repoId, entries);
+        const withSyncLinksMigrated = await this.migrateLegacySyncLinks(repoId, entries);
+        return this.migrateOriginIds(repoId, withSyncLinksMigrated);
+    }
+
+    /**
+     * Backfill the stable `originId`/`originProvider` scope identity on items that
+     * pre-date the field. An item physically stored under `<dataDir>/repos/<repoId>/`
+     * lives in that canonical origin scope by construction, so the directory key is
+     * the authoritative origin id. Runs once per repo: after the first pass (or for
+     * fresh repos where `addWorkItem` stamps the field) the `every` check short-circuits.
+     */
+    private async migrateOriginIds(
+        repoId: string,
+        entries: WorkItemIndexEntry[],
+    ): Promise<WorkItemIndexEntry[]> {
+        if (entries.every(entry => entry.originId)) return entries;
+
+        const originProvider = deriveWorkItemOriginProvider(repoId);
+        let changed = false;
+        for (const entry of entries) {
+            if (entry.originId) continue;
+            entry.originId = repoId;
+            entry.originProvider = originProvider;
+            changed = true;
+
+            const item = await this.readItem(repoId, entry.id);
+            if (item && !item.originId) {
+                item.originId = repoId;
+                item.originProvider = originProvider;
+                await this.writeItem(repoId, item);
+            }
+        }
+
+        if (changed) {
+            await this.writeIndex(repoId, entries);
+        }
+        return entries;
     }
 
     private async writeIndex(repoId: string, entries: WorkItemIndexEntry[]): Promise<void> {
@@ -499,6 +535,10 @@ export class FileWorkItemStore implements WorkItemStore {
     async addWorkItem(item: WorkItem): Promise<void> {
         return this.enqueueWrite(async () => {
             const { storageRepoId } = await this.resolveStorageScope(item.repoId);
+            // Stamp the stable canonical origin scope (independent of which caller
+            // URL family stamped repoId) plus its derived provider.
+            item.originId = storageRepoId;
+            item.originProvider = deriveWorkItemOriginProvider(storageRepoId);
             const index = await this.readIndex(storageRepoId);
             if (index.some(e => e.id === item.id)) {
                 throw new Error(`Work item already exists: ${item.id}`);
@@ -551,7 +591,7 @@ export class FileWorkItemStore implements WorkItemStore {
 
     async updateWorkItem(
         id: string,
-        updates: Partial<Omit<WorkItem, 'id' | 'repoId' | 'createdAt'>>,
+        updates: Partial<Omit<WorkItem, 'id' | 'repoId' | 'originId' | 'originProvider' | 'createdAt'>>,
         repoId?: string,
     ): Promise<WorkItem | undefined> {
         let updated: WorkItem | undefined;

--- a/packages/coc/src/server/work-items/work-item-sync-github-issue.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-github-issue.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import {
     getEffectiveType,
     isKnownWorkItemStatus,
@@ -260,6 +261,37 @@ export function stripGitHubWorkItemSyncMetadataBlocks(body: string | null | unde
         .replace(metadataBlockPattern(), '')
         .replace(/\n{3,}/g, '\n\n')
         .trim();
+}
+
+/**
+ * Stable content revision for a GitHub issue's CoC-owned content.
+ *
+ * Hashes only the fields CoC reads from the remote — title, the human-visible
+ * body (the hidden `coc-work-item-sync` metadata block is stripped so its
+ * per-push `lastSyncedAt` churn does not move the revision), open/closed state,
+ * and the deduped, case-insensitively sorted label set. The push gate compares
+ * this against the revision recorded at the last sync (`lastSyncedRemoteRevision`)
+ * so a conflict reflects a real change to CoC-owned content rather than any
+ * GitHub-side touch — a reaction, a comment, a cross-reference, a lock, or an
+ * unrelated label — that merely bumps `updated_at`. This is the "real revision"
+ * GitHub does not otherwise expose (issues have no monotonic revision number).
+ */
+export function githubIssueContentRevision(
+    issue: Pick<GitHubWorkItemIssueSnapshot, 'title' | 'body' | 'state' | 'labels'>,
+): string {
+    const labels: string[] = [];
+    const seenLabels = new Set<string>();
+    for (const label of issue.labels ?? []) {
+        addUnique(labels, seenLabels, labelName(label));
+    }
+    labels.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()) || a.localeCompare(b));
+    const payload = JSON.stringify({
+        title: issue.title ?? '',
+        body: stripGitHubWorkItemSyncMetadataBlocks(issue.body),
+        state: issue.state ?? '',
+        labels,
+    });
+    return crypto.createHash('sha256').update(payload).digest('hex');
 }
 
 export function formatGitHubWorkItemSyncMetadataBlock(metadata: GitHubWorkItemSyncMetadata): string {

--- a/packages/coc/src/server/work-items/work-item-sync-github-provider.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-github-provider.ts
@@ -6,6 +6,7 @@ import {
     buildGitHubWorkItemIssueUpdate,
     buildGitHubWorkItemLabels,
     buildGitHubWorkItemSyncMetadata,
+    githubIssueContentRevision,
     parseGitHubWorkItemIssue,
     upsertGitHubWorkItemSyncMetadataBlock,
     type GitHubIssueLabel,
@@ -420,6 +421,7 @@ function githubMirrorForIssue(issue: GitHubWorkItemIssue, pulledAt: string): Non
         state: issue.state,
         updatedAt: issue.updatedAt,
         lastPulledAt: pulledAt,
+        lastSyncedRemoteRevision: githubIssueContentRevision(issue),
     };
 }
 

--- a/packages/coc/src/server/work-items/work-item-sync-github-provider.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-github-provider.ts
@@ -93,6 +93,20 @@ type ExecFileAsync = (
     options: { encoding: 'utf8'; windowsHide: true; maxBuffer: number },
 ) => Promise<{ stdout: string; stderr: string }>;
 
+/**
+ * Surfaced when a GitHub→local pull kept an unpushed local edit instead of
+ * applying the conflicting remote value, so the divergence is observable.
+ */
+export interface GitHubSyncWarning {
+    provider: 'github';
+    code: 'local-edits-preserved';
+    workItemId: string;
+    issueNumber?: number;
+    /** GitHub-owned fields whose local edits were kept over a conflicting remote change. */
+    fields: string[];
+    message: string;
+}
+
 export interface ImportGitHubEpicTreeResult {
     root: WorkItem;
     items: WorkItem[];
@@ -100,6 +114,11 @@ export interface ImportGitHubEpicTreeResult {
     updated: number;
     deleted: number;
     deletedItemIds: string[];
+    /**
+     * Conflicts where a locally-dirty/unpushed field was preserved over a
+     * competing remote change during this pull. Empty when nothing conflicted.
+     */
+    warnings: GitHubSyncWarning[];
 }
 
 export interface ImportGitHubEpicTreeOptions {
@@ -984,6 +1003,118 @@ export function createGitHubWorkItemSyncProviderAdapter(options: CreateGitHubWor
 }
 
 /**
+ * GitHub-owned content fields a local user can edit between pulls. On re-pull
+ * these are reconciled with a 3-way merge (base = last-synced value) so an
+ * unpushed local edit survives instead of being clobbered by the remote value.
+ * Structural fields (type, parentId, tracker, githubMirror) stay remote-derived
+ * because they are recomputed from the issue tree on every pull.
+ */
+const GITHUB_MERGE_FIELDS = ['title', 'description', 'status', 'tags'] as const;
+type GitHubMergeField = (typeof GITHUB_MERGE_FIELDS)[number];
+
+interface GitHubOwnedFields {
+    title: string;
+    description: string;
+    status: WorkItemStatus;
+    tags: string[] | undefined;
+}
+
+interface GitHubOwnedFieldMergeResult {
+    fields: GitHubOwnedFields;
+    /** Per-field base hashes to persist as the next pull's last-synced fingerprint. */
+    baseHashes: Record<string, string>;
+    /** Fields where the local edit was kept over a conflicting remote change. */
+    conflictFields: GitHubMergeField[];
+}
+
+function normalizeGitHubMergeTags(tags: readonly string[] | undefined): string[] {
+    return [...(tags ?? [])]
+        .map(tag => tag.trim())
+        .filter(Boolean)
+        .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()) || a.localeCompare(b));
+}
+
+function githubFieldFingerprint(field: GitHubMergeField, value: unknown): string {
+    const normalized = field === 'tags'
+        ? normalizeGitHubMergeTags(value as string[] | undefined)
+        : String(value ?? '');
+    return crypto.createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+}
+
+function githubOwnedFieldHashes(fields: GitHubOwnedFields): Record<string, string> {
+    const hashes: Record<string, string> = {};
+    for (const field of GITHUB_MERGE_FIELDS) {
+        hashes[field] = githubFieldFingerprint(field, fields[field]);
+    }
+    return hashes;
+}
+
+function assignGitHubOwnedField(
+    target: GitHubOwnedFields,
+    field: GitHubMergeField,
+    source: GitHubOwnedFields,
+): void {
+    switch (field) {
+        case 'title': target.title = source.title; break;
+        case 'description': target.description = source.description; break;
+        case 'status': target.status = source.status; break;
+        case 'tags': target.tags = source.tags; break;
+    }
+}
+
+/**
+ * Three-way merge of GitHub-owned fields between an existing local mirror and an
+ * incoming remote pull. A field is kept local only when it diverged from the
+ * last synced value (`lastSyncedFieldHashes`); otherwise the remote value wins,
+ * preserving the prior remote-authoritative behavior for clean and legacy items.
+ */
+function mergeGitHubOwnedFields(
+    existing: WorkItem,
+    remote: GitHubOwnedFields,
+): GitHubOwnedFieldMergeResult {
+    const base = existing.githubMirror?.lastSyncedFieldHashes;
+    const local: GitHubOwnedFields = {
+        title: existing.title,
+        description: existing.description ?? '',
+        status: existing.status,
+        tags: existing.tags,
+    };
+    const fields: GitHubOwnedFields = { ...remote };
+    const baseHashes: Record<string, string> = {};
+    const conflictFields: GitHubMergeField[] = [];
+
+    for (const field of GITHUB_MERGE_FIELDS) {
+        const remoteHash = githubFieldFingerprint(field, remote[field]);
+        const localHash = githubFieldFingerprint(field, local[field]);
+        const baseHash = base?.[field];
+
+        if (localHash === remoteHash) {
+            // Local already equals remote (untouched, or pushed): take remote.
+            baseHashes[field] = remoteHash;
+            continue;
+        }
+        if (baseHash === undefined || localHash === baseHash) {
+            // No recorded base (legacy/first pull) or local untouched since the
+            // last sync: remote wins, matching the prior behavior.
+            baseHashes[field] = remoteHash;
+            continue;
+        }
+        // Local diverged from the last sync: keep the unpushed local edit so it
+        // survives the pull. Hold the prior base so the field stays "dirty" and
+        // keeps surviving on later pulls until it is pushed.
+        assignGitHubOwnedField(fields, field, local);
+        baseHashes[field] = baseHash;
+        if (remoteHash !== baseHash) {
+            // Remote also moved since the last sync: a genuine conflict the user
+            // should know about.
+            conflictFields.push(field);
+        }
+    }
+
+    return { fields, baseHashes, conflictFields };
+}
+
+/**
  * Import or re-pull a GitHub-backed Epic tree into CoC's read mirror.
  *
  * The tree root is the imported GitHub issue. Descendants are discovered only
@@ -1006,6 +1137,7 @@ export async function importGitHubEpicTreeAsWorkItems(
     const items: WorkItem[] = [];
     let created = 0;
     let updated = 0;
+    const warnings: GitHubSyncWarning[] = [];
 
     for (const { issue, parsed } of tree) {
         const existing = await findLocalMirrorForIssue(context, repo, index, issue, parsed);
@@ -1032,15 +1164,38 @@ export async function importGitHubEpicTreeAsWorkItems(
             : undefined;
         const isRoot = issue.number === rootIssue.number;
         const desiredId = existing?.id ?? parsed.metadata?.workItemId ?? crypto.randomUUID();
-        const commonFields = {
+        const remoteOwned: GitHubOwnedFields = {
             title: issue.title,
             description: parsed.bodyWithoutMetadata,
             status: workItemStatusForGitHubIssue(issue, parsed),
+            tags: tagsForMirror(parsed),
+        };
+        // Re-pull keeps unpushed local edits to GitHub-owned fields via a 3-way
+        // merge; a fresh mirror records the remote values as the synced base.
+        const merge = existing
+            ? mergeGitHubOwnedFields(existing, remoteOwned)
+            : { fields: remoteOwned, baseHashes: githubOwnedFieldHashes(remoteOwned), conflictFields: [] };
+        if (existing && merge.conflictFields.length > 0) {
+            warnings.push({
+                provider: 'github',
+                code: 'local-edits-preserved',
+                workItemId: existing.id,
+                issueNumber: issue.number,
+                fields: merge.conflictFields,
+                message: `GitHub issue #${issue.number} changed remotely while local edits to `
+                    + `${merge.conflictFields.join(', ')} were unpushed; the local edits were kept `
+                    + 'and the remote values were not applied.',
+            });
+        }
+        const commonFields = {
+            title: merge.fields.title,
+            description: merge.fields.description,
+            status: merge.fields.status,
             type,
             parentId,
             tracker: isRoot ? githubBackedTrackerForRoot(issue, pulledAt) : undefined,
-            githubMirror: githubMirrorForIssue(issue, pulledAt),
-            tags: tagsForMirror(parsed),
+            githubMirror: { ...githubMirrorForIssue(issue, pulledAt), lastSyncedFieldHashes: merge.baseHashes },
+            tags: merge.fields.tags,
         };
 
         let item: WorkItem;
@@ -1080,5 +1235,5 @@ export async function importGitHubEpicTreeAsWorkItems(
             new Set(tree.map(({ issue }) => issue.number)),
         )
         : { deleted: 0, deletedItemIds: [] };
-    return { root, items, created, updated, ...pruneResult };
+    return { root, items, created, updated, warnings, ...pruneResult };
 }

--- a/packages/coc/test/server/work-items/work-item-github-edit.test.ts
+++ b/packages/coc/test/server/work-items/work-item-github-edit.test.ts
@@ -9,6 +9,7 @@ import { registerWorkItemRoutes } from '../../../src/server/routes/work-item-rou
 import { FileWorkItemStore } from '../../../src/server/work-items/work-item-store';
 import type { WorkItem } from '../../../src/server/work-items/types';
 import {
+    githubIssueContentRevision,
     parseGitHubWorkItemIssue,
     type GitHubWorkItemIssue,
     type GitHubWorkItemIssueTransport,
@@ -465,6 +466,93 @@ describe('GitHub-backed work item edits', () => {
 
         expect(res.status).toBe(200);
         expect(mock.calls.getIssue).toHaveLength(0);
+        expect(mock.calls.updateIssue).toHaveLength(0);
+    });
+});
+
+describe('GitHub-backed edit conflict detection via content revision', () => {
+    const EPIC_LABELS = ['coc:type:epic', 'coc:status:created', 'coc:priority:normal'];
+
+    function epicRemoteIssue(overrides: Partial<GitHubWorkItemIssue> = {}): GitHubWorkItemIssue {
+        return mirroredIssue(10, {
+            title: 'GitHub Epic',
+            body: 'Remote prose',
+            labels: EPIC_LABELS,
+            ...overrides,
+        });
+    }
+
+    function rootWithRevision(remote: GitHubWorkItemIssue, overrides: Partial<WorkItem> = {}): WorkItem {
+        return githubBackedRoot({
+            githubMirror: {
+                issueId: 'I_10',
+                issueNumber: 10,
+                issueUrl: issueUrl(10),
+                state: 'open',
+                updatedAt: NOW,
+                lastPulledAt: NOW,
+                lastSyncedRemoteRevision: githubIssueContentRevision(remote),
+            },
+            ...overrides,
+        });
+    }
+
+    it('allows a local save when only the remote updated_at moved but CoC-owned content is unchanged', async () => {
+        // Same content the mirror last synced, but GitHub bumped updated_at for a
+        // non-content reason (a reaction/comment). The old timestamp-string check
+        // would have raised a spurious WORK_ITEM_SYNC_CONFLICT here.
+        const remote = epicRemoteIssue({ updatedAt: LATER });
+        await store.addWorkItem(rootWithRevision(remote));
+        const mock = makeMockTransport([remote]);
+        await startServer(mock);
+
+        const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/epic-1`, {
+            title: 'Locally renamed epic',
+        });
+
+        expect(res.status).toBe(200);
+        expect(mock.calls.updateIssue).toHaveLength(1);
+        const stored = await store.getWorkItem('epic-1', REPO_ID);
+        expect(stored?.title).toBe('Locally renamed epic');
+        // The mirror records the revision of the just-pushed issue, so it
+        // round-trips and a follow-up edit does not spuriously conflict.
+        expect(stored?.githubMirror?.lastSyncedRemoteRevision)
+            .toBe(githubIssueContentRevision(mock.issues.get(10)!));
+    });
+
+    it('rejects a local save when the remote CoC-owned content actually changed (revision diverged)', async () => {
+        const syncedRemote = epicRemoteIssue();
+        await store.addWorkItem(rootWithRevision(syncedRemote));
+        // Remote title changed AND updated_at moved — a genuine remote edit.
+        const mock = makeMockTransport([epicRemoteIssue({ title: 'Remote changed title', updatedAt: LATER })]);
+        await startServer(mock);
+
+        const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/epic-1`, {
+            title: 'Stale local title',
+        });
+
+        expect(res.status).toBe(409);
+        expect(res.body.code).toBe('WORK_ITEM_SYNC_CONFLICT');
+        expect(mock.calls.updateIssue).toHaveLength(0);
+        const stored = await store.getWorkItem('epic-1', REPO_ID);
+        expect(stored?.title).toBe('GitHub Epic');
+    });
+
+    it('catches a remote content change even when updated_at is byte-identical (revision, not timestamp)', async () => {
+        const syncedRemote = epicRemoteIssue();
+        await store.addWorkItem(rootWithRevision(syncedRemote));
+        // Content changed but updated_at is unchanged (NOW). The old
+        // timestamp-string-equality check would have missed this and silently
+        // overwritten the remote edit; the revision check still flags it.
+        const mock = makeMockTransport([epicRemoteIssue({ body: 'Remote prose edited elsewhere', updatedAt: NOW })]);
+        await startServer(mock);
+
+        const res = await request('PATCH', `/api/workspaces/${REPO_ID}/work-items/epic-1`, {
+            title: 'Local title that should not clobber remote',
+        });
+
+        expect(res.status).toBe(409);
+        expect(res.body.code).toBe('WORK_ITEM_SYNC_CONFLICT');
         expect(mock.calls.updateIssue).toHaveLength(0);
     });
 });

--- a/packages/coc/test/server/work-items/work-item-github-pull-poller.test.ts
+++ b/packages/coc/test/server/work-items/work-item-github-pull-poller.test.ts
@@ -475,4 +475,68 @@ describe('WorkItemGitHubPullPoller', () => {
         expect(pullResult.truncated).toBe(false);
         expect(logs).toEqual([]);
     });
+
+    it('preserves an unpushed local edit on poll, surfaces it as a warning, and logs it', async () => {
+        const issues = new Map<number, GitHubWorkItemIssue>([
+            [100, makeIssue(100, 'Remote Epic', { labels: ['coc:type:epic'], body: 'Remote epic' })],
+        ]);
+        const tree = await importTree(store, issues);
+        const rootId = tree.root.id;
+
+        // The user edits the title locally but has not pushed it back to GitHub.
+        await store.updateWorkItem(rootId, { title: 'Local unpushed title' });
+        // The remote title also moves, so the next poll is a genuine conflict.
+        issues.set(100, makeIssue(100, 'Remote moved title', {
+            labels: ['coc:type:epic'],
+            body: 'Remote epic',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+        }));
+
+        writeRepoPreferences(tmpDir, REPO_ID, {
+            workItems: { sync: { github: { owner: OWNER, repo: REPO, pollingEnabled: true, pollIntervalMinutes: 1 } } },
+        });
+
+        const scheduled: Array<{ handler: () => void | Promise<void> }> = [];
+        const timerApi: WorkItemGitHubPullPollerTimerApi = {
+            setInterval(handler) {
+                scheduled.push({ handler });
+                return scheduled.length;
+            },
+            clearInterval() {
+                // no-op
+            },
+        };
+        const logs: string[] = [];
+        const poller = new WorkItemGitHubPullPoller({
+            dataDir: tmpDir,
+            processStore: processStore(tmpDir),
+            workItemStore: store,
+            transport: makeTransport(issues),
+            now: () => '2026-01-03T00:00:00.000Z',
+            timerApi,
+            logError: message => logs.push(message),
+        });
+
+        // Structured warning is surfaced from the pull result.
+        const pullResult = await poller.pollWorkspace(REPO_ID);
+        expect(pullResult.warnings).toHaveLength(1);
+        expect(pullResult.warnings[0]).toMatchObject({
+            code: 'local-edits-preserved',
+            workItemId: rootId,
+            issueNumber: 100,
+            fields: ['title'],
+        });
+
+        // The scheduled (timer-driven) poll logs the conflict so it is observable.
+        await poller.configureWorkspace(REPO_ID);
+        expect(scheduled).toHaveLength(1);
+        await scheduled[0].handler();
+        expect(logs.some(message =>
+            message.includes('#100') && message.toLowerCase().includes('unpushed'),
+        )).toBe(true);
+
+        // The unpushed local edit survives both polls.
+        const updated = await store.getWorkItem(rootId, REPO_ID);
+        expect(updated?.title).toBe('Local unpushed title');
+    });
 });

--- a/packages/coc/test/server/work-items/work-item-github-pull-poller.test.ts
+++ b/packages/coc/test/server/work-items/work-item-github-pull-poller.test.ts
@@ -6,9 +6,11 @@ import { writeRepoPreferences } from '../../../src/server/preferences-handler';
 import { FileWorkItemStore } from '../../../src/server/work-items/work-item-store';
 import {
     WorkItemGitHubPullPoller,
+    WORK_ITEM_SYNC_MAX_ITEMS,
     importGitHubEpicTreeAsWorkItems,
     type AvailableGitHubWorkItemSyncRepo,
     type GitHubWorkItemIssue,
+    type GitHubWorkItemIssueListFilters,
     type GitHubWorkItemIssueTransport,
     type WorkItemGitHubPullPollerTimerApi,
 } from '../../../src/server/work-items';
@@ -393,5 +395,84 @@ describe('WorkItemGitHubPullPoller', () => {
         const afterOpen = await store.listWorkItems({ repoId: REPO_ID });
         expect(afterOpen.items.map(item => item.githubMirror?.issueNumber).filter(Boolean).sort())
             .toEqual([100, 101]);
+    });
+
+    it('flags and logs truncation when the candidate fetch reaches the cap', async () => {
+        const root = makeIssue(100, 'Remote Epic', {
+            labels: ['coc:type:epic'],
+            body: 'Remote epic',
+        });
+        await importTree(store, new Map([[100, root]]));
+
+        // More remote issues exist than the cap allows; the transport honors the
+        // limit (like the real gh-CLI transport) and returns exactly the cap.
+        const candidates: GitHubWorkItemIssue[] = [root];
+        for (let n = 1; candidates.length < WORK_ITEM_SYNC_MAX_ITEMS + 50; n++) {
+            if (n === 100) continue;
+            candidates.push(makeIssue(n, `Filler ${n}`));
+        }
+        const cappingTransport: GitHubWorkItemIssueTransport = {
+            async getRepository() {},
+            async listIssues(_repo, filters?: GitHubWorkItemIssueListFilters) {
+                const limit = filters?.limit ?? candidates.length;
+                return candidates.slice(0, limit);
+            },
+            async getIssue(_repo: AvailableGitHubWorkItemSyncRepo, issueNumber: number) {
+                return candidates.find(issue => issue.number === issueNumber);
+            },
+            async createIssue(): Promise<GitHubWorkItemIssue> {
+                throw new Error('createIssue is not used by the GitHub pull poller.');
+            },
+            async updateIssue(): Promise<GitHubWorkItemIssue> {
+                throw new Error('updateIssue is not used by the GitHub pull poller.');
+            },
+        };
+
+        writeRepoPreferences(tmpDir, REPO_ID, {
+            workItems: { sync: { github: { owner: OWNER, repo: REPO, pollingEnabled: true } } },
+        });
+        const logs: string[] = [];
+        const poller = new WorkItemGitHubPullPoller({
+            dataDir: tmpDir,
+            processStore: processStore(tmpDir),
+            workItemStore: store,
+            transport: cappingTransport,
+            now: () => '2026-01-03T00:00:00.000Z',
+            logError: message => logs.push(message),
+        });
+
+        const pullResult = await poller.pollWorkspace(REPO_ID);
+
+        expect(pullResult.candidatesConsidered).toBe(WORK_ITEM_SYNC_MAX_ITEMS);
+        expect(pullResult.truncated).toBe(true);
+        expect(pullResult.errors).toEqual([]);
+        expect(logs.some(message =>
+            message.includes(String(WORK_ITEM_SYNC_MAX_ITEMS)) && message.toLowerCase().includes('truncated'),
+        )).toBe(true);
+    });
+
+    it('does not flag truncation when the candidate fetch is under the cap', async () => {
+        const issues = new Map<number, GitHubWorkItemIssue>([
+            [100, makeIssue(100, 'Remote Epic', { labels: ['coc:type:epic'], body: 'Remote epic' })],
+        ]);
+        await importTree(store, issues);
+        writeRepoPreferences(tmpDir, REPO_ID, {
+            workItems: { sync: { github: { owner: OWNER, repo: REPO, pollingEnabled: true } } },
+        });
+        const logs: string[] = [];
+        const poller = new WorkItemGitHubPullPoller({
+            dataDir: tmpDir,
+            processStore: processStore(tmpDir),
+            workItemStore: store,
+            transport: makeTransport(issues),
+            now: () => '2026-01-03T00:00:00.000Z',
+            logError: message => logs.push(message),
+        });
+
+        const pullResult = await poller.pollWorkspace(REPO_ID);
+
+        expect(pullResult.candidatesConsidered).toBe(1);
+        expect(pullResult.truncated).toBe(false);
+        expect(logs).toEqual([]);
     });
 });

--- a/packages/coc/test/server/work-items/work-item-import-from-github.test.ts
+++ b/packages/coc/test/server/work-items/work-item-import-from-github.test.ts
@@ -533,7 +533,7 @@ describe('POST /api/workspaces/:id/work-items/import-from-github', () => {
         expect(res.body.syncLinks).toBeUndefined();
     });
 
-    it('re-pulls GitHub-owned fields and status while preserving plans and execution history', async () => {
+    it('preserves unpushed local edits to GitHub-owned fields on re-pull while still applying remote-only changes', async () => {
         const issues = new Map<number, GitHubWorkItemIssue>([
             [70, makeMockIssue(70, 'Remote Epic', 'open', {
                 labels: ['coc:type:epic', 'remote-tag'],
@@ -548,6 +548,8 @@ describe('POST /api/workspaces/:id/work-items/import-from-github', () => {
             [...issues.values()],
             () => NOW,
         );
+        // Local edits the user has NOT pushed back to GitHub. tags are left
+        // untouched so the remote tag change still flows through on re-pull.
         await store.updateWorkItem(first.root.id, {
             title: 'Local title edit',
             description: 'Local body edit',
@@ -564,6 +566,7 @@ describe('POST /api/workspaces/:id/work-items/import-from-github', () => {
                 status: 'running',
             }],
         });
+        // Remote also moved title/description/status and changed tags.
         issues.set(70, makeMockIssue(70, 'Remote Epic Updated', 'closed', {
             labels: ['coc:type:epic', 'coc:status:done', 'github-tag'],
             body: 'Remote body updated',
@@ -579,12 +582,24 @@ describe('POST /api/workspaces/:id/work-items/import-from-github', () => {
         );
 
         expect(second).toMatchObject({ created: 0, updated: 1 });
+        // The conflicting fields are reported so the divergence is observable.
+        expect(second.warnings).toHaveLength(1);
+        expect(second.warnings[0]).toMatchObject({
+            provider: 'github',
+            code: 'local-edits-preserved',
+            workItemId: first.root.id,
+            issueNumber: 70,
+        });
+        expect([...second.warnings[0].fields].sort()).toEqual(['description', 'status', 'title']);
+
         const updated = await store.getWorkItem(first.root.id, REPO_ID);
         expect(updated).toMatchObject({
-            title: 'Remote Epic Updated',
-            description: 'Remote body updated',
+            // Unpushed local edits survive the pull.
+            title: 'Local title edit',
+            description: 'Local body edit',
+            status: 'planning',
             type: 'epic',
-            status: 'done',
+            // tags were not edited locally, so the remote change still applies.
             tags: ['github-tag'],
             githubMirror: {
                 issueNumber: 70,
@@ -595,6 +610,136 @@ describe('POST /api/workspaces/:id/work-items/import-from-github', () => {
         });
         expect(updated?.plan?.content).toBe('Local plan');
         expect(updated?.executionHistory?.[0].taskId).toBe('task-1');
+    });
+
+    it('applies remote GitHub-owned changes when the local mirror has no unpushed edits', async () => {
+        const issues = new Map<number, GitHubWorkItemIssue>([
+            [71, makeMockIssue(71, 'Remote Epic', 'open', {
+                labels: ['coc:type:epic', 'remote-tag'],
+                body: 'Remote body',
+            })],
+        ]);
+
+        const first = await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(71)!,
+            [...issues.values()],
+            () => NOW,
+        );
+        // No local edits before the remote moves: a clean mirror takes the
+        // remote values, matching the prior remote-authoritative behavior.
+        issues.set(71, makeMockIssue(71, 'Remote Epic Updated', 'closed', {
+            labels: ['coc:type:epic', 'coc:status:done', 'github-tag'],
+            body: 'Remote body updated',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+        }));
+
+        const second = await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(71)!,
+            [...issues.values()],
+            () => '2026-01-03T00:00:00.000Z',
+        );
+
+        expect(second).toMatchObject({ created: 0, updated: 1 });
+        expect(second.warnings).toHaveLength(0);
+        const updated = await store.getWorkItem(first.root.id, REPO_ID);
+        expect(updated).toMatchObject({
+            title: 'Remote Epic Updated',
+            description: 'Remote body updated',
+            status: 'done',
+            tags: ['github-tag'],
+        });
+    });
+
+    it('keeps an unpushed local edit without a conflict warning when the remote field is unchanged', async () => {
+        const issues = new Map<number, GitHubWorkItemIssue>([
+            [72, makeMockIssue(72, 'Remote Epic', 'open', {
+                labels: ['coc:type:epic'],
+                body: 'Remote body',
+            })],
+        ]);
+
+        const first = await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(72)!,
+            [...issues.values()],
+            () => NOW,
+        );
+        await store.updateWorkItem(first.root.id, { title: 'Local title only' });
+        // Remote re-pull leaves title untouched (same issue), only bumps state.
+        issues.set(72, makeMockIssue(72, 'Remote Epic', 'open', {
+            labels: ['coc:type:epic'],
+            body: 'Remote body',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+        }));
+
+        const second = await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(72)!,
+            [...issues.values()],
+            () => '2026-01-03T00:00:00.000Z',
+        );
+
+        // Local edit survives, and since the remote title did not move there is
+        // no conflict to warn about.
+        expect(second.warnings).toHaveLength(0);
+        const updated = await store.getWorkItem(first.root.id, REPO_ID);
+        expect(updated?.title).toBe('Local title only');
+    });
+
+    it('preserves an unpushed local edit across repeated re-pulls until it is reconciled', async () => {
+        const issues = new Map<number, GitHubWorkItemIssue>([
+            [73, makeMockIssue(73, 'Remote Epic', 'open', {
+                labels: ['coc:type:epic'],
+                body: 'Remote body',
+            })],
+        ]);
+
+        const first = await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(73)!,
+            [...issues.values()],
+            () => NOW,
+        );
+        await store.updateWorkItem(first.root.id, { title: 'Local title edit' });
+        issues.set(73, makeMockIssue(73, 'Remote Title A', 'open', {
+            labels: ['coc:type:epic'],
+            body: 'Remote body',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+        }));
+
+        await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(73)!,
+            [...issues.values()],
+            () => '2026-01-03T00:00:00.000Z',
+        );
+        // Even though the first pull persisted a fresh mirror, the local edit is
+        // still dirty relative to the original synced base, so a second remote
+        // move must not silently overwrite it.
+        issues.set(73, makeMockIssue(73, 'Remote Title B', 'open', {
+            labels: ['coc:type:epic'],
+            body: 'Remote body',
+            updatedAt: '2026-01-04T00:00:00.000Z',
+        }));
+        const third = await importGitHubEpicTreeAsWorkItems(
+            { workspaceId: REPO_ID, workItemStore: store },
+            configuredRepo(),
+            issues.get(73)!,
+            [...issues.values()],
+            () => '2026-01-05T00:00:00.000Z',
+        );
+
+        expect(third.warnings).toHaveLength(1);
+        const updated = await store.getWorkItem(first.root.id, REPO_ID);
+        expect(updated?.title).toBe('Local title edit');
     });
 
     it('prunes mirrored descendants that disappear from the GitHub Epic subtree on re-pull', async () => {

--- a/packages/coc/test/server/work-items/work-item-origin-identity.test.ts
+++ b/packages/coc/test/server/work-items/work-item-origin-identity.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { getRepoDataPath } from '@plusplusoneplusplus/forge';
+import {
+    FileWorkItemStore,
+    type WorkItemStorageScope,
+} from '../../../src/server/work-items/work-item-store';
+import {
+    deriveWorkItemOriginProvider,
+    type WorkItem,
+    type WorkItemIndexEntry,
+} from '../../../src/server/work-items/types';
+
+let tmpDir: string;
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+    return {
+        id: `wi-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        repoId: 'test-repo',
+        title: 'Test work item',
+        description: 'A test work item description',
+        status: 'created',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        source: 'manual',
+        ...overrides,
+    };
+}
+
+/**
+ * Write a pre-origin-identity work item straight to disk (no originId), mirroring
+ * data created before this field existed, so the store's backfill can be exercised.
+ */
+async function writePreMigrationItem(repoId: string, item: WorkItem): Promise<void> {
+    const dir = getRepoDataPath(tmpDir, repoId, 'work-items');
+    await fs.mkdir(dir, { recursive: true });
+    const indexPath = path.join(dir, 'index.json');
+    let index: WorkItemIndexEntry[] = [];
+    try {
+        index = JSON.parse(await fs.readFile(indexPath, 'utf-8')) as WorkItemIndexEntry[];
+    } catch {
+        index = [];
+    }
+    const entry: WorkItemIndexEntry = {
+        id: item.id,
+        workItemNumber: item.workItemNumber,
+        repoId: item.repoId,
+        title: item.title,
+        description: item.description || undefined,
+        status: item.status,
+        type: item.type,
+        parentId: item.parentId,
+        source: item.source,
+        priority: item.priority,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        tags: item.tags,
+    };
+    const nextIndex = [...index.filter(e => e.id !== item.id), entry];
+    await fs.writeFile(path.join(dir, `${item.id}.json`), JSON.stringify(item, null, 2), 'utf-8');
+    await fs.writeFile(indexPath, JSON.stringify(nextIndex, null, 2), 'utf-8');
+}
+
+async function readItemFile(repoId: string, id: string): Promise<WorkItem> {
+    const file = path.join(getRepoDataPath(tmpDir, repoId, 'work-items'), `${id}.json`);
+    return JSON.parse(await fs.readFile(file, 'utf-8')) as WorkItem;
+}
+
+async function readIndexFile(repoId: string): Promise<WorkItemIndexEntry[]> {
+    const file = path.join(getRepoDataPath(tmpDir, repoId, 'work-items'), 'index.json');
+    return JSON.parse(await fs.readFile(file, 'utf-8')) as WorkItemIndexEntry[];
+}
+
+beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'coc-wi-origin-'));
+});
+
+afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('deriveWorkItemOriginProvider', () => {
+    it('maps canonical origin id prefixes to providers', () => {
+        expect(deriveWorkItemOriginProvider('gh_owner_repo')).toBe('github');
+        expect(deriveWorkItemOriginProvider('ado_org_project')).toBe('azure-devops');
+        expect(deriveWorkItemOriginProvider('git_deadbeef')).toBe('git');
+        expect(deriveWorkItemOriginProvider('local_ws-abc')).toBe('local');
+    });
+
+    it('defaults non-canonical caller stamps and absent ids to local', () => {
+        expect(deriveWorkItemOriginProvider('ws-hcv3mg')).toBe('local');
+        expect(deriveWorkItemOriginProvider('test-repo')).toBe('local');
+        expect(deriveWorkItemOriginProvider(undefined)).toBe('local');
+    });
+});
+
+describe('FileWorkItemStore origin identity (AC-03)', () => {
+    it('stamps a local-scope origin identity on create when no resolver is configured', async () => {
+        const store = new FileWorkItemStore({ dataDir: tmpDir });
+        const item = makeWorkItem({ id: 'wi-local', repoId: 'test-repo' });
+        await store.addWorkItem(item);
+
+        // Mutated in place by the store.
+        expect(item.originId).toBe('test-repo');
+        expect(item.originProvider).toBe('local');
+
+        const retrieved = await store.getWorkItem('wi-local', 'test-repo');
+        expect(retrieved?.originId).toBe('test-repo');
+        expect(retrieved?.originProvider).toBe('local');
+
+        const onDisk = await readItemFile('test-repo', 'wi-local');
+        expect(onDisk.originId).toBe('test-repo');
+        expect(onDisk.originProvider).toBe('local');
+
+        const [entry] = await readIndexFile('test-repo');
+        expect(entry.originId).toBe('test-repo');
+        expect(entry.originProvider).toBe('local');
+    });
+
+    it('stamps the canonical origin scope independent of the caller URL family', async () => {
+        const sameOriginScope: WorkItemStorageScope = {
+            storageRepoId: 'gh_owner_repo',
+            legacyRepoIds: ['clone-a', 'clone-b'],
+        };
+        const store = new FileWorkItemStore({
+            dataDir: tmpDir,
+            scopeResolver: () => sameOriginScope,
+        });
+
+        const item = makeWorkItem({ id: 'origin-shared', repoId: 'clone-a' });
+        await store.addWorkItem(item);
+
+        expect(item.originId).toBe('gh_owner_repo');
+        expect(item.originProvider).toBe('github');
+
+        // Read back through a *different* clone id — origin identity is stable.
+        const fromOtherClone = await store.getWorkItem('origin-shared', 'clone-b');
+        expect(fromOtherClone?.repoId).toBe('clone-a');
+        expect(fromOtherClone?.originId).toBe('gh_owner_repo');
+        expect(fromOtherClone?.originProvider).toBe('github');
+
+        const list = await store.listWorkItems({ repoId: 'clone-b' });
+        expect(list.items[0]?.originId).toBe('gh_owner_repo');
+        expect(list.items[0]?.originProvider).toBe('github');
+
+        // Persisted under the canonical origin directory.
+        const onDisk = await readItemFile('gh_owner_repo', 'origin-shared');
+        expect(onDisk.originId).toBe('gh_owner_repo');
+        expect(onDisk.originProvider).toBe('github');
+    });
+
+    it('backfills origin identity for pre-existing items and persists it', async () => {
+        const legacy = makeWorkItem({ id: 'legacy-1', repoId: 'gh_owner_repo' });
+        await writePreMigrationItem('gh_owner_repo', legacy);
+
+        // Confirm the fixture really lacks the field.
+        const before = await readItemFile('gh_owner_repo', 'legacy-1');
+        expect(before.originId).toBeUndefined();
+
+        const store = new FileWorkItemStore({ dataDir: tmpDir });
+        const list = await store.listWorkItems({ repoId: 'gh_owner_repo' });
+        expect(list.items[0]?.originId).toBe('gh_owner_repo');
+        expect(list.items[0]?.originProvider).toBe('github');
+
+        const retrieved = await store.getWorkItem('legacy-1', 'gh_owner_repo');
+        expect(retrieved?.originId).toBe('gh_owner_repo');
+        expect(retrieved?.originProvider).toBe('github');
+
+        // Migration is persisted to disk, not merely computed on read.
+        const onDiskItem = await readItemFile('gh_owner_repo', 'legacy-1');
+        expect(onDiskItem.originId).toBe('gh_owner_repo');
+        expect(onDiskItem.originProvider).toBe('github');
+
+        const [onDiskEntry] = await readIndexFile('gh_owner_repo');
+        expect(onDiskEntry.originId).toBe('gh_owner_repo');
+        expect(onDiskEntry.originProvider).toBe('github');
+    });
+
+    it('backfills a local origin scope for a non-remote workspace directory', async () => {
+        const legacy = makeWorkItem({ id: 'legacy-local', repoId: 'local_ws-xyz' });
+        await writePreMigrationItem('local_ws-xyz', legacy);
+
+        const store = new FileWorkItemStore({ dataDir: tmpDir });
+        const retrieved = await store.getWorkItem('legacy-local', 'local_ws-xyz');
+        expect(retrieved?.originId).toBe('local_ws-xyz');
+        expect(retrieved?.originProvider).toBe('local');
+    });
+
+    it('does not overwrite an already-stamped origin identity', async () => {
+        const store = new FileWorkItemStore({ dataDir: tmpDir });
+        const item = makeWorkItem({ id: 'keep-origin', repoId: 'gh_owner_repo' });
+        await store.addWorkItem(item);
+        expect(item.originId).toBe('gh_owner_repo');
+
+        // A later read must not re-derive or change the stored origin id.
+        await store.listWorkItems({ repoId: 'gh_owner_repo' });
+        const onDisk = await readItemFile('gh_owner_repo', 'keep-origin');
+        expect(onDisk.originId).toBe('gh_owner_repo');
+        expect(onDisk.originProvider).toBe('github');
+    });
+});

--- a/packages/coc/test/server/work-items/work-item-sync-github-issue.test.ts
+++ b/packages/coc/test/server/work-items/work-item-sync-github-issue.test.ts
@@ -3,6 +3,7 @@ import {
     buildGitHubWorkItemIssueUpdate,
     buildGitHubWorkItemLabels,
     formatGitHubWorkItemSyncMetadataBlock,
+    githubIssueContentRevision,
     hasExactlyOneGitHubWorkItemSyncMetadataBlock,
     parseGitHubWorkItemIssue,
     parseGitHubWorkItemSyncMetadataBlocks,
@@ -235,5 +236,57 @@ describe('work item GitHub issue mapping', () => {
         expect(rawMetadata).not.toContain('/home/example/repo');
         expect(rawMetadata).not.toContain('accessToken');
         expect(rawMetadata).not.toContain('localPath');
+    });
+});
+
+describe('githubIssueContentRevision', () => {
+    const baseIssue = {
+        title: 'Implement sync',
+        body: 'Prose for the issue.',
+        state: 'open',
+        labels: ['coc:type:feature', 'coc:status:planning', 'customer'],
+    };
+
+    it('is stable across label reordering and label object/string forms', () => {
+        const reordered = {
+            ...baseIssue,
+            labels: [{ name: 'customer' }, { name: 'coc:status:planning' }, 'coc:type:feature'],
+        };
+        expect(githubIssueContentRevision(reordered)).toBe(githubIssueContentRevision(baseIssue));
+    });
+
+    it('ignores the hidden coc-work-item-sync metadata block so per-push lastSyncedAt churn does not move it', () => {
+        const block = formatGitHubWorkItemSyncMetadataBlock({
+            schemaVersion: 1,
+            provider: 'github',
+            remote: { owner: 'octo-org', repo: 'octo-repo' },
+            type: 'feature',
+            status: 'planning',
+            lastSyncedAt: '2026-03-03T03:03:03.000Z',
+        });
+        const laterBlock = formatGitHubWorkItemSyncMetadataBlock({
+            schemaVersion: 1,
+            provider: 'github',
+            remote: { owner: 'octo-org', repo: 'octo-repo' },
+            type: 'feature',
+            status: 'planning',
+            lastSyncedAt: '2026-09-09T09:09:09.000Z',
+        });
+        const first = { ...baseIssue, body: `${baseIssue.body}\n\n${block}` };
+        const second = { ...baseIssue, body: `${baseIssue.body}\n\n${laterBlock}` };
+        expect(githubIssueContentRevision(second)).toBe(githubIssueContentRevision(first));
+        // And equal to the bare-prose revision, since the block is stripped.
+        expect(githubIssueContentRevision(first)).toBe(githubIssueContentRevision(baseIssue));
+    });
+
+    it('changes when CoC-owned content (title, body, state, or labels) changes', () => {
+        const base = githubIssueContentRevision(baseIssue);
+        expect(githubIssueContentRevision({ ...baseIssue, title: 'Renamed' })).not.toBe(base);
+        expect(githubIssueContentRevision({ ...baseIssue, body: 'Different prose.' })).not.toBe(base);
+        expect(githubIssueContentRevision({ ...baseIssue, state: 'closed' })).not.toBe(base);
+        expect(githubIssueContentRevision({
+            ...baseIssue,
+            labels: [...baseIssue.labels, 'coc:status:executing'],
+        })).not.toBe(base);
     });
 });

--- a/packages/coc/test/server/work-items/work-item-tool-explicit-target.test.ts
+++ b/packages/coc/test/server/work-items/work-item-tool-explicit-target.test.ts
@@ -1,0 +1,192 @@
+/**
+ * AC-02 — Create/update can target an explicit workspace/origin.
+ *
+ * The `create_update_work_item` AI tool bakes in the active workspace's repoId
+ * at construction. These tests prove the new `targetWorkspaceId` argument lets a
+ * caller scope a create (or update) to a DIFFERENT workspace of the same upstream
+ * repo, resolved to its canonical origin — so an item can be born directly under
+ * a mirrored parent (e.g. PBI-17) without the cross-workspace error — while
+ * omitting the argument preserves today's active-workspace behavior byte-for-byte.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    FileWorkItemStore,
+    type WorkItemStorageScopeResolver,
+} from '../../../src/server/work-items/work-item-store';
+import { createCreateUpdateWorkItemTool } from '../../../src/server/llm-tools/create-update-work-item-tool';
+import type { WorkItem } from '../../../src/server/work-items/types';
+
+// Canonical origin scopes (where items physically live).
+const LOCAL_ORIGIN = 'local_localclone';
+const MIRROR_ORIGIN = 'gh_owner_repo';
+const OTHER_ORIGIN = 'gh_owner_other';
+// Per-clone workspace ids that resolve to the origins above.
+const WS_LOCAL = 'ws-local';
+const WS_MIRROR = 'ws-mirror';
+const NOW = '2026-01-01T00:00:00.000Z';
+
+let tmpDir: string;
+let store: FileWorkItemStore;
+
+// Mirrors createWorkItemStorageScopeResolver: a per-clone ws-* id and its
+// canonical origin collapse to one storageRepoId; unrelated repos differ.
+const scopeResolver: WorkItemStorageScopeResolver = (repoId: string) => {
+    if (repoId === WS_LOCAL || repoId === LOCAL_ORIGIN) {
+        return { storageRepoId: LOCAL_ORIGIN, legacyRepoIds: [WS_LOCAL] };
+    }
+    if (repoId === WS_MIRROR || repoId === MIRROR_ORIGIN) {
+        return { storageRepoId: MIRROR_ORIGIN, legacyRepoIds: [WS_MIRROR] };
+    }
+    if (repoId === OTHER_ORIGIN) {
+        return { storageRepoId: OTHER_ORIGIN };
+    }
+    return undefined;
+};
+
+function makeItem(overrides: Partial<WorkItem>): WorkItem {
+    return {
+        id: overrides.id ?? 'item-1',
+        repoId: overrides.repoId ?? MIRROR_ORIGIN,
+        title: overrides.title ?? 'Item',
+        description: overrides.description ?? '',
+        status: overrides.status ?? 'created',
+        type: overrides.type,
+        parentId: overrides.parentId,
+        createdAt: overrides.createdAt ?? NOW,
+        updatedAt: overrides.updatedAt ?? NOW,
+        source: overrides.source ?? 'manual',
+    };
+}
+
+/** Rewrite a stored item's stamped repoId to simulate a foreign-origin stamp. */
+async function restampStoredRepoId(storageRepoId: string, id: string, repoId: string): Promise<void> {
+    const file = path.join(tmpDir, 'repos', storageRepoId, 'work-items', `${id}.json`);
+    const raw = JSON.parse(await fs.readFile(file, 'utf-8'));
+    raw.repoId = repoId;
+    await fs.writeFile(file, JSON.stringify(raw, null, 2));
+}
+
+// The active local workspace the tool is constructed against.
+function makeTool() {
+    const { tool } = createCreateUpdateWorkItemTool(tmpDir, WS_LOCAL, undefined, {
+        workItemStore: store,
+        getHierarchyEnabled: () => true,
+        getSyncEnabled: () => false,
+    });
+    return tool;
+}
+
+beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wi-tool-target-'));
+    store = new FileWorkItemStore({ dataDir: tmpDir, scopeResolver });
+});
+
+afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('AC-02 — create with explicit targetWorkspaceId', () => {
+    it('creates an item under a mirrored parent when targetWorkspaceId is the mirror origin', async () => {
+        // PBI born under the canonical mirror origin scope (gh_*).
+        await store.addWorkItem(makeItem({ id: 'pbi-17', type: 'pbi', repoId: MIRROR_ORIGIN }));
+        const tool = makeTool();
+
+        const result: any = await tool.handler({
+            title: 'Task under mirrored PBI',
+            parentId: 'pbi-17',
+            targetWorkspaceId: MIRROR_ORIGIN,
+        });
+
+        expect(result.created).toBe(true);
+        expect(result.parentId).toBe('pbi-17');
+        // Stamped + physically stored under the mirror origin, not the active local one.
+        const inMirror = await store.getWorkItem(result.id, MIRROR_ORIGIN);
+        expect(inMirror?.repoId).toBe(MIRROR_ORIGIN);
+        expect(inMirror?.parentId).toBe('pbi-17');
+        // Not present in the active local workspace scope.
+        const inLocal = await store.listWorkItems({ repoId: LOCAL_ORIGIN });
+        expect(inLocal.items.some(i => i.id === result.id)).toBe(false);
+    });
+
+    it('resolves a ws-* target workspace to its canonical origin scope', async () => {
+        await store.addWorkItem(makeItem({ id: 'pbi-17', type: 'pbi', repoId: MIRROR_ORIGIN }));
+        const tool = makeTool();
+
+        const result: any = await tool.handler({
+            title: 'Task via ws-* mirror id',
+            parentId: 'pbi-17',
+            targetWorkspaceId: WS_MIRROR,
+        });
+
+        expect(result.created).toBe(true);
+        const stored = await store.getWorkItem(result.id, MIRROR_ORIGIN);
+        // Resolved to the canonical origin even though a ws-* id was passed.
+        expect(stored?.repoId).toBe(MIRROR_ORIGIN);
+        expect(stored?.parentId).toBe('pbi-17');
+    });
+
+    it('still rejects a parent that resolves to a genuinely different origin than the target', async () => {
+        await store.addWorkItem(makeItem({ id: 'pbi-foreign', type: 'pbi', repoId: MIRROR_ORIGIN }));
+        await restampStoredRepoId(MIRROR_ORIGIN, 'pbi-foreign', OTHER_ORIGIN);
+        const tool = makeTool();
+
+        const result: any = await tool.handler({
+            title: 'Task',
+            parentId: 'pbi-foreign',
+            targetWorkspaceId: MIRROR_ORIGIN,
+        });
+
+        expect(result.created).toBe(false);
+        expect(result.error).toContain('Parent work item must be in the same workspace');
+    });
+});
+
+describe('AC-02 — default (no targetWorkspaceId) preserves active-workspace behavior', () => {
+    it('stamps the active workspace id and stores under its origin', async () => {
+        const tool = makeTool();
+
+        const result: any = await tool.handler({ title: 'Solo local task' });
+
+        expect(result.created).toBe(true);
+        // Stamped with the baked-in active workspace id (NOT rewritten to origin).
+        const stored = await store.getWorkItem(result.id, WS_LOCAL);
+        expect(stored?.repoId).toBe(WS_LOCAL);
+        // Physically stored under the active workspace's origin scope.
+        const inLocalOrigin = await store.listWorkItems({ repoId: LOCAL_ORIGIN });
+        expect(inLocalOrigin.items.some(i => i.id === result.id)).toBe(true);
+        // Not present in the unrelated mirror scope.
+        const inMirror = await store.listWorkItems({ repoId: MIRROR_ORIGIN });
+        expect(inMirror.items.some(i => i.id === result.id)).toBe(false);
+    });
+
+    it('treats a blank targetWorkspaceId as omitted', async () => {
+        const tool = makeTool();
+
+        const result: any = await tool.handler({ title: 'Blank target task', targetWorkspaceId: '   ' });
+
+        expect(result.created).toBe(true);
+        const stored = await store.getWorkItem(result.id, WS_LOCAL);
+        expect(stored?.repoId).toBe(WS_LOCAL);
+    });
+});
+
+describe('AC-02 — update with explicit targetWorkspaceId', () => {
+    it('updates an item that lives in the targeted workspace scope', async () => {
+        await store.addWorkItem(makeItem({ id: 'mirror-item', title: 'Original', repoId: MIRROR_ORIGIN }));
+        const tool = makeTool();
+
+        const result: any = await tool.handler({
+            target: 'mirror-item',
+            title: 'Renamed in mirror',
+            targetWorkspaceId: MIRROR_ORIGIN,
+        });
+
+        expect(result.updated).toBe(true);
+        const stored = await store.getWorkItem('mirror-item', MIRROR_ORIGIN);
+        expect(stored?.title).toBe('Renamed in mirror');
+    });
+});


### PR DESCRIPTION
- **feat(work-items): AC-02 — honor explicit targetWorkspaceId in create_update tool**
- **feat(work-items): AC-03 — persist stable originId + originProvider scope identity**
- **feat(work-items): AC-05 — make GitHub pull truncation observable**
- **feat(work-items): AC-05 — preserve unpushed local edits on GitHub pull**
- **feat(work-items): AC-05 — content-revision GitHub conflict check**
