### PR TITLE
feat(forge,coc): add shared ADO token resolver with single-flight con…

### DIFF
--- a/packages/coc/src/server/providers/provider-factory.ts
+++ b/packages/coc/src/server/providers/provider-factory.ts
@@ -12,15 +12,13 @@ import {
     ProviderType,
     createGitHubPullRequestsAdapter,
     createAdoPullRequestsAdapter,
-    execAsync,
     getOrResolveAdoUserId,
+    resolveAdoAccessTokenValue,
+    ADO_RESOURCE_ID,
 } from '@plusplusoneplusplus/forge';
 import type { ProvidersFileConfig } from './providers-config';
 
-export { ProviderType };
-
-/** Azure DevOps resource ID for OAuth token requests via `az account get-access-token`. */
-export const ADO_RESOURCE_ID = '499b84ac-1321-427f-aa17-267ca6975798';
+export { ProviderType, ADO_RESOURCE_ID };
 
 /** Sentinel returned when an ADO remote is detected but no credentials are available. */
 export interface AdoNoCredentialsSentinel {
@@ -110,8 +108,8 @@ export class ProviderFactory {
     /**
      * Instantiate an IPullRequestsService for the given remote URL and config.
      *
-     * For ADO remotes, uses `az account get-access-token` bearer token (requires `az login`).
-     * Returns `{ error: 'no-ado-credentials' }` sentinel when the Azure CLI call fails.
+     * For ADO remotes, uses the shared ADO token resolver (cached + single-flighted).
+     * Returns `{ error: 'no-ado-credentials' }` sentinel when no token is available.
      *
      * For other providers: returns `null` when credentials are absent or the URL
      * is unrecognized (does not throw).
@@ -119,6 +117,7 @@ export class ProviderFactory {
     static async createPullRequestsService(
         remoteUrl: string,
         config: ProvidersFileConfig,
+        options?: { dataDir?: string },
     ): Promise<IPullRequestsService | AdoNoCredentialsSentinel | null> {
         const providerType = ProviderFactory.detectProviderType(remoteUrl);
 
@@ -142,30 +141,22 @@ export class ProviderFactory {
                 return { error: 'no-ado-credentials' };
             }
 
-            // Azure CLI bearer token
-            try {
-                const { stdout } = await execAsync(
-                    `az account get-access-token --resource ${ADO_RESOURCE_ID} --query accessToken -o tsv`,
-                );
-                const bearerToken = stdout.trim();
-                if (bearerToken) {
-                    // Best-effort: resolve the current user's ADO identity GUID
-                    // so the adapter can filter PRs to the current user.
-                    let currentUserId: string | undefined;
-                    try {
-                        currentUserId = (await getOrResolveAdoUserId(orgUrl, bearerToken)) ?? undefined;
-                    } catch { /* identity resolution is best-effort */ }
+            const bearerToken = await resolveAdoAccessTokenValue({ dataDir: options?.dataDir });
+            if (bearerToken) {
+                // Best-effort: resolve the current user's ADO identity GUID
+                // so the adapter can filter PRs to the current user.
+                let currentUserId: string | undefined;
+                try {
+                    currentUserId = (await getOrResolveAdoUserId(orgUrl, bearerToken)) ?? undefined;
+                } catch { /* identity resolution is best-effort */ }
 
-                    return createAdoPullRequestsAdapter({
-                        orgUrl,
-                        token: bearerToken,
-                        project: parsed?.project,
-                        repo: parsed?.repo,
-                        currentUserId,
-                    });
-                }
-            } catch {
-                // az not available or not logged in — fall through to sentinel
+                return createAdoPullRequestsAdapter({
+                    orgUrl,
+                    token: bearerToken,
+                    project: parsed?.project,
+                    repo: parsed?.repo,
+                    currentUserId,
+                });
             }
 
             return { error: 'no-ado-credentials' };

--- a/packages/coc/src/server/repos/pr-routes.ts
+++ b/packages/coc/src/server/repos/pr-routes.ts
@@ -387,7 +387,7 @@ async function resolvePullRequestsService(
     }
 
     const cfg = await readProvidersConfig(dataDir);
