### PR TITLE
feat(schedules): add "Refine with AI ✨" for prompt routine instructions

### DIFF
--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -217,6 +217,7 @@ All Dreams routes are workspace-scoped and gated by `dreams.enabled` (default `f
 | DELETE | `/api/schedules/:id` | Delete schedule |
 | POST | `/api/schedules/:id/run` | Trigger immediate run |
 | GET | `/api/schedules/:id/runs` | Run history |
+| POST | `/api/schedules/refine` | AI-refine prompt-routine instructions (`{ instructions, hint?, model? }` → `{ refined, raw }`) |
 
 Prompt schedules expose Ask and Autopilot modes. Stored or incoming schedule entries with `mode='plan'` are read as Ask at runtime; no schedule data migration is required.
 

--- a/packages/coc-client/src/contracts/schedules.ts
+++ b/packages/coc-client/src/contracts/schedules.ts
@@ -88,3 +88,19 @@ export interface UpdateScheduleRequest {
 export interface MoveScheduleRequest {
   destination: ScheduleSource;
 }
+
+export interface RefineScheduleInstructionsRequest {
+  /** The current free-text instructions to refine. */
+  instructions: string;
+  /** Optional guidance describing how the AI should improve the instructions. */
+  hint?: string;
+  /** Optional model override; defaults to the active provider's model. */
+  model?: string;
+}
+
+export interface RefineScheduleInstructionsResponse {
+  /** The refined instructions. */
+  refined: string;
+  /** The raw AI response before fence stripping. */
+  raw?: string;
+}

--- a/packages/coc-client/src/domains/schedules.ts
+++ b/packages/coc-client/src/domains/schedules.ts
@@ -3,6 +3,8 @@ import type {
   DeleteScheduleResponse,
   ListSchedulesResponse,
   MoveScheduleRequest,
+  RefineScheduleInstructionsRequest,
+  RefineScheduleInstructionsResponse,
   RunScheduleResponse,
   Schedule,
   ScheduleHistoryResponse,
@@ -10,7 +12,7 @@ import type {
   ScheduleStatus,
   UpdateScheduleRequest,
 } from '../contracts';
-import type { RequestAdapter } from '../types';
+import type { CocRequestOptions, RequestAdapter } from '../types';
 import { encodePathSegment } from '../url';
 
 function schedulesPath(workspaceId: string, suffix = ''): string {
@@ -65,6 +67,27 @@ export class SchedulesClient {
     return this.transport.request<ScheduleMutationResponse>(schedulePath(workspaceId, scheduleId, '/move'), {
       method: 'POST',
       body: { destination },
+    });
+  }
+
+  /**
+   * Ask AI to refine a prompt routine's free-text instructions into a clearer,
+   * well-structured prompt. Scoped per workspace; abortable via `options.signal`.
+   */
+  refine(
+    workspaceId: string,
+    request: RefineScheduleInstructionsRequest,
+    options: Pick<CocRequestOptions, 'signal' | 'timeoutMs'> = {},
+  ): Promise<RefineScheduleInstructionsResponse> {
+    return this.transport.request<RefineScheduleInstructionsResponse>(schedulesPath(workspaceId, '/refine'), {
+      method: 'POST',
+      body: {
+        instructions: request.instructions,
+        hint: request.hint,
+        model: request.model,
+      },
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
     });
   }
 

--- a/packages/coc-client/test/domains/schedules.test.ts
+++ b/packages/coc-client/test/domains/schedules.test.ts
@@ -49,6 +49,27 @@ describe('SchedulesClient', () => {
     expect(adapter.calls[8].options).toMatchObject({ method: 'DELETE' });
   });
 
+  it('posts instruction-refine requests with signal/timeout passthrough', async () => {
+    const adapter = createMockAdapter({ refined: 'Cleaner instructions.', raw: 'Cleaner instructions.' });
+    const client = new SchedulesClient(adapter);
+    const controller = new AbortController();
+
+    const result = await client.refine(
+      'repo/a',
+      { instructions: 'rough notes', hint: 'be specific', model: 'opus' },
+      { signal: controller.signal, timeoutMs: 5000 },
+    );
+
+    expect(result).toEqual({ refined: 'Cleaner instructions.', raw: 'Cleaner instructions.' });
+    expect(adapter.calls[0].path).toBe('/workspaces/repo%2Fa/schedules/refine');
+    expect(adapter.calls[0].options).toMatchObject({
+      method: 'POST',
+      body: { instructions: 'rough notes', hint: 'be specific', model: 'opus' },
+      signal: controller.signal,
+      timeoutMs: 5000,
+    });
+  });
+
   it('unwraps list and history response arrays with empty-array defaults', async () => {
     const adapter = createMockAdapter({});
     const client = new SchedulesClient(adapter);

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -503,7 +503,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerScheduleRoutes(routes, scheduleManager, async (repoId) => {
         const workspaces = await store.getWorkspaces();
         return workspaces.find(w => w.id === repoId)?.rootPath;
-    });
+    }, resolvedAiService);
 
     // Loop routes
     if (opts.loopStore && opts.loopExecutor) {

--- a/packages/coc/src/server/schedule/schedule-handler.ts
+++ b/packages/coc/src/server/schedule/schedule-handler.ts
@@ -8,6 +8,8 @@
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 
+import type { ISDKService } from '@plusplusoneplusplus/forge';
+import { denyAllPermissions } from '@plusplusoneplusplus/forge';
 import { sendJSON, sendError } from '../core/api-handler';
 import { parseBodyOrReject } from '../shared/handler-utils';
 import { getErrorMessage } from '../shared/fs-utils';
@@ -16,6 +18,28 @@ import { ScheduleManager, describeCron, nextCronTime, parseCron } from './schedu
 import type { ScheduleEntry, ScheduleOnFailure, ScheduleStatus } from './schedule-manager';
 import type { TargetType, ChatMode } from '../tasks/task-types';
 import { normalizeChatMode } from '../tasks/task-types';
+
+// ============================================================================
+// AI instruction refinement
+// ============================================================================
+
+/** Pure text generation, no tool use — give it a generous 2 min budget. */
+const INSTRUCTION_REFINE_TIMEOUT_MS = 120_000;
+
+const INSTRUCTION_REFINE_SYSTEM_PROMPT = `You refine the instructions for a scheduled AI prompt routine. The user wrote rough notes; rewrite them into a single, clear, well-structured prompt the AI can follow each time the schedule runs.
+
+Rules:
+- Preserve the original intent and scope. Do NOT invent new tasks, tools, or requirements.
+- Make the instructions specific, actionable, and unambiguous.
+- Keep it concise. Use short sentences or bullet points where they help.
+- Output ONLY the refined instructions. Do NOT wrap them in markdown code fences. Do NOT add any commentary before or after.`;
+
+/** Strip a wrapping markdown code fence from an AI response, else return trimmed text. */
+function extractRefinedInstructions(response: string): string {
+    const fenced = response.match(/```[a-zA-Z]*\s*\n([\s\S]*?)```/);
+    if (fenced) return fenced[1].trim();
+    return response.trim();
+}
 
 // ============================================================================
 // Validation
@@ -96,6 +120,7 @@ export function registerScheduleRoutes(
     routes: Route[],
     manager: ScheduleManager,
     getWorkspacePath?: (repoId: string) => Promise<string | undefined>,
+    aiService?: ISDKService,
 ): void {
 
     /** Lazily register workspace path with the manager on first request for a repo. */
@@ -153,6 +178,77 @@ export function registerScheduleRoutes(
                 sendJSON(res, 201, { schedule: serializeSchedule(schedule, manager) });
             } catch (err) {
                 return sendError(res, 400, getErrorMessage(err, 'Failed to create schedule'));
+            }
+        },
+    });
+
+    // ------------------------------------------------------------------
+    // POST /api/workspaces/:id/schedules/refine — AI-assisted instruction refinement
+    //
+    // Rewrites a prompt routine's free-text instructions into a clearer,
+    // well-structured prompt. Scoped per workspace and routed to the workspace's
+    // working directory so it is multi-repo safe.
+    // ------------------------------------------------------------------
+    routes.push({
+        method: 'POST',
+        pattern: /^\/api\/workspaces\/([^/]+)\/schedules\/refine$/,
+        handler: async (req, res, match) => {
+            const repoId = decodeURIComponent(match![1]);
+            const body = await parseBodyOrReject(req, res);
+            if (body === null) return;
+
+            const instructions = typeof body.instructions === 'string' ? body.instructions : '';
+            if (!instructions.trim()) {
+                return sendError(res, 400, 'Missing required field: instructions');
+            }
+            const hint = typeof body.hint === 'string' ? body.hint.trim() : '';
+            const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : undefined;
+
+            if (!aiService) {
+                return sendError(res, 503, 'AI service not configured');
+            }
+
+            let available: { available: boolean };
+            try {
+                available = await aiService.isAvailable();
+            } catch {
+                available = { available: false };
+            }
+            if (!available.available) {
+                return sendError(res, 503, 'AI service unavailable');
+            }
+
+            await ensureWorkspaceLoaded(repoId);
+            const workingDirectory = getWorkspacePath ? await getWorkspacePath(repoId) : undefined;
+
+            const userPrompt = `Current instructions:\n\n${instructions.trim()}\n\n${hint ? `Additional guidance from the user:\n\n${hint}\n\n` : ''}Return the improved instructions.`;
+
+            try {
+                const result = await aiService.sendMessage({
+                    prompt: INSTRUCTION_REFINE_SYSTEM_PROMPT + '\n\n' + userPrompt,
+                    model,
+                    workingDirectory,
+                    timeoutMs: INSTRUCTION_REFINE_TIMEOUT_MS,
+                    onPermissionRequest: denyAllPermissions,
+                });
+
+                if (!result.success) {
+                    return sendError(res, 500, 'Instruction refinement failed: ' + (result.error || 'Unknown error'));
+                }
+
+                const raw = result.response || '';
+                const refined = extractRefinedInstructions(raw);
+                if (!refined) {
+                    return sendError(res, 500, 'Instruction refinement returned an empty result');
+                }
+
+                sendJSON(res, 200, { refined, raw });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                if (message.toLowerCase().includes('timeout')) {
+                    return sendError(res, 504, 'Instruction refinement timed out');
+                }
+                return sendError(res, 500, 'Instruction refinement failed: ' + message);
             }
         },
     });

--- a/packages/coc/src/server/spa/client/react/features/schedules/PromptScheduleForm.tsx
+++ b/packages/coc/src/server/spa/client/react/features/schedules/PromptScheduleForm.tsx
@@ -12,6 +12,7 @@ import { getSpaCocClient } from '../../api/cocClient';
 import { useCocClient } from '../../repos/cloneRouting';
 import { getActiveProvider } from '../../utils/config';
 import { ScheduleTriggerPanel } from './ScheduleTriggerPanel';
+import { ScheduleInstructionsRefinePanel } from './ScheduleInstructionsRefinePanel';
 import {
     PROMPT_SCHEDULE_PRESETS,
     WEEKDAY_CHIPS,
@@ -83,6 +84,19 @@ export function PromptScheduleForm({ workspaceId, onCreated, onCancel, onAdvance
 
     const [error, setError] = useState('');
     const [submitting, setSubmitting] = useState(false);
+    const [refineOpen, setRefineOpen] = useState(false);
+
+    // Ask AI to rewrite the rough instructions into a clearer prompt. Routed to
+    // the selected clone's server and scoped to this workspace; respects the
+    // model selected in the form.
+    const handleRefineInstructions = (hint: string, signal: AbortSignal): Promise<string> =>
+        cloneClient.schedules
+            .refine(
+                workspaceId,
+                { instructions, hint: hint || undefined, model: model.trim() || undefined },
+                { signal },
+            )
+            .then(result => result.refined);
 
     // Load available models
     useEffect(() => {
@@ -210,8 +224,21 @@ export function PromptScheduleForm({ workspaceId, onCreated, onCancel, onAdvance
             </label>
 
             {/* Instructions */}
-            <label className="flex flex-col gap-1">
-                <span className="text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc]">Instructions</span>
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc]">Instructions</span>
+                    <button
+                        type="button"
+                        className="text-[10px] text-[#0078d4] hover:underline disabled:opacity-40 disabled:no-underline disabled:cursor-not-allowed"
+                        onClick={() => setRefineOpen(o => !o)}
+                        disabled={!instructions.trim()}
+                        aria-expanded={refineOpen}
+                        title={instructions.trim() ? 'Ask AI to refine these instructions' : 'Write some instructions first'}
+                        data-testid="prompt-refine-btn"
+                    >
+                        Refine with AI ✨
+                    </button>
+                </div>
                 <textarea
                     className="text-xs px-2.5 py-2 border border-[#d0d0d0] dark:border-[#555] rounded bg-white dark:bg-[#2a2a2a] text-[#1e1e1e] dark:text-[#ccc] resize-y min-h-[96px]"
                     placeholder="Review open PRs and summarize any issues..."
@@ -244,7 +271,17 @@ export function PromptScheduleForm({ workspaceId, onCreated, onCancel, onAdvance
                         </select>
                     </label>
                 </div>
-            </label>
+
+                {/* AI refine flow — only available when there is text to refine */}
+                {refineOpen && instructions.trim() && (
+                    <ScheduleInstructionsRefinePanel
+                        currentInstructions={instructions}
+                        refine={handleRefineInstructions}
+                        onApply={refined => { setInstructions(refined); setRefineOpen(false); }}
+                        onCancel={() => setRefineOpen(false)}
+                    />
+                )}
+            </div>
 
             {/* Schedule */}
             <div className="flex flex-col gap-2">

--- a/packages/coc/src/server/spa/client/react/features/schedules/ScheduleInstructionsRefinePanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/schedules/ScheduleInstructionsRefinePanel.tsx
@@ -1,0 +1,166 @@
+/**
+ * ScheduleInstructionsRefinePanel — lets users ask AI to rewrite rough prompt
+ * routine instructions into a clearer, well-structured prompt.
+ *
+ * Mirrors the three-phase WorkflowAIRefinePanel flow (input → refining →
+ * preview) but works on plain instruction text and renders the change as a
+ * before/after unified diff. The actual request is supplied via the `refine`
+ * callback so the panel stays decoupled from the CoC client (and clone routing).
+ */
+
+import { useState, useRef } from 'react';
+import { Button, Spinner } from '../../ui';
+import { UnifiedDiffViewer } from '../git/diff/UnifiedDiffViewer';
+import { generateUnifiedDiff } from '../git/diff/unifiedDiffUtils';
+
+export interface ScheduleInstructionsRefinePanelProps {
+    /** The current instructions being refined (the "before" side of the diff). */
+    currentInstructions: string;
+    /** Performs the refine request; resolves with the refined instructions. */
+    refine: (hint: string, signal: AbortSignal) => Promise<string>;
+    /** Called with the refined text when the user applies the result. */
+    onApply: (refined: string) => void | Promise<void>;
+    /** Called when the user dismisses the panel without applying. */
+    onCancel: () => void;
+}
+
+type RefinePhase = 'input' | 'refining' | 'preview';
+
+/** Treat caller aborts as a silent return (no error banner). */
+function isAbort(err: unknown): boolean {
+    const e = err as { name?: string; code?: string } | null | undefined;
+    return e?.name === 'AbortError' || e?.code === 'ABORTED';
+}
+
+export function ScheduleInstructionsRefinePanel({
+    currentInstructions,
+    refine,
+    onApply,
+    onCancel,
+}: ScheduleInstructionsRefinePanelProps) {
+    const [phase, setPhase] = useState<RefinePhase>('input');
+    const [hint, setHint] = useState('');
+    const [refined, setRefined] = useState('');
+    const [diff, setDiff] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [applying, setApplying] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
+
+    async function handleRefine() {
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        setPhase('refining');
+        setError(null);
+
+        try {
+            const result = await refine(hint.trim(), controller.signal);
+            const next = (result ?? '').trim();
+            setDiff(generateUnifiedDiff(currentInstructions, next, 'instructions.txt'));
+            setRefined(next);
+            setPhase('preview');
+        } catch (err) {
+            if (isAbort(err)) {
+                setPhase('input');
+            } else {
+                setError((err as Error)?.message || 'Refinement failed. Please try again.');
+                setPhase('input');
+            }
+        }
+    }
+
+    function handleCancel() {
+        abortRef.current?.abort();
+        if (phase === 'refining') {
+            // Cancelling mid-refine just returns to input — the panel stays open.
+            setPhase('input');
+        } else {
+            onCancel();
+        }
+    }
+
+    async function handleApply() {
+        setApplying(true);
+        try {
+            await Promise.resolve(onApply(refined));
+        } catch (err) {
+            setError((err as Error)?.message || 'Failed to apply changes');
+        } finally {
+            setApplying(false);
+        }
+    }
+
+    const panelTitle =
+        phase === 'preview' ? 'Review Changes' :
+        phase === 'refining' ? 'Refining...' :
+        'Refine Instructions with AI';
+
+    return (
+        <div
+            className="rounded border border-[#d0d0d0] dark:border-[#555] bg-[#f8f8f8] dark:bg-[#252526] p-3 mt-2"
+            data-testid="schedule-refine-panel"
+        >
+            <h4 className="text-xs font-semibold text-[#1e1e1e] dark:text-[#cccccc] mb-2">{panelTitle}</h4>
+
+            {phase === 'input' && (
+                <div className="flex flex-col gap-2">
+                    <textarea
+                        value={hint}
+                        onChange={e => { setHint(e.target.value.slice(0, 500)); setError(null); }}
+                        placeholder="Optional: tell AI how to improve it (e.g. 'make it more specific')"
+                        rows={2}
+                        className="w-full px-2 py-1.5 text-xs border border-[#d0d0d0] dark:border-[#555] bg-white dark:bg-[#2a2a2a] text-[#1e1e1e] dark:text-[#ccc] rounded resize-y"
+                        data-testid="schedule-refine-hint"
+                    />
+
+                    {error && (
+                        <div className="text-[10px] text-red-500 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded px-2 py-1" data-testid="schedule-refine-error">
+                            {error}
+                        </div>
+                    )}
+
+                    <div className="flex justify-end gap-2">
+                        <Button variant="secondary" size="sm" onClick={handleCancel}>Cancel</Button>
+                        <Button size="sm" onClick={handleRefine} data-testid="schedule-refine-submit">
+                            Refine with AI ✨
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {phase === 'refining' && (
+                <div className="flex flex-col gap-2">
+                    <div className="flex flex-col items-center gap-2 py-3">
+                        <Spinner size="md" />
+                        <div className="text-xs text-[#1e1e1e] dark:text-[#cccccc]">Refining instructions...</div>
+                        <div className="text-[10px] text-[#848484]">⏱ This usually takes 10–30 seconds.</div>
+                    </div>
+                    <div className="flex justify-end">
+                        <Button variant="secondary" size="sm" onClick={handleCancel}>Cancel</Button>
+                    </div>
+                </div>
+            )}
+
+            {phase === 'preview' && (
+                <div className="flex flex-col gap-2">
+                    <UnifiedDiffViewer diff={diff} fileName="instructions.txt" data-testid="schedule-refine-diff" />
+
+                    {error && (
+                        <div className="text-[10px] text-red-500 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded px-2 py-1" data-testid="schedule-refine-error">
+                            {error}
+                        </div>
+                    )}
+
+                    <div className="flex justify-end gap-2">
+                        <Button variant="secondary" size="sm" onClick={() => setPhase('input')}>← Back</Button>
+                        <Button variant="secondary" size="sm" onClick={handleRefine}>Re-refine 🔄</Button>
+                        <Button size="sm" loading={applying} onClick={handleApply} data-testid="schedule-refine-apply">
+                            Apply ✓
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/coc/test/server/schedule-refine-handler.test.ts
+++ b/packages/coc/test/server/schedule-refine-handler.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Schedule Instruction Refine Handler Tests
+ *
+ * Tests for POST /api/workspaces/:id/schedules/refine (AI prompt-instruction
+ * refinement used by the New/Edit Prompt Routine form).
+ *
+ * Uses port 0 (OS-assigned) for test isolation.
+ * Mocks the SDK service to avoid real AI calls.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createExecutionServer } from '../../src/server/index';
+import { FileProcessStore } from '@plusplusoneplusplus/forge';
+import type { ExecutionServer } from '@plusplusoneplusplus/coc-server';
+import { createMockSDKService } from '../helpers/mock-sdk-service';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function request(
+    url: string,
+    options: { method?: string; body?: string; headers?: Record<string, string> } = {}
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const req = http.request(
+            {
+                hostname: parsed.hostname,
+                port: parsed.port,
+                path: parsed.pathname + parsed.search,
+                method: options.method || 'GET',
+                headers: options.headers,
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    resolve({
+                        status: res.statusCode || 0,
+                        headers: res.headers,
+                        body: Buffer.concat(chunks).toString('utf-8'),
+                    });
+                });
+            }
+        );
+        req.on('error', reject);
+        if (options.body) {
+            req.write(options.body);
+        }
+        req.end();
+    });
+}
+
+function postJSON(url: string, data: unknown) {
+    return request(url, {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+// ============================================================================
+// Integration tests — Refine endpoint
+// ============================================================================
+
+describe('Schedule Instruction Refine Handler', () => {
+    let server: ExecutionServer | undefined;
+    let dataDir: string;
+    let workspaceDir: string;
+    let mockService: ReturnType<typeof createMockSDKService>;
+
+    const ROUGH_INSTRUCTIONS = 'check prs and tell me whats broken';
+
+    beforeEach(() => {
+        dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-refine-test-'));
+        workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-refine-ws-'));
+        mockService = createMockSDKService();
+        vi.clearAllMocks();
+    });
+
+    afterEach(async () => {
+        if (server) {
+            await server.close();
+            server = undefined;
+        }
+        fs.rmSync(dataDir, { recursive: true, force: true });
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    async function startServer(): Promise<ExecutionServer> {
+        const store = new FileProcessStore({ dataDir });
+        server = await createExecutionServer({ port: 0, host: 'localhost', store, dataDir, aiService: mockService.service as any });
+        return server;
+    }
+
+    async function registerWorkspace(srv: ExecutionServer, rootPath: string): Promise<string> {
+        const id = 'test-ws-' + Date.now();
+        const res = await postJSON(`${srv.url}/api/workspaces`, {
+            id,
+            name: 'Test Workspace',
+            rootPath,
+        });
+        expect(res.status).toBe(201);
+        return id;
+    }
+
+    function configureMockAI(options: {
+        available?: boolean;
+        success?: boolean;
+        response?: string;
+        error?: string;
+        throwError?: Error;
+    }) {
+        const {
+            available = true,
+            success = true,
+            response = 'Review all open pull requests and report any that have failing checks, merge conflicts, or unresolved review comments.',
+            error,
+            throwError,
+        } = options;
+
+        mockService.mockIsAvailable.mockResolvedValue({ available });
+        mockService.service.sendMessage.mockClear();
+        mockService.mockSendMessage.mockClear();
+        mockService.mockSendMessage.mockImplementation(async () => {
+            if (throwError) { throw throwError; }
+            return { success, response, error };
+        });
+        return mockService.service;
+    }
+
+    describe('POST /api/workspaces/:id/schedules/refine', () => {
+        it('refines instructions — happy path', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            const refined = 'Review all open pull requests and summarize any blockers.';
+            configureMockAI({ response: refined });
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+            });
+            expect(res.status).toBe(200);
+
+            const data = JSON.parse(res.body);
+            expect(data.refined).toBe(refined);
+            expect(data.raw).toBe(refined);
+        });
+
+        it('strips markdown code fences from the AI response', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            const inner = 'Review open PRs and report blockers.';
+            const fenced = 'Here you go:\n```\n' + inner + '\n```\nDone!';
+            configureMockAI({ response: fenced });
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+            });
+            expect(res.status).toBe(200);
+
+            const data = JSON.parse(res.body);
+            expect(data.refined).toBe(inner);
+            expect(data.raw).toBe(fenced);
+        });
+
+        it('returns 400 when instructions are missing', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {});
+            expect(res.status).toBe(400);
+            expect(JSON.parse(res.body).error).toContain('instructions');
+        });
+
+        it('returns 400 when instructions are blank', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: '   ',
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 503 when the AI service is unavailable', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            configureMockAI({ available: false });
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+            });
+            expect(res.status).toBe(503);
+        });
+
+        it('returns 500 when refinement fails', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            configureMockAI({ success: false, error: 'Model overloaded' });
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+            });
+            expect(res.status).toBe(500);
+            expect(JSON.parse(res.body).error).toContain('Model overloaded');
+        });
+
+        it('returns 504 on timeout', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            configureMockAI({ throwError: new Error('Request timeout exceeded') });
+
+            const res = await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+            });
+            expect(res.status).toBe(504);
+        });
+
+        it('forwards the model to the AI service when provided', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            const svc = configureMockAI({});
+
+            await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+                model: 'gpt-4',
+            });
+
+            expect(svc.sendMessage).toHaveBeenCalledTimes(1);
+            expect(svc.sendMessage.mock.calls[0][0].model).toBe('gpt-4');
+        });
+
+        it('calls sendMessage with denyAllPermissions', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            const svc = configureMockAI({});
+
+            await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+            });
+
+            expect(svc.sendMessage.mock.calls[0][0].onPermissionRequest).toBeDefined();
+        });
+
+        it('includes the instructions and hint in the prompt', async () => {
+            const srv = await startServer();
+            const wsId = await registerWorkspace(srv, workspaceDir);
+            const svc = configureMockAI({});
+
+            await postJSON(`${srv.url}/api/workspaces/${wsId}/schedules/refine`, {
+                instructions: ROUGH_INSTRUCTIONS,
+                hint: 'make it more specific',
+            });
+
+            const prompt = svc.sendMessage.mock.calls[0][0].prompt;
+            expect(prompt).toContain(ROUGH_INSTRUCTIONS);
+            expect(prompt).toContain('make it more specific');
+        });
+    });
+});

--- a/packages/coc/test/spa/react/repos/PromptScheduleForm.test.tsx
+++ b/packages/coc/test/spa/react/repos/PromptScheduleForm.test.tsx
@@ -13,6 +13,7 @@ const { mockSchedulesClient, mockModelsClient, mockAgentProvidersClient } = vi.h
         create: vi.fn(),
         update: vi.fn(),
         disable: vi.fn(),
+        refine: vi.fn(),
     },
     mockModelsClient: {
         list: vi.fn(),
@@ -20,6 +21,16 @@ const { mockSchedulesClient, mockModelsClient, mockAgentProvidersClient } = vi.h
     mockAgentProvidersClient: {
         listModels: vi.fn(),
     },
+}));
+
+// Keep the AI refine panel light — stub the diff viewer/generator it renders.
+vi.mock('../../../../src/server/spa/client/react/features/git/diff/UnifiedDiffViewer', () => ({
+    UnifiedDiffViewer: ({ diff, 'data-testid': testId }: any) => <div data-testid={testId}>{diff}</div>,
+    HunkNavButtons: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/git/diff/unifiedDiffUtils', () => ({
+    generateUnifiedDiff: (oldText: string, newText: string) => `@@\n-${oldText}\n+${newText}`,
 }));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
@@ -57,6 +68,7 @@ beforeEach(() => {
     mockSchedulesClient.create.mockResolvedValue({ id: 'new-sched-1' });
     mockSchedulesClient.update.mockResolvedValue({});
     mockSchedulesClient.disable.mockResolvedValue({});
+    mockSchedulesClient.refine.mockResolvedValue({ refined: 'Review all open PRs and report blockers.' });
     mockModelsClient.list.mockResolvedValue([]);
     mockAgentProvidersClient.listModels.mockResolvedValue({ models: [] });
 });
@@ -343,6 +355,67 @@ describe('PromptScheduleForm — edit mode', () => {
         expect(screen.getByTestId('prompt-day-fri').className).toContain('border-[#0078d4]');
         expect((screen.getByTestId('prompt-hour-select') as HTMLSelectElement).value).toBe('14');
         expect((screen.getByTestId('prompt-minute-select') as HTMLSelectElement).value).toBe('30');
+    });
+});
+
+describe('PromptScheduleForm — AI refine instructions', () => {
+    it('disables the refine button when instructions are empty', async () => {
+        await renderPromptForm();
+
+        const btn = screen.getByTestId('prompt-refine-btn');
+        expect(btn.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('enables the refine button once instructions are present', async () => {
+        const user = userEvent.setup();
+        await renderPromptForm();
+
+        await user.type(screen.getByTestId('prompt-instructions-input'), 'check the prs');
+        expect(screen.getByTestId('prompt-refine-btn').hasAttribute('disabled')).toBe(false);
+    });
+
+    it('opens the refine panel and applies the refined text to the textarea', async () => {
+        const user = userEvent.setup();
+        await renderPromptForm();
+
+        await user.type(screen.getByTestId('prompt-instructions-input'), 'check the prs');
+        await user.click(screen.getByTestId('prompt-refine-btn'));
+
+        expect(screen.getByTestId('schedule-refine-panel')).toBeTruthy();
+
+        // Run the refine → preview → apply flow.
+        await user.click(screen.getByTestId('schedule-refine-submit'));
+        await waitFor(() => expect(screen.getByTestId('schedule-refine-apply')).toBeTruthy());
+
+        expect(mockSchedulesClient.refine).toHaveBeenCalledWith(
+            'ws-test',
+            expect.objectContaining({ instructions: 'check the prs' }),
+            expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+
+        await user.click(screen.getByTestId('schedule-refine-apply'));
+
+        await waitFor(() => {
+            expect((screen.getByTestId('prompt-instructions-input') as HTMLTextAreaElement).value)
+                .toBe('Review all open PRs and report blockers.');
+        });
+        // Panel closes after apply.
+        expect(screen.queryByTestId('schedule-refine-panel')).toBeNull();
+    });
+
+    it('closes the refine panel on cancel without changing instructions', async () => {
+        const user = userEvent.setup();
+        await renderPromptForm();
+
+        await user.type(screen.getByTestId('prompt-instructions-input'), 'check the prs');
+        await user.click(screen.getByTestId('prompt-refine-btn'));
+        const panel = screen.getByTestId('schedule-refine-panel');
+        expect(panel).toBeTruthy();
+
+        await user.click(within(panel).getByRole('button', { name: /cancel/i }));
+
+        expect(screen.queryByTestId('schedule-refine-panel')).toBeNull();
+        expect((screen.getByTestId('prompt-instructions-input') as HTMLTextAreaElement).value).toBe('check the prs');
     });
 });
 

--- a/packages/coc/test/spa/react/repos/ScheduleInstructionsRefinePanel.test.tsx
+++ b/packages/coc/test/spa/react/repos/ScheduleInstructionsRefinePanel.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Tests for ScheduleInstructionsRefinePanel — the AI prompt-instruction
+ * refinement UI used by the New/Edit Prompt Routine form.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+// Mock the diff viewer + diff generator so the test stays focused on the panel.
+vi.mock('../../../../src/server/spa/client/react/features/git/diff/UnifiedDiffViewer', () => ({
+    UnifiedDiffViewer: ({ diff, 'data-testid': testId }: any) => (
+        <div data-testid={testId}>{diff}</div>
+    ),
+    HunkNavButtons: () => null,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/git/diff/unifiedDiffUtils', () => ({
+    generateUnifiedDiff: (oldText: string, newText: string, fileName: string) =>
+        `--- a/${fileName}\n+++ b/${fileName}\n@@ mock diff @@\n-${oldText}\n+${newText}`,
+}));
+
+import { ScheduleInstructionsRefinePanel } from '../../../../src/server/spa/client/react/features/schedules/ScheduleInstructionsRefinePanel';
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof ScheduleInstructionsRefinePanel>> = {}) {
+    return {
+        currentInstructions: 'check prs and tell me whats broken',
+        refine: vi.fn().mockResolvedValue('Review open PRs and report blockers.'),
+        onApply: vi.fn(),
+        onCancel: vi.fn(),
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+// ── Input phase ──────────────────────────────────────────────────────────────
+
+describe('input phase', () => {
+    it('renders the hint textarea and refine button', () => {
+        render(<ScheduleInstructionsRefinePanel {...makeProps()} />);
+        expect(screen.getByTestId('schedule-refine-panel')).toBeTruthy();
+        expect(screen.getByTestId('schedule-refine-hint')).toBeTruthy();
+        expect(screen.getByTestId('schedule-refine-submit')).toBeTruthy();
+        expect(screen.getByText('Refine Instructions with AI')).toBeTruthy();
+    });
+
+    it('calls onCancel when Cancel is clicked', () => {
+        const props = makeProps();
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+        fireEvent.click(screen.getByText('Cancel'));
+        expect(props.onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the current instructions and trimmed hint to refine', async () => {
+        const props = makeProps();
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+
+        fireEvent.change(screen.getByTestId('schedule-refine-hint'), {
+            target: { value: '  make it specific  ' },
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+
+        expect(props.refine).toHaveBeenCalledTimes(1);
+        expect(props.refine.mock.calls[0][0]).toBe('make it specific');
+        expect(props.refine.mock.calls[0][1]).toBeInstanceOf(AbortSignal);
+    });
+});
+
+// ── Refining phase ───────────────────────────────────────────────────────────
+
+describe('refining phase', () => {
+    it('shows the spinner/refining message after submitting', async () => {
+        let resolveRefine!: (v: string) => void;
+        const props = makeProps({ refine: vi.fn().mockReturnValue(new Promise<string>(r => { resolveRefine = r; })) });
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+
+        expect(screen.getByText('Refining...')).toBeTruthy();
+        expect(screen.getByText('Refining instructions...')).toBeTruthy();
+
+        resolveRefine('done');
+    });
+
+    it('cancel during refining returns to input without calling onCancel', async () => {
+        let resolveRefine!: (v: string) => void;
+        const props = makeProps({ refine: vi.fn().mockReturnValue(new Promise<string>(r => { resolveRefine = r; })) });
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByText('Cancel'));
+        });
+
+        expect(screen.getByTestId('schedule-refine-hint')).toBeTruthy();
+        expect(props.onCancel).not.toHaveBeenCalled();
+
+        resolveRefine('done');
+    });
+});
+
+// ── Preview phase ────────────────────────────────────────────────────────────
+
+describe('preview phase', () => {
+    async function goToPreview(props = makeProps()) {
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+        return props;
+    }
+
+    it('shows the diff and action buttons after a successful refine', async () => {
+        await goToPreview();
+        expect(screen.getByText('Review Changes')).toBeTruthy();
+        expect(screen.getByTestId('schedule-refine-diff')).toBeTruthy();
+        expect(screen.getByTestId('schedule-refine-apply')).toBeTruthy();
+        expect(screen.getByText('← Back')).toBeTruthy();
+        expect(screen.getByText('Re-refine 🔄')).toBeTruthy();
+    });
+
+    it('Apply calls onApply with the refined text', async () => {
+        const props = await goToPreview();
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-apply'));
+        });
+        expect(props.onApply).toHaveBeenCalledWith('Review open PRs and report blockers.');
+    });
+
+    it('Apply shows an error and stays in preview on failure', async () => {
+        const props = makeProps({ onApply: vi.fn().mockRejectedValue(new Error('apply boom')) });
+        await goToPreview(props);
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-apply'));
+        });
+        expect(screen.getByText('Review Changes')).toBeTruthy();
+        expect(screen.getByTestId('schedule-refine-error')).toBeTruthy();
+        expect(screen.getByText('apply boom')).toBeTruthy();
+    });
+
+    it('Re-refine re-runs the refine request', async () => {
+        const refine = vi.fn()
+            .mockResolvedValueOnce('first refinement')
+            .mockResolvedValueOnce('second refinement');
+        await goToPreview(makeProps({ refine }));
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Re-refine 🔄'));
+        });
+
+        expect(refine).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('Review Changes')).toBeTruthy();
+    });
+
+    it('Back returns to the input phase', async () => {
+        await goToPreview();
+        fireEvent.click(screen.getByText('← Back'));
+        expect(screen.getByTestId('schedule-refine-hint')).toBeTruthy();
+    });
+});
+
+// ── Error handling ───────────────────────────────────────────────────────────
+
+describe('error handling', () => {
+    it('shows an error banner and returns to input on failure', async () => {
+        const props = makeProps({ refine: vi.fn().mockRejectedValue(new Error('server exploded')) });
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+
+        expect(screen.getByTestId('schedule-refine-hint')).toBeTruthy();
+        expect(screen.getByTestId('schedule-refine-error')).toBeTruthy();
+        expect(screen.getByText('server exploded')).toBeTruthy();
+    });
+
+    it('returns to input silently on an aborted request (code ABORTED)', async () => {
+        const abortErr = Object.assign(new Error('CoC API request was aborted'), { code: 'ABORTED' });
+        const props = makeProps({ refine: vi.fn().mockRejectedValue(abortErr) });
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+
+        expect(screen.getByTestId('schedule-refine-hint')).toBeTruthy();
+        expect(screen.queryByTestId('schedule-refine-error')).toBeNull();
+    });
+
+    it('returns to input silently on a DOMException AbortError', async () => {
+        const abortErr = new DOMException('Aborted', 'AbortError');
+        const props = makeProps({ refine: vi.fn().mockRejectedValue(abortErr) });
+        render(<ScheduleInstructionsRefinePanel {...props} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('schedule-refine-submit'));
+        });
+
+        expect(screen.getByTestId('schedule-refine-hint')).toBeTruthy();
+        expect(screen.queryByTestId('schedule-refine-error')).toBeNull();
+    });
+});


### PR DESCRIPTION
Add an AI-assisted refine action next to the Instructions field in the
New/Edit Prompt Routine form so users can turn rough notes into a clearer,
well-structured prompt. Mirrors the existing WorkflowAIRefinePanel flow.

- Server: POST /api/workspaces/:id/schedules/refine refines plain instruction
  text via the SDK service (input → refined string), scoped per workspace.
- coc-client: SchedulesClient.refine() + request/response contracts.
- SPA: ScheduleInstructionsRefinePanel (input/hint → refining → preview diff →
  apply/cancel/re-refine, abortable) wired into PromptScheduleForm via the
  clone-routed client; disabled when instructions are empty; respects the
  selected model.

Tests: server refine route (happy/strip-fences/validation/unavailable/failure/
timeout/model/permissions), panel phases + abort/error handling, form
integration (disabled-when-empty, apply replaces textarea, cancel), and the
coc-client domain method.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
