### PR TITLE
fix(spa): route git review popout calls to remote CoC server for remote workspaces

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/CommitStrip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/CommitStrip.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { DetectedCommit } from './commitDetection';
 import { buildGitReviewPopOutUrl } from '../../../layout/Router';
 import { useGitReviewPopOut, gitReviewPopOutKey } from '../../../contexts/GitReviewPopOutContext';
+import { lookupCloneBaseUrl } from '../../../repos/cloneRegistry';
 
 export interface CommitStripProps {
     commits: DetectedCommit[];
@@ -32,7 +33,7 @@ export function CommitStrip({ commits, workspaceId }: CommitStripProps) {
         e.stopPropagation();
         if (!workspaceId) return;
         const hash = commit.fullHash || commit.shortHash;
-        const url = buildGitReviewPopOutUrl(workspaceId, hash);
+        const url = buildGitReviewPopOutUrl(workspaceId, hash, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-${hash}`, 'width=1200,height=800');
         if (win) {
             markPoppedOut(gitReviewPopOutKey(workspaceId, hash));

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup.tsx
@@ -18,6 +18,7 @@ import type { DetectedPullRequest } from '../pullRequestDetection';
 import { CommitStrip } from '../CommitStrip';
 import { buildGitReviewPopOutUrl } from '../../../../layout/Router';
 import { useGitReviewPopOut, gitReviewPopOutKey } from '../../../../contexts/GitReviewPopOutContext';
+import { lookupCloneBaseUrl } from '../../../../repos/cloneRegistry';
 import { normalizeToolName } from './toolNormalization';
 
 interface ToolLike {
@@ -521,7 +522,7 @@ function CommitHoverPopover({ commits, workspaceId, anchorRef, popoverRef, onMou
         e.stopPropagation();
         if (!workspaceId) return;
         const hash = commit.fullHash || commit.shortHash;
-        const url = buildGitReviewPopOutUrl(workspaceId, hash);
+        const url = buildGitReviewPopOutUrl(workspaceId, hash, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-${hash}`, 'width=1200,height=800');
         if (win) {
             markPoppedOut(gitReviewPopOutKey(workspaceId, hash));

--- a/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
@@ -17,7 +17,7 @@ import { useWebSocket } from '../../hooks/useWebSocket';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { getSpaCocClientErrorMessage } from '../../api/cocClient';
 import { useCocClient } from '../../repos/cloneRouting';
-import { getCocClientForWorkspace } from '../../repos/cloneRegistry';
+import { getCocClientForWorkspace, lookupCloneBaseUrl } from '../../repos/cloneRegistry';
 import { Spinner } from '../../ui';
 import { CommitList, isTouchOnly } from './commits/CommitList';
 import type { GitCommitItem } from './commits/CommitList';
@@ -714,7 +714,7 @@ export function RepoGitTab({ workspaceId }: RepoGitTabProps) {
 
     const handleOpenAsPopup = useCallback((commit: GitCommitItem) => {
         closeContextMenu();
-        const url = buildGitReviewPopOutUrl(workspaceId, commit.hash);
+        const url = buildGitReviewPopOutUrl(workspaceId, commit.hash, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-${commit.hash}`, 'width=1200,height=800');
         if (win) {
             markPoppedOut(gitReviewPopOutKey(workspaceId, commit.hash));

--- a/packages/coc/src/server/spa/client/react/features/git/branches/BranchRangeOverview.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/branches/BranchRangeOverview.tsx
@@ -17,6 +17,7 @@ import type { BranchRangeInfo } from './BranchChanges';
 import { useGitReviewPopOut, gitReviewBranchPopOutKey } from '../../../contexts/GitReviewPopOutContext';
 import { buildGitBranchRangePopOutUrl } from '../../../layout/Router';
 import { createGitRangeContextDragPayload } from '../../chat/sessionContextDrag';
+import { lookupCloneBaseUrl } from '../../../repos/cloneRegistry';
 import { isSessionContextAttachmentsEnabled } from '../../../utils/config';
 
 const RANGE_STORAGE_KEY = 'coc.branchRangeOverview.upperHeight';
@@ -61,7 +62,7 @@ export function BranchRangeOverview({ workspaceId, range, commits: rangeCommits,
         : null;
 
     const handlePopOut = useCallback(() => {
-        const url = buildGitBranchRangePopOutUrl(workspaceId);
+        const url = buildGitBranchRangePopOutUrl(workspaceId, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-branch-${workspaceId}`, 'width=1200,height=800');
         if (win) {
             markPoppedOut(gitReviewBranchPopOutKey(workspaceId));

--- a/packages/coc/src/server/spa/client/react/features/git/commits/CommitDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/commits/CommitDetail.tsx
@@ -25,6 +25,7 @@ import { useQueue } from '../../../contexts/QueueContext';
 import { useGitReviewPopOut, gitReviewPopOutKey } from '../../../contexts/GitReviewPopOutContext';
 import { buildGitReviewPopOutUrl } from '../../../layout/Router';
 import { getSpaCocClient } from '../../../api/cocClient';
+import { lookupCloneBaseUrl } from '../../../repos/cloneRegistry';
 import { useClassification } from '../diff/useClassification';
 import { useModalJobAiSelection } from '../../../shared/ModalJobAiControls';
 import { ClassifyDiffAiControls } from '../diff/ClassifyDiffAiControls';
@@ -174,7 +175,7 @@ export function CommitDetail({ workspaceId, hash, commit, isPopOut, scrollToFile
 
     const handlePopOut = useCallback(() => {
         if (!hash) return;
-        const url = buildGitReviewPopOutUrl(workspaceId, hash);
+        const url = buildGitReviewPopOutUrl(workspaceId, hash, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-${hash}`, 'width=1200,height=800');
         if (win) {
             markPoppedOut(gitReviewPopOutKey(workspaceId, hash));

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -37,6 +37,7 @@ import type { ClassificationKey } from '../git/diff/diffSource';
 import { buildGitPrPopOutUrl } from '../../layout/Router';
 import { resolveCanonicalOriginId } from '../../repos/originScope';
 import { useGitReviewPopOut, gitReviewPrPopOutKey } from '../../contexts/GitReviewPopOutContext';
+import { lookupCloneBaseUrl } from '../../repos/cloneRegistry';
 import { useReviewChatPresentation } from '../git/hooks/useReviewChatPresentation';
 import type { ReviewChatTarget } from '../git/commits/commitChatPlacement';
 import {
@@ -152,7 +153,7 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
     }, [assistantOpen, toggleAssistant]);
 
     const handleFileClick = useCallback((filePath: string) => {
-        const url = buildGitPrPopOutUrl(workspaceId, String(repoId), String(prId), originId);
+        const url = buildGitPrPopOutUrl(workspaceId, String(repoId), String(prId), originId, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-pr-${prId}`, 'width=1200,height=800');
         if (win) {
             markPoppedOut(gitReviewPrPopOutKey(workspaceId, String(prId)));

--- a/packages/coc/src/server/spa/client/react/layout/PopOutGitReviewShell.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/PopOutGitReviewShell.tsx
@@ -16,7 +16,7 @@ import { QueueProvider } from '../contexts/QueueContext';
 import { ThemeProvider } from './ThemeProvider';
 import { ToastProvider } from '../contexts/ToastContext';
 import { ToastContainer, useToast } from '../ui';
-import { getSpaCocClient } from '../api/cocClient';
+import { registerCloneBaseUrls, getCocClientForWorkspace } from '../repos/cloneRegistry';
 import { CommitChatPanel } from '../features/git/commits/CommitChatPanel';
 import { CommitChatPlacementFrame } from '../features/git/commits/CommitChatPlacementFrame';
 import { ReviewChatPlacementFrame } from '../features/git/reviewChat/ReviewChatPlacementFrame';
@@ -66,6 +66,8 @@ export interface PopOutGitReviewParams {
     prId?: string;
     repoId?: string;
     originId?: string;
+    /** Remote clone baseUrl for the workspace, when the workspace lives on a remote CoC server. */
+    cloneBaseUrl?: string;
 }
 
 export function parsePopOutGitReviewRoute(hash: string, search: string): PopOutGitReviewParams | null {
@@ -77,14 +79,16 @@ export function parsePopOutGitReviewRoute(hash: string, search: string): PopOutG
     const workspaceId = searchParams.get('workspace');
     if (!workspaceId) return null;
 
+    const cloneBaseUrl = searchParams.get('cloneBaseUrl') || undefined;
+
     if (parts[2] === 'branch-range') {
-        return { workspaceId, reviewType: 'branch-range' };
+        return { workspaceId, reviewType: 'branch-range', cloneBaseUrl };
     }
 
     if (parts[2] === 'pr' && parts[3]) {
         const repoId = searchParams.get('repo') ?? workspaceId;
         const originId = searchParams.get('origin')?.trim() || undefined;
-        return { workspaceId, reviewType: 'pr', prId: decodeURIComponent(parts[3]), repoId, originId };
+        return { workspaceId, reviewType: 'pr', prId: decodeURIComponent(parts[3]), repoId, originId, cloneBaseUrl };
     }
 
     // 'pr' without a prId is invalid
@@ -93,7 +97,7 @@ export function parsePopOutGitReviewRoute(hash: string, search: string): PopOutG
     }
 
     if (parts[2]) {
-        return { workspaceId, reviewType: 'commit', commitHash: decodeURIComponent(parts[2]) };
+        return { workspaceId, reviewType: 'commit', commitHash: decodeURIComponent(parts[2]), cloneBaseUrl };
     }
 
     return null;
@@ -164,7 +168,7 @@ function CommitReviewContent({ workspaceId, commitHash }: { workspaceId: string;
 
     useEffect(() => {
         setLoading(true);
-        getSpaCocClient().git.getCommit(workspaceId, commitHash)
+        getCocClientForWorkspace(workspaceId).git.getCommit(workspaceId, commitHash)
             .then((data: GitCommitItem) => {
                 setCommit(data);
             })
@@ -173,7 +177,7 @@ function CommitReviewContent({ workspaceId, commitHash }: { workspaceId: string;
     }, [workspaceId, commitHash]);
 
     // Fetch the diff to extract file list (shares cache with CommitDetail)
-    const diffUrl = getSpaCocClient().git.commitDiffPath(workspaceId, commitHash);
+    const diffUrl = getCocClientForWorkspace(workspaceId).git.commitDiffPath(workspaceId, commitHash);
     const { diff } = useCachedDiff(diffUrl, workspaceId, commitHash);
     const fileList = useMemo(() => diff ? parseDiffFileList(diff) : [], [diff]);
     const filePaths = useMemo(() => fileList.map(f => f.path), [fileList]);
@@ -458,10 +462,10 @@ function BranchRangeReviewContent({ workspaceId }: { workspaceId: string }) {
         setLoading(true);
         setError(null);
 
-        const client = getSpaCocClient();
+        const client = getCocClientForWorkspace(workspaceId);
         Promise.all([
             client.git.getBranchRange(workspaceId),
-            client.git.listBranchRangeFiles(workspaceId).catch(() => ({ files: [] })),
+            client.git.listBranchRangeFiles(workspaceId),
         ])
             .then(([rangeData, filesData]) => {
                 if (isBranchRangeInfo(rangeData)) setRange(rangeData);
@@ -683,7 +687,7 @@ function PrReviewContent({ workspaceId, repoId, prId, originId, onTitleLoaded }:
     useEffect(() => {
         setLoading(true);
         setError(null);
-        const client = getSpaCocClient();
+        const client = getCocClientForWorkspace(workspaceId);
 
         Promise.all([
             client.pullRequests.getForOrigin(progressOriginId, prId, { workspaceId, repoId }) as Promise<{ title?: string; headSha?: string }>,
@@ -1018,6 +1022,12 @@ function PopOutGitReviewContent({ params }: { params: PopOutGitReviewParams }) {
 
 export function PopOutGitReviewShell() {
     const params = parsePopOutGitReviewRoute(window.location.hash, window.location.search);
+
+    // Seed the clone registry so workspace-scoped calls route to the remote server.
+    // Must run synchronously before any child renders, since the registry is module-level.
+    if (params?.cloneBaseUrl) {
+        registerCloneBaseUrls([{ workspaceId: params.workspaceId, baseUrl: params.cloneBaseUrl }]);
+    }
 
     if (!params) {
         return (

--- a/packages/coc/src/server/spa/client/react/layout/Router.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/Router.tsx
@@ -144,19 +144,22 @@ export function parseGitFileDeepLink(hash: string): { commitHash: string; filePa
 }
 
 /** Build a pop-out URL for git commit review. */
-export function buildGitReviewPopOutUrl(workspaceId: string, commitHash: string): string {
-    return `/?workspace=${encodeURIComponent(workspaceId)}#popout/git-review/${encodeURIComponent(commitHash)}`;
+export function buildGitReviewPopOutUrl(workspaceId: string, commitHash: string, cloneBaseUrl?: string): string {
+    const cloneParam = cloneBaseUrl ? `&cloneBaseUrl=${encodeURIComponent(cloneBaseUrl)}` : '';
+    return `/?workspace=${encodeURIComponent(workspaceId)}${cloneParam}#popout/git-review/${encodeURIComponent(commitHash)}`;
 }
 
 /** Build a pop-out URL for branch-range review. */
-export function buildGitBranchRangePopOutUrl(workspaceId: string): string {
-    return `/?workspace=${encodeURIComponent(workspaceId)}#popout/git-review/branch-range`;
+export function buildGitBranchRangePopOutUrl(workspaceId: string, cloneBaseUrl?: string): string {
+    const cloneParam = cloneBaseUrl ? `&cloneBaseUrl=${encodeURIComponent(cloneBaseUrl)}` : '';
+    return `/?workspace=${encodeURIComponent(workspaceId)}${cloneParam}#popout/git-review/branch-range`;
 }
 
 /** Build a pop-out URL for PR review. */
-export function buildGitPrPopOutUrl(workspaceId: string, repoId: string, prId: string | number, originId?: string): string {
+export function buildGitPrPopOutUrl(workspaceId: string, repoId: string, prId: string | number, originId?: string, cloneBaseUrl?: string): string {
     const originParam = originId ? `&origin=${encodeURIComponent(originId)}` : '';
-    return `/?workspace=${encodeURIComponent(workspaceId)}&repo=${encodeURIComponent(repoId)}${originParam}#popout/git-review/pr/${encodeURIComponent(String(prId))}`;
+    const cloneParam = cloneBaseUrl ? `&cloneBaseUrl=${encodeURIComponent(cloneBaseUrl)}` : '';
+    return `/?workspace=${encodeURIComponent(workspaceId)}&repo=${encodeURIComponent(repoId)}${originParam}${cloneParam}#popout/git-review/pr/${encodeURIComponent(String(prId))}`;
 }
 
 export function parseWorkflowDeepLink(hash: string): { repoId: string; processId: string } | null {

--- a/packages/coc/test/spa/react/RepoGitTab.test.ts
+++ b/packages/coc/test/spa/react/RepoGitTab.test.ts
@@ -1202,7 +1202,8 @@ describe('RepoGitTab', () => {
         it('defines handleOpenAsPopup with the commit pop-out URL and window target', () => {
             const block = source.match(/const handleOpenAsPopup = useCallback[\s\S]*?\}, \[workspaceId, closeContextMenu, markPoppedOut\]\)/);
             expect(block).toBeTruthy();
-            expect(block![0]).toContain('buildGitReviewPopOutUrl(workspaceId, commit.hash)');
+            // Must pass cloneBaseUrl so remote workspaces route to the remote server.
+            expect(block![0]).toContain('buildGitReviewPopOutUrl(workspaceId, commit.hash, lookupCloneBaseUrl(workspaceId))');
             expect(block![0]).toContain("window.open(url, `coc-git-review-${commit.hash}`, 'width=1200,height=800')");
             expect(block![0]).toContain('markPoppedOut(gitReviewPopOutKey(workspaceId, commit.hash))');
         });

--- a/packages/coc/test/spa/react/layout/PopOutGitReviewShell.test.tsx
+++ b/packages/coc/test/spa/react/layout/PopOutGitReviewShell.test.tsx
@@ -161,8 +161,11 @@ describe('PopOutGitReviewShell: content components', () => {
 });
 
 describe('PopOutGitReviewShell: typed client loading', () => {
-    it('loads git review data through the shared SPA CoC client', () => {
-        expect(SOURCE).toContain('getSpaCocClient');
+    it('routes git calls through getCocClientForWorkspace, not getSpaCocClient directly', () => {
+        // All git data loading goes through getCocClientForWorkspace so remote workspaces
+        // route to the correct remote CoC server instead of the local one.
+        expect(SOURCE).toContain('getCocClientForWorkspace');
+        expect(SOURCE).not.toContain('getSpaCocClient()');
         expect(SOURCE).toContain('.git.getCommit');
         expect(SOURCE).toContain('.git.getBranchRange');
         expect(SOURCE).toContain('.git.listBranchRangeFiles');
@@ -177,6 +180,61 @@ describe('PopOutGitReviewShell: typed client loading', () => {
         expect(SOURCE).toContain('getDiffForOrigin(progressOriginId, prId');
         expect(SOURCE).toContain('originId: progressOriginId');
         expect(SOURCE).not.toContain('getDiff(repoId, prId)');
+    });
+});
+
+describe('PopOutGitReviewShell: remote clone registry bootstrap', () => {
+    it('imports registerCloneBaseUrls for registry seeding', () => {
+        expect(SOURCE).toContain('registerCloneBaseUrls');
+    });
+
+    it('seeds registry from cloneBaseUrl param when present', () => {
+        // The shell must call registerCloneBaseUrls with the workspace/baseUrl pair
+        // so all workspace-scoped calls inside the popout route to the remote server.
+        expect(SOURCE).toContain("cloneBaseUrl");
+        expect(SOURCE).toContain("registerCloneBaseUrls([{ workspaceId");
+    });
+
+    it('parses cloneBaseUrl from URL search params for commit route', () => {
+        const result = parsePopOutGitReviewRoute(
+            '#popout/git-review/abc123',
+            '?workspace=ws1&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4000'
+        );
+        expect(result).not.toBeNull();
+        expect(result!.cloneBaseUrl).toBe('http://127.0.0.1:4000');
+    });
+
+    it('parses cloneBaseUrl for branch-range route', () => {
+        const result = parsePopOutGitReviewRoute(
+            '#popout/git-review/branch-range',
+            '?workspace=ws2&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4001'
+        );
+        expect(result).not.toBeNull();
+        expect(result!.cloneBaseUrl).toBe('http://127.0.0.1:4001');
+    });
+
+    it('parses cloneBaseUrl for PR route', () => {
+        const result = parsePopOutGitReviewRoute(
+            '#popout/git-review/pr/42',
+            '?workspace=ws3&repo=r1&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4002'
+        );
+        expect(result).not.toBeNull();
+        expect(result!.cloneBaseUrl).toBe('http://127.0.0.1:4002');
+    });
+
+    it('omits cloneBaseUrl for local workspaces (no param in URL)', () => {
+        const result = parsePopOutGitReviewRoute(
+            '#popout/git-review/abc123',
+            '?workspace=ws1'
+        );
+        expect(result).not.toBeNull();
+        expect(result!.cloneBaseUrl).toBeUndefined();
+    });
+
+    it('surfaces listBranchRangeFiles errors instead of swallowing them', () => {
+        // Branch-range calls must NOT use .catch(() => ({ files: [] })) — that would
+        // silently hide remote routing failures and show an empty list with no message.
+        expect(SOURCE).not.toContain('.catch(() => ({ files: [] }))');
     });
 });
 

--- a/packages/coc/test/spa/react/layout/Router.git-review-popout.test.ts
+++ b/packages/coc/test/spa/react/layout/Router.git-review-popout.test.ts
@@ -24,6 +24,17 @@ describe('buildGitReviewPopOutUrl', () => {
         const url = buildGitReviewPopOutUrl('ws1', 'abc/123');
         expect(url).toContain('#popout/git-review/abc%2F123');
     });
+
+    it('includes encoded cloneBaseUrl when provided', () => {
+        const url = buildGitReviewPopOutUrl('ws-1', 'abc123', 'http://127.0.0.1:4000');
+        expect(url).toContain('cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4000');
+        expect(url).toBe('/?workspace=ws-1&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4000#popout/git-review/abc123');
+    });
+
+    it('omits cloneBaseUrl param when not provided', () => {
+        const url = buildGitReviewPopOutUrl('ws-1', 'abc123');
+        expect(url).not.toContain('cloneBaseUrl');
+    });
 });
 
 describe('buildGitBranchRangePopOutUrl', () => {
@@ -35,6 +46,17 @@ describe('buildGitBranchRangePopOutUrl', () => {
     it('encodes workspace ID', () => {
         const url = buildGitBranchRangePopOutUrl('ws with space');
         expect(url).toContain('workspace=ws%20with%20space');
+    });
+
+    it('includes encoded cloneBaseUrl when provided', () => {
+        const url = buildGitBranchRangePopOutUrl('ws-1', 'http://127.0.0.1:4001');
+        expect(url).toContain('cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4001');
+        expect(url).toBe('/?workspace=ws-1&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4001#popout/git-review/branch-range');
+    });
+
+    it('omits cloneBaseUrl param when not provided', () => {
+        const url = buildGitBranchRangePopOutUrl('ws-1');
+        expect(url).not.toContain('cloneBaseUrl');
     });
 });
 
@@ -59,5 +81,21 @@ describe('buildGitPrPopOutUrl', () => {
     it('includes the origin ID when provided', () => {
         const url = buildGitPrPopOutUrl('ws-1', 'repo-1', '42', 'gh_owner_repo');
         expect(url).toBe('/?workspace=ws-1&repo=repo-1&origin=gh_owner_repo#popout/git-review/pr/42');
+    });
+
+    it('includes encoded cloneBaseUrl when provided', () => {
+        const url = buildGitPrPopOutUrl('ws-1', 'repo-1', '42', 'gh_owner_repo', 'http://127.0.0.1:4002');
+        expect(url).toContain('cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4002');
+        expect(url).toBe('/?workspace=ws-1&repo=repo-1&origin=gh_owner_repo&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4002#popout/git-review/pr/42');
+    });
+
+    it('omits cloneBaseUrl param when not provided', () => {
+        const url = buildGitPrPopOutUrl('ws-1', 'repo-1', '42', 'gh_owner_repo');
+        expect(url).not.toContain('cloneBaseUrl');
+    });
+
+    it('includes cloneBaseUrl without originId when originId is omitted', () => {
+        const url = buildGitPrPopOutUrl('ws-1', 'repo-1', '42', undefined, 'http://127.0.0.1:4003');
+        expect(url).toBe('/?workspace=ws-1&repo=repo-1&cloneBaseUrl=http%3A%2F%2F127.0.0.1%3A4003#popout/git-review/pr/42');
     });
 });


### PR DESCRIPTION
The popout window boots without ReposProvider, so the clone registry
(cloneBaseUrlByWorkspace) was never seeded — all workspace-scoped git
calls fell through to the local server, producing an empty file list
for remote repositories.

Fix:
- URL builders (buildGitReviewPopOutUrl/BranchRange/Pr) now accept an
  optional cloneBaseUrl param encoded as a query string.
- Callers pass lookupCloneBaseUrl(workspaceId) so the URL carries the
  remote server's baseUrl into the popout.
- PopOutGitReviewShell reads cloneBaseUrl from URL params and calls
  registerCloneBaseUrls() synchronously before any child renders,
  seeding the registry for the popout's JS module scope.
- All direct getSpaCocClient() calls in the popout replaced with
  getCocClientForWorkspace(workspaceId) so they route to the remote
  server when the registry entry is present.
- Removed .catch(() => ({ files: [] })) from listBranchRangeFiles so
  routing failures surface as an error message instead of a blank list.

Tests: new assertions verify cloneBaseUrl round-trips through parse/build,
registry seeding call site, no direct getSpaCocClient() usage in the shell,
and error propagation; URL builder tests cover the cloneBaseUrl param.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
