### PR TITLE
pr/fa123bf4a featforge add centralized machine scoped

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -920,11 +920,14 @@ only) that `aggregateRemoteWorkspaces` populates on every repo refresh via
 cleared when the flag is OFF or the registry is unavailable). Remote markers
 carry `remote.cloneKey = remote:${encodeURIComponent(serverId)}:${encodeURIComponent(workspaceId)}`;
 `repos/cloneIdentity.ts` centralizes clone-key build/parse, selection ids, and
-old path-only fallback resolution. Unique remote workspace ids still resolve
-directly; when cached/legacy rows collide on workspace id, `ReposContext` records
-the selected clone key with `setActiveCloneForRouting(...)` so bare workspace-id
-service calls from the selected `RepoDetail` resolve to the chosen server instead
-of the other clone. The registry exposes `lookupCloneBaseUrl(workspaceIdOrCloneKey)`,
+old path-only fallback resolution: `#repos/ws-*` links that no longer match a
+registered workspace are matched by the legacy root-path hash to the migrated
+local workspace, or to a single unambiguous remote clone key. Unique remote
+workspace ids still resolve directly; when cached/legacy rows collide on
+workspace id, `ReposContext` records the selected clone key with
+`setActiveCloneForRouting(...)` so bare workspace-id service calls from the
+selected `RepoDetail` resolve to the chosen server instead of the other clone.
+The registry exposes `lookupCloneBaseUrl(workspaceIdOrCloneKey)`,
 `getCocClientForWorkspace(workspaceIdOrCloneKey)` (= `getCocClientFor(lookupCloneBaseUrl(id))`,
 falling back to `getSpaCocClient()` for a local/unknown id so local behavior is
 byte-for-byte unchanged), `cloneApiBase(workspaceIdOrCloneKey)` (absolute remote

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -895,14 +895,15 @@ OFF, `aggregateRemoteWorkspaces()` returns empty and performs no remote fetch, s
 the classic flow is unchanged.
 
 **Per-clone request routing**: a remote clone's REST + WS can be routed to its
-server's `baseUrl` via opt-in primitives — there is NO global "active baseUrl";
-the default `getSpaCocClient()` singleton and the repos-list/git-info aggregation
-stay on the page origin. `getCocClientFor(baseUrl?)` (`api/cocClient.ts`) returns
-the default singleton when `baseUrl` is omitted, else a per-`baseUrl`-cached
-`CocClient` whose REST (`/api` base) and `events` WebSocket target that origin.
+server's `baseUrl` via opt-in primitives; the default `getSpaCocClient()`
+singleton and the repos-list/git-info aggregation stay on the page origin.
+`getCocClientFor(baseUrl?)` (`api/cocClient.ts`) returns the default singleton
+when `baseUrl` is omitted, else a per-`baseUrl`-cached `CocClient` whose REST
+(`/api` base) and `events` WebSocket target that origin.
 `resolveCloneBaseUrl(ref, repos)` (`repos/cloneRouting.ts`) maps a workspace
-object or id to its remote `baseUrl` (or `undefined` when local) using the AC-01
-remote markers. WS URL construction goes through `cloneWsUrl(path, baseUrl?)`
+object, workspace id, or remote clone key to its remote `baseUrl` (or
+`undefined` when local) using the AC-01 remote markers. WS URL construction goes
+through `cloneWsUrl(path, baseUrl?)`
 (`api/wsUrl.ts`): with a `baseUrl` it derives `ws(s)://{host:port}{path}`
 (http→ws, https→wss) keeping the path+query verbatim; without one it reproduces
 the legacy `window.location` behavior. The shared `/ws` process-event stream
@@ -913,19 +914,26 @@ SDK's `buildWebSocketUrl`.
 (Activity/Chats, Git, Terminal, Explorer, Schedules, Pull Requests, Work Items,
 Notes) loads and writes against a selected remote clone's own server, never the
 local one. The seam is `repos/cloneRegistry.ts` — a module-level
-`workspaceId → baseUrl` map (remote workspaces only) that `aggregateRemoteWorkspaces`
-populates on every repo refresh via `registerCloneBaseUrls` (full replace,
-covering online AND cached/offline rows; cleared when the flag is OFF or the
-registry is unavailable). It exposes `lookupCloneBaseUrl(workspaceId)`,
-`getCocClientForWorkspace(workspaceId)` (= `getCocClientFor(lookupCloneBaseUrl(id))`,
+`cloneKey → baseUrl` map plus `workspaceId → cloneKeys` index (remote workspaces
+only) that `aggregateRemoteWorkspaces` populates on every repo refresh via
+`registerCloneBaseUrls` (full replace, covering online AND cached/offline rows;
+cleared when the flag is OFF or the registry is unavailable). Remote markers
+carry `remote.cloneKey = remote:${encodeURIComponent(serverId)}:${encodeURIComponent(workspaceId)}`;
+`repos/cloneIdentity.ts` centralizes clone-key build/parse, selection ids, and
+old path-only fallback resolution. Unique remote workspace ids still resolve
+directly; when cached/legacy rows collide on workspace id, `ReposContext` records
+the selected clone key with `setActiveCloneForRouting(...)` so bare workspace-id
+service calls from the selected `RepoDetail` resolve to the chosen server instead
+of the other clone. The registry exposes `lookupCloneBaseUrl(workspaceIdOrCloneKey)`,
+`getCocClientForWorkspace(workspaceIdOrCloneKey)` (= `getCocClientFor(lookupCloneBaseUrl(id))`,
 falling back to `getSpaCocClient()` for a local/unknown id so local behavior is
-byte-for-byte unchanged), `cloneApiBase(workspaceId)` (absolute remote REST base
-for hand-built URLs like the `EventSource` process stream),
-`cloneWsUrlForWorkspace(path, workspaceId)`, and `requestForWorkspace(workspaceId,
-url, options?)` (clone-routed analog of `requestSpaApi` that fetches a RELATIVE
-api path against the clone — same `toSpaCocRequestOptions`/error-translation as
-`requestSpaApi`, used by the git diff-viewing layer which builds a bare path and
-then fetches it). The routing hooks
+byte-for-byte unchanged), `cloneApiBase(workspaceIdOrCloneKey)` (absolute remote
+REST base for hand-built URLs like the `EventSource` process stream),
+`cloneWsUrlForWorkspace(path, workspaceIdOrCloneKey)`, and
+`requestForWorkspace(workspaceIdOrCloneKey, url, options?)` (clone-routed analog
+of `requestSpaApi` that fetches a RELATIVE api path against the clone — same
+`toSpaCocRequestOptions`/error-translation as `requestSpaApi`, used by the git
+diff-viewing layer which builds a bare path and then fetches it). The routing hooks
 (`useResolveCloneBaseUrl()`, `useCocClient(ref?)`, `useCloneWsUrl(ref?)`) resolve a
 bare workspace id through this registry (no `ReposContext` dependency, so they are
 safe in deep per-tab components and unit tests) and a workspace **object** from its
@@ -1005,11 +1013,11 @@ the input:
   (`patchDiffComment`/`deleteDiffCommentById`) routes via
   `getCocClientForWorkspace(wsId)`.
 
-No-local-fallthrough guarantee: a remote clone's id always resolves to its
-`baseUrl`, so its clone-scoped REST/WS never hit the default local client; an
-OFFLINE-selected clone still resolves to its last-known `baseUrl` (degrades to
-empty/cached UI, never a silent local call) because cached/offline rows are
-registered too.
+No-local-fallthrough guarantee: a selected remote clone's clone key, or its bare
+workspace id when unique / active-disambiguated, resolves to its `baseUrl`, so
+its clone-scoped REST/WS never hit the default local client; an OFFLINE-selected
+clone still resolves to its last-known `baseUrl` (degrades to empty/cached UI,
+never a silent local call) because cached/offline rows are registered too.
 
 The sub-tab taxonomy and feature-flag/git/layout gating live in
 `features/repo-detail/repoSubTabs.ts` (`SUB_TABS`, `VISIBLE_SUB_TABS`,

--- a/.github/skills/coc-knowledge/references/process-store.md
+++ b/.github/skills/coc-knowledge/references/process-store.md
@@ -35,6 +35,7 @@ Commit, Pull Request, and Work Item binding routes also expose a workspace-scope
 - **Seen state:** `seen_at TEXT` column for read/unread tracking
 - **Pending messages:** `pendingMessages` persisted in process metadata
 - **Prompt autocomplete:** `getBestPromptCompletion` and `getPromptAutocompleteContext` for ghost text
+- **Workspace ID re-keying:** `renameWorkspaceId(oldId, newId)` atomically rewrites physical workspace IDs across workspace records, process rows and metadata, seen-state-bearing process history, workspace-scoped bindings, task groups, loops/container routing references, and queued/scheduled repo IDs. Origin-scoped IDs remain keyed by their existing origin values unless a row still uses the legacy physical workspace ID directly.
 - **Conversation cost read model:** Process detail reads derive `conversationCostEstimate` from turn-level token usage without persisting it. Pricing model resolution starts with `metadata.model`, falls back to `config.model`, and can be overridden by later user turns with a `model` field. `token-usage` process events can also carry the live `cumulativeTokenUsage` and derived `conversationCostEstimate` snapshot for running-chat UI updates; final process reads remain authoritative.
 - **Dream internals:** Dream analyzer and critic steps are persisted as read-only internal process records (`dream-analyzer` / `dream-critic`) with `metadata.dreamStep` carrying workspace ID, Dream run ID, purpose, read-only/no-tools policy, parent Dream process ID, and analyzer-to-critic linkage. Completed outer `dream-run` process metadata also stores analyzer/critic process IDs under `metadata.dream` so queue history and task-detail fallbacks can expose the links without loading full process results. If the outer Dream run aborts while an internal step is in flight, the internal process is finalized as `cancelled` rather than left running or treated as a usable successful step.
 
@@ -104,8 +105,9 @@ Per-message operations:
 On startup:
 1. `migrateWorkspaceRegistryIfNeeded()` — workspace/wiki registries from JSON to SQLite
 2. `migrateProcessHistoryIfNeeded()` — file-based processes to SQLite
+3. `migrateWorkspaceIdsToV2IfNeeded()` — legacy physical `ws-*` workspace IDs to machine-scoped `ws-v2-*` IDs, moving `~/.coc/repos/<oldId>/` to `<newId>/` when safe and surfacing conflicts without overwrites
 
-Both idempotent, non-destructive (rename source to `.migrated`).
+Migrations are idempotent and non-destructive.
 
 ## Instantiation
 

--- a/.github/skills/coc-knowledge/references/server-architecture.md
+++ b/.github/skills/coc-knowledge/references/server-architecture.md
@@ -228,7 +228,7 @@ Exit codes: 0=success, 1=error, 2=config, 3=AI unavailable, 130=SIGINT.
 ## Server Startup
 
 1. Model metadata store warmed before listening (so executors can resolve reasoning effort)
-2. Auto-migrations: workspace registry JSON → SQLite, file-based process history → SQLite
+2. Auto-migrations: workspace registry JSON → SQLite, file-based process history → SQLite, and legacy physical `ws-*` workspace IDs → raw-hostname-scoped `ws-v2-*` IDs with repo data directories moved when conflict-free
 3. Chat/follow-up executors initialize model metadata on demand if task starts before cache warm
 4. Variant models with `capabilities.family` base preserved in process metadata but sent to SDK as base model + reasoning effort
 5. Copilot long-context tier resolved automatically at the provider boundary: chat and follow-up executors pass `contextTier: "long_context"` only when the resolved Copilot model's catalog metadata advertises `billing.tokenPrices.longContext.contextMax` (via `getCopilotContextTierForModel`); the field is omitted for Copilot models without that metadata and never sent for Codex/Claude. Static fallback models carry no long-context metadata, so a failed catalog fetch disables long context for that run

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -50,6 +50,7 @@ import { gitInfoCache } from './git/git-info-cache';
 import { NotesGitTimerManager } from './notes/git/notes-git-timer-manager';
 import { migrateWorkspaceRegistryIfNeeded } from './storage/startup-workspace-migration';
 import { migrateProcessHistoryIfNeeded } from './storage/startup-process-migration';
+import { migrateWorkspaceIdsToV2IfNeeded } from './storage/startup-workspace-id-migration';
 import { DevTunnelConnector } from './servers/devtunnel-connector';
 import { SshConnector } from './servers/ssh-connector';
 import { RemoteServerStore } from './servers/remote-server-store';
@@ -404,6 +405,11 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
 
     // Auto-migrate legacy file-based process histories to SQLite
     await migrateProcessHistoryIfNeeded(dataDir, store);
+
+    // Auto-migrate legacy path-only workspace IDs to the machine-scoped
+    // (ws-v2-) scheme so colliding clones on different machines stay distinct.
+    // Uses the RAW OS hostname as the machine identity.
+    await migrateWorkspaceIdsToV2IfNeeded(dataDir, store, os.hostname());
 
     // Auto-update stale globally-installed bundled skills (non-blocking on errors)
     if (resolvedConfig.skills.autoUpdate) {

--- a/packages/coc/src/server/processes/in-memory-process-store.ts
+++ b/packages/coc/src/server/processes/in-memory-process-store.ts
@@ -52,6 +52,7 @@ export function createStubStore(): ProcessStore {
         registerWorkspace: async () => {},
         removeWorkspace: async () => false,
         updateWorkspace: async () => undefined,
+        renameWorkspaceId: async () => false,
         getWikis: async () => [],
         registerWiki: async () => {},
         removeWiki: async () => false,

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -8,8 +8,9 @@
 import * as url from 'url';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import type { MCPServerConfig, ProcessStore, WorkspaceInfo } from '@plusplusoneplusplus/forge';
-import { BranchService, loadDefaultMcpConfig, loadWorkspaceMcpConfig, detectRemoteUrl, resolvePathForHostFilesystem } from '@plusplusoneplusplus/forge';
+import { BranchService, loadDefaultMcpConfig, loadWorkspaceMcpConfig, detectRemoteUrl, resolvePathForHostFilesystem, computeWorkspaceId } from '@plusplusoneplusplus/forge';
 import type { Route } from '../types';
 import { sendJSON } from '../core/api-handler';
 import { handleAPIError, missingFields, notFound, badRequest } from '../errors';
@@ -235,8 +236,8 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
             const body = await parseBodyOrReject(req, res);
             if (body === null) return;
 
-            if (!body.id || !body.name || !body.rootPath) {
-                return handleAPIError(res, missingFields(['id', 'name', 'rootPath']));
+            if (!body.name || !body.rootPath) {
+                return handleAPIError(res, missingFields(['name', 'rootPath']));
             }
 
             let remoteUrl: string | undefined = body.remoteUrl;
@@ -244,8 +245,20 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
                 remoteUrl = await detectRemoteUrl(body.rootPath);
             }
 
+            // Workspace identity is server-authoritative for the UI registration
+            // paths (Add Repo / Add Folder / Clone), which no longer author ids:
+            // when no id is supplied the server derives a machine-scoped id from
+            // this machine's raw OS hostname + root path, so two machines
+            // registering the same absolute path produce distinct ids and never
+            // collide in the remote view. An explicitly supplied id is honored
+            // as-is — virtual/system workspaces (My Work, My Life, Global) keep
+            // their fixed, machine-independent ids, and explicit callers (data
+            // import, fixtures) keep theirs.
+            const providedId = typeof body.id === 'string' && body.id.trim() ? body.id.trim() : undefined;
+            const id = providedId ?? computeWorkspaceId(os.hostname(), body.rootPath);
+
             const workspace: WorkspaceInfo = {
-                id: body.id,
+                id,
                 name: body.name,
                 rootPath: body.rootPath,
                 color: body.color,

--- a/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
@@ -36,6 +36,13 @@ import {
     persistRemoteSelection,
     resolvePersistedRemoteSelection,
 } from '../repos/remoteSelectionPersistence';
+import {
+    findRepoBySelectionId,
+    getRepoSelectionId,
+    getWorkspaceSelectionId,
+    parseRemoteCloneKey,
+} from '../repos/cloneIdentity';
+import { setActiveCloneForRouting } from '../repos/cloneRegistry';
 
 import type { RepoData } from '../repos/repoGrouping';
 import type { AggregatedRemoteWorkspaces } from '../repos/remoteWorkspaceAggregation';
@@ -60,7 +67,7 @@ const ReposContext = createContext<ReposContextValue | null>(null);
  */
 function buildRemoteRepoData(aggregate: AggregatedRemoteWorkspaces): RepoData[] {
     return aggregate.workspaces.map((ws): RepoData => {
-        const git = aggregate.gitInfo[ws.id];
+        const git = aggregate.gitInfo[getWorkspaceSelectionId(ws)] ?? aggregate.gitInfo[ws.id];
         return {
             workspace: ws,
             gitInfo: git ?? { isGitRepo: !!ws.isGitRepo, branch: null, dirty: false },
@@ -205,9 +212,12 @@ export function ReposProvider({ children }: { children: ReactNode }) {
             // Check against the full workspaces list (not enriched) so virtual
             // workspaces like My Work / My Life don't get deselected on refresh.
             // Remote workspaces are included so a selected remote clone survives a refresh.
-            const selectionStillPresent = selectedRepoIdRef.current
-                ? workspaces.some((ws: any) => ws.id === selectedRepoIdRef.current)
-                    || remoteRepos.some(r => r.workspace.id === selectedRepoIdRef.current)
+            const selectedId = selectedRepoIdRef.current;
+            const selectionStillPresent = selectedId
+                ? parseRemoteCloneKey(selectedId)
+                    ? Boolean(findRepoBySelectionId(remoteRepos, selectedId))
+                    : workspaces.some((ws: any) => ws.id === selectedId)
+                        || Boolean(findRepoBySelectionId(remoteRepos, selectedId))
                 : true;
             if (!selectionStillPresent) {
                 dispatch({ type: 'SET_SELECTED_REPO', id: null });
@@ -370,15 +380,23 @@ export function ReposProvider({ children }: { children: ReactNode }) {
     // only extra action for a known-local selection is dropping a stale REMOTE key.
     useEffect(() => {
         const selectedId = appState.selectedRepoId;
-        if (!selectedId) return;
-        const selected = repos.find(r => r.workspace.id === selectedId);
-        if (!selected) return;
+        if (!selectedId) {
+            setActiveCloneForRouting(null);
+            return;
+        }
+        const selected = findRepoBySelectionId(repos, selectedId);
+        if (!selected) {
+            setActiveCloneForRouting(selectedId);
+            return;
+        }
         if (isRemoteWorkspace(selected.workspace)) {
+            setActiveCloneForRouting(getRepoSelectionId(selected));
             persistRemoteSelection({
                 serverId: selected.workspace.remote.serverId,
                 workspaceId: selected.workspace.id,
             });
         } else {
+            setActiveCloneForRouting(null);
             clearPersistedRemoteSelection();
         }
     }, [appState.selectedRepoId, repos]);

--- a/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
+++ b/packages/coc/src/server/spa/client/react/contexts/ReposContext.tsx
@@ -41,6 +41,8 @@ import {
     getRepoSelectionId,
     getWorkspaceSelectionId,
     parseRemoteCloneKey,
+    resolveLegacyPathOnlySelectionId,
+    rewriteRepoHashSelectionId,
 } from '../repos/cloneIdentity';
 import { setActiveCloneForRouting } from '../repos/cloneRegistry';
 
@@ -212,7 +214,17 @@ export function ReposProvider({ children }: { children: ReactNode }) {
             // Check against the full workspaces list (not enriched) so virtual
             // workspaces like My Work / My Life don't get deselected on refresh.
             // Remote workspaces are included so a selected remote clone survives a refresh.
-            const selectedId = selectedRepoIdRef.current;
+            let selectedId = selectedRepoIdRef.current;
+            const legacyResolvedId = resolveLegacyPathOnlySelectionId(combined, selectedId);
+            if (legacyResolvedId && selectedId) {
+                const rewrittenHash = rewriteRepoHashSelectionId(location.hash, selectedId, legacyResolvedId);
+                selectedId = legacyResolvedId;
+                selectedRepoIdRef.current = legacyResolvedId;
+                dispatch({ type: 'SET_SELECTED_REPO', id: legacyResolvedId });
+                if (rewrittenHash && typeof window !== 'undefined') {
+                    window.history.replaceState(null, '', rewrittenHash);
+                }
+            }
             const selectionStillPresent = selectedId
                 ? parseRemoteCloneKey(selectedId)
                     ? Boolean(findRepoBySelectionId(remoteRepos, selectedId))
@@ -238,9 +250,9 @@ export function ReposProvider({ children }: { children: ReactNode }) {
                 remoteRepos.map(r => r.workspace),
             );
             if (resolvedRemoteId) {
-                const current = selectionStillPresent ? selectedRepoIdRef.current : null;
+                const current = selectionStillPresent ? selectedId : null;
                 if (current === null || current === resolvedRemoteId) {
-                    if (selectedRepoIdRef.current !== resolvedRemoteId) {
+                    if (selectedId !== resolvedRemoteId) {
                         dispatch({ type: 'SET_SELECTED_REPO', id: resolvedRemoteId });
                     }
                 }

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -29,6 +29,7 @@ import { useRepoQueueStats, isHidden as isHiddenTask } from '../../queue/hooks/u
 import { useGitInfo } from '../git/hooks/useGitInfo';
 import { computeVisibleSubTabs, type SubTabDef } from '../repo-detail/repoSubTabs';
 import { groupReposByRemote, isRemoteRepo, truncatePath, getRepoHashColor } from '../../repos/repoGrouping';
+import { getRepoSelectionId } from '../../repos/cloneIdentity';
 import {
     partitionShellTabs, computeCloneStatusMap, cloneStatusColor, summarizeRemote, computeVisibleTabKeys,
     remoteProviderLabel,
@@ -215,7 +216,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
             if (removingSelected) {
                 const sibling = clones.find(c => String(c.workspace.id) !== String(repo.workspace.id));
                 if (sibling) {
-                    selectClone(String(sibling.workspace.id));
+                    selectClone(getRepoSelectionId(sibling));
                 }
             }
             setRemoveRepo(null);
@@ -342,7 +343,8 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                         </div>
                         {clones.map((c, i) => {
                             const cid = String(c.workspace.id);
-                            const isSel = cid === cloneId;
+                            const selectionId = getRepoSelectionId(c);
+                            const isSel = selectionId === getRepoSelectionId(repo);
                             const st = cloneStatus[cid];
                             const isRemote = isRemoteRepo(c);
                             // Offline (AC-06): reuse the AC-05 blended status — a remote
@@ -360,7 +362,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                             const cloneUnreadCount = unseenCounts[cid] ?? 0;
                             return (
                                 <button
-                                    key={cid}
+                                    key={selectionId}
                                     data-testid="clone-popover-item"
                                     data-remote={isRemote ? 'true' : 'false'}
                                     data-clone-status={st ?? 'idle'}
@@ -380,7 +382,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                                         // Block selection/navigation for offline clones so a
                                         // dead remote server's tabs are never opened.
                                         if (isOffline) return;
-                                        selectClone(cid);
+                                        selectClone(selectionId);
                                         setCloneOpen(false);
                                     }}
                                     className={

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteTopBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteTopBar.tsx
@@ -15,6 +15,7 @@ import { useQueue } from '../../contexts/QueueContext';
 import { useRepos } from '../../contexts/ReposContext';
 import { groupReposByRemote, groupKey } from '../../repos/repoGrouping';
 import type { RepoGroup } from '../../repos/repoGrouping';
+import { getRepoSelectionId, isRepoSelected } from '../../repos/cloneIdentity';
 import { isHidden as isHiddenTask } from '../../queue/hooks/useRepoQueueStats';
 import { CloneRepoDialog } from '../../repos/CloneRepoDialog';
 import { AddRepoDialog } from '../../repos/AddRepoDialog';
@@ -55,16 +56,16 @@ export function RemoteTopBar() {
     const selectedId = state.selectedRepoId;
     const activeGroupKey = useMemo(() => {
         for (const g of groups) {
-            if (g.repos.some(r => String(r.workspace.id) === selectedId)) return groupKey(g);
+            if (g.repos.some(r => isRepoSelected(r, repos, selectedId))) return groupKey(g);
         }
         return null;
-    }, [groups, selectedId]);
+    }, [groups, repos, selectedId]);
 
     useEffect(() => {
         if (!selectedId) return;
-        const g = groups.find(grp => grp.repos.some(r => String(r.workspace.id) === selectedId));
-        if (g) lastCloneByRemote.current[groupKey(g)] = selectedId;
-    }, [groups, selectedId]);
+        const g = groups.find(grp => grp.repos.some(r => isRepoSelected(r, repos, selectedId)));
+        if (g && selectedId) lastCloneByRemote.current[groupKey(g)] = selectedId;
+    }, [groups, repos, selectedId]);
 
     useEffect(() => {
         if (!addMenuOpen) return;
@@ -83,9 +84,9 @@ export function RemoteTopBar() {
     const pickRemote = (g: RepoGroup) => {
         const key = groupKey(g);
         const remembered = lastCloneByRemote.current[key];
-        const target = remembered && g.repos.some(r => String(r.workspace.id) === remembered)
+        const target = remembered && g.repos.some(r => isRepoSelected(r, repos, remembered))
             ? remembered
-            : (g.repos[0] ? String(g.repos[0].workspace.id) : undefined);
+            : (g.repos[0] ? getRepoSelectionId(g.repos[0]) : undefined);
         if (target) selectClone(target);
     };
 

--- a/packages/coc/src/server/spa/client/react/layout/Router.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/Router.tsx
@@ -17,6 +17,7 @@ import { lazy, Suspense } from 'react';
 import type { DashboardTab, RepoSubTab, WikiProjectTab, WikiAdminTab, MemorySubTab, SkillsSubTab, AdminSubTab, PrDetailTab, SettingsSection } from '../types/dashboard';
 import { SETTINGS_SECTION_VALUES, REPO_SUB_TAB_VALUES, WIKI_PROJECT_TAB_VALUES, WIKI_ADMIN_TAB_VALUES } from '../types/dashboard';
 import type { NativeCliSessionProviderId } from '@plusplusoneplusplus/coc-client';
+import { getWorkspaceIdFromSelectionId } from '../repos/cloneIdentity';
 
 const AdminPanel = lazy(() => import('../admin/AdminPanel').then(m => ({ default: m.AdminPanel })));
 // Memory/Skills/Logs/Usage/Models/Servers no longer mount as standalone
@@ -827,7 +828,7 @@ export function Router() {
                 const letter = e.code.replace('Key', '').toLowerCase();
                 if (letter === 'q') {
                     e.preventDefault();
-                    queueDispatch({ type: 'OPEN_DIALOG', workspaceId: state.selectedRepoId });
+                    queueDispatch({ type: 'OPEN_DIALOG', workspaceId: getWorkspaceIdFromSelectionId(state.selectedRepoId) });
                     return;
                 }
                 const rawTab = REPO_TAB_SHORTCUTS[letter];

--- a/packages/coc/src/server/spa/client/react/repos/AddFolderDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/AddFolderDialog.tsx
@@ -8,7 +8,6 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Dialog, Button } from '../ui';
-import { hashString } from './repoGrouping';
 import {
     browseWorkspaceFolders,
     discoverWorkspaces,
@@ -213,8 +212,9 @@ export function AddFolderDialog({ open, onClose, onAdded }: AddFolderDialogProps
             const repo = selected[i];
             try {
                 if (isContainerMode() && selectedAgentId) setCurrentAgentId(selectedAgentId);
+                // Id is server-authoritative (machine-scoped); the server computes
+                // the canonical workspace id from each repo path.
                 await registerWorkspace({
-                    id: 'ws-' + hashString(repo.path),
                     name: repo.name,
                     rootPath: repo.path,
                 });

--- a/packages/coc/src/server/spa/client/react/repos/AddRepoDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/AddRepoDialog.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { Dialog, Button } from '../ui';
-import { hashString, normalizeRemoteUrl } from './repoGrouping';
+import { normalizeRemoteUrl } from './repoGrouping';
 import type { RepoData } from './repoGrouping';
 import { resolveAutoColor } from '../features/git/diff/colorUtils';
 import {
@@ -239,9 +239,9 @@ export function AddRepoDialog({ open, onClose, editId, repos, onSuccess }: AddRe
                 await updateWorkspace(editId, { name: name.trim(), color: resolvedColor });
             } else {
                 const wsName = name.trim() || getPathLeaf(trimmedPath) || 'repo';
-                const id = 'ws-' + hashString(trimmedPath);
+                // Id is server-authoritative (machine-scoped). Send only the
+                // root path and let the server compute the canonical workspace id.
                 const created = await registerWorkspace({
-                    id,
                     name: wsName,
                     rootPath: trimmedPath,
                     color: resolvedColor,

--- a/packages/coc/src/server/spa/client/react/repos/CloneRepoDialog.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/CloneRepoDialog.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Dialog, Button } from '../ui';
 import { useApp } from '../contexts/AppContext';
-import { hashString } from './repoGrouping';
 import {
     browseWorkspaceFolders,
     cloneRepository,
@@ -210,8 +209,9 @@ export function CloneRepoDialog({ open, onClose, onSuccess }: CloneRepoDialogPro
                 parentDir: trimmedParentDir,
                 dirName: trimmedFolderName || undefined,
             });
+            // Id is server-authoritative (machine-scoped); the server computes
+            // the canonical workspace id from the cloned path.
             const workspace = await registerWorkspace({
-                id: 'ws-' + hashString(clonedPath),
                 name: getPathLeaf(clonedPath) || 'repo',
                 rootPath: clonedPath,
             });

--- a/packages/coc/src/server/spa/client/react/repos/ReposGrid.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/ReposGrid.tsx
@@ -18,6 +18,7 @@ import { AddFolderDialog } from './AddFolderDialog';
 import { CloneRepoDialog } from './CloneRepoDialog';
 import { groupReposByRemote, groupReposByAgent, applyGroupOrder, groupKey } from './repoGrouping';
 import type { RepoData, RepoGroup } from './repoGrouping';
+import { getRepoSelectionId, isRepoSelected } from './cloneIdentity';
 import { getGlobalPreferences, updateGlobalPreferences } from './repositoryService';
 import { isContainerMode, isContainerDefaultAgentEnabled } from '../utils/config';
 
@@ -121,7 +122,8 @@ export function ReposGrid({ repos, onRefresh }: ReposGridProps) {
         });
     };
 
-    const selectRepo = (id: string, agentId?: string | null) => {
+    const selectRepo = (repo: RepoData, agentId?: string | null) => {
+        const id = getRepoSelectionId(repo);
         if (agentId) dispatch({ type: 'SET_CURRENT_AGENT', agentId });
         dispatch({ type: 'SET_SELECTED_REPO', id });
         queueDispatch({ type: 'SELECT_QUEUE_TASK', id: null });
@@ -274,11 +276,11 @@ export function ReposGrid({ repos, onRefresh }: ReposGridProps) {
                         <div className="flex flex-col gap-1 mt-0.5">
                             {group.repos.map(repo => (
                                 <RepoCard
-                                    key={repo.workspace.id}
+                                    key={getRepoSelectionId(repo)}
                                     repo={repo}
-                                    isSelected={repo.workspace.id === state.selectedRepoId}
+                                    isSelected={isRepoSelected(repo, repos, state.selectedRepoId)}
                                     inGroup
-                                    onClick={() => selectRepo(repo.workspace.id, repo.workspace.agentId)}
+                                    onClick={() => selectRepo(repo, repo.workspace.agentId)}
                                 />
                             ))}
                         </div>
@@ -291,7 +293,7 @@ export function ReposGrid({ repos, onRefresh }: ReposGridProps) {
         // Ungrouped repos
         return group.repos.map((repo, repoIdx) => (
             <div
-                key={repo.workspace.id}
+                key={getRepoSelectionId(repo)}
                 className={cn(isDragging && repoIdx === 0 && 'opacity-50')}
                 {...(repoIdx === 0 ? dragHandleProps : {})}
             >
@@ -304,8 +306,8 @@ export function ReposGrid({ repos, onRefresh }: ReposGridProps) {
                     >⠿</span>
                     <RepoCard
                         repo={repo}
-                        isSelected={repo.workspace.id === state.selectedRepoId}
-                        onClick={() => selectRepo(repo.workspace.id, repo.workspace.agentId)}
+                        isSelected={isRepoSelected(repo, repos, state.selectedRepoId)}
+                        onClick={() => selectRepo(repo, repo.workspace.agentId)}
                     />
                 </div>
                 {showBelow && repoIdx === group.repos.length - 1 && <div className={dropIndicatorClass} />}

--- a/packages/coc/src/server/spa/client/react/repos/ReposView.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/ReposView.tsx
@@ -18,6 +18,7 @@ import { useRemoteShellEnabled } from '../hooks/feature-flags/useRemoteShellEnab
 import { ContainerSessionView, CONTAINER_DEFAULT_REPO_ID } from '../features/container-session/ContainerSessionView';
 import { MyWorkView, MY_WORK_WORKSPACE_ID } from './MyWorkView';
 import { MyLifeView, MY_LIFE_WORKSPACE_ID } from './MyLifeView';
+import { findRepoBySelectionId, getRepoSelectionId } from './cloneIdentity';
 
 
 export function ReposView() {
@@ -54,7 +55,7 @@ export function ReposView() {
     // list yet (repo data still loading), keep showing the loading indicator
     // rather than flashing the empty "Select a repository" panel.
     // Exception: my_work is a virtual workspace that won't appear in repos list (only when enabled).
-    if (loading && state.selectedRepoId && !(myWorkEnabled && state.selectedRepoId === MY_WORK_WORKSPACE_ID) && !(myLifeEnabled && state.selectedRepoId === MY_LIFE_WORKSPACE_ID) && !repos.find(r => r.workspace.id === state.selectedRepoId)) {
+    if (loading && state.selectedRepoId && !(myWorkEnabled && state.selectedRepoId === MY_WORK_WORKSPACE_ID) && !(myLifeEnabled && state.selectedRepoId === MY_LIFE_WORKSPACE_ID) && !findRepoBySelectionId(repos, state.selectedRepoId)) {
         return (
             <div id="view-repos" className={`flex items-center justify-center ${heightClass} text-sm text-[#848484]`}>
                 Loading repositories...
@@ -71,10 +72,10 @@ export function ReposView() {
     // Container default session — smart routing chat
     const isContainerDefault = state.selectedRepoId === CONTAINER_DEFAULT_REPO_ID;
 
-    const selectedRepo = repos.find(r =>
-        r.workspace.id === state.selectedRepoId &&
-        (!state.currentAgentId || !r.workspace.agentId || r.workspace.agentId === state.currentAgentId)
-    ) || repos.find(r => r.workspace.id === state.selectedRepoId) || null;
+    const selectedRepo = findRepoBySelectionId(
+        repos.filter(r => !state.currentAgentId || !r.workspace.agentId || r.workspace.agentId === state.currentAgentId),
+        state.selectedRepoId,
+    ) || findRepoBySelectionId(repos, state.selectedRepoId);
 
     return (
         <div id="view-repos" className={`flex ${heightClass} overflow-hidden`}>
@@ -98,7 +99,7 @@ export function ReposView() {
                 hasSelection && selectedRepo ? (
                     <div className="flex-1 min-w-0 min-h-0 flex flex-col">
                         <main className="flex-1 min-w-0 min-h-0 flex flex-col bg-white dark:bg-[#1e1e1e] overflow-hidden">
-                            <RepoDetail key={`${selectedRepo.workspace.id}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
+                            <RepoDetail key={`${getRepoSelectionId(selectedRepo)}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
                         </main>
                     </div>
                 ) : (
@@ -115,11 +116,11 @@ export function ReposView() {
                             <>
                                 <RemoteSubBar repo={selectedRepo} repos={repos} />
                                 <div className="flex-1 min-h-0 min-w-0 flex flex-col">
-                                    <RepoDetail chromeless key={`${selectedRepo.workspace.id}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
+                                    <RepoDetail chromeless key={`${getRepoSelectionId(selectedRepo)}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
                                 </div>
                             </>
                         ) : (
-                            <RepoDetail key={`${selectedRepo.workspace.id}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
+                            <RepoDetail key={`${getRepoSelectionId(selectedRepo)}-${state.currentAgentId ?? ''}`} repo={selectedRepo} repos={repos} onRefresh={fetchRepos} />
                         )
                     ) : (
                         <div id="repo-detail-empty" data-testid="repo-detail-empty" className="flex-1 flex items-center justify-center text-sm text-[#848484]">

--- a/packages/coc/src/server/spa/client/react/repos/cloneIdentity.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneIdentity.ts
@@ -1,0 +1,96 @@
+const REMOTE_CLONE_KEY_PREFIX = 'remote:';
+
+export interface RemoteCloneKeyParts {
+    serverId: string;
+    workspaceId: string;
+}
+
+export interface WorkspaceSelectionLike {
+    id?: unknown;
+    remote?: {
+        serverId?: unknown;
+        cloneKey?: unknown;
+    } | null;
+}
+
+export interface RepoSelectionLike {
+    workspace: WorkspaceSelectionLike;
+}
+
+export function buildRemoteCloneKey(serverId: string, workspaceId: string): string {
+    return `${REMOTE_CLONE_KEY_PREFIX}${encodeURIComponent(serverId)}:${encodeURIComponent(workspaceId)}`;
+}
+
+export function parseRemoteCloneKey(value: string | null | undefined): RemoteCloneKeyParts | null {
+    if (!value?.startsWith(REMOTE_CLONE_KEY_PREFIX)) return null;
+    const encoded = value.slice(REMOTE_CLONE_KEY_PREFIX.length);
+    const separator = encoded.indexOf(':');
+    if (separator <= 0 || separator === encoded.length - 1) return null;
+    try {
+        const serverId = decodeURIComponent(encoded.slice(0, separator));
+        const workspaceId = decodeURIComponent(encoded.slice(separator + 1));
+        if (!serverId || !workspaceId) return null;
+        return { serverId, workspaceId };
+    } catch {
+        return null;
+    }
+}
+
+export function getWorkspaceIdFromSelectionId(selectionId: string): string {
+    return parseRemoteCloneKey(selectionId)?.workspaceId ?? selectionId;
+}
+
+export function getRemoteCloneKey(workspace: WorkspaceSelectionLike | null | undefined): string | null {
+    if (!workspace || typeof workspace.id !== 'string') return null;
+    const remote = workspace.remote;
+    if (!remote || typeof remote !== 'object') return null;
+    if (typeof remote.cloneKey === 'string' && parseRemoteCloneKey(remote.cloneKey)) {
+        return remote.cloneKey;
+    }
+    if (typeof remote.serverId === 'string' && remote.serverId.length > 0) {
+        return buildRemoteCloneKey(remote.serverId, workspace.id);
+    }
+    return null;
+}
+
+export function getWorkspaceSelectionId(workspace: WorkspaceSelectionLike): string {
+    const remoteKey = getRemoteCloneKey(workspace);
+    if (remoteKey) return remoteKey;
+    return typeof workspace.id === 'string' ? workspace.id : '';
+}
+
+export function getRepoSelectionId(repo: RepoSelectionLike): string {
+    return getWorkspaceSelectionId(repo.workspace);
+}
+
+export function findRepoBySelectionId<T extends RepoSelectionLike>(
+    repos: readonly T[],
+    selectionId: string | null | undefined,
+): T | null {
+    if (!selectionId) return null;
+    const parsed = parseRemoteCloneKey(selectionId);
+    if (parsed) {
+        return repos.find(repo => {
+            const workspace = repo.workspace;
+            if (getRemoteCloneKey(workspace) === selectionId) return true;
+            return (
+                typeof workspace.id === 'string' &&
+                workspace.id === parsed.workspaceId &&
+                typeof workspace.remote?.serverId === 'string' &&
+                workspace.remote.serverId === parsed.serverId
+            );
+        }) ?? null;
+    }
+
+    const matches = repos.filter(repo => repo.workspace.id === selectionId);
+    if (matches.length === 0) return null;
+    return matches.find(repo => !getRemoteCloneKey(repo.workspace)) ?? matches[0];
+}
+
+export function isRepoSelected<T extends RepoSelectionLike>(
+    repo: T,
+    repos: readonly T[],
+    selectionId: string | null | undefined,
+): boolean {
+    return findRepoBySelectionId(repos, selectionId) === repo;
+}

--- a/packages/coc/src/server/spa/client/react/repos/cloneIdentity.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneIdentity.ts
@@ -1,4 +1,8 @@
+import { hashString } from './repoGrouping';
+
 const REMOTE_CLONE_KEY_PREFIX = 'remote:';
+const LEGACY_PATH_ONLY_WORKSPACE_ID_PREFIX = 'ws-';
+const MACHINE_SCOPED_WORKSPACE_ID_PREFIX = 'ws-v2-';
 
 export interface RemoteCloneKeyParts {
     serverId: string;
@@ -93,4 +97,57 @@ export function isRepoSelected<T extends RepoSelectionLike>(
     selectionId: string | null | undefined,
 ): boolean {
     return findRepoBySelectionId(repos, selectionId) === repo;
+}
+
+export function legacyPathOnlyWorkspaceIdForRootPath(rootPath: string): string {
+    return LEGACY_PATH_ONLY_WORKSPACE_ID_PREFIX + hashString(rootPath);
+}
+
+export function isLegacyPathOnlyWorkspaceId(value: string | null | undefined): boolean {
+    return (
+        typeof value === 'string' &&
+        value.startsWith(LEGACY_PATH_ONLY_WORKSPACE_ID_PREFIX) &&
+        !value.startsWith(MACHINE_SCOPED_WORKSPACE_ID_PREFIX) &&
+        parseRemoteCloneKey(value) === null
+    );
+}
+
+export function resolveLegacyPathOnlySelectionId<T extends RepoSelectionLike>(
+    repos: readonly T[],
+    selectionId: string | null | undefined,
+): string | null {
+    if (!isLegacyPathOnlyWorkspaceId(selectionId)) return null;
+    if (findRepoBySelectionId(repos, selectionId)) return null;
+
+    const matches = repos.filter(repo => {
+        const rootPath = (repo.workspace as { rootPath?: unknown }).rootPath;
+        return typeof rootPath === 'string' && legacyPathOnlyWorkspaceIdForRootPath(rootPath) === selectionId;
+    });
+    if (matches.length === 0) return null;
+
+    const localMatches = matches.filter(repo => getRemoteCloneKey(repo.workspace) === null);
+    const candidates = localMatches.length > 0 ? localMatches : matches;
+    return candidates.length === 1 ? getRepoSelectionId(candidates[0]) : null;
+}
+
+export function rewriteRepoHashSelectionId(
+    hash: string,
+    oldSelectionId: string,
+    newSelectionId: string,
+): string | null {
+    const cleaned = hash.replace(/^#/, '');
+    const queryStart = cleaned.indexOf('?');
+    const pathPart = queryStart >= 0 ? cleaned.slice(0, queryStart) : cleaned;
+    const queryPart = queryStart >= 0 ? cleaned.slice(queryStart + 1) : null;
+    const parts = pathPart.split('/');
+    if (parts[0] !== 'repos' || !parts[1]) return null;
+
+    try {
+        if (decodeURIComponent(parts[1]) !== oldSelectionId) return null;
+    } catch {
+        return null;
+    }
+
+    parts[1] = encodeURIComponent(newSelectionId);
+    return '#' + parts.join('/') + (queryPart !== null ? '?' + queryPart : '');
 }

--- a/packages/coc/src/server/spa/client/react/repos/cloneRegistry.ts
+++ b/packages/coc/src/server/spa/client/react/repos/cloneRegistry.ts
@@ -7,20 +7,19 @@
  * receive a bare `workspaceId` and call `getSpaCocClient()` directly; they have no
  * access to React context. This module is the seam for them.
  *
- * It holds a module-level `workspaceId → baseUrl` map covering REMOTE workspaces
- * only. AC-01's `aggregateRemoteWorkspaces` populates it every refresh (so the
+ * It holds module-level clone routing maps covering REMOTE workspaces only.
+ * AC-01's `aggregateRemoteWorkspaces` populates them every refresh (so the
  * registry tracks devtunnel port reassignment). Services resolve the right client
- * via `getCocClientForWorkspace(workspaceId)`.
+ * via `getCocClientForWorkspace(workspaceIdOrCloneKey)`.
  *
- * Crucially this is a per-workspace LOOKUP, NOT a global mutable "active baseUrl"
- * override:
+ * Crucially this is a per-clone LOOKUP, not a broad global baseUrl override:
  *   • A LOCAL workspace id is absent from the map → `lookupCloneBaseUrl` returns
  *     `undefined` → `getCocClientFor(undefined)` → the EXISTING default
  *     `getSpaCocClient()` singleton. Local clones are byte-for-byte unchanged.
- *   • A REMOTE workspace id resolves to its server's effectiveUrl → a cached
- *     CocClient pinned to that origin. A remote clone therefore NEVER falls
- *     through to the local server ("no local fallthrough" guarantee): its
- *     clone-scoped REST/WS always targets the remote `baseUrl`.
+ *   • A REMOTE clone key resolves to its server's effectiveUrl → a cached
+ *     CocClient pinned to that origin. A unique remote workspace id also resolves
+ *     directly. If legacy/cached remote rows collide on workspace id, the active
+ *     clone key disambiguates bare workspace-id calls from selected repo tabs.
  *
  * The repos-list / git-info AGGREGATION itself is never rerouted through here —
  * it keeps using the default client (AC-01 owns its own self-contained remote
@@ -31,14 +30,32 @@ import type { CocClient } from '@plusplusoneplusplus/coc-client';
 import { getCocClientFor, getSpaCocClient, toSpaCocRequestOptions, translateSpaCocClientError } from '../api/cocClient';
 import { cloneWsUrl } from '../api/wsUrl';
 import { getApiBase } from '../utils/config';
+import { buildRemoteCloneKey, parseRemoteCloneKey } from './cloneIdentity';
 
-/** workspaceId → remote baseUrl. Remote workspaces only; local ids are absent. */
-const cloneBaseUrlByWorkspace = new Map<string, string>();
+/** cloneKey → remote baseUrl. Remote workspaces only; local ids are absent. */
+const cloneBaseUrlByKey = new Map<string, string>();
+/** workspaceId → cloneKeys. Multiple keys mean a legacy/cached collision exists. */
+const cloneKeysByWorkspace = new Map<string, Set<string>>();
+let activeCloneKey: string | null = null;
 
 /** A minimal remote-workspace shape: just the routing essentials. */
 export interface CloneRegistryEntry {
     workspaceId: string;
     baseUrl: string;
+    serverId?: string;
+    cloneKey?: string;
+}
+
+export interface CloneRegistryLookup {
+    workspaceId?: string | null;
+    serverId?: string | null;
+    cloneKey?: string | null;
+}
+
+function getEntryKey(entry: CloneRegistryEntry): string | null {
+    if (entry.cloneKey && parseRemoteCloneKey(entry.cloneKey)) return entry.cloneKey;
+    if (entry.serverId) return buildRemoteCloneKey(entry.serverId, entry.workspaceId);
+    return entry.workspaceId || null;
 }
 
 /**
@@ -50,12 +67,26 @@ export interface CloneRegistryEntry {
  * of reachable/cached remote clones (and follows devtunnel port reassignment).
  */
 export function registerCloneBaseUrls(entries: Iterable<CloneRegistryEntry>): void {
-    cloneBaseUrlByWorkspace.clear();
-    for (const { workspaceId, baseUrl } of entries) {
-        if (workspaceId && baseUrl) {
-            cloneBaseUrlByWorkspace.set(workspaceId, baseUrl);
+    cloneBaseUrlByKey.clear();
+    cloneKeysByWorkspace.clear();
+    for (const entry of entries) {
+        const { workspaceId, baseUrl } = entry;
+        const key = getEntryKey(entry);
+        if (workspaceId && baseUrl && key) {
+            cloneBaseUrlByKey.set(key, baseUrl);
+            const keys = cloneKeysByWorkspace.get(workspaceId) ?? new Set<string>();
+            keys.add(key);
+            cloneKeysByWorkspace.set(workspaceId, keys);
         }
     }
+    if (activeCloneKey && !cloneBaseUrlByKey.has(activeCloneKey)) {
+        activeCloneKey = null;
+    }
+}
+
+export function setActiveCloneForRouting(selectionId: string | null | undefined): void {
+    const parsed = parseRemoteCloneKey(selectionId);
+    activeCloneKey = parsed ? buildRemoteCloneKey(parsed.serverId, parsed.workspaceId) : null;
 }
 
 /**
@@ -63,9 +94,34 @@ export function registerCloneBaseUrls(entries: Iterable<CloneRegistryEntry>): vo
  * workspace (or unknown). Local/unknown ids deliberately resolve to `undefined`
  * so downstream `getCocClientFor(undefined)` returns the default local client.
  */
-export function lookupCloneBaseUrl(workspaceId: string | null | undefined): string | undefined {
-    if (!workspaceId) return undefined;
-    return cloneBaseUrlByWorkspace.get(workspaceId);
+export function lookupCloneBaseUrl(ref: string | CloneRegistryLookup | null | undefined): string | undefined {
+    if (!ref) return undefined;
+    if (typeof ref === 'object') {
+        if (ref.cloneKey && cloneBaseUrlByKey.has(ref.cloneKey)) {
+            return cloneBaseUrlByKey.get(ref.cloneKey);
+        }
+        if (ref.serverId && ref.workspaceId) {
+            return cloneBaseUrlByKey.get(buildRemoteCloneKey(ref.serverId, ref.workspaceId));
+        }
+        return ref.workspaceId ? lookupCloneBaseUrl(ref.workspaceId) : undefined;
+    }
+
+    if (cloneBaseUrlByKey.has(ref)) {
+        return cloneBaseUrlByKey.get(ref);
+    }
+    const parsed = parseRemoteCloneKey(ref);
+    if (parsed) {
+        return cloneBaseUrlByKey.get(buildRemoteCloneKey(parsed.serverId, parsed.workspaceId));
+    }
+    const keys = cloneKeysByWorkspace.get(ref);
+    if (!keys || keys.size === 0) return undefined;
+    if (activeCloneKey && keys.has(activeCloneKey)) {
+        return cloneBaseUrlByKey.get(activeCloneKey);
+    }
+    if (keys.size === 1) {
+        return cloneBaseUrlByKey.get([...keys][0]);
+    }
+    return undefined;
 }
 
 /**
@@ -137,5 +193,7 @@ export function cloneWsUrlForWorkspace(path: string, workspaceId: string | null 
 
 /** Test-only: clear the registry between cases. */
 export function resetCloneRegistryForTests(): void {
-    cloneBaseUrlByWorkspace.clear();
+    cloneBaseUrlByKey.clear();
+    cloneKeysByWorkspace.clear();
+    activeCloneKey = null;
 }

--- a/packages/coc/src/server/spa/client/react/repos/remoteSelectionPersistence.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteSelectionPersistence.ts
@@ -12,7 +12,8 @@
  * CURRENT remote workspaces by `remote.serverId === serverId && id === workspaceId`.
  * Because the match is on the stable `serverId` (not `baseUrl`), a changed
  * port/baseUrl still resolves to the same clone. The resolved value is the
- * workspace's CURRENT id, which the caller restores as the active selection.
+ * workspace's CURRENT dashboard selection id, which the caller restores as the
+ * active selection.
  *
  * LOCAL clones are NOT persisted here: they keep riding the existing
  * `#repos/{id}` hash mechanism unchanged. This module is purely additive on top
@@ -21,6 +22,7 @@
  */
 
 import { isRemoteWorkspace, type RemoteWorkspaceInfo } from './remoteWorkspaceAggregation';
+import { getWorkspaceSelectionId } from './cloneIdentity';
 
 const STORAGE_KEY = 'coc-remote-clone-selection';
 
@@ -83,12 +85,13 @@ export function loadPersistedRemoteSelection(): PersistedRemoteSelection | null 
 
 /**
  * Resolve a persisted `{ serverId, workspaceId }` pair to the CURRENT matching
- * remote workspace's id, scanning the freshly-aggregated remote workspaces.
+ * remote workspace's dashboard selection id, scanning the freshly-aggregated
+ * remote workspaces.
  *
  * Match is on the stable `remote.serverId` plus the workspace `id` — so a clone
  * whose `baseUrl`/port changed (devtunnel reassignment) still resolves, and a
  * workspace id that collides ACROSS two servers disambiguates by serverId.
- * Returns the matching workspace id (its current id) or `null` when no remote
+ * Returns the matching selection id or `null` when no remote
  * workspace matches (e.g. the server was removed and nothing is cached).
  */
 export function resolvePersistedRemoteSelection(
@@ -102,7 +105,7 @@ export function resolvePersistedRemoteSelection(
             workspace.remote.serverId === selection.serverId &&
             workspace.id === selection.workspaceId
         ) {
-            return workspace.id;
+            return getWorkspaceSelectionId(workspace);
         }
     }
     return null;

--- a/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
+++ b/packages/coc/src/server/spa/client/react/repos/remoteWorkspaceAggregation.ts
@@ -9,10 +9,11 @@
  * result with the local list. Offline / unreachable servers contribute their
  * LAST-KNOWN list from a persisted cache, each entry flagged `offline`.
  *
- * Routing seam (IMMUTABLE): a remote workspace carries `baseUrl` (= the server's
- * effectiveUrl); local workspaces have none. There are NO composite workspace
- * IDs and NO new serverId namespace — `baseUrl` is the routing key, `serverId`
- * is referenced for persistence/caching only.
+ * Routing seam: a remote workspace carries `baseUrl` (= the server's
+ * effectiveUrl); local workspaces have none. Server-generated machine-scoped
+ * workspace IDs are the primary identity. A dashboard-only `cloneKey` is also
+ * attached so cached/legacy duplicate workspace IDs can still be selected and
+ * routed without replacing one another.
  *
  * The remote fetch here is intentionally self-contained (a small CocClient bound
  * to `effectiveUrl`); it does NOT re-plumb the shared SPA client (AC-03 owns
@@ -35,6 +36,7 @@ import {
     loadRemoteWorkspaceCache,
     saveRemoteWorkspaceCacheEntry,
 } from './remoteWorkspaceCache';
+import { buildRemoteCloneKey } from './cloneIdentity';
 
 /**
  * Remote server connection state, mirrored from the registry's runtime status.
@@ -59,6 +61,8 @@ export interface RemoteWorkspaceMarker {
     serverId: string;
     /** Human-readable server label for badges/grouping. */
     serverLabel: string;
+    /** Dashboard selection/routing key for this exact remote clone. */
+    cloneKey?: string;
     /** True when this entry came from cache because the server is offline/unreachable. */
     offline: boolean;
     /**
@@ -160,6 +164,7 @@ export function tagRemoteWorkspaces(
             baseUrl,
             serverId: server.id,
             serverLabel,
+            cloneKey: buildRemoteCloneKey(server.id, workspace.id),
             offline,
             connection,
             queue: status.queueByWorkspace?.[workspace.id] ?? 'idle',
@@ -327,7 +332,15 @@ export async function aggregateRemoteWorkspaces(): Promise<AggregatedRemoteWorks
     const gitInfo: RemoteGitInfoMap = {};
     for (const source of sources) {
         workspaces.push(...source.workspaces);
-        Object.assign(gitInfo, source.gitInfo);
+        for (const workspace of source.workspaces) {
+            if (!Object.prototype.hasOwnProperty.call(source.gitInfo, workspace.id)) {
+                continue;
+            }
+            const info = source.gitInfo[workspace.id] ?? null;
+            const cloneKey = workspace.remote.cloneKey ?? buildRemoteCloneKey(workspace.remote.serverId, workspace.id);
+            gitInfo[cloneKey] = info;
+            gitInfo[workspace.id] = info;
+        }
     }
 
     // Publish the workspaceId → baseUrl lookup (AC-07) so non-React services and
@@ -335,7 +348,12 @@ export async function aggregateRemoteWorkspaces(): Promise<AggregatedRemoteWorks
     // covering online AND cached/offline remote rows (an offline-selected clone
     // still resolves to its last-known baseUrl rather than silently hitting the
     // local server).
-    registerCloneBaseUrls(workspaces.map(ws => ({ workspaceId: ws.id, baseUrl: ws.baseUrl })));
+    registerCloneBaseUrls(workspaces.map(ws => ({
+        workspaceId: ws.id,
+        serverId: ws.remote.serverId,
+        cloneKey: ws.remote.cloneKey,
+        baseUrl: ws.baseUrl,
+    })));
 
     return { sources, workspaces, gitInfo, warnings };
 }

--- a/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
+++ b/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
@@ -197,7 +197,7 @@ export function groupReposByAgent(
     return result;
 }
 
-/** djb2-style hash → base36 string. Used for deterministic workspace IDs. */
+/** djb2-style hash → base36 string. Used for colors and legacy workspace-id links. */
 export function hashString(s: string): string {
     let hash = 0;
     for (let i = 0; i < s.length; i++) {

--- a/packages/coc/src/server/storage/startup-workspace-id-migration.ts
+++ b/packages/coc/src/server/storage/startup-workspace-id-migration.ts
@@ -1,0 +1,154 @@
+/**
+ * Startup Machine-Scoped Workspace-ID Migration
+ *
+ * Re-keys legacy path-only physical workspace IDs (`ws-<base36hash>`) to the
+ * machine-scoped scheme (`ws-v2-<hash>` over raw OS hostname + normalized root
+ * path). This lets the dashboard tell two machines that registered the same
+ * repository at the same absolute path apart, instead of collapsing them into
+ * one entry.
+ *
+ * For each legacy physical workspace the migration:
+ *   1. computes the new id from the raw hostname + the workspace root path,
+ *   2. moves the repo-scoped data directory `repos/<oldId>/` → `repos/<newId>/`
+ *      (this carries git-ops/paste-context/preferences and, for the file-backed
+ *      store, the process history too) when the source exists and the target
+ *      does not, and
+ *   3. asks the store to re-key its records via {@link ProcessStore.renameWorkspaceId}.
+ *
+ * The migration is:
+ * - Conflict-safe: it never overwrites an existing target workspace or data
+ *   directory; conflicts are logged and the legacy workspace is left untouched.
+ * - Crash-resilient: the directory is moved before the records are re-keyed, and
+ *   the legacy workspace record drives re-migration, so an interrupted run is
+ *   completed on the next startup.
+ * - Idempotent: already-migrated (`ws-v2-`) and virtual workspaces are skipped.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ProcessStore } from '@plusplusoneplusplus/forge';
+import { computeWorkspaceId, isLegacyPhysicalWorkspaceId } from '@plusplusoneplusplus/forge';
+
+const PREFIX = '[WorkspaceIdMigration]';
+
+export interface WorkspaceIdMigrationResult {
+    /** Number of workspaces successfully re-keyed to the v2 scheme. */
+    migrated: number;
+    /** Successful renames, in application order. */
+    renames: Array<{ oldId: string; newId: string }>;
+    /** Workspaces left untouched because re-keying them was unsafe. */
+    conflicts: Array<{ oldId: string; newId: string; reason: string }>;
+}
+
+function log(message: string): void {
+    process.stderr.write(`${PREFIX} ${message}\n`);
+}
+
+/**
+ * Detect and migrate legacy path-only physical workspace IDs to the
+ * machine-scoped `ws-v2-` scheme. Safe to call on every startup; a no-op once
+ * every physical workspace is already on the v2 scheme.
+ *
+ * @param dataDir CoC data directory (the parent of `repos/`).
+ * @param store Active process store whose workspace records are re-keyed.
+ * @param rawHostname Raw OS hostname (`os.hostname()`) — NOT a shortened or
+ *   configured display name.
+ */
+export async function migrateWorkspaceIdsToV2IfNeeded(
+    dataDir: string,
+    store: ProcessStore,
+    rawHostname: string,
+): Promise<WorkspaceIdMigrationResult> {
+    const result: WorkspaceIdMigrationResult = { migrated: 0, renames: [], conflicts: [] };
+
+    const workspaces = await store.getWorkspaces();
+    // Track which ids are taken so two legacy workspaces can never collapse onto
+    // the same new id (and so we honor ids claimed earlier in this same run).
+    const takenIds = new Set(workspaces.map(w => w.id));
+    const reposRoot = path.join(dataDir, 'repos');
+
+    for (const ws of workspaces) {
+        // Only physical repository workspaces are machine-scoped. Virtual/system
+        // workspaces (My Work, My Life, Global) keep their fixed ids, and
+        // already-migrated v2 ids are not legacy.
+        if (ws.virtual || !isLegacyPhysicalWorkspaceId(ws.id)) {
+            continue;
+        }
+        const oldId = ws.id;
+        const newId = computeWorkspaceId(rawHostname, ws.rootPath);
+        if (newId === oldId) {
+            continue;
+        }
+
+        const oldDir = path.join(reposRoot, oldId);
+        const newDir = path.join(reposRoot, newId);
+
+        // Conflict: another workspace already owns the target id.
+        if (takenIds.has(newId)) {
+            const reason = 'target-workspace-exists';
+            log(`Skipping ${oldId} → ${newId}: ${reason}`);
+            result.conflicts.push({ oldId, newId, reason });
+            continue;
+        }
+        // Conflict: both source and target data directories hold data — never
+        // merge or overwrite.
+        if (fs.existsSync(oldDir) && fs.existsSync(newDir)) {
+            const reason = 'target-data-dir-exists';
+            log(`Skipping ${oldId} → ${newId}: ${reason}`);
+            result.conflicts.push({ oldId, newId, reason });
+            continue;
+        }
+
+        let movedDataDir = false;
+        try {
+            if (typeof store.renameWorkspaceId !== 'function') {
+                const reason = 'store-rename-unavailable';
+                log(`Skipping ${oldId} → ${newId}: ${reason}`);
+                result.conflicts.push({ oldId, newId, reason });
+                continue;
+            }
+
+            // Move the repo-scoped data directory first so an interrupted run is
+            // re-driven by the still-legacy workspace record on next startup.
+            if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) {
+                fs.mkdirSync(reposRoot, { recursive: true });
+                fs.renameSync(oldDir, newDir);
+                movedDataDir = true;
+            }
+
+            const renamed = await store.renameWorkspaceId(oldId, newId);
+            if (!renamed) {
+                const reason = 'store-rename-rejected';
+                if (movedDataDir && !fs.existsSync(oldDir) && fs.existsSync(newDir)) {
+                    fs.renameSync(newDir, oldDir);
+                }
+                log(`Skipping ${oldId} → ${newId}: ${reason}`);
+                result.conflicts.push({ oldId, newId, reason });
+                continue;
+            }
+
+            takenIds.delete(oldId);
+            takenIds.add(newId);
+            result.migrated += 1;
+            result.renames.push({ oldId, newId });
+            log(`Migrated workspace ${oldId} → ${newId}`);
+        } catch (err) {
+            if (movedDataDir && !fs.existsSync(oldDir) && fs.existsSync(newDir)) {
+                try {
+                    fs.renameSync(newDir, oldDir);
+                } catch (rollbackErr) {
+                    log(`Failed to roll back data directory ${newId} → ${oldId}: ${(rollbackErr as Error)?.message ?? rollbackErr}`);
+                }
+            }
+            const reason = `error: ${(err as Error)?.message ?? err}`;
+            log(`Failed to migrate ${oldId} → ${newId}: ${reason}`);
+            result.conflicts.push({ oldId, newId, reason });
+        }
+    }
+
+    if (result.migrated > 0) {
+        log(`Migration complete — ${result.migrated} workspace(s) re-keyed to the machine-scoped scheme`);
+    }
+
+    return result;
+}

--- a/packages/coc/test/server/group-pin-handler.test.ts
+++ b/packages/coc/test/server/group-pin-handler.test.ts
@@ -58,8 +58,10 @@ describe('Group Pin REST API', () => {
     let dbPath: string;
     let store: SqliteProcessStore | undefined;
 
-    const wsA = 'ws-group-pins-a';
-    const wsB = 'ws-group-pins-b';
+    const legacyWsA = 'ws-group-pins-a';
+    const legacyWsB = 'ws-group-pins-b';
+    let wsA: string;
+    let wsB: string;
 
     beforeEach(async () => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-group-pins-'));
@@ -75,18 +77,28 @@ describe('Group Pin REST API', () => {
 
     async function startServer() {
         store = new SqliteProcessStore({ dbPath });
-        await store.registerWorkspace({
-            id: wsA,
-            name: 'Workspace A',
-            rootPath: '/tmp/group-pins-a',
-        });
-        await store.registerWorkspace({
-            id: wsB,
-            name: 'Workspace B',
-            rootPath: '/tmp/group-pins-b',
-        });
+        if ((await store.getWorkspaces()).length === 0) {
+            await store.registerWorkspace({
+                id: legacyWsA,
+                name: 'Workspace A',
+                rootPath: '/tmp/group-pins-a',
+            });
+            await store.registerWorkspace({
+                id: legacyWsB,
+                name: 'Workspace B',
+                rootPath: '/tmp/group-pins-b',
+            });
+        }
         server = await createExecutionServer({ port: 0, dataDir: tmpDir, store });
         baseUrl = server.url;
+        const workspaces = await store.getWorkspaces();
+        const workspaceA = workspaces.find(workspace => workspace.name === 'Workspace A');
+        const workspaceB = workspaces.find(workspace => workspace.name === 'Workspace B');
+        if (!workspaceA || !workspaceB) {
+            throw new Error('Expected group pin test workspaces to be registered');
+        }
+        wsA = workspaceA.id;
+        wsB = workspaceB.id;
     }
 
     async function restartServer() {

--- a/packages/coc/test/server/notes-write-binding-cascade.test.ts
+++ b/packages/coc/test/server/notes-write-binding-cascade.test.ts
@@ -59,7 +59,8 @@ function postJSON(url: string, data: unknown) {
 }
 
 describe('Notes write — rename/delete binding cascade', { timeout: 30_000 }, () => {
-    const wsId = 'ws-cascade';
+    const legacyWsId = 'ws-cascade';
+    let wsId: string;
     let server: ExecutionServer;
     let baseUrl: string;
     let tmpDir: string;
@@ -84,9 +85,11 @@ describe('Notes write — rename/delete binding cascade', { timeout: 30_000 }, (
     beforeEach(async () => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-notes-cascade-'));
         store = new SqliteProcessStore({ dbPath: path.join(tmpDir, 'test.db') });
-        await store.registerWorkspace({ id: wsId, name: 'Cascade WS', rootPath: tmpDir });
+        await store.registerWorkspace({ id: legacyWsId, name: 'Cascade WS', rootPath: tmpDir });
         server = await createExecutionServer({ port: 0, dataDir: tmpDir, store });
         baseUrl = server.url;
+        const [workspace] = await store.getWorkspaces();
+        wsId = workspace.id;
         notesRoot = path.join(tmpDir, 'repos', wsId, 'notes');
         fs.mkdirSync(notesRoot, { recursive: true });
         bindings = new NoteChatBindingStore(store.getDatabase());

--- a/packages/coc/test/server/process-history-mapper.test.ts
+++ b/packages/coc/test/server/process-history-mapper.test.ts
@@ -556,9 +556,12 @@ describe('Store-backed history across restart', () => {
             expect(failedEntry.error).toBe('timeout');
 
             const dreamEntry = body.history.find((t: any) => t.id === 'dream-task-1');
+            const migratedWorkspace = (await store.getWorkspaces()).find(workspace => workspace.name === 'test');
+            expect(migratedWorkspace).toBeDefined();
+            const migratedWorkspaceId = migratedWorkspace!.id;
             expect(dreamEntry).toMatchObject({
                 type: 'dream-run',
-                repoId: 'ws-1',
+                repoId: migratedWorkspaceId,
                 payload: {
                     kind: 'dream-run',
                     trigger: 'manual',
@@ -572,10 +575,10 @@ describe('Store-backed history across restart', () => {
                     },
                 },
             });
-            await expect(store.getProcess(dreamEntry.payload.processes.analyzerProcessId, 'ws-1')).resolves.toMatchObject({
+            await expect(store.getProcess(dreamEntry.payload.processes.analyzerProcessId, migratedWorkspaceId)).resolves.toMatchObject({
                 type: 'dream-analyzer',
                 metadata: {
-                    workspaceId: 'ws-1',
+                    workspaceId: migratedWorkspaceId,
                     dreamStep: {
                         kind: 'analyzer',
                         readOnly: true,
@@ -584,10 +587,10 @@ describe('Store-backed history across restart', () => {
                     },
                 },
             });
-            await expect(store.getProcess(dreamEntry.payload.processes.criticProcessId, 'ws-1')).resolves.toMatchObject({
+            await expect(store.getProcess(dreamEntry.payload.processes.criticProcessId, migratedWorkspaceId)).resolves.toMatchObject({
                 type: 'dream-critic',
                 metadata: {
-                    workspaceId: 'ws-1',
+                    workspaceId: migratedWorkspaceId,
                     dreamStep: {
                         kind: 'critic',
                         analyzerProcessId: 'queue_dream-analyzer-1',

--- a/packages/coc/test/server/required-fields.test.ts
+++ b/packages/coc/test/server/required-fields.test.ts
@@ -6,7 +6,7 @@
  *
  * Routes tested (all in packages/coc-server):
  *   POST /api/processes — requires id, promptPreview, status, startTime
- *   POST /api/workspaces — requires id, name, rootPath
+ *   POST /api/workspaces — requires name, rootPath (id is server-computed)
  *   PATCH /api/workspaces/:id — 200 no-op for empty body
  *
  * Cross-platform compatible (Linux/macOS/Windows).
@@ -217,30 +217,54 @@ describe('POST /api/workspaces — required fields', () => {
         expect((body as any).code).toBe('MISSING_FIELDS');
     });
 
-    it('returns 400 MISSING_FIELDS when id is absent', async () => {
+    it('registers (201) when id is absent — the server computes a machine-scoped id', async () => {
+        // Id is no longer a required field: physical workspace ids are
+        // server-authoritative and derived from hostname + root path.
         const { status, body } = await apiRequest(baseUrl, '/api/workspaces', {
             method: 'POST',
             body: { name: 'project', rootPath: '/some/path' },
         });
-        expect(status).toBe(400);
-        expect((body as any).code).toBe('MISSING_FIELDS');
+        expect(status).toBe(201);
+        expect((body as any).id).toMatch(/^ws-v2-[0-9a-f]+$/);
     });
 
     it('returns 400 MISSING_FIELDS when name is absent', async () => {
         const { status, body } = await apiRequest(baseUrl, '/api/workspaces', {
             method: 'POST',
-            body: { id: 'ws-2', rootPath: '/some/path' },
+            body: { rootPath: '/some/path' },
         });
         expect(status).toBe(400);
         expect((body as any).code).toBe('MISSING_FIELDS');
     });
 
-    it('registers workspace successfully when all required fields present', async () => {
-        const { status } = await apiRequest(baseUrl, '/api/workspaces', {
+    it('honors an explicitly supplied virtual workspace id (e.g. my_work)', async () => {
+        const { status, body } = await apiRequest(baseUrl, '/api/workspaces', {
             method: 'POST',
-            body: { id: 'ws-ok', name: 'my-project', rootPath: '/some/path' },
+            body: { id: 'my_work', name: 'My Work', rootPath: '/some/path' },
         });
         expect(status).toBe(201);
+        expect((body as any).id).toBe('my_work');
+    });
+
+    it('honors an explicitly supplied id for explicit/fixture callers', async () => {
+        const { status, body } = await apiRequest(baseUrl, '/api/workspaces', {
+            method: 'POST',
+            body: { id: 'ws-explicit-fixture', name: 'fixture', rootPath: '/some/path' },
+        });
+        expect(status).toBe(201);
+        expect((body as any).id).toBe('ws-explicit-fixture');
+    });
+
+    it('derives the same machine-scoped id for the same path when id is omitted', async () => {
+        const reg = () => apiRequest(baseUrl, '/api/workspaces', {
+            method: 'POST',
+            body: { name: 'stable', rootPath: '/some/stable/path' },
+        });
+        const first = await reg();
+        const second = await reg();
+        expect(first.status).toBe(201);
+        expect((first.body as any).id).toBe((second.body as any).id);
+        expect((first.body as any).id).toMatch(/^ws-v2-/);
     });
 });
 

--- a/packages/coc/test/server/spa/client/repos/AddRepoDialog.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/AddRepoDialog.test.tsx
@@ -225,7 +225,8 @@ describe('AddRepoDialog', () => {
             const body = repositoryServiceMocks.registerWorkspace.mock.calls[0][0];
             expect(body.name).toBe('My Repo');
             expect(body.rootPath).toBe('/my/repo');
-            expect(body.id).toMatch(/^ws-/);
+            // Id is server-authoritative now — the client no longer sends one.
+            expect(body.id).toBeUndefined();
         });
 
         it('calls onSuccess and onClose after successful POST', async () => {

--- a/packages/coc/test/server/startup-workspace-id-migration.test.ts
+++ b/packages/coc/test/server/startup-workspace-id-migration.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    computeWorkspaceId,
+    FileProcessStore,
+    SqliteProcessStore,
+    type AIProcess,
+    type WorkspaceInfo,
+} from '@plusplusoneplusplus/forge';
+import { migrateWorkspaceIdsToV2IfNeeded } from '../../src/server/storage/startup-workspace-id-migration';
+
+function createTempDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'ws-id-v2-migration-test-'));
+}
+
+function makeWorkspace(id: string, rootPath: string, overrides?: Partial<WorkspaceInfo>): WorkspaceInfo {
+    return {
+        id,
+        name: path.basename(rootPath),
+        rootPath,
+        ...overrides,
+    };
+}
+
+function makeProcess(id: string, workspaceId: string, overrides?: Partial<AIProcess>): AIProcess {
+    return {
+        id,
+        type: 'ai',
+        promptPreview: 'test prompt',
+        fullPrompt: 'test full prompt',
+        status: 'completed',
+        startTime: new Date('2026-01-01T00:00:00.000Z'),
+        endTime: new Date('2026-01-01T00:01:00.000Z'),
+        metadata: { type: 'ai', workspaceId },
+        ...overrides,
+    };
+}
+
+function scalarCount(row: unknown): number {
+    return (row as { cnt: number }).cnt;
+}
+
+describe('migrateWorkspaceIdsToV2IfNeeded', () => {
+    let dataDir: string;
+
+    beforeEach(() => {
+        dataDir = createTempDir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(dataDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('migrates SQLite workspace records, process history, seen state, repo data, and persisted references', async () => {
+        const store = new SqliteProcessStore({ dbPath: path.join(dataDir, 'processes.db') });
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        try {
+            const oldId = 'ws-legacy-sqlite';
+            const rootPath = path.join(dataDir, 'repo');
+            const newId = computeWorkspaceId('raw-host-a', rootPath);
+            await store.registerWorkspace(makeWorkspace(oldId, rootPath));
+            await store.addProcess(makeProcess('p1', oldId));
+            const seenAt = '2026-01-01T00:01:00.000Z';
+            store.markSeen('p1', seenAt);
+
+            const db = store.getDatabase();
+            db.prepare('INSERT INTO commit_chat_bindings (workspace_id, commit_hash, task_id, created_at) VALUES (?, ?, ?, ?)').run(oldId, 'abc123', 'p1', seenAt);
+            db.prepare('INSERT INTO note_chat_bindings (workspace_id, note_path, task_id, created_at) VALUES (?, ?, ?, ?)').run(oldId, 'notes/a.md', 'p1', seenAt);
+            db.prepare('INSERT INTO pull_request_chat_bindings (workspace_id, pr_id, task_id, created_at) VALUES (?, ?, ?, ?)').run(oldId, '42', 'p1', seenAt);
+            db.prepare('INSERT INTO pull_request_chat_bindings (workspace_id, pr_id, task_id, created_at) VALUES (?, ?, ?, ?)').run('gh_owner_repo', '43', 'p-origin', seenAt);
+            db.prepare('INSERT INTO work_item_chat_bindings (workspace_id, work_item_id, task_id, created_at) VALUES (?, ?, ?, ?)').run(oldId, 'wi-1', 'p1', seenAt);
+            db.prepare('INSERT INTO task_groups (workspace_id, group_id, type, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(oldId, 'g1', 'ralph', 'Ralph', 'running', seenAt, seenAt);
+            db.prepare('INSERT INTO task_group_members (workspace_id, group_id, role, task_id, process_id, linked_at) VALUES (?, ?, ?, ?, ?, ?)').run(oldId, 'g1', 'iteration', 't1', 'p1', seenAt);
+            db.prepare('INSERT INTO queue_tasks (id, repo_id, type, created_at) VALUES (?, ?, ?, ?)').run('q1', oldId, 'chat', Date.now());
+            db.prepare('INSERT INTO queue_repo_state (repo_id) VALUES (?)').run(oldId);
+            db.exec('CREATE TABLE IF NOT EXISTS queue_repo_paths (repo_id TEXT PRIMARY KEY, root_path TEXT NOT NULL)');
+            db.prepare('INSERT INTO queue_repo_paths (repo_id, root_path) VALUES (?, ?)').run(oldId, rootPath);
+            db.prepare('INSERT INTO schedule_runs (id, schedule_id, repo_id, started_at, status) VALUES (?, ?, ?, ?, ?)').run('sr1', 'sched1', oldId, seenAt, 'running');
+            db.exec('ALTER TABLE loops ADD COLUMN workspace_id TEXT');
+            db.prepare('INSERT INTO loops (id, process_id, interval_ms, created_at, expires_at, workspace_id) VALUES (?, ?, ?, ?, ?, ?)').run('loop1', 'p1', 1000, seenAt, seenAt, oldId);
+            db.exec('CREATE TABLE IF NOT EXISTS container_sessions (id TEXT PRIMARY KEY, status TEXT NOT NULL DEFAULT \'active\', routing_override_agent_id TEXT, routing_override_workspace_id TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)');
+            db.exec('CREATE TABLE IF NOT EXISTS container_session_turns (session_id TEXT NOT NULL, turn_index INTEGER NOT NULL, role TEXT NOT NULL, content TEXT NOT NULL, routing_agent_id TEXT NOT NULL, routing_workspace_id TEXT NOT NULL, routing_confidence REAL NOT NULL DEFAULT 1.0, routing_reason TEXT NOT NULL DEFAULT \'\', downstream_process_id TEXT, timestamp TEXT NOT NULL, PRIMARY KEY (session_id, turn_index))');
+            db.prepare('INSERT INTO container_sessions (id, routing_override_agent_id, routing_override_workspace_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)').run('cs1', 'agent-a', oldId, seenAt, seenAt);
+            db.prepare('INSERT INTO container_session_turns (session_id, turn_index, role, content, routing_agent_id, routing_workspace_id, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)').run('cs1', 0, 'user', 'hi', 'agent-a', oldId, seenAt);
+
+            const oldDataDir = path.join(dataDir, 'repos', oldId);
+            fs.mkdirSync(oldDataDir, { recursive: true });
+            fs.writeFileSync(path.join(oldDataDir, 'preferences.json'), '{"ok":true}');
+
+            const result = await migrateWorkspaceIdsToV2IfNeeded(dataDir, store, 'raw-host-a');
+
+            expect(result).toEqual({ migrated: 1, renames: [{ oldId, newId }], conflicts: [] });
+            expect(fs.existsSync(oldDataDir)).toBe(false);
+            expect(fs.readFileSync(path.join(dataDir, 'repos', newId, 'preferences.json'), 'utf8')).toBe('{"ok":true}');
+
+            const workspaces = await store.getWorkspaces();
+            expect(workspaces.map(w => w.id)).toEqual([newId]);
+            const process = await store.getProcess('p1');
+            expect(process?.metadata?.workspaceId).toBe(newId);
+            expect(store.getSeenMap(oldId)).toEqual({});
+            expect(store.getSeenMap(newId)).toEqual({ p1: seenAt });
+
+            for (const table of ['commit_chat_bindings', 'note_chat_bindings', 'pull_request_chat_bindings', 'work_item_chat_bindings', 'task_groups', 'task_group_members']) {
+                expect(scalarCount(db.prepare(`SELECT COUNT(*) AS cnt FROM ${table} WHERE workspace_id = ?`).get(newId))).toBeGreaterThan(0);
+                expect(scalarCount(db.prepare(`SELECT COUNT(*) AS cnt FROM ${table} WHERE workspace_id = ?`).get(oldId))).toBe(0);
+            }
+            expect(scalarCount(db.prepare('SELECT COUNT(*) AS cnt FROM pull_request_chat_bindings WHERE workspace_id = ?').get('gh_owner_repo'))).toBe(1);
+            for (const table of ['queue_tasks', 'queue_repo_state', 'queue_repo_paths', 'schedule_runs']) {
+                expect(scalarCount(db.prepare(`SELECT COUNT(*) AS cnt FROM ${table} WHERE repo_id = ?`).get(newId))).toBeGreaterThan(0);
+                expect(scalarCount(db.prepare(`SELECT COUNT(*) AS cnt FROM ${table} WHERE repo_id = ?`).get(oldId))).toBe(0);
+            }
+            expect(scalarCount(db.prepare('SELECT COUNT(*) AS cnt FROM loops WHERE workspace_id = ?').get(newId))).toBe(1);
+            expect(scalarCount(db.prepare('SELECT COUNT(*) AS cnt FROM container_sessions WHERE routing_override_workspace_id = ?').get(newId))).toBe(1);
+            expect(scalarCount(db.prepare('SELECT COUNT(*) AS cnt FROM container_session_turns WHERE routing_workspace_id = ?').get(newId))).toBe(1);
+            expect(stderrSpy.mock.calls.some(call => String(call[0]).includes(`Migrated workspace ${oldId}`))).toBe(true);
+        } finally {
+            store.close();
+        }
+    });
+
+    it('migrates file-backed workspace records, repo data, active index entries, and process files', async () => {
+        const store = new FileProcessStore({ dataDir });
+        const oldId = 'ws-legacy-file';
+        const rootPath = path.join(dataDir, 'repo');
+        const newId = computeWorkspaceId('raw-host-b', rootPath);
+        await store.registerWorkspace(makeWorkspace(oldId, rootPath));
+        await store.addProcess(makeProcess('p-file', oldId));
+        fs.writeFileSync(path.join(dataDir, 'repos', oldId, 'preferences.json'), '{"file":true}');
+
+        const result = await migrateWorkspaceIdsToV2IfNeeded(dataDir, store, 'raw-host-b');
+
+        expect(result).toEqual({ migrated: 1, renames: [{ oldId, newId }], conflicts: [] });
+        expect(fs.existsSync(path.join(dataDir, 'repos', oldId))).toBe(false);
+        expect(fs.readFileSync(path.join(dataDir, 'repos', newId, 'preferences.json'), 'utf8')).toBe('{"file":true}');
+        expect((await store.getWorkspaces()).map(w => w.id)).toEqual([newId]);
+        expect(await store.getProcess('p-file', oldId)).toBeUndefined();
+        expect((await store.getProcess('p-file', newId))?.metadata?.workspaceId).toBe(newId);
+
+        const index = JSON.parse(fs.readFileSync(path.join(dataDir, 'repos', newId, 'processes', 'index.json'), 'utf8')) as Array<{ workspaceId: string }>;
+        expect(index.every(entry => entry.workspaceId === newId)).toBe(true);
+        const stored = JSON.parse(fs.readFileSync(path.join(dataDir, 'repos', newId, 'processes', 'p-file.json'), 'utf8')) as { workspaceId: string; process: { metadata?: { workspaceId?: string } } };
+        expect(stored.workspaceId).toBe(newId);
+        expect(stored.process.metadata?.workspaceId).toBe(newId);
+    });
+
+    it('skips virtual and already-v2 workspaces', async () => {
+        const store = new SqliteProcessStore({ dbPath: path.join(dataDir, 'processes.db') });
+        try {
+            const v2Id = computeWorkspaceId('raw-host-c', path.join(dataDir, 'repo'));
+            await store.registerWorkspace(makeWorkspace('my_work', '/virtual/my-work', { virtual: true }));
+            await store.registerWorkspace(makeWorkspace(v2Id, path.join(dataDir, 'repo')));
+
+            const result = await migrateWorkspaceIdsToV2IfNeeded(dataDir, store, 'raw-host-c');
+
+            expect(result).toEqual({ migrated: 0, renames: [], conflicts: [] });
+            expect((await store.getWorkspaces()).map(w => w.id).sort()).toEqual(['my_work', v2Id].sort());
+        } finally {
+            store.close();
+        }
+    });
+
+    it('surfaces conflicts without overwriting an existing target workspace or data directory', async () => {
+        const store = new SqliteProcessStore({ dbPath: path.join(dataDir, 'processes.db') });
+        try {
+            const oldId = 'ws-legacy-conflict';
+            const rootPath = path.join(dataDir, 'repo');
+            const newId = computeWorkspaceId('raw-host-d', rootPath);
+            await store.registerWorkspace(makeWorkspace(oldId, rootPath));
+            await store.registerWorkspace(makeWorkspace(newId, rootPath));
+            fs.mkdirSync(path.join(dataDir, 'repos', oldId), { recursive: true });
+            fs.writeFileSync(path.join(dataDir, 'repos', oldId, 'old.txt'), 'old');
+            fs.mkdirSync(path.join(dataDir, 'repos', newId), { recursive: true });
+            fs.writeFileSync(path.join(dataDir, 'repos', newId, 'new.txt'), 'new');
+
+            const result = await migrateWorkspaceIdsToV2IfNeeded(dataDir, store, 'raw-host-d');
+
+            expect(result.migrated).toBe(0);
+            expect(result.conflicts).toEqual([{ oldId, newId, reason: 'target-workspace-exists' }]);
+            expect(fs.readFileSync(path.join(dataDir, 'repos', oldId, 'old.txt'), 'utf8')).toBe('old');
+            expect(fs.readFileSync(path.join(dataDir, 'repos', newId, 'new.txt'), 'utf8')).toBe('new');
+            expect((await store.getWorkspaces()).map(w => w.id).sort()).toEqual([oldId, newId].sort());
+        } finally {
+            store.close();
+        }
+    });
+});

--- a/packages/coc/test/server/task-group-routes.test.ts
+++ b/packages/coc/test/server/task-group-routes.test.ts
@@ -36,21 +36,23 @@ describe('Task Group REST API', () => {
     let tmpDir: string;
     let store: SqliteProcessStore | undefined;
 
-    const wsA = 'ws-task-groups-a';
-    const wsB = 'ws-task-groups-b';
+    const legacyWsA = 'ws-task-groups-a';
+    const legacyWsB = 'ws-task-groups-b';
+    let wsA: string;
+    let wsB: string;
 
     beforeEach(async () => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-task-groups-'));
         store = new SqliteProcessStore({ dbPath: path.join(tmpDir, 'test.db') });
-        await store.registerWorkspace({ id: wsA, name: 'Workspace A', rootPath: '/tmp/task-groups-a' });
-        await store.registerWorkspace({ id: wsB, name: 'Workspace B', rootPath: '/tmp/task-groups-b' });
+        await store.registerWorkspace({ id: legacyWsA, name: 'Workspace A', rootPath: '/tmp/task-groups-a' });
+        await store.registerWorkspace({ id: legacyWsB, name: 'Workspace B', rootPath: '/tmp/task-groups-b' });
 
         // Seed the registry through the shared database, as feature
         // orchestrators do via TaskGroupService.
         const registry = new SqliteTaskGroupStore(store.getDatabase());
         registry.upsertGroup({
             groupId: 'run-1',
-            workspaceId: wsA,
+            workspaceId: legacyWsA,
             type: 'for-each',
             title: 'Process 2 items',
             status: 'running',
@@ -59,11 +61,11 @@ describe('Task Group REST API', () => {
             updatedAt: '2026-06-11T10:05:00.000Z',
             extra: { itemCount: 2 },
         });
-        registry.linkChild(wsA, 'run-1', { role: 'generation', processId: 'proc-gen' });
-        registry.linkChild(wsA, 'run-1', { role: 'item', taskId: 'task-a', itemKey: 'item-a', memberIndex: 1 });
+        registry.linkChild(legacyWsA, 'run-1', { role: 'generation', processId: 'proc-gen' });
+        registry.linkChild(legacyWsA, 'run-1', { role: 'item', taskId: 'task-a', itemKey: 'item-a', memberIndex: 1 });
         registry.upsertGroup({
             groupId: 'dream-1',
-            workspaceId: wsA,
+            workspaceId: legacyWsA,
             type: 'dream',
             status: 'completed',
             hidden: true,
@@ -72,7 +74,7 @@ describe('Task Group REST API', () => {
         });
         registry.upsertGroup({
             groupId: 'session-1',
-            workspaceId: wsB,
+            workspaceId: legacyWsB,
             type: 'ralph',
             status: 'running',
             createdAt: '2026-06-11T08:00:00.000Z',
@@ -81,6 +83,14 @@ describe('Task Group REST API', () => {
 
         server = await createExecutionServer({ port: 0, dataDir: tmpDir, store });
         baseUrl = server.url;
+        const workspaces = await store.getWorkspaces();
+        const workspaceA = workspaces.find(workspace => workspace.name === 'Workspace A');
+        const workspaceB = workspaces.find(workspace => workspace.name === 'Workspace B');
+        if (!workspaceA || !workspaceB) {
+            throw new Error('Expected task group test workspaces to be registered');
+        }
+        wsA = workspaceA.id;
+        wsB = workspaceB.id;
     });
 
     afterEach(async () => {

--- a/packages/coc/test/spa/react/Router.test.ts
+++ b/packages/coc/test/spa/react/Router.test.ts
@@ -1942,8 +1942,8 @@ describe('Router source-level: Alt+<letter> keyboard shortcuts', () => {
         expect(ROUTER_SOURCE).toContain("type: 'OPEN_DIALOG'");
     });
 
-    it('Alt+Q handler passes workspaceId from selectedRepoId', () => {
-        expect(ROUTER_SOURCE).toContain('workspaceId: state.selectedRepoId');
+    it('Alt+Q handler strips remote clone keys to the source workspace id', () => {
+        expect(ROUTER_SOURCE).toContain('workspaceId: getWorkspaceIdFromSelectionId(state.selectedRepoId)');
     });
 
     it('uses the shared repo sub-tab suffix builder for shortcut navigation', () => {

--- a/packages/coc/test/spa/react/context/ReposContext.test.tsx
+++ b/packages/coc/test/spa/react/context/ReposContext.test.tsx
@@ -55,7 +55,10 @@ import {
     loadPersistedRemoteSelection,
     persistRemoteSelection,
 } from '../../../../src/server/spa/client/react/repos/remoteSelectionPersistence';
-import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
+import {
+    buildRemoteCloneKey,
+    legacyPathOnlyWorkspaceIdForRootPath,
+} from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 
 afterEach(() => {
     vi.clearAllMocks();
@@ -180,10 +183,12 @@ describe('ReposContext', () => {
         // Default: no remote workspaces (classic flow). Overridden per AC-08 test.
         aggregateRemoteWorkspacesMock.mockResolvedValue(emptyAggregate());
         _resetRemoteSelectionForTests();
+        window.history.replaceState(null, '', '/');
     });
 
     afterEach(() => {
         _resetRemoteSelectionForTests();
+        window.history.replaceState(null, '', '/');
     });
 
     it('throws when useRepos is used outside ReposProvider', () => {
@@ -416,6 +421,46 @@ describe('ReposContext', () => {
             await waitFor(() => {
                 expect(loadPersistedRemoteSelection()).toEqual({ serverId: 'srv-1', workspaceId: 'remote-ws' });
             });
+        });
+    });
+
+    describe('legacy path-only repo deep links', () => {
+        it('resolves an old path-only hash to the migrated local workspace and preserves the suffix', async () => {
+            const rootPath = '/repos/shared-path';
+            const legacyId = legacyPathOnlyWorkspaceIdForRootPath(rootPath);
+            const migrated = { ...makeWorkspace('ws-v2-local', 'Migrated Local'), rootPath };
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([migrated]).workspaces);
+            location.hash = '#repos/' + encodeURIComponent(legacyId) + '/git';
+
+            render(<ProviderWithPreselectedRepo repoId={legacyId} />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-repo').textContent).toBe('ws-v2-local');
+            });
+            expect(location.hash).toBe('#repos/ws-v2-local/git');
+        });
+
+        it('resolves an old path-only hash to the single matching remote clone key', async () => {
+            const rootPath = '/repos/remote-shared-path';
+            const legacyId = legacyPathOnlyWorkspaceIdForRootPath(rootPath);
+            const expectedSelectionId = buildRemoteCloneKey('srv-1', 'ws-v2-remote');
+            const tagged = tagRemoteWorkspaces(
+                { id: 'srv-1', label: 'srv-1' },
+                'http://127.0.0.1:4000',
+                [{ id: 'ws-v2-remote', name: 'Remote Migrated', rootPath }],
+                false,
+                { connection: 'online' },
+            );
+            repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([]).workspaces);
+            aggregateRemoteWorkspacesMock.mockResolvedValueOnce({ sources: [], workspaces: tagged, gitInfo: {}, warnings: [] });
+            location.hash = '#repos/' + encodeURIComponent(legacyId) + '/chats';
+
+            render(<ProviderWithPreselectedRepo repoId={legacyId} />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-repo').textContent).toBe(expectedSelectionId);
+            });
+            expect(location.hash).toBe('#repos/' + encodeURIComponent(expectedSelectionId) + '/chats');
         });
     });
 });

--- a/packages/coc/test/spa/react/context/ReposContext.test.tsx
+++ b/packages/coc/test/spa/react/context/ReposContext.test.tsx
@@ -55,6 +55,7 @@ import {
     loadPersistedRemoteSelection,
     persistRemoteSelection,
 } from '../../../../src/server/spa/client/react/repos/remoteSelectionPersistence';
+import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 
 afterEach(() => {
     vi.clearAllMocks();
@@ -306,6 +307,8 @@ describe('ReposContext', () => {
 
     // ── AC-08: remote-clone selection persistence across reload ──────────────
     describe('remote-clone selection persistence (AC-08)', () => {
+        const remoteSelectionId = buildRemoteCloneKey('srv-1', 'remote-ws');
+
         it('restores the persisted remote clone once aggregation completes (cold reload, no hash)', async () => {
             // Simulate a prior session having selected the remote clone.
             persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'remote-ws' });
@@ -324,7 +327,7 @@ describe('ReposContext', () => {
             );
 
             await waitFor(() => {
-                expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+                expect(screen.getByTestId('selected-repo').textContent).toBe(remoteSelectionId);
             });
             // The remote workspace is present in the merged list.
             expect(screen.getByTestId('repo-remote-ws')).toBeTruthy();
@@ -347,7 +350,7 @@ describe('ReposContext', () => {
             // Resolved purely via the stable serverId — the changed baseUrl/port
             // does not prevent restoration.
             await waitFor(() => {
-                expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+                expect(screen.getByTestId('selected-repo').textContent).toBe(remoteSelectionId);
             });
         });
 
@@ -358,12 +361,12 @@ describe('ReposContext', () => {
             repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
             aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:4000', 'remote-ws'));
 
-            render(<ProviderWithPreselectedRepo repoId="remote-ws" />);
+            render(<ProviderWithPreselectedRepo repoId={remoteSelectionId} />);
 
             await waitFor(() => {
                 expect(screen.getByTestId('repo-loading').textContent).toBe('false');
             });
-            expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+            expect(screen.getByTestId('selected-repo').textContent).toBe(remoteSelectionId);
         });
 
         it('does not hijack an unrelated active local selection', async () => {
@@ -405,10 +408,10 @@ describe('ReposContext', () => {
             repositoryServiceMocks.listWorkspaces.mockResolvedValueOnce(makeWorkspacesResponse([makeWorkspace('local-1')]).workspaces);
             aggregateRemoteWorkspacesMock.mockResolvedValueOnce(remoteAggregate('srv-1', 'http://127.0.0.1:4000', 'remote-ws'));
 
-            render(<ProviderWithPreselectedRepo repoId="remote-ws" />);
+            render(<ProviderWithPreselectedRepo repoId={remoteSelectionId} />);
 
             await waitFor(() => {
-                expect(screen.getByTestId('selected-repo').textContent).toBe('remote-ws');
+                expect(screen.getByTestId('selected-repo').textContent).toBe(remoteSelectionId);
             });
             await waitFor(() => {
                 expect(loadPersistedRemoteSelection()).toEqual({ serverId: 'srv-1', workspaceId: 'remote-ws' });

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../../../../src/server/spa/client/react/repos/repositoryService', () =>
 }));
 
 import { RemoteSubBar } from '../../../../src/server/spa/client/react/features/remote-shell/RemoteSubBar';
+import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 
 const SHORTCUTS = 'https://github.com/acme/shortcuts.git';
 const repo = (id: string, name: string, branch = 'main') => ({
@@ -57,11 +58,12 @@ const remoteRepo = (
     branch = 'main',
     connection: string = 'online',
     queue: string = 'idle',
+    serverId = 'srv-1',
 ) => ({
     workspace: {
         id, name, color: '#0078d4', remoteUrl, rootPath: `/remote/${id}`,
         baseUrl: 'http://127.0.0.1:4000',
-        remote: { baseUrl: 'http://127.0.0.1:4000', serverId: 'srv-1', serverLabel, offline: connection !== 'online', connection, queue },
+        remote: { baseUrl: 'http://127.0.0.1:4000', serverId, serverLabel, offline: connection !== 'online', connection, queue },
     },
     gitInfo: remoteUrl ? { isGitRepo: true, branch, dirty: false, remoteUrl } : undefined,
 });
@@ -253,6 +255,18 @@ describe('RemoteSubBar', () => {
         expect(screen.getByTestId('clone-remote-badge').textContent).toBe('edge-1');
     });
 
+    it('keeps colliding remote clone workspace ids as separate selectable rows', () => {
+        const first = remoteRepo('ws-shared', 'shared@one', 'one', SHORTCUTS, 'main', 'online', 'idle', 'srv-1');
+        const second = remoteRepo('ws-shared', 'shared@two', 'two', SHORTCUTS, 'main', 'online', 'idle', 'srv-2');
+        render(<RemoteSubBar repo={first as any} repos={[first, second] as any} />);
+        fireEvent.click(screen.getByTestId('clone-switch'));
+
+        const rows = screen.getAllByTestId('clone-popover-item');
+        expect(rows).toHaveLength(2);
+        fireEvent.click(rows[1]);
+        expect(mockSelectClone).toHaveBeenCalledWith(buildRemoteCloneKey('srv-2', 'ws-shared'));
+    });
+
     it('does not badge any row when every clone is local', () => {
         renderBar();
         fireEvent.click(screen.getByTestId('clone-switch'));
@@ -347,7 +361,7 @@ describe('RemoteSubBar', () => {
         expect((row as HTMLButtonElement).disabled).toBe(false);
         expect(row.querySelector('[data-testid="clone-offline-badge"]')).toBeNull();
         fireEvent.click(row);
-        expect(mockSelectClone).toHaveBeenCalledWith('b');
+        expect(mockSelectClone).toHaveBeenCalledWith(buildRemoteCloneKey('srv-1', 'b'));
     });
 
     it('keeps the offline clone VISIBLE in its group (row still rendered)', () => {
@@ -369,7 +383,7 @@ describe('RemoteSubBar', () => {
         expect(row.getAttribute('data-offline')).toBe('false');
         expect((row as HTMLButtonElement).disabled).toBe(false);
         fireEvent.click(row);
-        expect(mockSelectClone).toHaveBeenCalledWith('b');
+        expect(mockSelectClone).toHaveBeenCalledWith(buildRemoteCloneKey('srv-1', 'b'));
     });
 
     it('never greys a LOCAL clone (offline treatment is remote-only)', () => {

--- a/packages/coc/test/spa/react/remote-shell/RemoteTopBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteTopBar.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../../../src/server/spa/client/react/repos/AddRepoDialog', () => ({
 }));
 
 import { RemoteTopBar } from '../../../../src/server/spa/client/react/features/remote-shell/RemoteTopBar';
+import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 
 const repo = (id: string, name: string, remoteUrl: string, color = '#123456') => ({
     workspace: { id, name, color, remoteUrl, rootPath: `/r/${id}` },
@@ -155,7 +156,7 @@ describe('RemoteTopBar', () => {
         mockRepos = [remoteRepo('edge', 'edge-svc', REMOTE_ONLY, 'edge-1')];
         render(<RemoteTopBar />);
         fireEvent.click(screen.getAllByTestId('remote-tab')[0]);
-        expect(mockSelectClone).toHaveBeenCalledWith('edge');
+        expect(mockSelectClone).toHaveBeenCalledWith(buildRemoteCloneKey('srv-1', 'edge'));
     });
 
     it('picks the LOCAL clone when selecting a remote that also has a remote checkout', () => {

--- a/packages/coc/test/spa/react/repos/AddFolderDialog.test.tsx
+++ b/packages/coc/test/spa/react/repos/AddFolderDialog.test.tsx
@@ -587,7 +587,8 @@ describe('AddFolderDialog', () => {
 
             expect(frontend).toBeDefined();
             expect(frontend.rootPath).toBe('/home/user/projects/frontend');
-            expect(frontend.id).toMatch(/^ws-/);
+            // Id is server-authoritative now — the client no longer sends one.
+            expect(frontend.id).toBeUndefined();
 
             expect(backend).toBeDefined();
             expect(backend.rootPath).toBe('/home/user/projects/backend');

--- a/packages/coc/test/spa/react/repos/CloneRepoDialog.test.tsx
+++ b/packages/coc/test/spa/react/repos/CloneRepoDialog.test.tsx
@@ -95,8 +95,9 @@ describe('CloneRepoDialog', () => {
             parentDir: '/projects',
             dirName: 'repo',
         }));
+        // Id is server-authoritative now — the client sends only name + path,
+        // and navigates using the id returned by the server (mocked 'ws-cloned').
         expect(repositoryServiceMocks.registerWorkspace).toHaveBeenCalledWith({
-            id: expect.stringMatching(/^ws-/),
             name: 'repo',
             rootPath: '/projects/repo',
         });

--- a/packages/coc/test/spa/react/repos/cloneRegistry.test.ts
+++ b/packages/coc/test/spa/react/repos/cloneRegistry.test.ts
@@ -20,7 +20,9 @@ import {
     lookupCloneBaseUrl,
     registerCloneBaseUrls,
     resetCloneRegistryForTests,
+    setActiveCloneForRouting,
 } from '../../../../src/server/spa/client/react/repos/cloneRegistry';
+import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 import {
     getCocClientFor,
     getSpaCocClient,
@@ -72,6 +74,23 @@ describe('lookupCloneBaseUrl', () => {
         registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:4000' }]);
         registerCloneBaseUrls([{ workspaceId: 'remote-1', baseUrl: 'http://127.0.0.1:9999' }]);
         expect(lookupCloneBaseUrl('remote-1')).toBe('http://127.0.0.1:9999');
+    });
+
+    it('routes duplicate remote workspace ids by server-scoped clone key', () => {
+        const key1 = buildRemoteCloneKey('srv-1', 'ws-shared');
+        const key2 = buildRemoteCloneKey('srv-2', 'ws-shared');
+        registerCloneBaseUrls([
+            { workspaceId: 'ws-shared', serverId: 'srv-1', cloneKey: key1, baseUrl: 'http://127.0.0.1:4000' },
+            { workspaceId: 'ws-shared', serverId: 'srv-2', cloneKey: key2, baseUrl: 'http://127.0.0.1:4001' },
+        ]);
+
+        expect(lookupCloneBaseUrl(key1)).toBe('http://127.0.0.1:4000');
+        expect(lookupCloneBaseUrl(key2)).toBe('http://127.0.0.1:4001');
+        expect(lookupCloneBaseUrl({ workspaceId: 'ws-shared', serverId: 'srv-2' })).toBe('http://127.0.0.1:4001');
+        expect(lookupCloneBaseUrl('ws-shared')).toBeUndefined();
+
+        setActiveCloneForRouting(key2);
+        expect(lookupCloneBaseUrl('ws-shared')).toBe('http://127.0.0.1:4001');
     });
 
     it('ignores entries with a missing id or baseUrl', () => {

--- a/packages/coc/test/spa/react/repos/remoteSelectionPersistence.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteSelectionPersistence.test.ts
@@ -22,6 +22,7 @@ import {
     tagRemoteWorkspaces,
     type RemoteWorkspaceInfo,
 } from '../../../../src/server/spa/client/react/repos/remoteWorkspaceAggregation';
+import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 
 const STORAGE_KEY = 'coc-remote-clone-selection';
 
@@ -80,7 +81,7 @@ describe('resolvePersistedRemoteSelection', () => {
     it('resolves the pair to the matching remote workspace id', () => {
         const workspaces = [remoteWs('srv-1', 'http://127.0.0.1:4000', 'ws-a')];
         const resolved = resolvePersistedRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' }, workspaces);
-        expect(resolved).toBe('ws-a');
+        expect(resolved).toBe(buildRemoteCloneKey('srv-1', 'ws-a'));
     });
 
     it('returns null when no persisted pair is given', () => {
@@ -104,7 +105,7 @@ describe('resolvePersistedRemoteSelection', () => {
         persistRemoteSelection({ serverId: 'srv-1', workspaceId: 'ws-a' });
         const reloadedWorkspaces = [remoteWs('srv-1', 'http://127.0.0.1:9999', 'ws-a')];
         const resolved = resolvePersistedRemoteSelection(loadPersistedRemoteSelection(), reloadedWorkspaces);
-        expect(resolved).toBe('ws-a');
+        expect(resolved).toBe(buildRemoteCloneKey('srv-1', 'ws-a'));
         // And the matched workspace carries the CURRENT (reassigned) baseUrl.
         expect(reloadedWorkspaces[0].baseUrl).toBe('http://127.0.0.1:9999');
     });
@@ -117,7 +118,7 @@ describe('resolvePersistedRemoteSelection', () => {
         ];
         // The persisted pair pins srv-2 → it must resolve to srv-2's row, routed at :4001.
         const resolved = resolvePersistedRemoteSelection({ serverId: 'srv-2', workspaceId: 'ws-shared' }, workspaces);
-        expect(resolved).toBe('ws-shared');
+        expect(resolved).toBe(buildRemoteCloneKey('srv-2', 'ws-shared'));
         const matched = workspaces.find(w => w.remote.serverId === 'srv-2')!;
         expect(matched.baseUrl).toBe('http://127.0.0.1:4001');
     });

--- a/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
+++ b/packages/coc/test/spa/react/repos/remoteWorkspaceAggregation.test.ts
@@ -95,6 +95,7 @@ import {
     lookupCloneBaseUrl,
     resetCloneRegistryForTests,
 } from '../../../../src/server/spa/client/react/repos/cloneRegistry';
+import { buildRemoteCloneKey } from '../../../../src/server/spa/client/react/repos/cloneIdentity';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -176,6 +177,7 @@ describe('tagRemoteWorkspaces', () => {
                 baseUrl: 'http://127.0.0.1:4000',
                 serverId: 'srv-1',
                 serverLabel: 'Ubuntu ARM',
+                cloneKey: `remote:${encodeURIComponent('srv-1')}:${encodeURIComponent(t.id)}`,
                 offline: false,
                 // AC-05: an online (offline=false) tag defaults to an online
                 // connection + idle queue when no explicit status is supplied.
@@ -499,6 +501,23 @@ describe('aggregateRemoteWorkspaces — clone lookup registry (AC-07)', () => {
 
         await aggregateRemoteWorkspaces();
         expect(lookupCloneBaseUrl('w1')).toBe('http://127.0.0.1:4000');
+    });
+
+    it('keeps duplicate legacy workspace ids as distinct server-scoped clone routes', async () => {
+        serversList.mockResolvedValue([
+            onlineServer('srv-1', 'Server One', 'http://127.0.0.1:4000'),
+            onlineServer('srv-2', 'Server Two', 'http://127.0.0.1:4001'),
+        ]);
+        remoteResponses.set('http://127.0.0.1:4000', { workspaces: [ws('ws-legacy', 'same path')] });
+        remoteResponses.set('http://127.0.0.1:4001', { workspaces: [ws('ws-legacy', 'same path')] });
+
+        const result = await aggregateRemoteWorkspaces();
+
+        expect(result.workspaces).toHaveLength(2);
+        expect(result.workspaces.map(w => w.remote.serverId).sort()).toEqual(['srv-1', 'srv-2']);
+        expect(lookupCloneBaseUrl(buildRemoteCloneKey('srv-1', 'ws-legacy'))).toBe('http://127.0.0.1:4000');
+        expect(lookupCloneBaseUrl(buildRemoteCloneKey('srv-2', 'ws-legacy'))).toBe('http://127.0.0.1:4001');
+        expect(lookupCloneBaseUrl('ws-legacy')).toBeUndefined();
     });
 
     it('clears the registry when the remote-shell flag is OFF (per-clone routing reverts to local)', async () => {

--- a/packages/forge/src/file-process-store.ts
+++ b/packages/forge/src/file-process-store.ts
@@ -691,6 +691,93 @@ export class FileProcessStore implements ProcessStore {
         return updated;
     }
 
+    /**
+     * Re-key a physical workspace from `oldId` to `newId`. The repo data
+     * directory (`repos/<oldId>/`) is moved to `repos/<newId>/` by the startup
+     * migration orchestrator BEFORE this runs, so the process files already
+     * live under the new id; this method rewrites the workspace record in
+     * `workspaces.json` and the embedded workspace id inside every (active and
+     * pruned) process file/index entry so each conversation reports its
+     * migrated workspace.
+     *
+     * Returns false without changing anything when `oldId` is unknown or a
+     * workspace `newId` already exists, so the migration never merges two
+     * workspaces.
+     */
+    async renameWorkspaceId(oldId: string, newId: string): Promise<boolean> {
+        if (!oldId || !newId || oldId === newId) {
+            return false;
+        }
+        let applied = false;
+        await this.enqueueWrite(async () => {
+            const workspaces = await this.readWorkspaces();
+            const srcIdx = workspaces.findIndex(w => w.id === oldId);
+            if (srcIdx < 0) {
+                return; // unknown workspace
+            }
+            if (workspaces.some(w => w.id === newId)) {
+                return; // target already exists — never merge
+            }
+            await this.rewriteEmbeddedWorkspaceId(newId);
+            workspaces[srcIdx] = { ...workspaces[srcIdx], id: newId };
+            await this.writeWorkspaces(workspaces);
+            applied = true;
+        });
+        return applied;
+    }
+
+    /**
+     * Force every embedded workspace id under `repos/<workspaceId>/processes/`
+     * (the active index + each process file, plus every pruned bucket) to
+     * `workspaceId`. Called after the data directory has been moved to the new
+     * id so stale ids inside the moved files are corrected.
+     */
+    private async rewriteEmbeddedWorkspaceId(workspaceId: string): Promise<void> {
+        // Active index + process files.
+        const index = await this.readIndex(workspaceId);
+        if (index.length > 0) {
+            for (const entry of index) {
+                const stored = await this.readProcessFile(workspaceId, entry.id);
+                if (!stored) { continue; }
+                stored.workspaceId = workspaceId;
+                const metadataType = stored.process.metadata?.type ?? stored.process.type ?? 'ai';
+                stored.process.metadata = { ...(stored.process.metadata ?? { type: metadataType }), type: metadataType, workspaceId };
+                await this.writeProcessFile(workspaceId, entry.id, stored);
+            }
+            await this.writeIndex(workspaceId, index.map(e => ({ ...e, workspaceId })));
+        }
+
+        // Pruned buckets (processes/pruned/YYYY-MM/).
+        let buckets: string[];
+        try {
+            const dirents = await fs.readdir(this.prunedRootFor(workspaceId), { withFileTypes: true });
+            buckets = dirents.filter(d => d.isDirectory()).map(d => d.name);
+        } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                buckets = [];
+            } else {
+                throw err;
+            }
+        }
+        for (const bucket of buckets) {
+            const bucketIndexPath = path.join(this.prunedRootFor(workspaceId), bucket, 'index.json');
+            const entries = JSON.parse(await fs.readFile(bucketIndexPath, 'utf-8')) as ProcessIndexEntry[];
+            for (const entry of entries) {
+                const filePath = path.join(this.prunedRootFor(workspaceId), bucket, this.sanitizeId(entry.id) + '.json');
+                const stored = JSON.parse(await fs.readFile(filePath, 'utf-8')) as StoredProcessEntry;
+                stored.workspaceId = workspaceId;
+                const metadataType = stored.process.metadata?.type ?? stored.process.type ?? 'ai';
+                stored.process.metadata = { ...(stored.process.metadata ?? { type: metadataType }), type: metadataType, workspaceId };
+                await fs.writeFile(filePath, JSON.stringify(stored, null, 2), 'utf-8');
+            }
+            await fs.writeFile(
+                bucketIndexPath,
+                JSON.stringify(entries.map(e => ({ ...e, workspaceId })), null, 2),
+                'utf-8',
+            );
+        }
+    }
+
     // --- Wiki CRUD ---
 
     async registerWiki(wiki: WikiInfo): Promise<void> {

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -959,3 +959,18 @@ export * from './github';
 // ============================================================================
 
 export { getRepoDataPath } from './paths';
+
+// ============================================================================
+// Workspace Identity (machine-scoped physical workspace IDs)
+// ============================================================================
+
+export {
+    computeWorkspaceId,
+    normalizeWorkspaceRootPath,
+    normalizeWorkspaceHostname,
+    isV2WorkspaceId,
+    isLegacyPhysicalWorkspaceId,
+    isPhysicalWorkspaceId,
+    WORKSPACE_ID_V2_PREFIX,
+    PHYSICAL_WORKSPACE_ID_PREFIX,
+} from './workspace-id';

--- a/packages/forge/src/process-store.ts
+++ b/packages/forge/src/process-store.ts
@@ -179,7 +179,8 @@ export interface ProcessOutputEvent {
 
 /**
  * Workspace identity for multi-workspace process tracking.
- * `id` is a stable hash of the workspace root path.
+ * Physical workspace `id` values are machine-scoped; virtual/system workspace
+ * IDs are fixed.
  */
 export interface WorkspaceInfo {
     /** Stable unique identifier — hash of rootPath */
@@ -364,6 +365,24 @@ export interface ProcessStore {
     removeWorkspace(id: string): Promise<boolean>;
     /** Partial-update a workspace. Returns updated workspace or undefined if not found. */
     updateWorkspace(id: string, updates: Partial<Omit<WorkspaceInfo, 'id'>>): Promise<WorkspaceInfo | undefined>;
+
+    /**
+     * Optional store-level re-key for physical workspace IDs. Implementations
+     * that persist workspace-scoped state should rewrite every reference to
+     * `oldId` so it points at `newId`: the workspace record itself, process
+     * history (including seen/unseen state), workspace-scoped bindings,
+     * task-group/queue/schedule rows, and any on-disk process files.
+     *
+     * Returns `true` when the rename was applied. Returns `false` — leaving the
+     * store unchanged — when `oldId` has no workspace record or a workspace
+     * `newId` already exists, so the caller can treat a `false` result as a
+     * conflict and fall back safely (never merging two workspaces).
+     *
+     * The repo-scoped data directory (`<dataDir>/repos/<id>/`) is moved by the
+     * migration orchestrator BEFORE this is called, so file-backed stores find
+     * their process files already under the new id.
+     */
+    renameWorkspaceId?(oldId: string, newId: string): Promise<boolean>;
 
     /** Return all known wikis. */
     getWikis(): Promise<WikiInfo[]>;

--- a/packages/forge/src/sqlite-process-store.ts
+++ b/packages/forge/src/sqlite-process-store.ts
@@ -45,6 +45,27 @@ import { computeMessagePreview } from './utils/message-preview';
 
 const logger = getLogger();
 
+/**
+ * SQLite columns outside `processes`/`workspaces` that may hold a physical
+ * workspace id. Some tables are created by CoC feature stores after forge
+ * initializes the base schema, so each update is guarded by column existence.
+ */
+const WORKSPACE_ID_REFERENCE_COLUMNS = [
+    { table: 'commit_chat_bindings', column: 'workspace_id' },
+    { table: 'note_chat_bindings', column: 'workspace_id' },
+    { table: 'pull_request_chat_bindings', column: 'workspace_id' },
+    { table: 'work_item_chat_bindings', column: 'workspace_id' },
+    { table: 'task_groups', column: 'workspace_id' },
+    { table: 'task_group_members', column: 'workspace_id' },
+    { table: 'loops', column: 'workspace_id' },
+    { table: 'container_sessions', column: 'routing_override_workspace_id' },
+    { table: 'container_session_turns', column: 'routing_workspace_id' },
+    { table: 'queue_tasks', column: 'repo_id' },
+    { table: 'queue_repo_state', column: 'repo_id' },
+    { table: 'queue_repo_paths', column: 'repo_id' },
+    { table: 'schedule_runs', column: 'repo_id' },
+] as const;
+
 // ============================================================================
 // Options
 // ============================================================================
@@ -1424,6 +1445,74 @@ export class SqliteProcessStore implements ProcessStore {
 
         const row = this.db.prepare('SELECT * FROM workspaces WHERE id = ?').get(id) as WorkspaceRow | undefined;
         return row ? rowToWorkspace(row) : undefined;
+    }
+
+    /**
+     * Re-key every reference to a physical workspace from `oldId` to `newId`
+     * inside this database, in a single transaction. Covers the workspace
+     * record, process history (and the seen/unseen state carried on those
+     * rows), process metadata, workspace-scoped bindings, task-group records,
+     * loop/container routing references, and queued/scheduled work keyed by
+     * repo id. Returns false without changing anything when `oldId` is unknown
+     * or a workspace `newId` already exists, so the startup migration can treat
+     * a false result as a conflict and never merge two workspaces.
+     */
+    async renameWorkspaceId(oldId: string, newId: string): Promise<boolean> {
+        if (!oldId || !newId || oldId === newId) {
+            return false;
+        }
+        const run = this.db.transaction((): boolean => {
+            const source = this.db.prepare('SELECT 1 FROM workspaces WHERE id = ?').get(oldId);
+            if (!source) {
+                return false;
+            }
+            const target = this.db.prepare('SELECT 1 FROM workspaces WHERE id = ?').get(newId);
+            if (target) {
+                // A workspace already owns newId — never silently merge into it.
+                return false;
+            }
+            this.rewriteProcessMetadataWorkspaceId(oldId, newId);
+            this.db.prepare('UPDATE workspaces SET id = ? WHERE id = ?').run(newId, oldId);
+            this.db.prepare('UPDATE processes SET workspace_id = ? WHERE workspace_id = ?').run(newId, oldId);
+            for (const { table, column } of WORKSPACE_ID_REFERENCE_COLUMNS) {
+                if (!this.columnExists(table, column)) { continue; }
+                this.db.prepare(`UPDATE ${table} SET ${column} = ? WHERE ${column} = ?`).run(newId, oldId);
+            }
+            return true;
+        });
+        return run();
+    }
+
+    private rewriteProcessMetadataWorkspaceId(oldId: string, newId: string): void {
+        const rows = this.db.prepare(
+            'SELECT id, metadata FROM processes WHERE workspace_id = ?',
+        ).all(oldId) as Array<{ id: string; metadata: string | null }>;
+        if (rows.length === 0) {
+            return;
+        }
+
+        const update = this.db.prepare('UPDATE processes SET metadata = ? WHERE id = ?');
+        for (const row of rows) {
+            const envelope = jsonParse<MetadataEnvelope>(row.metadata) ?? {};
+            update.run(JSON.stringify({ ...envelope, workspaceId: newId }), row.id);
+        }
+    }
+
+    /** True when a table with the given name exists in this database. */
+    private tableExists(name: string): boolean {
+        return (
+            this.db
+                .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+                .get(name) !== undefined
+        );
+    }
+
+    private columnExists(table: string, column: string): boolean {
+        if (!this.tableExists(table)) {
+            return false;
+        }
+        const columns = this.db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+        return columns.some(info => info.name === column);
     }
 
     // ========================================================================

--- a/packages/forge/src/workspace-id.ts
+++ b/packages/forge/src/workspace-id.ts
@@ -1,0 +1,119 @@
+/**
+ * Centralized, machine-scoped physical workspace ID generation.
+ *
+ * Physical repository workspaces are identified by BOTH the machine they live on
+ * (the raw OS hostname) and their normalized root path. The same repository at
+ * the same absolute path on two different machines therefore produces two
+ * distinct IDs. This is what lets the dashboard aggregate clones from multiple
+ * remote CoC servers without two machines collapsing into one entry.
+ *
+ * This module is the SINGLE source of truth for the physical workspace ID
+ * scheme. Add Repo, Add Folder, Clone Repo, and server-side registration must
+ * all route through {@link computeWorkspaceId} so the scheme cannot drift.
+ *
+ * Virtual/system workspaces (My Work, My Life, Global) keep their fixed,
+ * machine-independent IDs and must NOT be passed through {@link computeWorkspaceId};
+ * use {@link isPhysicalWorkspaceId} to tell them apart.
+ */
+
+import crypto from 'crypto';
+import path from 'path';
+
+/** Prefix for the machine-scoped (v2) physical workspace ID scheme. */
+export const WORKSPACE_ID_V2_PREFIX = 'ws-v2-';
+
+/**
+ * Prefix shared by every physical workspace ID — both the legacy path-only
+ * scheme (`ws-<base36hash>`) and the v2 machine-scoped scheme
+ * (`ws-v2-<hash>`). Virtual workspace IDs never start with this prefix.
+ */
+export const PHYSICAL_WORKSPACE_ID_PREFIX = 'ws-';
+
+/**
+ * Delimiter between hostname and path in the hash input. A NUL byte can appear
+ * in neither an OS hostname nor a filesystem path, so distinct (hostname, path)
+ * pairs can never collapse to the same hash input (e.g. host `ab` + path `/c`
+ * never aliases host `a` + path `b/c`). Built via fromCharCode so no literal
+ * control character lives in source.
+ */
+const WORKSPACE_ID_DELIMITER = String.fromCharCode(0);
+
+/** Fallback identity used when the OS hostname is empty/unavailable. */
+const UNKNOWN_HOSTNAME = 'unknown-host';
+
+/** Length (in hex chars) of the truncated sha256 digest embedded in v2 IDs. */
+const WORKSPACE_ID_HASH_LENGTH = 24;
+
+/**
+ * Normalize a filesystem root path for stable workspace-ID hashing.
+ *
+ * Resolves to an absolute, canonical form (collapsing `.`/`..` and duplicate
+ * separators) and strips any trailing separator so that `/foo/bar`, `/foo/bar/`
+ * and `/foo//bar` all hash identically. Inputs are always absolute repo roots,
+ * so `path.resolve` is deterministic and does not depend on the process CWD.
+ */
+export function normalizeWorkspaceRootPath(rootPath: string): string {
+    const resolved = path.resolve(rootPath);
+    if (resolved.length > 1) {
+        return resolved.replace(/[/\\]+$/, '') || resolved;
+    }
+    return resolved;
+}
+
+/**
+ * Normalize the raw OS hostname used as machine identity. Trims surrounding
+ * whitespace and falls back to a stable sentinel when empty. The hostname is
+ * otherwise used raw — not shortened, not the configured display name, not a
+ * remote server label.
+ */
+export function normalizeWorkspaceHostname(rawHostname: string | null | undefined): string {
+    const trimmed = (rawHostname ?? '').trim();
+    return trimmed.length > 0 ? trimmed : UNKNOWN_HOSTNAME;
+}
+
+/**
+ * Compute the canonical machine-scoped physical workspace ID.
+ *
+ * Format: `ws-v2-<hash>`, where `<hash>` is a truncated sha256 over
+ * `<rawHostname><NUL><normalizedRootPath>`.
+ *
+ * @param rawHostname Raw OS hostname (e.g. `os.hostname()`).
+ * @param rootPath Absolute repository root path.
+ */
+export function computeWorkspaceId(rawHostname: string | null | undefined, rootPath: string): string {
+    const host = normalizeWorkspaceHostname(rawHostname);
+    const normalizedPath = normalizeWorkspaceRootPath(rootPath);
+    const digest = crypto
+        .createHash('sha256')
+        .update(host + WORKSPACE_ID_DELIMITER + normalizedPath)
+        .digest('hex')
+        .slice(0, WORKSPACE_ID_HASH_LENGTH);
+    return `${WORKSPACE_ID_V2_PREFIX}${digest}`;
+}
+
+/** True for a machine-scoped (v2) physical workspace ID. */
+export function isV2WorkspaceId(id: string | null | undefined): boolean {
+    return typeof id === 'string' && id.startsWith(WORKSPACE_ID_V2_PREFIX);
+}
+
+/**
+ * True for a physical workspace ID from the old path-only scheme
+ * (`ws-<base36hash>`), i.e. a `ws-` ID that is not yet machine-scoped. These
+ * are the IDs migrated to the v2 scheme on startup.
+ */
+export function isLegacyPhysicalWorkspaceId(id: string | null | undefined): boolean {
+    return (
+        typeof id === 'string' &&
+        id.startsWith(PHYSICAL_WORKSPACE_ID_PREFIX) &&
+        !id.startsWith(WORKSPACE_ID_V2_PREFIX)
+    );
+}
+
+/**
+ * True for any physical repository workspace ID (legacy or v2). Virtual/system
+ * workspaces (My Work, My Life, Global) return false, so callers can exclude
+ * them from machine-scoping and migration.
+ */
+export function isPhysicalWorkspaceId(id: string | null | undefined): boolean {
+    return typeof id === 'string' && id.startsWith(PHYSICAL_WORKSPACE_ID_PREFIX);
+}

--- a/packages/forge/test/workspace-id.test.ts
+++ b/packages/forge/test/workspace-id.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Workspace ID generation tests.
+ *
+ * Covers the machine-scoped (v2) physical workspace ID scheme: same path on
+ * different hostnames must produce different IDs; same hostname + same path must
+ * be stable; path normalization; and the discriminators that keep virtual/system
+ * workspaces out of the machine-scoping/migration paths.
+ */
+
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+    computeWorkspaceId,
+    normalizeWorkspaceRootPath,
+    normalizeWorkspaceHostname,
+    isV2WorkspaceId,
+    isLegacyPhysicalWorkspaceId,
+    isPhysicalWorkspaceId,
+    WORKSPACE_ID_V2_PREFIX,
+} from '../src/index';
+
+const ABS = path.resolve('/home/alice/projects/myrepo');
+
+describe('computeWorkspaceId', () => {
+    it('produces a ws-v2- prefixed id', () => {
+        const id = computeWorkspaceId('host-a', ABS);
+        expect(id.startsWith(WORKSPACE_ID_V2_PREFIX)).toBe(true);
+        expect(id).toMatch(/^ws-v2-[0-9a-f]{24}$/);
+    });
+
+    it('is stable for the same hostname + same path', () => {
+        const a = computeWorkspaceId('host-a', ABS);
+        const b = computeWorkspaceId('host-a', ABS);
+        expect(a).toBe(b);
+    });
+
+    it('produces DIFFERENT ids for the same path on different hostnames', () => {
+        const onA = computeWorkspaceId('machine-a', ABS);
+        const onB = computeWorkspaceId('machine-b', ABS);
+        expect(onA).not.toBe(onB);
+    });
+
+    it('produces different ids for different paths on the same hostname', () => {
+        const one = computeWorkspaceId('host-a', path.resolve('/repos/one'));
+        const two = computeWorkspaceId('host-a', path.resolve('/repos/two'));
+        expect(one).not.toBe(two);
+    });
+
+    it('normalizes trailing separators and duplicate separators to the same id', () => {
+        const base = computeWorkspaceId('host-a', path.resolve('/repos/proj'));
+        const trailing = computeWorkspaceId('host-a', path.resolve('/repos/proj') + path.sep);
+        const dup = computeWorkspaceId('host-a', '/repos//proj');
+        expect(trailing).toBe(base);
+        expect(dup).toBe(base);
+    });
+
+    it('falls back to a stable identity for an empty/whitespace hostname', () => {
+        const empty = computeWorkspaceId('', ABS);
+        const blank = computeWorkspaceId('   ', ABS);
+        const nil = computeWorkspaceId(null, ABS);
+        expect(empty).toBe(blank);
+        expect(empty).toBe(nil);
+        expect(empty.startsWith(WORKSPACE_ID_V2_PREFIX)).toBe(true);
+    });
+
+    it('treats the hostname/path boundary as delimiter-safe (no aliasing)', () => {
+        // Without a safe delimiter, host "ab" + path "/c" could alias host "a"
+        // + path "b/c". The NUL delimiter prevents that.
+        const left = computeWorkspaceId('ab', path.resolve('/c'));
+        const right = computeWorkspaceId('a', path.resolve('/b/c'));
+        expect(left).not.toBe(right);
+    });
+});
+
+describe('normalizeWorkspaceRootPath', () => {
+    it('strips a trailing separator', () => {
+        expect(normalizeWorkspaceRootPath(path.resolve('/x/y') + path.sep)).toBe(path.resolve('/x/y'));
+    });
+
+    it('returns an absolute path unchanged when already canonical', () => {
+        const abs = path.resolve('/x/y');
+        expect(normalizeWorkspaceRootPath(abs)).toBe(abs);
+    });
+});
+
+describe('normalizeWorkspaceHostname', () => {
+    it('trims and falls back to unknown-host', () => {
+        expect(normalizeWorkspaceHostname('  Foo  ')).toBe('Foo');
+        expect(normalizeWorkspaceHostname('')).toBe('unknown-host');
+        expect(normalizeWorkspaceHostname(undefined)).toBe('unknown-host');
+        expect(normalizeWorkspaceHostname(null)).toBe('unknown-host');
+    });
+});
+
+describe('workspace id discriminators', () => {
+    const v2 = computeWorkspaceId('host-a', ABS);
+    const legacy = 'ws-1a2b3c'; // old path-only scheme
+
+    it('classifies v2 ids', () => {
+        expect(isV2WorkspaceId(v2)).toBe(true);
+        expect(isLegacyPhysicalWorkspaceId(v2)).toBe(false);
+        expect(isPhysicalWorkspaceId(v2)).toBe(true);
+    });
+
+    it('classifies legacy path-only ids', () => {
+        expect(isV2WorkspaceId(legacy)).toBe(false);
+        expect(isLegacyPhysicalWorkspaceId(legacy)).toBe(true);
+        expect(isPhysicalWorkspaceId(legacy)).toBe(true);
+    });
+
+    it('excludes virtual/system workspaces from every physical discriminator', () => {
+        for (const virtual of ['my_work', 'my_life', 'global-workspace-00']) {
+            expect(isV2WorkspaceId(virtual)).toBe(false);
+            expect(isLegacyPhysicalWorkspaceId(virtual)).toBe(false);
+            expect(isPhysicalWorkspaceId(virtual)).toBe(false);
+        }
+    });
+
+    it('handles null/undefined ids safely', () => {
+        expect(isV2WorkspaceId(null)).toBe(false);
+        expect(isLegacyPhysicalWorkspaceId(undefined)).toBe(false);
+        expect(isPhysicalWorkspaceId(null)).toBe(false);
+    });
+});


### PR DESCRIPTION
- **feat(forge): add centralized machine-scoped workspace ID generation**
- **feat(coc): make physical workspace IDs server-authoritative and machine-scoped**
- **Migrate legacy workspace ids to machine-scoped ids**
- **Handle remote clone selection collisions**
- **Resolve legacy workspace deep links**
- **test(coc): align legacy workspace fixtures with v2 migration**
