### PR TITLE
Fix Copilot sub-agent detail tool nesting

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -577,6 +577,13 @@ the `task` startup acknowledgement. Limitation: `content`-type timeline items
 carry no parent linkage, so a sub-agent's prose isn't attributed — its Task
 result (or matching `read_agent` final output) shows as the closing content
 instead.
+`ConversationTurnBubble` builds parent/child chunk maps after falling back from
+timeline events to persisted `toolCalls`, so nested child tools still render
+inside their parent Task when a detail view (or older history record) only has
+flat tool-call snapshots. Whisper mode (`toolCompactness === 3`) applies to the
+same synthetic assistant turn: preceding descendant tool calls collapse into the
+normal `WhisperCollapsedGroup` and the sub-agent result remains visible as the
+tail content.
 Styles live in scoped `agent-canvas.css` (`.agent-canvas`,
 light/dark via `.dark`); there is no clock scrubber (the prototype's replay
 control is dropped — the real view is

--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -90,6 +90,8 @@ const svc = sdkServiceRegistry.getOrThrow(SDK_PROVIDER_COPILOT);
 
 Each `sendMessage()` call creates its **own `CopilotClient`** child process — no shared client. Concurrent tasks with different working directories cannot interfere.
 
+Copilot streaming tool telemetry is normalized through `SessionTelemetry` into the shared `ToolCall` / `ToolEvent` contract. `parentToolCallId` is preserved from either the start or terminal SDK event; if the terminal event supplies or corrects the parent, the stored `ToolCall` is updated too. This keeps Copilot-backed sub-agent descendants reconstructable from both live timelines and persisted `toolCalls`.
+
 ### One-shot `transform` primitive
 
 `ISDKService.transform(input, options?)` is the provider-agnostic primitive for isolated, single-shot text transformations (e.g. chat-title generation, PR ranking). Contract:

--- a/packages/coc-agent-sdk/src/session-telemetry.ts
+++ b/packages/coc-agent-sdk/src/session-telemetry.ts
@@ -162,6 +162,9 @@ export class SessionTelemetry {
         let resultContent  = data.result?.content;
 
         if (capturedTool) {
+            if (data.parentToolCallId) {
+                capturedTool.parentToolCallId = data.parentToolCallId;
+            }
             capturedTool.status  = data.success ? 'completed' : 'failed';
             capturedTool.endTime = new Date();
             if (data.success) {

--- a/packages/coc-agent-sdk/test/copilot-sdk-wrapper/session-telemetry.test.ts
+++ b/packages/coc-agent-sdk/test/copilot-sdk-wrapper/session-telemetry.test.ts
@@ -210,6 +210,26 @@ describe('SessionTelemetry — tool call tracking', () => {
 
         // Complete event parentToolCallId takes precedence
         expect(event.parentToolCallId).toBe('parent-complete');
+        expect(t.toolCallsMap.get('child')!.parentToolCallId).toBe('parent-complete');
+    });
+
+    it('captures parentToolCallId that arrives only on the complete event', () => {
+        const t = new SessionTelemetry();
+        t.recordToolStart({ toolCallId: 'child', toolName: 'view', arguments: { path: 'file.ts' } });
+        t.recordToolComplete({
+            toolCallId: 'child',
+            success: true,
+            result: { content: 'ok' },
+            parentToolCallId: 'task-parent',
+        });
+
+        const captured = t.getCapturedToolCalls();
+        expect(captured).toHaveLength(1);
+        expect(captured![0]).toMatchObject({
+            id: 'child',
+            parentToolCallId: 'task-parent',
+            status: 'completed',
+        });
     });
 });
 

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -984,19 +984,6 @@ function buildAssistantRender(turn: ClientConversationTurn, wsId?: string, optio
         }
     }
 
-    const chunksByParent = new Map<string, RenderChunk[]>();
-    for (const chunk of chunks) {
-        const parentId = chunk.kind === 'tool'
-            ? (chunk.toolId ? toolParentById.get(chunk.toolId) : undefined)
-            : (chunk.parentToolId && inferredById.has(chunk.parentToolId) ? chunk.parentToolId : undefined);
-        if (!parentId) continue;
-        if (!chunksByParent.has(parentId)) {
-            chunksByParent.set(parentId, []);
-        }
-        chunksByParent.get(parentId)!.push(chunk);
-        toolsWithChildren.add(parentId);
-    }
-
     if (!hasContent) {
         const fallbackHtml = toContentHtml(turn.content || '', wsId, options);
         if (fallbackHtml) {
@@ -1008,6 +995,19 @@ function buildAssistantRender(turn: ClientConversationTurn, wsId?: string, optio
         for (const call of inferred) {
             chunks.push({ kind: 'tool', key: `tool-${call.id}`, toolId: call.id });
         }
+    }
+
+    const chunksByParent = new Map<string, RenderChunk[]>();
+    for (const chunk of chunks) {
+        const parentId = chunk.kind === 'tool'
+            ? (chunk.toolId ? toolParentById.get(chunk.toolId) : undefined)
+            : (chunk.parentToolId && inferredById.has(chunk.parentToolId) ? chunk.parentToolId : undefined);
+        if (!parentId) continue;
+        if (!chunksByParent.has(parentId)) {
+            chunksByParent.set(parentId, []);
+        }
+        chunksByParent.get(parentId)!.push(chunk);
+        toolsWithChildren.add(parentId);
     }
 
     return {

--- a/packages/coc/test/spa/react/ConversationTurnBubble-compact-grouping.test.tsx
+++ b/packages/coc/test/spa/react/ConversationTurnBubble-compact-grouping.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ConversationTurnBubble } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
+import { buildSubAgentTurns } from '../../../src/server/spa/client/react/features/chat/agent-canvas/buildSubAgentTurns';
 import type { ClientConversationTurn } from '../../../src/server/spa/client/react/types/dashboard';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -271,6 +272,131 @@ describe('ConversationTurnBubble — compact tool grouping', () => {
         const whisper = container.querySelector('[data-testid="whisper-collapsed-group"]');
         expect(whisper).toBeTruthy();
         expect(whisper?.getAttribute('data-tool-count')).toBe('3');
+    });
+
+    it('renders Copilot SDK sub-agent detail steps in whisper mode while keeping the final result visible', () => {
+        mockToolCompactness = 3;
+        const sourceTurns: ClientConversationTurn[] = [
+            {
+                role: 'assistant',
+                content: 'orchestrator done',
+                timestamp: '2026-01-15T10:30:00Z',
+                timeline: [],
+                toolCalls: [
+                    {
+                        id: 'task-parent',
+                        toolName: 'Task',
+                        args: { prompt: 'inspect the repo', name: 'repo inspector' },
+                        result: 'sub-agent final result',
+                        status: 'completed',
+                    },
+                    {
+                        id: 'parent-view',
+                        toolName: 'view',
+                        args: { path: 'packages/coc/src/index.ts' },
+                        result: 'index contents',
+                        status: 'completed',
+                        parentToolCallId: 'task-parent',
+                    },
+                    {
+                        id: 'parent-shell',
+                        toolName: 'bash',
+                        args: { command: 'npm test' },
+                        result: 'passed',
+                        status: 'completed',
+                        parentToolCallId: 'task-parent',
+                    },
+                    {
+                        id: 'nested-task',
+                        toolName: 'Task',
+                        args: { prompt: 'nested check', name: 'nested agent' },
+                        result: 'nested done',
+                        status: 'completed',
+                        parentToolCallId: 'task-parent',
+                    },
+                    {
+                        id: 'nested-view',
+                        toolName: 'view',
+                        args: { path: 'packages/coc/package.json' },
+                        result: 'package contents',
+                        status: 'completed',
+                        parentToolCallId: 'nested-task',
+                    },
+                    {
+                        id: 'outside-view',
+                        toolName: 'view',
+                        args: { path: 'README.md' },
+                        result: 'outside',
+                        status: 'completed',
+                    },
+                ],
+            },
+        ];
+        const [, assistantTurn] = buildSubAgentTurns(sourceTurns, 'task-parent');
+
+        const { container } = render(<ConversationTurnBubble turn={assistantTurn} />);
+
+        const whisper = container.querySelector('[data-testid="whisper-collapsed-group"]');
+        expect(whisper).toBeTruthy();
+        expect(whisper?.getAttribute('data-tool-count')).toBe('4');
+        expect(container.textContent).toContain('sub-agent final result');
+        expect(container.textContent).not.toContain('outside');
+    });
+
+    it('re-roots Copilot SDK sub-agent detail so direct child tools are top-level and nested sub-agents stay nested', () => {
+        mockToolCompactness = 0;
+        const sourceTurns: ClientConversationTurn[] = [
+            {
+                role: 'assistant',
+                content: '',
+                timestamp: '2026-01-15T10:30:00Z',
+                timeline: [],
+                toolCalls: [
+                    {
+                        id: 'task-parent',
+                        toolName: 'Task',
+                        args: { prompt: 'parent prompt', name: 'parent agent' },
+                        result: 'parent result',
+                        status: 'completed',
+                    },
+                    {
+                        id: 'direct-view',
+                        toolName: 'view',
+                        args: { path: 'direct.ts' },
+                        result: 'direct result',
+                        status: 'completed',
+                        parentToolCallId: 'task-parent',
+                    },
+                    {
+                        id: 'nested-task',
+                        toolName: 'Task',
+                        args: { prompt: 'nested prompt', name: 'nested agent' },
+                        result: 'nested result',
+                        status: 'completed',
+                        parentToolCallId: 'task-parent',
+                    },
+                    {
+                        id: 'nested-child',
+                        toolName: 'view',
+                        args: { path: 'nested.ts' },
+                        result: 'nested child result',
+                        status: 'completed',
+                        parentToolCallId: 'nested-task',
+                    },
+                ],
+            },
+        ];
+        const [, assistantTurn] = buildSubAgentTurns(sourceTurns, 'task-parent');
+
+        const { container } = render(<ConversationTurnBubble turn={assistantTurn} />);
+
+        const direct = container.querySelector('[data-tool-id="direct-view"]');
+        const nestedTask = container.querySelector('[data-tool-id="nested-task"]');
+        const nestedChild = container.querySelector('[data-tool-id="nested-task"] [data-tool-id="nested-child"]');
+        expect(direct).toBeTruthy();
+        expect(nestedTask).toBeTruthy();
+        expect(nestedChild).toBeTruthy();
+        expect(direct?.closest('[data-tool-id="nested-task"]')).toBeNull();
     });
 
     it('does not render WhisperCollapsedGroup when toolCompactness === 2', () => {


### PR DESCRIPTION
Preserve terminal parent tool-call metadata for Copilot SDK runs and build fallback child chunk maps after persisted toolCalls are materialized. Add regression coverage for sub-agent drill-in whisper rendering and nested sub-agent re-rooting.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