-    const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg);
+    const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg, { dataDir });
     if (!prSvc || isNoAdoCredentials(prSvc)) {
         if (isNoAdoCredentials(prSvc)) {
             throw new PullRequestRouteError(401, 'no-ado-credentials', { error: 'no-ado-credentials' });
@@ -1258,7 +1258,7 @@ export function registerPrRoutes(
 
     async function createPullRequestsServiceForRepo(repo: RepoInfo): Promise<IPullRequestsService> {
         const cfg = await readProvidersConfig(dataDir);
-        const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg);
+        const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg, { dataDir });
         if (!prSvc || isNoAdoCredentials(prSvc)) {
             if (isNoAdoCredentials(prSvc)) {
                 throw new PullRequestRouteError(401, 'no-ado-credentials', { error: 'no-ado-credentials' });
@@ -1746,7 +1746,7 @@ export function registerPrRoutes(
                 const { workspaceId, repoId, repo, storageScope } = scopeResult.value;
 
                 const cfg = await readProvidersConfig(dataDir);
-                const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg);
+                const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg, { dataDir });
                 if (!prSvc || isNoAdoCredentials(prSvc)) {
                     if (isNoAdoCredentials(prSvc)) {
                         return sendJson(res, { error: 'no-ado-credentials' }, 401);
@@ -1808,7 +1808,7 @@ export function registerPrRoutes(
                 }
 
                 const cfg = await readProvidersConfig(dataDir);
-                const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg);
+                const prSvc = await ProviderFactory.createPullRequestsService(repo.remoteUrl ?? '', cfg, { dataDir });
                 if (!prSvc || isNoAdoCredentials(prSvc)) {
                     if (isNoAdoCredentials(prSvc)) {
                         return sendJson(res, { error: 'no-ado-credentials' }, 401);

--- a/packages/coc/src/server/work-items/work-item-sync-azure-boards-provider.ts
+++ b/packages/coc/src/server/work-items/work-item-sync-azure-boards-provider.ts
@@ -4,7 +4,7 @@ import type { IncomingMessage } from 'http';
 import * as https from 'https';
 import { promisify } from 'util';
 import type { WorkItemSyncProviderStatus } from '@plusplusoneplusplus/coc-client';
-import { ADO_RESOURCE_ID } from '../providers/provider-factory';
+import { ADO_RESOURCE_ID, resolveAdoAccessTokenValue } from '@plusplusoneplusplus/forge';
 import { readProvidersConfig } from '../providers/providers-config';
 import type {
     WorkItemSyncProviderAdapter,
@@ -1226,38 +1226,55 @@ export async function importAzureBoardsEpicTreeAsWorkItems(
     return { root, items, created, updated, warnings, ...pruneResult };
 }
 
+/**
+ * Resolve an Azure DevOps CLI access token.
+ *
+ * When called with default arguments, delegates to the shared token resolver
+ * (cached + single-flighted). When called with custom `run`/`platform`/`comSpec`
+ * arguments (tests), falls back to direct CLI invocation for backward compat.
+ */
 export async function resolveAzureDevOpsCliAccessToken(
-    run: ExecFileAsync = execFileAsync,
-    platform: NodeJS.Platform = process.platform,
-    comSpec: string | undefined = process.env.ComSpec,
+    run?: ExecFileAsync,
+    platform?: NodeJS.Platform,
+    comSpec?: string | undefined,
 ): Promise<string | undefined> {
-    try {
-        const accessTokenArgs = [...AZURE_DEVOPS_ACCESS_TOKEN_ARGS];
-        const command = platform === 'win32'
-            ? {
-                file: comSpec?.trim() || 'cmd.exe',
-                args: ['/d', '/s', '/c', 'az', ...accessTokenArgs],
-            }
-            : {
-                file: 'az',
-                args: accessTokenArgs,
-            };
-        const { stdout } = await run(command.file, command.args, {
-            encoding: 'utf8',
-            windowsHide: true,
-            maxBuffer: 1024 * 1024,
-        });
-        const token = stdout.trim();
-        return token.length > 0 ? token : undefined;
-    } catch {
-        return undefined;
+    // If called with non-default arguments (test injection), use direct CLI path.
+    if (run !== undefined || platform !== undefined || comSpec !== undefined) {
+        const effectiveRun = run ?? execFileAsync;
+        const effectivePlatform = platform ?? process.platform;
+        const effectiveComSpec = comSpec ?? process.env.ComSpec;
+        try {
+            const accessTokenArgs = [...AZURE_DEVOPS_ACCESS_TOKEN_ARGS];
+            const command = effectivePlatform === 'win32'
+                ? {
+                    file: effectiveComSpec?.trim() || 'cmd.exe',
+                    args: ['/d', '/s', '/c', 'az', ...accessTokenArgs],
+                }
+                : {
+                    file: 'az',
+                    args: accessTokenArgs,
+                };
+            const { stdout } = await effectiveRun(command.file, command.args, {
+                encoding: 'utf8',
+                windowsHide: true,
+                maxBuffer: 1024 * 1024,
+            });
+            const token = stdout.trim();
+            return token.length > 0 ? token : undefined;
+        } catch {
+            return undefined;
+        }
     }
+
+    // Default: use the shared cached/single-flighted resolver.
+    return resolveAdoAccessTokenValue();
 }
 
 export function createAzureBoardsWorkItemSyncProviderAdapter(
     options: CreateAzureBoardsWorkItemSyncProviderOptions,
 ): WorkItemSyncProviderAdapter {
-    const resolveAccessToken = options.resolveAccessToken ?? (() => resolveAzureDevOpsCliAccessToken());
+    const resolveAccessToken = options.resolveAccessToken
+        ?? (() => resolveAdoAccessTokenValue({ dataDir: options.dataDir }));
 
     return {
         provider: 'azure-boards',

--- a/packages/coc/test/server/api-fs-routes.test.ts
+++ b/packages/coc/test/server/api-fs-routes.test.ts
@@ -10,6 +10,11 @@ vi.mock('@plusplusoneplusplus/forge', () => ({
     // `sdkServiceRegistry`. A full forge mock must stub it (the bridge only calls
     // `.get()`, defensively) or the import graph throws on a missing export.
     sdkServiceRegistry: { get: () => undefined },
+    // The work-items import graph (work-item-commands -> azure-boards provider)
+    // pulls these in at module load. The full mock must stub them or the import
+    // graph throws on a missing export.
+    ADO_RESOURCE_ID: '499b84ac-1321-427f-aa17-267ca6975798',
+    resolveAdoAccessTokenValue: vi.fn(),
 }));
 
 vi.mock('fs', async () => {

--- a/packages/coc/test/server/provider-factory.test.ts
+++ b/packages/coc/test/server/provider-factory.test.ts
@@ -7,18 +7,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ProviderFactory, ProviderType } from '../../src/server/providers/provider-factory';
 import type { ProvidersFileConfig } from '../../src/server/providers/providers-config';
 
-// Mock execAsync, createAdoPullRequestsAdapter, and getOrResolveAdoUserId from forge
+// Mock resolveAdoAccessTokenValue, createAdoPullRequestsAdapter, and getOrResolveAdoUserId from forge
 vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
     return {
         ...actual,
-        execAsync: vi.fn(),
+        resolveAdoAccessTokenValue: vi.fn(),
         createAdoPullRequestsAdapter: vi.fn(actual.createAdoPullRequestsAdapter),
         getOrResolveAdoUserId: vi.fn(),
     };
 });
 
-import { execAsync, createAdoPullRequestsAdapter, getOrResolveAdoUserId } from '@plusplusoneplusplus/forge';
+import { resolveAdoAccessTokenValue, createAdoPullRequestsAdapter, getOrResolveAdoUserId } from '@plusplusoneplusplus/forge';
 
 // ── detectProviderType ────────────────────────────────────────────────────────
 
@@ -137,8 +137,8 @@ describe('ProviderFactory.parseAdoRemote', () => {
 describe('ProviderFactory.createPullRequestsService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Default: az CLI fails (not logged in)
-        (execAsync as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('az: command not found'));
+        // Default: shared resolver returns no token (not logged in)
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
         // Default: no cached user identity
         (getOrResolveAdoUserId as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     });
@@ -152,7 +152,7 @@ describe('ProviderFactory.createPullRequestsService', () => {
         expect(result).toBeNull();
     });
 
-    it('returns no-ado-credentials sentinel when az CLI fails', async () => {
+    it('returns no-ado-credentials sentinel when shared resolver returns no token', async () => {
         const config: ProvidersFileConfig = { providers: {} };
         const result = await ProviderFactory.createPullRequestsService(
             'https://dev.azure.com/org/proj/_git/repo',
@@ -161,8 +161,8 @@ describe('ProviderFactory.createPullRequestsService', () => {
         expect(result).toEqual({ error: 'no-ado-credentials' });
     });
 
-    it('returns a service when ADO token missing but az CLI succeeds', async () => {
-        (execAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: 'bearer-token-xyz\n', stderr: '' });
+    it('returns a service when shared resolver returns a token', async () => {
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token-xyz');
         const config: ProvidersFileConfig = { providers: {} };
         const result = await ProviderFactory.createPullRequestsService(
             'https://dev.azure.com/org/proj/_git/repo',
@@ -194,8 +194,8 @@ describe('ProviderFactory.createPullRequestsService', () => {
         expect(result).not.toBeNull();
     });
 
-    it('returns a service instance when ADO orgUrl is configured and az CLI succeeds', async () => {
-        (execAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: 'bearer-token-xyz\n', stderr: '' });
+    it('returns a service instance when ADO orgUrl is configured and shared resolver returns a token', async () => {
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token-xyz');
         const config: ProvidersFileConfig = {
             providers: {
                 ado: { orgUrl: 'https://dev.azure.com/myorg' },
@@ -232,7 +232,7 @@ describe('ProviderFactory.createPullRequestsService', () => {
     });
 
     it('passes parsed repo name to createAdoPullRequestsAdapter (regression: workspace ID bug)', async () => {
-        (execAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: 'bearer-token-xyz\n', stderr: '' });
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token-xyz');
         const config: ProvidersFileConfig = { providers: {} };
         await ProviderFactory.createPullRequestsService(
             'https://dev.azure.com/org/proj/_git/MyRepo',
@@ -243,8 +243,19 @@ describe('ProviderFactory.createPullRequestsService', () => {
         );
     });
 
+    it('passes dataDir to shared resolver', async () => {
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token');
+        const config: ProvidersFileConfig = { providers: {} };
+        await ProviderFactory.createPullRequestsService(
+            'https://dev.azure.com/org/proj/_git/repo',
+            config,
+            { dataDir: '/custom/data' },
+        );
+        expect(resolveAdoAccessTokenValue).toHaveBeenCalledWith({ dataDir: '/custom/data' });
+    });
+
     it('passes cached ADO user ID as currentUserId', async () => {
-        (execAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: 'bearer-token\n', stderr: '' });
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token');
         (getOrResolveAdoUserId as ReturnType<typeof vi.fn>).mockResolvedValue('ado-guid-123');
         const config: ProvidersFileConfig = { providers: {} };
         await ProviderFactory.createPullRequestsService(
@@ -258,7 +269,7 @@ describe('ProviderFactory.createPullRequestsService', () => {
     });
 
     it('creates adapter without currentUserId when identity resolution returns null', async () => {
-        (execAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: 'bearer-token\n', stderr: '' });
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token');
         (getOrResolveAdoUserId as ReturnType<typeof vi.fn>).mockResolvedValue(null);
         const config: ProvidersFileConfig = { providers: {} };
         await ProviderFactory.createPullRequestsService(
@@ -271,7 +282,7 @@ describe('ProviderFactory.createPullRequestsService', () => {
     });
 
     it('creates adapter without currentUserId when identity resolution throws', async () => {
-        (execAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: 'bearer-token\n', stderr: '' });
+        (resolveAdoAccessTokenValue as ReturnType<typeof vi.fn>).mockResolvedValue('bearer-token');
         (getOrResolveAdoUserId as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'));
         const config: ProvidersFileConfig = { providers: {} };
         const result = await ProviderFactory.createPullRequestsService(

--- a/packages/forge/src/ado/ado-connection-factory.ts
+++ b/packages/forge/src/ado/ado-connection-factory.ts
@@ -1,17 +1,9 @@
 import * as azdev from 'azure-devops-node-api';
 import { getLogger, LogCategory } from '../logger';
-import { execAsync } from '../utils/exec-utils';
 import type { AdoClientOptions, AdoConnectionResult } from './types';
-import {
-    AdoSessionCache,
-    readAdoSessionCache,
-    writeAdoSessionCache,
-    isTokenValid,
-} from './ado-session-cache';
+import { resolveAdoAccessToken } from './ado-token-resolver';
 
 const ENV_ORG_URL = 'AZURE_DEVOPS_ORG_URL';
-/** Azure DevOps resource ID for OAuth token requests. */
-const ADO_RESOURCE_ID = '499b84ac-1321-427f-aa17-267ca6975798';
 
 let _instance: AdoConnectionFactory | null = null;
 
@@ -40,97 +32,24 @@ export class AdoConnectionFactory {
         }
 
         const dataDir = options?.dataDir;
-        const cache = await this.resolveTokenCache(dataDir);
-        if (!cache.success) {
-            logger.warn(LogCategory.ADO, cache.error);
-            return { connected: false, error: cache.error };
+        const resolved = await resolveAdoAccessToken({ dataDir });
+        if (!resolved) {
+            const error = `Failed to get token from Azure CLI. Run 'az login' to authenticate.`;
+            logger.warn(LogCategory.ADO, error);
+            return { connected: false, error };
         }
 
-        const authHandler = azdev.getBearerHandler(cache.token);
+        const authHandler = azdev.getBearerHandler(resolved.token);
         logger.info(LogCategory.ADO, 'Using Azure CLI bearer token for authentication');
 
         try {
             const connection = new azdev.WebApi(orgUrl, authHandler);
             logger.info(LogCategory.ADO, `Connected to Azure DevOps at ${orgUrl}`);
-            return { connected: true, connection, account: cache.account };
+            return { connected: true, connection, account: resolved.account };
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             logger.error(LogCategory.ADO, `Failed to create Azure DevOps connection: ${msg}`);
             return { connected: false, error: msg };
-        }
-    }
-
-    /**
-     * Resolve a valid bearer token, using the on-disk cache when possible
-     * and falling back to `az account get-access-token` otherwise.
-     */
-    private async resolveTokenCache(dataDir?: string): Promise<
-        { success: true; token: string; account: AdoSessionCache['account'] } |
-        { success: false; error: string }
-    > {
-        const logger = getLogger();
-
-        const cached = await readAdoSessionCache(dataDir);
-        if (cached && isTokenValid(cached)) {
-            logger.info(LogCategory.ADO, 'Using cached ADO bearer token');
-            return { success: true, token: cached.token, account: cached.account };
-        }
-
-        return this.fetchAndCacheToken(dataDir);
-    }
-
-    /** Call az CLI to get a fresh token + account info and persist to cache. */
-    private async fetchAndCacheToken(dataDir?: string): Promise<
-        { success: true; token: string; account: AdoSessionCache['account'] } |
-        { success: false; error: string }
-    > {
-        const logger = getLogger();
-
-        try {
-            // Fetch token + expiry in one call.
-            const { stdout: tokenJson } = await execAsync(
-                `az account get-access-token --resource ${ADO_RESOURCE_ID} --query "{token:accessToken,expiresOn:expiresOn}" -o json`,
-            );
-            const tokenData = JSON.parse(tokenJson.trim()) as {
-                token: string;
-                expiresOn: string;
-            };
-            if (!tokenData.token) {
-                return { success: false, error: 'Azure CLI returned an empty token' };
-            }
-            const expiresAt = new Date(tokenData.expiresOn).getTime();
-
-            // Fetch account info (best-effort).
-            let account: AdoSessionCache['account'] = null;
-            try {
-                const { stdout: accountJson } = await execAsync(
-                    `az account show --query "{upn:user.name,displayName:user.name}" -o json`,
-                );
-                const accountData = JSON.parse(accountJson.trim()) as {
-                    upn: string;
-                    displayName: string;
-                };
-                account = { upn: accountData.upn, displayName: accountData.displayName, adoId: null };
-            } catch (accountErr) {
-                const msg = accountErr instanceof Error ? accountErr.message : String(accountErr);
-                logger.warn(LogCategory.ADO, `Failed to fetch account info from Azure CLI: ${msg}`);
-            }
-
-            const newCache: AdoSessionCache = { token: tokenData.token, expiresAt, account };
-            try {
-                await writeAdoSessionCache(newCache, dataDir);
-            } catch (writeErr) {
-                const msg = writeErr instanceof Error ? writeErr.message : String(writeErr);
-                logger.warn(LogCategory.ADO, `Failed to write ADO session cache: ${msg}`);
-            }
-
-            return { success: true, token: tokenData.token, account };
-        } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return {
-                success: false,
-                error: `Failed to get token from Azure CLI: ${msg}. Run 'az login' to authenticate.`,
-            };
         }
     }
 }

--- a/packages/forge/src/ado/ado-token-resolver.ts
+++ b/packages/forge/src/ado/ado-token-resolver.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared ADO token resolver — ensures at most one `az account get-access-token`
+ * process runs inside a CoC server process at any time.
+ *
+ * Concurrent callers that need the same Azure DevOps bearer token share the
+ * same in-flight token refresh. Once a valid token is cached, later callers
+ * use the cached token without invoking Azure CLI.
+ */
+import { getLogger, LogCategory } from '../logger';
+import { execAsync } from '../utils/exec-utils';
+import {
+    type AdoAccountInfo,
+    type AdoSessionCache,
+    readAdoSessionCache,
+    writeAdoSessionCache,
+    isTokenValid,
+} from './ado-session-cache';
+
+/** Azure DevOps resource ID for OAuth token requests. */
+export const ADO_RESOURCE_ID = '499b84ac-1321-427f-aa17-267ca6975798';
+
+/**
+ * Injectable runner for Azure CLI commands.
+ * Production code should not pass this; it exists for deterministic testing.
+ */
+export type AdoAzCliRunner = (command: string) => Promise<{ stdout: string; stderr: string }>;
+
+export interface ResolveAdoAccessTokenOptions {
+    dataDir?: string;
+    runAzCli?: AdoAzCliRunner;
+}
+
+export interface ResolvedAdoAccessToken {
+    token: string;
+    expiresAt: number;
+    account: AdoAccountInfo | null;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level single-flight state
+// ---------------------------------------------------------------------------
+
+/** In-flight refresh promises keyed by resolved dataDir. */
+const inflight = new Map<string, Promise<ResolvedAdoAccessToken | null>>();
+
+/** Global queue ensuring at most one az CLI token command at a time. */
+let azCliQueue: Promise<unknown> = Promise.resolve();
+
+function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const next = azCliQueue.then(operation, operation);
+    azCliQueue = next.catch(() => undefined);
+    return next;
+}
+
+function resolveCacheKey(dataDir?: string): string {
+    return dataDir ?? process.env.COC_DATA_DIR ?? '~default';
+}
+
+// ---------------------------------------------------------------------------
+// Default runner (uses cmd.exe on Windows for az.cmd resolution)
+// ---------------------------------------------------------------------------
+
+function defaultAzCliRunner(command: string): Promise<{ stdout: string; stderr: string }> {
+    if (process.platform === 'win32') {
+        const comSpec = process.env.ComSpec?.trim() || 'cmd.exe';
+        return execAsync(`${comSpec} /d /s /c ${command}`);
+    }
+    return execAsync(command);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an ADO access token, using the on-disk cache when valid and
+ * single-flighting concurrent refreshes.
+ */
+export async function resolveAdoAccessToken(
+    options?: ResolveAdoAccessTokenOptions,
+): Promise<ResolvedAdoAccessToken | null> {
+    const logger = getLogger();
+    const dataDir = options?.dataDir;
+    const runner = options?.runAzCli ?? defaultAzCliRunner;
+
+    // 1. Read cache — fast path.
+    const cached = await readAdoSessionCache(dataDir);
+    if (cached && isTokenValid(cached)) {
+        logger.info(LogCategory.ADO, 'ADO token resolver: using cached token');
+        return { token: cached.token, expiresAt: cached.expiresAt, account: cached.account };
+    }
+
+    // 2. Resolve cache key for single-flight deduplication.
+    const key = resolveCacheKey(dataDir);
+
+    // 3. If a refresh is already in-flight for this key, await it.
+    const existing = inflight.get(key);
+    if (existing) {
+        logger.info(LogCategory.ADO, 'ADO token resolver: awaiting in-flight refresh');
+        return existing;
+    }
+
+    // 4. Create and store a refresh promise.
+    const refreshPromise = (async (): Promise<ResolvedAdoAccessToken | null> => {
+        // Re-read cache inside the refresh in case another refresh completed
+        // between the outer cache read and this point.
+        const freshCache = await readAdoSessionCache(dataDir);
+        if (freshCache && isTokenValid(freshCache)) {
+            logger.info(LogCategory.ADO, 'ADO token resolver: cache populated by concurrent refresh');
+            return { token: freshCache.token, expiresAt: freshCache.expiresAt, account: freshCache.account };
+        }
+
+        // Run az CLI exclusively (one token command at a time process-wide).
+        return runExclusive(async () => {
+            // One more cache check after acquiring the queue slot.
+            const postQueueCache = await readAdoSessionCache(dataDir);
+            if (postQueueCache && isTokenValid(postQueueCache)) {
+                return { token: postQueueCache.token, expiresAt: postQueueCache.expiresAt, account: postQueueCache.account };
+            }
+
+            logger.info(LogCategory.ADO, 'ADO token resolver: fetching token via az CLI');
+
+            try {
+                const tokenCommand = `az account get-access-token --resource ${ADO_RESOURCE_ID} --query "{token:accessToken,expiresOn:expiresOn}" -o json`;
+                const { stdout: tokenJson } = await runner(tokenCommand);
+                const tokenData = JSON.parse(tokenJson.trim()) as {
+                    token: string;
+                    expiresOn: string;
+                };
+                if (!tokenData.token) {
+                    return null;
+                }
+                const expiresAt = new Date(tokenData.expiresOn).getTime();
+
+                // Best-effort account info.
+                let account: AdoAccountInfo | null = null;
+                try {
+                    const accountCommand = `az account show --query "{upn:user.name,displayName:user.name}" -o json`;
+                    const { stdout: accountJson } = await runner(accountCommand);
+                    const accountData = JSON.parse(accountJson.trim()) as {
+                        upn: string;
+                        displayName: string;
+                    };
+                    account = { upn: accountData.upn, displayName: accountData.displayName, adoId: null };
+                } catch (accountErr) {
+                    const msg = accountErr instanceof Error ? accountErr.message : String(accountErr);
+                    logger.warn(LogCategory.ADO, `ADO token resolver: failed to fetch account info: ${msg}`);
+                }
+
+                // Write to cache (best-effort).
+                const newCache: AdoSessionCache = { token: tokenData.token, expiresAt, account };
+                try {
+                    await writeAdoSessionCache(newCache, dataDir);
+                } catch (writeErr) {
+                    const msg = writeErr instanceof Error ? writeErr.message : String(writeErr);
+                    logger.warn(LogCategory.ADO, `ADO token resolver: failed to write cache: ${msg}`);
+                }
+
+                return { token: tokenData.token, expiresAt, account };
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                logger.warn(LogCategory.ADO, `ADO token resolver: az CLI failed: ${msg}`);
+                return null;
+            }
+        });
+    })();
+
+    inflight.set(key, refreshPromise);
+    try {
+        return await refreshPromise;
+    } finally {
+        inflight.delete(key);
+    }
+}
+
+/**
+ * Convenience wrapper that returns only the token string (or undefined).
+ * Suitable as an `AzureBoardsAccessTokenResolver`.
+ */
+export async function resolveAdoAccessTokenValue(
+    options?: ResolveAdoAccessTokenOptions,
+): Promise<string | undefined> {
+    const result = await resolveAdoAccessToken(options);
+    return result?.token;
+}
+
+/**
+ * Reset module-level state for test isolation.
+ */
+export function resetAdoTokenResolverForTests(): void {
+    inflight.clear();
+    azCliQueue = Promise.resolve();
+}

--- a/packages/forge/src/ado/index.ts
+++ b/packages/forge/src/ado/index.ts
@@ -7,6 +7,15 @@ export {
     writeAdoSessionCache,
     isTokenValid,
 } from './ado-session-cache';
+export {
+    ADO_RESOURCE_ID,
+    resolveAdoAccessToken,
+    resolveAdoAccessTokenValue,
+    resetAdoTokenResolverForTests,
+    type AdoAzCliRunner,
+    type ResolveAdoAccessTokenOptions,
+    type ResolvedAdoAccessToken,
+} from './ado-token-resolver';
 export { resolveAdoIdentity, resolveAndCacheAdoIdentity, getOrResolveAdoUserId, resolveAdoUserIdFromConnectionData } from './ado-identity-resolver';
 export { AdoWorkItemsService, AdoWorkItemError, type PatchOp, type FieldPatch } from './workitems-service';
 export {

--- a/packages/forge/test/ado/ado-connection-factory.test.ts
+++ b/packages/forge/test/ado/ado-connection-factory.test.ts
@@ -13,9 +13,13 @@ vi.mock('azure-devops-node-api', () => {
     };
 });
 
-vi.mock('../../src/utils/exec-utils', () => ({
-    execAsync: vi.fn(),
-}));
+vi.mock('../../src/ado/ado-token-resolver', async (importOriginal) => {
+    const original = await importOriginal<typeof import('../../src/ado/ado-token-resolver')>();
+    return {
+        ...original,
+        resolveAdoAccessToken: vi.fn(),
+    };
+});
 
 vi.mock('../../src/ado/ado-session-cache', async (importOriginal) => {
     const original = await importOriginal<typeof import('../../src/ado/ado-session-cache')>();
@@ -32,12 +36,11 @@ import {
     resetAdoConnectionFactory,
 } from '../../src/ado/ado-connection-factory';
 import * as azdev from 'azure-devops-node-api';
-import { execAsync } from '../../src/utils/exec-utils';
-import { readAdoSessionCache, writeAdoSessionCache } from '../../src/ado/ado-session-cache';
+import { resolveAdoAccessToken } from '../../src/ado/ado-token-resolver';
+import { readAdoSessionCache } from '../../src/ado/ado-session-cache';
 
-const mockedExecAsync = vi.mocked(execAsync);
+const mockedResolveToken = vi.mocked(resolveAdoAccessToken);
 const mockedReadCache = vi.mocked(readAdoSessionCache);
-const mockedWriteCache = vi.mocked(writeAdoSessionCache);
 
 const NOW = 1_700_000_000_000;
 const TOKEN_JSON = JSON.stringify({
@@ -54,9 +57,8 @@ describe('AdoConnectionFactory', () => {
         delete process.env.AZURE_DEVOPS_ORG_URL;
         vi.clearAllMocks();
         vi.setSystemTime(NOW);
-        // Default: no valid cache
-        mockedReadCache.mockResolvedValue(null);
-        mockedWriteCache.mockResolvedValue(undefined);
+        // Default: token resolver returns null (no token available)
+        mockedResolveToken.mockResolvedValue(null);
     });
 
     afterEach(() => {
@@ -96,8 +98,8 @@ describe('AdoConnectionFactory', () => {
             process.env.AZURE_DEVOPS_ORG_URL = 'https://dev.azure.com/myorg';
         });
 
-        it('skips az CLI when cache is valid', async () => {
-            mockedReadCache.mockResolvedValueOnce({
+        it('uses resolved token from shared resolver', async () => {
+            mockedResolveToken.mockResolvedValueOnce({
                 token: 'cached-token',
                 expiresAt: NOW + 10 * 60 * 1000,
                 account: { upn: 'user@example.com', displayName: 'Test User', adoId: null },
@@ -107,13 +109,12 @@ describe('AdoConnectionFactory', () => {
             const result = await factory.connect();
 
             expect(result.connected).toBe(true);
-            expect(mockedExecAsync).not.toHaveBeenCalled();
             expect(azdev.getBearerHandler).toHaveBeenCalledWith('cached-token');
         });
 
-        it('exposes account from cache on successful connect', async () => {
+        it('exposes account from resolver on successful connect', async () => {
             const account = { upn: 'user@example.com', displayName: 'Test User', adoId: 'guid-123' };
-            mockedReadCache.mockResolvedValueOnce({
+            mockedResolveToken.mockResolvedValueOnce({
                 token: 'cached-token',
                 expiresAt: NOW + 10 * 60 * 1000,
                 account,
@@ -129,59 +130,57 @@ describe('AdoConnectionFactory', () => {
         });
     });
 
-    describe('connect — Azure CLI fallback (cache miss)', () => {
+    describe('connect — token resolution (cache miss)', () => {
         beforeEach(() => {
             process.env.AZURE_DEVOPS_ORG_URL = 'https://dev.azure.com/myorg';
         });
 
-        it('fetches token via az CLI and writes cache', async () => {
-            mockedExecAsync
-                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })  // get-access-token
-                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' }); // account show
-
-            const factory = getAdoConnectionFactory();
-            const result = await factory.connect();
-
-            expect(result.connected).toBe(true);
-            expect(mockedExecAsync).toHaveBeenCalledWith(
-                expect.stringContaining('az account get-access-token'),
-            );
-            expect(mockedWriteCache).toHaveBeenCalledOnce();
-            expect(azdev.getBearerHandler).toHaveBeenCalledWith('az-bearer-token-123');
-        });
-
-        it('returns error when az CLI returns empty token', async () => {
-            mockedExecAsync.mockResolvedValueOnce({
-                stdout: JSON.stringify({ token: '', expiresOn: new Date().toISOString() }),
-                stderr: '',
+        it('connects when shared resolver returns a token', async () => {
+            mockedResolveToken.mockResolvedValueOnce({
+                token: 'az-bearer-token-123',
+                expiresAt: NOW + 3600_000,
+                account: { upn: 'user@example.com', displayName: 'Test User', adoId: null },
             });
 
             const factory = getAdoConnectionFactory();
             const result = await factory.connect();
 
-            expect(result.connected).toBe(false);
-            if (!result.connected) {
-                expect(result.error).toContain('empty token');
-            }
+            expect(result.connected).toBe(true);
+            expect(mockedResolveToken).toHaveBeenCalledWith({ dataDir: undefined });
+            expect(azdev.getBearerHandler).toHaveBeenCalledWith('az-bearer-token-123');
         });
 
-        it('returns error with helpful message when az CLI fails', async () => {
-            mockedExecAsync.mockRejectedValueOnce(new Error('az: command not found'));
+        it('returns error when token resolver returns null', async () => {
+            mockedResolveToken.mockResolvedValueOnce(null);
 
             const factory = getAdoConnectionFactory();
             const result = await factory.connect();
 
             expect(result.connected).toBe(false);
             if (!result.connected) {
-                expect(result.error).toContain('Azure CLI');
                 expect(result.error).toContain('az login');
             }
         });
 
-        it('still connects even if account show fails', async () => {
-            mockedExecAsync
-                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
-                .mockRejectedValueOnce(new Error('account show failed'));
+        it('passes dataDir to the shared resolver', async () => {
+            mockedResolveToken.mockResolvedValueOnce({
+                token: 'token-for-dir',
+                expiresAt: NOW + 3600_000,
+                account: null,
+            });
+
+            const factory = getAdoConnectionFactory();
+            await factory.connect({ orgUrl: 'https://dev.azure.com/myorg', dataDir: '/custom/dir' });
+
+            expect(mockedResolveToken).toHaveBeenCalledWith({ dataDir: '/custom/dir' });
+        });
+
+        it('still connects when account is null', async () => {
+            mockedResolveToken.mockResolvedValueOnce({
+                token: 'token-no-account',
+                expiresAt: NOW + 3600_000,
+                account: null,
+            });
 
             const factory = getAdoConnectionFactory();
             const result = await factory.connect();
@@ -191,42 +190,6 @@ describe('AdoConnectionFactory', () => {
                 expect(result.account).toBeNull();
             }
         });
-
-        it('still connects even if cache write fails', async () => {
-            mockedExecAsync
-                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
-                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' });
-            mockedWriteCache.mockRejectedValueOnce(new Error('disk full'));
-
-            const factory = getAdoConnectionFactory();
-            const result = await factory.connect();
-
-            expect(result.connected).toBe(true);
-        });
-    });
-
-    describe('connect — expired cache falls back to az CLI', () => {
-        beforeEach(() => {
-            process.env.AZURE_DEVOPS_ORG_URL = 'https://dev.azure.com/myorg';
-        });
-
-        it('calls az CLI when cached token is within 5-min buffer', async () => {
-            mockedReadCache.mockResolvedValueOnce({
-                token: 'old-token',
-                expiresAt: NOW + 3 * 60 * 1000, // < 5 min buffer
-                account: null,
-            });
-            mockedExecAsync
-                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
-                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' });
-
-            const factory = getAdoConnectionFactory();
-            const result = await factory.connect();
-
-            expect(result.connected).toBe(true);
-            expect(mockedExecAsync).toHaveBeenCalled();
-            expect(azdev.getBearerHandler).toHaveBeenCalledWith('az-bearer-token-123');
-        });
     });
 
     describe('connect — error handling', () => {
@@ -234,9 +197,11 @@ describe('AdoConnectionFactory', () => {
             vi.mocked(azdev.WebApi).mockImplementationOnce(function (this: any) {
                 throw new Error('network failure');
             });
-            mockedExecAsync
-                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
-                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' });
+            mockedResolveToken.mockResolvedValueOnce({
+                token: 'az-bearer-token-123',
+                expiresAt: NOW + 3600_000,
+                account: null,
+            });
             process.env.AZURE_DEVOPS_ORG_URL = 'https://org';
 
             const factory = getAdoConnectionFactory();

--- a/packages/forge/test/ado/ado-token-resolver.test.ts
+++ b/packages/forge/test/ado/ado-token-resolver.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/utils/exec-utils', () => ({
+    execAsync: vi.fn(),
+}));
+
+vi.mock('../../src/ado/ado-session-cache', async (importOriginal) => {
+    const original = await importOriginal<typeof import('../../src/ado/ado-session-cache')>();
+    return {
+        ...original,
+        readAdoSessionCache: vi.fn(),
+        writeAdoSessionCache: vi.fn(),
+    };
+});
+
+import {
+    resolveAdoAccessToken,
+    resolveAdoAccessTokenValue,
+    resetAdoTokenResolverForTests,
+    ADO_RESOURCE_ID,
+} from '../../src/ado/ado-token-resolver';
+import { readAdoSessionCache, writeAdoSessionCache } from '../../src/ado/ado-session-cache';
+
+const mockedReadCache = vi.mocked(readAdoSessionCache);
+const mockedWriteCache = vi.mocked(writeAdoSessionCache);
+
+const NOW = 1_700_000_000_000;
+const VALID_EXPIRY = NOW + 60 * 60 * 1000; // 1 hour from now
+const TOKEN_JSON = JSON.stringify({
+    token: 'fresh-token-123',
+    expiresOn: new Date(VALID_EXPIRY).toISOString(),
+});
+const ACCOUNT_JSON = JSON.stringify({ upn: 'user@example.com', displayName: 'Test User' });
+
+describe('ado-token-resolver', () => {
+    beforeEach(() => {
+        resetAdoTokenResolverForTests();
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+        mockedReadCache.mockResolvedValue(null);
+        mockedWriteCache.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        resetAdoTokenResolverForTests();
+        vi.useRealTimers();
+    });
+
+    describe('cache hit', () => {
+        it('returns cached token without calling az CLI', async () => {
+            const runner = vi.fn();
+            mockedReadCache.mockResolvedValueOnce({
+                token: 'cached-token',
+                expiresAt: NOW + 10 * 60 * 1000,
+                account: { upn: 'user@example.com', displayName: 'Test User', adoId: null },
+            });
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toEqual({
+                token: 'cached-token',
+                expiresAt: NOW + 10 * 60 * 1000,
+                account: { upn: 'user@example.com', displayName: 'Test User', adoId: null },
+            });
+            expect(runner).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cache miss — single token refresh', () => {
+        it('fetches token via az CLI and writes cache', async () => {
+            const runner = vi.fn()
+                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
+                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' });
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toEqual({
+                token: 'fresh-token-123',
+                expiresAt: VALID_EXPIRY,
+                account: { upn: 'user@example.com', displayName: 'Test User', adoId: null },
+            });
+            expect(runner).toHaveBeenCalledWith(
+                expect.stringContaining('az account get-access-token'),
+            );
+            expect(mockedWriteCache).toHaveBeenCalledOnce();
+        });
+
+        it('returns null when az CLI returns empty token', async () => {
+            const runner = vi.fn().mockResolvedValueOnce({
+                stdout: JSON.stringify({ token: '', expiresOn: new Date().toISOString() }),
+                stderr: '',
+            });
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when az CLI fails', async () => {
+            const runner = vi.fn().mockRejectedValueOnce(new Error('az: not found'));
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toBeNull();
+        });
+
+        it('still succeeds when account show fails', async () => {
+            const runner = vi.fn()
+                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
+                .mockRejectedValueOnce(new Error('account show failed'));
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toEqual({
+                token: 'fresh-token-123',
+                expiresAt: VALID_EXPIRY,
+                account: null,
+            });
+        });
+
+        it('still succeeds when cache write fails', async () => {
+            const runner = vi.fn()
+                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
+                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' });
+            mockedWriteCache.mockRejectedValueOnce(new Error('disk full'));
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result?.token).toBe('fresh-token-123');
+        });
+    });
+
+    describe('single-flight deduplication', () => {
+        it('concurrent cache misses call az CLI only once', async () => {
+            let resolveToken: (v: { stdout: string; stderr: string }) => void;
+            const tokenPromise = new Promise<{ stdout: string; stderr: string }>((r) => { resolveToken = r; });
+            const runner = vi.fn()
+                .mockReturnValueOnce(tokenPromise)
+                .mockResolvedValue({ stdout: ACCOUNT_JSON, stderr: '' });
+
+            // Launch multiple concurrent requests.
+            const p1 = resolveAdoAccessToken({ runAzCli: runner });
+            const p2 = resolveAdoAccessToken({ runAzCli: runner });
+            const p3 = resolveAdoAccessToken({ runAzCli: runner });
+
+            // Resolve the token.
+            resolveToken!({ stdout: TOKEN_JSON, stderr: '' });
+
+            const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+            expect(r1?.token).toBe('fresh-token-123');
+            expect(r2?.token).toBe('fresh-token-123');
+            expect(r3?.token).toBe('fresh-token-123');
+            // az account get-access-token should be called only once.
+            expect(runner).toHaveBeenCalledTimes(2); // token + account show
+        });
+
+        it('clears in-flight promise after failure so retry works', async () => {
+            const runner = vi.fn()
+                .mockRejectedValueOnce(new Error('first failure'))
+                .mockResolvedValueOnce({ stdout: TOKEN_JSON, stderr: '' })
+                .mockResolvedValueOnce({ stdout: ACCOUNT_JSON, stderr: '' });
+
+            const r1 = await resolveAdoAccessToken({ runAzCli: runner });
+            expect(r1).toBeNull();
+
+            const r2 = await resolveAdoAccessToken({ runAzCli: runner });
+            expect(r2?.token).toBe('fresh-token-123');
+        });
+    });
+
+    describe('queue prevents concurrent CLI commands', () => {
+        it('serializes token refreshes for different data dirs', async () => {
+            vi.useRealTimers();
+            const callOrder: string[] = [];
+            const runner = vi.fn().mockImplementation(async (cmd: string) => {
+                if (cmd.includes('get-access-token')) {
+                    callOrder.push('start-token');
+                    await new Promise((r) => setTimeout(r, 10));
+                    callOrder.push('end-token');
+                    return { stdout: TOKEN_JSON, stderr: '' };
+                }
+                return { stdout: ACCOUNT_JSON, stderr: '' };
+            });
+
+            // Use different dataDirs to avoid single-flight sharing.
+            const p1 = resolveAdoAccessToken({ dataDir: '/dir1', runAzCli: runner });
+            const p2 = resolveAdoAccessToken({ dataDir: '/dir2', runAzCli: runner });
+
+            await Promise.all([p1, p2]);
+
+            // The queue should serialize: start-token, end-token, start-token, end-token
+            expect(callOrder).toEqual(['start-token', 'end-token', 'start-token', 'end-token']);
+        });
+    });
+
+    describe('cache populated by concurrent refresh', () => {
+        it('uses cache written by another refresh when re-checking', async () => {
+            let firstCall = true;
+            mockedReadCache.mockImplementation(async () => {
+                if (firstCall) {
+                    firstCall = false;
+                    return null;
+                }
+                // Second call: cache populated by another refresh.
+                return {
+                    token: 'other-refresh-token',
+                    expiresAt: NOW + 10 * 60 * 1000,
+                    account: null,
+                };
+            });
+
+            const runner = vi.fn();
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result?.token).toBe('other-refresh-token');
+            expect(runner).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('resolveAdoAccessTokenValue', () => {
+        it('returns only the token string', async () => {
+            mockedReadCache.mockResolvedValueOnce({
+                token: 'value-only-token',
+                expiresAt: NOW + 10 * 60 * 1000,
+                account: null,
+            });
+
+            const value = await resolveAdoAccessTokenValue();
+
+            expect(value).toBe('value-only-token');
+        });
+
+        it('returns undefined when no token available', async () => {
+            const runner = vi.fn().mockRejectedValueOnce(new Error('no az'));
+
+            const value = await resolveAdoAccessTokenValue({ runAzCli: runner });
+
+            expect(value).toBeUndefined();
+        });
+    });
+
+    describe('ADO_RESOURCE_ID', () => {
+        it('uses the correct Azure DevOps resource ID', () => {
+            expect(ADO_RESOURCE_ID).toBe('499b84ac-1321-427f-aa17-267ca6975798');
+        });
+    });
+
+    describe('malformed token output', () => {
+        it('returns null for non-JSON output', async () => {
+            const runner = vi.fn().mockResolvedValueOnce({ stdout: 'not json', stderr: '' });
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null for JSON without token field', async () => {
+            const runner = vi.fn().mockResolvedValueOnce({
+                stdout: JSON.stringify({ expiresOn: new Date().toISOString() }),
+                stderr: '',
+            });
+
+            const result = await resolveAdoAccessToken({ runAzCli: runner });
+
+            expect(result).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
…currency

Add a centralized ADO token resolver in Forge that ensures at most one az account get-access-token process runs per CoC server process at any time. Concurrent callers share the same in-flight token refresh, and valid cached tokens are reused without invoking Azure CLI.

Key changes:
- Add packages/forge/src/ado/ado-token-resolver.ts with single-flight deduplication and an exclusive queue for Azure CLI commands
- Refactor AdoConnectionFactory to delegate to the shared resolver
- Refactor ProviderFactory.createPullRequestsService to use resolveAdoAccessTokenValue instead of direct execAsync calls
- Update PR routes to pass dataDir through to the shared resolver
- Update Azure Boards work-item sync provider to use the shared resolver by default (preserving backward-compat test injection)
- Update all affected tests to mock the shared resolver