### PR TITLE
fix(coc): reduce send completion timeout to 3s for faster button re-enabling

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useSendMessage.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useSendMessage.ts
@@ -162,12 +162,14 @@ export function useSendMessage({
         }
         return new Promise<void>(resolve => {
             resolveCurrentSendRef.current = resolve;
+            // Fallback timeout: 3s for follow-up completion.
+            // If main SSE is blocked/missed, this ensures send re-enables promptly.
             const timeout = setTimeout(() => {
                 if (resolveCurrentSendRef.current === resolve) {
                     resolveCurrentSendRef.current = null;
                     resolve();
                 }
-            }, 90_000);
+            }, 3_000);
             const origResolve = resolve;
             resolveCurrentSendRef.current = () => {
                 clearTimeout(timeout);


### PR DESCRIPTION
When the main SSE stream is blocked or missed, the send button can remain disabled for up to 90 seconds. Reducing the timeout to 3 seconds allows the send button to be re-enabled promptly when the follow-up message completes, even if the main SSE 'done' event is never received.

Co-Authored-By: Claude <noreply@anthropic.com>
