### PR TITLE
fix(diff): scope split-view text selection to one column

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/git/diff/SideBySideDiffViewer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/SideBySideDiffViewer.tsx
@@ -90,6 +90,12 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
         const containerRef        = useRef<HTMLDivElement>(null);
         const currentHunkIndexRef = useRef<number>(-1);
 
+        // Column the in-progress text selection started in. Left and right cells are
+        // interleaved per row in the DOM, so a native drag down one column would otherwise
+        // also sweep the interleaved cells of the other column. While a drag is active we
+        // set the OTHER column to `user-select: none`; reset to null on mouse up.
+        const [selectSide, setSelectSide] = useState<'left' | 'right' | null>(null);
+
         const [toolbar, setToolbar] = useState<{
             visible: boolean;
             position: { x: number; y: number };
@@ -180,6 +186,9 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
 
         const handleMouseUp = useCallback((e: React.MouseEvent) => {
             if (e.button !== 0) return;
+            // Selection (if any) is finalized on mouse up — release the column lock so both
+            // columns are selectable again for the next gesture (and for select-all).
+            setSelectSide(null);
             if (!enableComments) return;
             const clear = () => {
                 pendingSelectionRef.current = null;
@@ -247,6 +256,10 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
             // a mousedown with button===0 and ctrlKey===true. Skip clearing the pending
             // selection in that case so the contextmenu handler can still use it.
             if (e.button !== 0 || e.ctrlKey) return;
+            // Lock text selection to the column this drag starts in (see selectSide).
+            const side = (e.target as HTMLElement)
+                .closest('[data-split-side]')?.getAttribute('data-split-side');
+            setSelectSide(side === 'left' || side === 'right' ? side : null);
             pendingSelectionRef.current = null;
             setToolbar(t => ({ ...t, visible: false }));
         }, []);
@@ -299,6 +312,7 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
                     {/* LEFT column — removed or context */}
                     <div
                         className={`flex w-1/2 min-w-0 ${leftBg} ${leftHighlight}`}
+                        style={selectSide === 'right' ? { userSelect: 'none' } : undefined}
                         data-diff-line-index={leftLine && leftLine.originalIndex !== null ? leftLine.originalIndex : undefined}
                         data-line-type={enableComments && leftLine ? leftLine.type : undefined}
                         data-old-line={enableComments && leftLine ? (row.left.lineNumber ?? '') : undefined}
@@ -345,6 +359,7 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
                     {/* RIGHT column — added or context */}
                     <div
                         className={`flex w-1/2 min-w-0 border-l border-[#e0e0e0] dark:border-[#3c3c3c] ${rightBg} ${rightHighlight}`}
+                        style={selectSide === 'left' ? { userSelect: 'none' } : undefined}
                         data-diff-line-index={rightLine && rightLine.originalIndex !== null ? rightLine.originalIndex : undefined}
                         data-line-type={enableComments && rightLine ? rightLine.type : undefined}
                         data-old-line={enableComments && rightLine ? (row.left.lineNumber ?? '') : undefined}
@@ -397,8 +412,8 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
                 <div
                     ref={containerRef}
                     data-testid={testId}
-                    onMouseUp={enableComments ? handleMouseUp : undefined}
-                    onMouseDown={enableComments ? handleMouseDown : undefined}
+                    onMouseUp={handleMouseUp}
+                    onMouseDown={handleMouseDown}
                     onContextMenu={enableComments ? handleContextMenu : undefined}
                     className="font-mono text-xs leading-tight overflow-x-auto bg-[#f5f5f5] dark:bg-[#2d2d2d] border border-[#e0e0e0] dark:border-[#3c3c3c] rounded"
                 >

--- a/packages/coc/test/spa/react/repos/SideBySideDiffViewer.selection.test.tsx
+++ b/packages/coc/test/spa/react/repos/SideBySideDiffViewer.selection.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for SideBySideDiffViewer column-scoped text selection.
+ *
+ * Left and right cells are interleaved per row in the DOM, so a native drag down one
+ * column would otherwise also sweep the interleaved cells of the other column. While a
+ * drag is active the OTHER column must be `user-select: none`, scoped to the column the
+ * drag started in, and released on mouse up.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { SideBySideDiffViewer } from '../../../../src/server/spa/client/react/features/git/diff/SideBySideDiffViewer';
+
+const TWO_HUNK_DIFF = `diff --git a/foo.ts b/foo.ts
+index 0000000..1111111 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,3 +1,3 @@
+-old line 1
++new line 1
+ context line
+@@ -10,2 +10,2 @@
+-old line 10
++new line 10`;
+
+function columns(container: HTMLElement) {
+    const all = Array.from(container.querySelectorAll<HTMLElement>('.w-1\\/2'));
+    return {
+        left: all.filter(c => !c.className.includes('border-l')),
+        right: all.filter(c => c.className.includes('border-l')),
+    };
+}
+
+const isLocked = (el: HTMLElement) => el.style.userSelect === 'none';
+
+describe('SideBySideDiffViewer — column-scoped selection', () => {
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('locks the right column while a selection starts in the left column', () => {
+        const { container } = render(<SideBySideDiffViewer diff={TWO_HUNK_DIFF} enableComments />);
+        const { left, right } = columns(container);
+        expect(left.length).toBeGreaterThan(0);
+        expect(right.length).toBeGreaterThan(0);
+
+        // No lock before any interaction
+        expect(left.some(isLocked)).toBe(false);
+        expect(right.some(isLocked)).toBe(false);
+
+        fireEvent.mouseDown(left[0], { button: 0 });
+
+        const after = columns(container);
+        expect(after.right.every(isLocked)).toBe(true);
+        expect(after.left.some(isLocked)).toBe(false);
+    });
+
+    it('locks the left column while a selection starts in the right column', () => {
+        const { container } = render(<SideBySideDiffViewer diff={TWO_HUNK_DIFF} enableComments />);
+        const { right } = columns(container);
+
+        fireEvent.mouseDown(right[0], { button: 0 });
+
+        const after = columns(container);
+        expect(after.left.every(isLocked)).toBe(true);
+        expect(after.right.some(isLocked)).toBe(false);
+    });
+
+    it('releases the lock on mouse up', () => {
+        const { container } = render(<SideBySideDiffViewer diff={TWO_HUNK_DIFF} enableComments />);
+        const { left } = columns(container);
+
+        fireEvent.mouseDown(left[0], { button: 0 });
+        expect(columns(container).right.every(isLocked)).toBe(true);
+
+        fireEvent.mouseUp(left[0], { button: 0 });
+
+        const after = columns(container);
+        expect(after.left.some(isLocked)).toBe(false);
+        expect(after.right.some(isLocked)).toBe(false);
+    });
+
+    it('locks the column even when comments are disabled', () => {
+        // The cross-column selection bug affects plain (non-comment) split views too,
+        // so the mousedown lock must be wired regardless of enableComments.
+        const { container } = render(<SideBySideDiffViewer diff={TWO_HUNK_DIFF} />);
+        const { left } = columns(container);
+
+        fireEvent.mouseDown(left[0], { button: 0 });
+
+        expect(columns(container).right.every(isLocked)).toBe(true);
+    });
+
+    it('does not lock either column for a right-button mousedown', () => {
+        const { container } = render(<SideBySideDiffViewer diff={TWO_HUNK_DIFF} enableComments />);
+        const { left } = columns(container);
+
+        fireEvent.mouseDown(left[0], { button: 2 });
+
+        const after = columns(container);
+        expect(after.left.some(isLocked)).toBe(false);
+        expect(after.right.some(isLocked)).toBe(false);
+    });
+});


### PR DESCRIPTION
In the side-by-side (split) diff viewer, left and right cells are
interleaved one flex row per line, so a native drag down the left column
also swept the right cells of every intermediate row (and vice versa),
contaminating the selection and clipboard copy.

Lock text selection to the column the drag starts in: on mousedown,
detect the column via data-split-side and set user-select:none on the
other column for the duration of the drag; release on mouseup. The lock
handlers are now wired regardless of enableComments, since the bug
affects plain split views too.

Adds SideBySideDiffViewer.selection.test.tsx covering the lock on each
side, release on mouseup, the comments-disabled path, and that a
right-button mousedown does not lock.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
