### PR TITLE
pr/f51e3bc43 featcoc place ralph repo and agent selec

### DIFF
--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -126,7 +126,12 @@ all have their own `references/*.md`.
   client (`explorer.readTrustedBlob`), inlines it in the prompt, drops
   `context.files`, and enqueues on the target repo's routed `useCocClient`
   `CloneRef`. Targets come from `buildImplementTargets` (current repo + local +
-  **online** remote clones only); the selector is gated on `isRemoteShellEnabled()`
+  **online** remote clones only), scoped to the current repo's **canonical git
+  origin** so only same-origin clones appear; the current origin is taken from
+  the caller's `remoteUrl`, falling back to the current repo's own list entry
+  (`gitInfo.remoteUrl ?? workspace.remoteUrl`, the same source candidates use) so
+  the filter still engages for a remote-clone current workspace whose appState
+  entry lacks a remote URL. The selector is gated on `isRemoteShellEnabled()`
   with no new flag. Implementation records (target identity + status) always
   persist on the **source** task via the source client. The card also surfaces
   for **canvas-backed plans**: `scanTurnsForPlanCanvas` (in `conversationScan.ts`)

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphStartPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphStartPanel.tsx
@@ -185,27 +185,29 @@ export function RalphStartPanel({ processId, workspaceId, turns, onStarted, goal
             <p className="text-xs text-[#848484]">
                 Edit the goal spec below, then click <strong>Confirm &amp; Start</strong> to begin the Ralph execution loop.
             </p>
-            <div>
-                <RalphExecutionRepoSelector
-                    groups={repoSelection.groups}
-                    loading={repoSelection.loading}
-                    loadError={repoSelection.loadError}
-                    warnings={repoSelection.warnings}
-                    selectedKey={repoSelection.selectedKey}
-                    onSelectedKeyChange={repoSelection.setSelectedKey}
-                    disabled={starting || loadingFile}
-                    testIdPrefix="ralph-start"
-                />
-            </div>
-            <div>
-                <div className="block text-xs text-[#848484] mb-1">
-                    Agent:
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
+                <div className="flex-1 min-w-0">
+                    <RalphExecutionRepoSelector
+                        groups={repoSelection.groups}
+                        loading={repoSelection.loading}
+                        loadError={repoSelection.loadError}
+                        warnings={repoSelection.warnings}
+                        selectedKey={repoSelection.selectedKey}
+                        onSelectedKeyChange={repoSelection.setSelectedKey}
+                        disabled={starting || loadingFile}
+                        testIdPrefix="ralph-start"
+                    />
                 </div>
-                <ModalJobAiControls
-                    selection={aiSelection}
-                    disabled={starting || loadingFile}
-                    testIdPrefix="ralph-start"
-                />
+                <div className="flex-1 min-w-0">
+                    <div className="block text-xs text-[#848484] mb-1">
+                        Agent:
+                    </div>
+                    <ModalJobAiControls
+                        selection={aiSelection}
+                        disabled={starting || loadingFile}
+                        testIdPrefix="ralph-start"
+                    />
+                </div>
             </div>
             <textarea
                 data-testid="ralph-goal-spec-input"

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ChatComposerPrChips.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ChatComposerPrChips.tsx
@@ -38,7 +38,7 @@ function sortNewestFirst(items: PrStatusCardItem[]): PrStatusCardItem[] {
 }
 
 export function ChatComposerPrChips(options: ChatComposerPrChipsProps) {
-    const { items, retry } = usePrChatStatusItems(options);
+    const { items, retry, refresh, refreshing } = usePrChatStatusItems(options);
     const [dismissed, setDismissed] = useState<ReadonlySet<string>>(() => new Set());
 
     const dismiss = useCallback((key: string) => {
@@ -55,7 +55,14 @@ export function ChatComposerPrChips(options: ChatComposerPrChipsProps) {
     return (
         <div className="overflow-hidden rounded-t-lg" data-testid="composer-pr-chips">
             {visible.map(item => (
-                <ComposerPrChip key={item.key} item={item} onDismiss={dismiss} onRetry={retry} />
+                <ComposerPrChip
+                    key={item.key}
+                    item={item}
+                    onDismiss={dismiss}
+                    onRetry={retry}
+                    onRefresh={refresh}
+                    refreshing={refreshing}
+                />
             ))}
         </div>
     );

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ComposerPrChip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ComposerPrChip.tsx
@@ -31,6 +31,10 @@ export interface ComposerPrChipProps {
     onDismiss: (key: string) => void;
     /** Retry a failed detail fetch. */
     onRetry?: (key: string) => void;
+    /** Force-refresh PR status + checks now, bypassing the cache. Omit to hide the button. */
+    onRefresh?: () => void;
+    /** A force-refresh is in flight — spins the icon and disables the button. */
+    refreshing?: boolean;
 }
 
 const ROW_CLASS =
@@ -62,6 +66,37 @@ function PinGlyph() {
                 <path d="M8 8.7v4.8" />
             </svg>
         </span>
+    );
+}
+
+function RefreshButton({ itemKey, onRefresh, refreshing }: { itemKey: string; onRefresh: () => void; refreshing?: boolean }) {
+    return (
+        <button
+            type="button"
+            onClick={() => onRefresh()}
+            disabled={refreshing}
+            className="shrink-0 inline-flex h-[22px] w-[22px] items-center justify-center rounded-md border-none bg-transparent text-[#57606a] hover:bg-black/[0.05] hover:text-[#0969da] dark:text-[#8b949e] dark:hover:bg-white/[0.08] dark:hover:text-[#58a6ff] cursor-pointer leading-none disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent"
+            aria-label="Refresh pull request status"
+            title={refreshing ? 'Refreshing…' : 'Refresh status'}
+            data-testid={`composer-pr-chip-refresh-${itemKey}`}
+            data-refreshing={refreshing ? 'true' : 'false'}
+        >
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                className={cn(refreshing && 'animate-spin')}
+            >
+                <path d="M13.6 8a5.6 5.6 0 1 1-1.64-3.96" />
+                <path d="M13.5 2.4V5H10.9" />
+            </svg>
+        </button>
     );
 }
 
@@ -174,7 +209,7 @@ function ViewLink({ target, itemKey }: { target: PrLinkTarget; itemKey: string }
     );
 }
 
-export function ComposerPrChip({ item, onDismiss, onRetry }: ComposerPrChipProps) {
+export function ComposerPrChip({ item, onDismiss, onRetry, onRefresh, refreshing }: ComposerPrChipProps) {
     const number = item.pr?.number ?? item.number;
     const linkTarget = getPrLinkTarget(item, number);
 
@@ -245,6 +280,7 @@ export function ComposerPrChip({ item, onDismiss, onRetry }: ComposerPrChipProps
                     <span className="font-semibold text-[#cf222e] dark:text-[#f85149]">−{diff.deletions}</span>
                 </span>
             )}
+            {onRefresh && <RefreshButton itemKey={item.key} onRefresh={onRefresh} refreshing={refreshing} />}
             <ViewLink target={linkTarget} itemKey={item.key} />
             <DismissButton itemKey={item.key} onDismiss={onDismiss} />
         </div>

--- a/packages/coc/src/server/spa/client/react/features/chat/implementTargets.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/implementTargets.ts
@@ -6,11 +6,17 @@
  * scoped to the current repo's git origin: when the current repo has a known
  * remote URL, only repos sharing that canonical origin (sibling local clones +
  * ONLINE remote clones of the same repo) are runnable targets, so unrelated
- * repos never appear in the dropdown. When the current origin is unknown (no
- * remote URL), no origin filter is applied and every local repo plus every
- * online remote clone is included. Offline / unreachable remote clones are
- * always excluded. The current repo is always present and placed first, so it
- * remains the default selection and the one-click local behavior is unchanged.
+ * repos never appear in the dropdown. The current origin is taken from the
+ * caller-supplied `remoteUrl`, falling back to the current repo's own entry in
+ * the dashboard list (the same `gitInfo.remoteUrl` source the candidates are
+ * compared against) — this keeps the comparison symmetric so the filter still
+ * engages when the caller cannot supply a remote URL (e.g. a remote-clone
+ * current workspace whose appState entry lacks one). When no origin can be
+ * resolved from either source, no origin filter is applied and every local repo
+ * plus every online remote clone is included. Offline / unreachable remote
+ * clones are always excluded. The current repo is always present and placed
+ * first, so it remains the default selection and the one-click local behavior
+ * is unchanged.
  */
 
 import { resolveCanonicalOriginId, resolveRepoOriginScope } from '../../repos/originScope';
@@ -43,12 +49,24 @@ export function buildImplementTargets(
     const targets: ImplementTarget[] = [];
     const seen = new Set<string>();
 
-    // Same-origin scoping: only active when the current repo has a known remote
-    // URL. Computed once from the current ref so every candidate is compared
-    // against a stable canonical origin id. When null, no origin filter applies.
+    // Same-origin scoping: only active when the current repo's git origin can be
+    // resolved. Prefer the caller-supplied remoteUrl; otherwise fall back to the
+    // current repo's own entry in the dashboard list, which carries the same
+    // gitInfo.remoteUrl the candidates resolve their origin from. This makes the
+    // comparison symmetric so the filter engages even when the caller could not
+    // supply a remoteUrl (e.g. a remote-clone current workspace). Computed once
+    // so every candidate is compared against a stable canonical origin id. When
+    // no origin can be resolved, no filter applies.
+    const currentRepoEntry = current.workspaceId
+        ? (repos ?? []).find(repo => String(repo?.workspace?.id ?? '') === current.workspaceId)
+        : undefined;
+    const currentRemoteUrl =
+        typeof current.remoteUrl === 'string' && current.remoteUrl.trim()
+            ? current.remoteUrl
+            : currentRepoEntry?.gitInfo?.remoteUrl ?? currentRepoEntry?.workspace?.remoteUrl ?? null;
     const currentOriginId =
-        current.workspaceId && typeof current.remoteUrl === 'string' && current.remoteUrl.trim()
-            ? resolveCanonicalOriginId({ workspaceId: current.workspaceId, remoteUrl: current.remoteUrl })
+        current.workspaceId && typeof currentRemoteUrl === 'string' && currentRemoteUrl.trim()
+            ? resolveCanonicalOriginId({ workspaceId: current.workspaceId, remoteUrl: currentRemoteUrl })
             : null;
 
     for (const repo of repos ?? []) {

--- a/packages/coc/test/server/spa/client/repos/implementTargets.test.ts
+++ b/packages/coc/test/server/spa/client/repos/implementTargets.test.ts
@@ -210,5 +210,53 @@ describe('buildImplementTargets', () => {
             const targets = buildImplementTargets(repos, { workspaceId: 'ws-current', remoteUrl: ORIGIN });
             expect(targets.map(t => t.workspaceId)).toEqual(['ws-current']);
         });
+
+        it('resolves the current origin from its list entry when the caller omits remoteUrl', () => {
+            const repos = [
+                // Current repo's origin lives on its own list entry, not the ref.
+                localRepo('ws-current', 'shortcuts', '/cur', ORIGIN),
+                localRepo('ws-other', 'breadthseek', '/other', 'https://github.com/acme/breadthseek.git'),
+            ];
+            // No remoteUrl passed on the ref — the filter must still engage via the
+            // current repo's list entry, dropping the unrelated repo.
+            const targets = buildImplementTargets(repos, { workspaceId: 'ws-current' });
+            expect(targets.map(t => t.workspaceId)).toEqual(['ws-current']);
+        });
+
+        it('resolves the current origin from gitInfo when the caller omits remoteUrl (remote-clone case)', () => {
+            // A remote-clone current workspace whose origin is only known via the
+            // git-info batch (gitInfo.remoteUrl), as built by buildRemoteRepoData.
+            const current = {
+                workspace: {
+                    id: 'ws-current',
+                    name: 'shortcuts',
+                    rootPath: '/cur',
+                    baseUrl: 'http://127.0.0.1:5000',
+                    remote: {
+                        baseUrl: 'http://127.0.0.1:5000',
+                        serverId: 'srv-1',
+                        serverLabel: 'ubuntu-arm',
+                        offline: false,
+                        connection: 'online',
+                        queue: 'idle',
+                    },
+                },
+                gitInfo: { isGitRepo: true, branch: 'main', dirty: false, remoteUrl: ORIGIN },
+            } as unknown as RepoData;
+            const repos = [
+                current,
+                remoteRepo('ws-sib', 'shortcuts', {
+                    offline: false,
+                    connection: 'online',
+                    serverLabel: 'ubuntu-arm',
+                    remoteUrl: ORIGIN,
+                }),
+                localRepo('ws-other', 'breadthseek', '/other', 'https://github.com/acme/breadthseek.git'),
+            ];
+            // No remoteUrl on the ref (appState lacked it) — gitInfo.remoteUrl on the
+            // current entry must drive the filter, keeping only the same-origin pair.
+            const targets = buildImplementTargets(repos, { workspaceId: 'ws-current' });
+            expect(targets.map(t => t.workspaceId).sort()).toEqual(['ws-current', 'ws-sib']);
+        });
     });
 });

--- a/packages/coc/test/spa/react/ChatComposerPrChips.test.tsx
+++ b/packages/coc/test/spa/react/ChatComposerPrChips.test.tsx
@@ -110,6 +110,36 @@ describe('ChatComposerPrChips / usePrChatStatusItems', () => {
         expect(getByTestId('composer-pr-chip-diff').textContent).toContain('+142');
     });
 
+    it('clicking the refresh button force-refreshes the PR detail (bypasses the cache)', async () => {
+        mocks.pullRequests.listChatBindingsForOrigin.mockResolvedValue({ bindings: {} });
+        mocks.pullRequests.getForOrigin.mockResolvedValue({
+            number: 42,
+            title: 'Refreshable PR',
+            status: 'open',
+            sourceBranch: 'feat/x',
+            targetBranch: 'main',
+            createdAt: '2024-01-01T00:00:00Z',
+            url: GH_URL,
+        });
+
+        const { findByText, getByTestId } = render(
+            <ChatComposerPrChips turns={[turnWithPrCreate(GH_URL)]} workspaceId="ws1" remoteUrl={GH_REMOTE} taskId="t1" />,
+        );
+
+        await findByText('Refreshable PR');
+        // Initial detail load did not force a cache bypass.
+        expect(mocks.pullRequests.getForOrigin).toHaveBeenLastCalledWith(GH_ORIGIN, '42', { workspaceId: 'ws1' });
+
+        fireEvent.click(getByTestId(`composer-pr-chip-refresh-${GH_ORIGIN}:42`));
+
+        await waitFor(() =>
+            expect(mocks.pullRequests.getForOrigin).toHaveBeenLastCalledWith(GH_ORIGIN, '42', {
+                workspaceId: 'ws1',
+                force: true,
+            }),
+        );
+    });
+
     it('renders detected Azure DevOps PR links directly to Azure DevOps', async () => {
         mocks.pullRequests.listChatBindingsForOrigin.mockResolvedValue({ bindings: {} });
         mocks.pullRequests.getForOrigin.mockResolvedValue({

--- a/packages/coc/test/spa/react/ComposerPrChip.test.tsx
+++ b/packages/coc/test/spa/react/ComposerPrChip.test.tsx
@@ -141,6 +141,35 @@ describe('ComposerPrChip', () => {
         expect(onDismiss).toHaveBeenCalledWith(KEY);
     });
 
+    it('ready: the refresh button force-refreshes when clicked', () => {
+        const onRefresh = vi.fn();
+        const { getByTestId } = render(
+            <ComposerPrChip item={readyItem()} onDismiss={() => {}} onRefresh={onRefresh} />,
+        );
+        const btn = getByTestId(`composer-pr-chip-refresh-${KEY}`) as HTMLButtonElement;
+        expect(btn.disabled).toBe(false);
+        expect(btn.getAttribute('data-refreshing')).toBe('false');
+        fireEvent.click(btn);
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('ready: the refresh button is disabled and marked refreshing while a refresh is in flight', () => {
+        const onRefresh = vi.fn();
+        const { getByTestId } = render(
+            <ComposerPrChip item={readyItem()} onDismiss={() => {}} onRefresh={onRefresh} refreshing />,
+        );
+        const btn = getByTestId(`composer-pr-chip-refresh-${KEY}`) as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+        expect(btn.getAttribute('data-refreshing')).toBe('true');
+        fireEvent.click(btn);
+        expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it('ready: omits the refresh button when no onRefresh handler is provided', () => {
+        const { queryByTestId } = render(<ComposerPrChip item={readyItem()} onDismiss={() => {}} />);
+        expect(queryByTestId(`composer-pr-chip-refresh-${KEY}`)).toBeNull();
+    });
+
     it('loading: shows a skeleton with the number and no title', () => {
         const { getByTestId, queryByTestId } = render(
             <ComposerPrChip item={{ key: KEY, repoId: 'ws1', number: 42, state: 'loading' }} onDismiss={() => {}} />,


### PR DESCRIPTION
- **feat(coc): place Ralph repo and agent selectors on one row**
- **fix(coc): scope implement-plan dropdown to same-origin repos for remote-clone current workspace**
- **feat(coc): add force-refresh button to in-composer PR chip**
