### PR TITLE
fix(coc): stop e2e SSE heartbeat guard latching on the warm-only stream

### DIFF
--- a/packages/coc/test/e2e/queue-conversation.spec.ts
+++ b/packages/coc/test/e2e/queue-conversation.spec.ts
@@ -82,6 +82,16 @@ async function waitForStreamingToComplete(page: Page): Promise<void> {
  * subscription exists and any subsequently-released chunk is delivered rather
  * than dropped in the pre-subscription window.
  *
+ * Only the MAIN process stream relays chunks. A conversation view also opens a
+ * warm-only stream (`/processes/:id/stream?warm=1`, from `useWarmClientStatus`)
+ * that sends its OWN immediate heartbeat — but it subscribes on a chunk-less
+ * path and, unlike the main stream, skips the `await store.requestFlush(...)`
+ * step, so its heartbeat almost always lands first. Counting it would resolve
+ * {@link waitForSseSubscribed} before the chunk subscription is live, letting
+ * the first released chunk slip through the pre-subscription window — the exact
+ * flake this guard exists to prevent. So we ignore the `warm=1` stream and only
+ * latch on the main stream's heartbeat.
+ *
  * Must be called BEFORE navigation so the init script patches `EventSource`
  * before app scripts construct it. The flag resets on every document load.
  */
@@ -92,7 +102,8 @@ async function instrumentSseHeartbeat(page: Page): Promise<void> {
         class InstrumentedEventSource extends NativeES {
             constructor(url: string | URL, init?: EventSourceInit) {
                 super(url, init);
-                if (String(url).includes('/stream')) {
+                const href = String(url);
+                if (href.includes('/stream') && !href.includes('warm=1')) {
                     this.addEventListener('heartbeat', () => {
                         (window as Window & { __sseHeartbeat?: boolean }).__sseHeartbeat = true;
                     });


### PR DESCRIPTION
The queue-conversation streaming e2e tests gate AI chunks until the main
process SSE subscription is confirmed live, waiting on the first
`heartbeat` frame via instrumentSseHeartbeat / waitForSseSubscribed. The
instrumented EventSource matched ANY `/stream` URL, so it also latched on
the warm-only stream (`?warm=1`, from useWarmClientStatus mounted by
FollowUpInputArea). That stream skips the main stream's
`await store.requestFlush(...)` and sends its heartbeat first, so the
guard resolved before the main stream's `store.onProcessOutput`
subscription existed. A chunk released right after was dropped in the
pre-subscription window, leaving `.chat-message-content` empty — the
intermittent `expected "First" / "Hello" / "Part one"` e2e (3) failures
seen on main.

Fix: latch only on the main stream's heartbeat by excluding `warm=1`
URLs, so waitForSseSubscribed again proves the chunk-relay subscription
is live before any chunk is released.

Verified: 30/30 passes (3 gated streaming tests x 10 repeats, retries
disabled); full Streaming suite green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
