### PR TITLE
pr/bd8f63537 featchat add new chat button to collapse

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -34,6 +34,7 @@ import { useChatSSE } from './hooks/useChatSSE';
 import type { RalphGrillPlanningProgress, CanvasUpdatedEvent } from './hooks/useChatSSE';
 import { CanvasPanel } from '../canvas/CanvasPanel';
 import { SourceCanvasDock, useSourceCanvasState, useSourceCanvasContent, useSourceCanvasDirectory } from './source-canvas';
+import { readCanvasClosed, writeCanvasClosed } from './canvasClosedPreference';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { hydrateAskUserBatch } from './hooks/hydrateAskUserBatch';
 import { useSendMessage } from './hooks/useSendMessage';
@@ -287,6 +288,10 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const scratchpadEnabled = useScratchpadEnabled() && !disableScratchpad;
     const { scratchpadLayout } = useDisplaySettings();
     const bareTaskId = isQueueProcessId(taskId) ? toTaskId(taskId) : taskId;
+    // Conversation identity used to key the agent-canvas "closed" preference in
+    // localStorage — the same `processId ?? bareTaskId` the canvas discovery
+    // effect uses, so the persisted flag is read/written under one identity.
+    const canvasPid = processId ?? bareTaskId;
     const scratchpad = useScratchpadState(scratchpadContainerRef, scratchpadLayout, bareTaskId);
     const workspaceRootPath = useMemo(() => {
         const workspace = appState.workspaces.find((ws: any) => ws.id === workspaceId);
@@ -1031,7 +1036,10 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         onCanvasUpdated: (data) => {
             setActiveCanvasId(data.canvasId);
             setCanvasLiveEvent(data);
+            // A fresh AI canvas edit auto-opens the panel AND clears any
+            // persisted deliberate-close, so future switch-backs auto-open too.
             setCanvasPanelClosed(false);
+            writeCanvasClosed(workspaceId, canvasPid, false);
             sourceCanvas.close();
         },
     });
@@ -1044,19 +1052,23 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
 
     // Canvas side panel: reset on chat switch, then discover canvases linked
     // to this process (live `canvas-updated` SSE events take over from there).
+    // Note: this no longer force-opens the panel — the persisted per-chat
+    // "closed" flag is applied by the discovery effect below, so a deliberately
+    // closed canvas stays collapsed when the user switches away and back.
     useEffect(() => {
         setActiveCanvasId(null);
         setCanvasLiveEvent(null);
-        setCanvasPanelClosed(false);
         sourceCanvas.close();
     }, [taskId]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        if (!isCanvasEnabled() || !workspaceId) return;
-        const pid = processId ?? bareTaskId;
-        if (!pid) return;
+        if (!isCanvasEnabled() || !workspaceId || !canvasPid) return;
+        // Apply the persisted deliberate-close preference synchronously, before
+        // the async discovery resolves `activeCanvasId`, so a closed chat settles
+        // straight into the collapsed rail without flashing the expanded panel.
+        setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid));
         let cancelled = false;
-        client.canvases.list(workspaceId, { processId: pid })
+        client.canvases.list(workspaceId, { processId: canvasPid })
             .then(canvases => {
                 if (!cancelled && canvases.length > 0) {
                     setActiveCanvasId(prev => prev ?? canvases[0].id);
@@ -1064,7 +1076,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
             })
             .catch(() => { /* canvas discovery is best-effort */ });
         return () => { cancelled = true; };
-    }, [workspaceId, processId, bareTaskId]);
+    }, [workspaceId, canvasPid]);
 
     const canvasResize = useResizablePanel({
         initialWidth: 520,
@@ -1096,7 +1108,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 <button
                     type="button"
                     className="inline-flex items-center justify-center w-7 h-7 rounded text-[#848484] hover:text-[#1e1e1e] dark:hover:text-[#cccccc] hover:bg-[#e8e8e8] dark:hover:bg-[#2d2d2d]"
-                    onClick={() => { sourceCanvas.close(); setCanvasPanelClosed(false); }}
+                    onClick={() => { sourceCanvas.close(); setCanvasPanelClosed(false); writeCanvasClosed(workspaceId, canvasPid, false); }}
                     aria-label="Open canvas"
                     title="Open canvas"
                     data-testid="canvas-reopen"
@@ -1127,7 +1139,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     workspaceId={workspaceId}
                     canvasId={activeCanvasId}
                     liveEvent={canvasLiveEvent}
-                    onClose={() => setCanvasPanelClosed(true)}
+                    onClose={() => { setCanvasPanelClosed(true); writeCanvasClosed(workspaceId, canvasPid, true); }}
                     onFullscreenChange={setCanvasFullscreen}
                     onPopOut={handleCanvasPopOut}
                     onAskAi={(prompt) => {

--- a/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
@@ -823,6 +823,23 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         if (isMobile) setMobileShowDetail(true);
     }, [isMobile, mode, queueDispatch, selectedTaskId, workspaceId]);
 
+    const handleNewChat = useCallback(() => {
+        if (isMobile) {
+            mobileNewChatRef.current = true;
+            setMobileShowDetail(true);
+        }
+        queueDispatch({ type: 'SELECT_QUEUE_TASK', id: null, repoId: workspaceId });
+        setSelectedTask(null);
+        selectedTaskRef.current = null;
+        setSelectedRalphSessionId(null);
+        setSelectedRalphFileName(null);
+        setSelectedForEachRunId(null);
+        setSelectedMapReduceRunId(null);
+        const tabSegment = getActivityTabSegment(mode);
+        location.hash = '#repos/' + encodeURIComponent(workspaceId) + '/' + tabSegment;
+        if (isMobile) setMobileShowDetail(true);
+    }, [isMobile, mode, queueDispatch, workspaceId]);
+
     const { focusedPane, cursorTaskId } = useChatPaneNavigation({
         listContainerRef,
         detailContainerRef,
@@ -894,22 +911,7 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
             selectedMapReduceRunId={selectedMapReduceRunId}
             onSelectMapReduceRun={handleOpenMapReduceRun}
             cursorTaskId={cursorTaskId}
-            onNewChat={() => {
-                if (isMobile) {
-                    mobileNewChatRef.current = true;
-                    setMobileShowDetail(true);
-                }
-                queueDispatch({ type: 'SELECT_QUEUE_TASK', id: null, repoId: workspaceId });
-                setSelectedTask(null);
-                selectedTaskRef.current = null;
-                setSelectedRalphSessionId(null);
-                setSelectedRalphFileName(null);
-                setSelectedForEachRunId(null);
-                setSelectedMapReduceRunId(null);
-                const tabSegment = getActivityTabSegment(mode);
-                location.hash = '#repos/' + encodeURIComponent(workspaceId) + '/' + tabSegment;
-                if (isMobile) setMobileShowDetail(true);
-            }}
+            onNewChat={handleNewChat}
         />
     );
 
@@ -1017,6 +1019,18 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
                     <button
                         type="button"
                         className="w-7 h-7 flex items-center justify-center rounded text-[#848484] hover:bg-[#e8e8e8] dark:hover:bg-[#2d2d2d]"
+                        onClick={handleNewChat}
+                        aria-label="Start a new conversation"
+                        title="Start a new conversation"
+                        data-testid="activity-list-collapsed-new-chat"
+                    >
+                        <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden="true">
+                            <path d="M7 2v10M2 7h10" />
+                        </svg>
+                    </button>
+                    <button
+                        type="button"
+                        className="mt-1 w-7 h-7 flex items-center justify-center rounded text-[#848484] hover:bg-[#e8e8e8] dark:hover:bg-[#2d2d2d]"
                         onClick={() => toggleListCollapsed(false)}
                         aria-label="Show chat list"
                         title="Show chat list"

--- a/packages/coc/src/server/spa/client/react/features/chat/canvasClosedPreference.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/canvasClosedPreference.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-conversation persistence for the agent canvas "closed" state.
+ *
+ * When a user deliberately closes the agent canvas in a chat, we remember that
+ * choice in `localStorage` so switching away and back — or reloading the page —
+ * keeps the panel collapsed (showing the reopen rail) instead of auto-expanding.
+ * Storage stays sparse: only deliberately-closed conversations keep a key, and
+ * reopening (or a fresh AI canvas edit) removes it.
+ *
+ * Key shape mirrors the existing per-workspace width key
+ * `coc.canvasPanel.width.<workspaceId>`:
+ *
+ *     coc.canvasPanel.closed.<workspaceId>.<pid>
+ *
+ * where `pid = processId ?? bareTaskId` — the same conversation identity the
+ * canvas discovery effect uses. All access is wrapped in try/catch so
+ * SSR / test / quota-exceeded environments never throw.
+ */
+
+const CANVAS_CLOSED_KEY_PREFIX = 'coc.canvasPanel.closed';
+
+/**
+ * Build the per-conversation storage key, or `null` when either identity is
+ * missing (in which case there is nothing to persist).
+ */
+export function canvasClosedStorageKey(
+    workspaceId: string | null | undefined,
+    pid: string | null | undefined,
+): string | null {
+    if (!workspaceId || !pid) {
+        return null;
+    }
+    return `${CANVAS_CLOSED_KEY_PREFIX}.${encodeURIComponent(workspaceId)}.${encodeURIComponent(pid)}`;
+}
+
+/**
+ * Returns `true` when the user has deliberately closed the canvas for this
+ * conversation (the key exists). Defaults to `false` (auto-open) when no key is
+ * present or storage is unavailable.
+ */
+export function readCanvasClosed(
+    workspaceId: string | null | undefined,
+    pid: string | null | undefined,
+): boolean {
+    const key = canvasClosedStorageKey(workspaceId, pid);
+    if (!key) {
+        return false;
+    }
+    try {
+        return localStorage.getItem(key) !== null;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Persist (`closed === true`) or clear (`closed === false`) the deliberate-close
+ * flag for this conversation. Clearing removes the key so storage stays sparse.
+ */
+export function writeCanvasClosed(
+    workspaceId: string | null | undefined,
+    pid: string | null | undefined,
+    closed: boolean,
+): void {
+    const key = canvasClosedStorageKey(workspaceId, pid);
+    if (!key) {
+        return;
+    }
+    try {
+        if (closed) {
+            localStorage.setItem(key, '1');
+        } else {
+            localStorage.removeItem(key);
+        }
+    } catch {
+        /* ignore SSR / quota-exceeded / disabled-storage errors */
+    }
+}

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-closed.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-closed.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment node
+ *
+ * Source-level regression guard for the persisted per-chat agent-canvas
+ * "closed" state (AC-02). Runs in node (no localStorage), so it asserts on the
+ * ChatDetail source text rather than behaviour — the jsdom integration test in
+ * `test/spa/react/repos/ChatDetailCanvasClosed.test.tsx` covers the runtime flow.
+ *
+ * Invariants guarded here:
+ *  - The persistence helper is imported and keyed off `canvasPid`.
+ *  - A deliberate close (CanvasPanel `onClose`) persists "closed".
+ *  - The collapsed-rail reopen and a fresh AI canvas edit clear the flag.
+ *  - The discovery effect reads the persisted flag into `canvasPanelClosed`.
+ *  - The `taskId`-keyed reset effect no longer force-opens the panel.
+ *  - The transient source-canvas mutual-exclusion collapse does NOT persist.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const src = readFileSync(
+    resolve(__dirname, '../../../../../src/server/spa/client/react/features/chat/ChatDetail.tsx'),
+    'utf-8',
+);
+
+/** Slice the source between `start` (inclusive) and the first `end` after it. */
+function block(start: string, end: string): string {
+    const i = src.indexOf(start);
+    expect(i, `expected to find "${start}" in ChatDetail.tsx`).toBeGreaterThan(-1);
+    const j = src.indexOf(end, i);
+    expect(j, `expected to find "${end}" after "${start}"`).toBeGreaterThan(-1);
+    return src.slice(i, j + end.length);
+}
+
+describe('ChatDetail — persisted canvas closed wiring', () => {
+    it('imports the persistence helper', () => {
+        expect(src).toContain("from './canvasClosedPreference'");
+        expect(src).toContain('readCanvasClosed');
+        expect(src).toContain('writeCanvasClosed');
+    });
+
+    it('derives a single canvasPid identity (processId ?? bareTaskId)', () => {
+        expect(src).toContain('const canvasPid = processId ?? bareTaskId');
+    });
+
+    it('persists "closed" on the deliberate CanvasPanel close', () => {
+        expect(src).toContain('writeCanvasClosed(workspaceId, canvasPid, true)');
+    });
+
+    it('clears the flag on collapsed-rail reopen and on a fresh AI canvas edit', () => {
+        const clears = src.split('writeCanvasClosed(workspaceId, canvasPid, false)').length - 1;
+        // One in the reopen-rail onClick, one in onCanvasUpdated.
+        expect(clears).toBeGreaterThanOrEqual(2);
+    });
+
+    it('reads the persisted flag in the canvas discovery effect', () => {
+        expect(src).toContain('setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid))');
+    });
+
+    it('the taskId-keyed reset effect no longer force-opens the panel', () => {
+        const resetEffect = block('setActiveCanvasId(null);', '[taskId]); // eslint-disable-line');
+        expect(resetEffect).not.toContain('setCanvasPanelClosed');
+    });
+
+    it('the source-canvas onOpen collapse is transient (does NOT persist)', () => {
+        const onOpen = block('const sourceCanvas = useSourceCanvasState({', '});');
+        expect(onOpen).toContain('setCanvasPanelClosed(true)');
+        expect(onOpen).not.toContain('writeCanvasClosed');
+    });
+});

--- a/packages/coc/test/spa/react/repos/ChatDetailCanvasClosed.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetailCanvasClosed.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * Integration tests for the persisted per-chat agent-canvas "closed" state.
+ *
+ * These exercise the AC-02 wiring in ChatDetail: a deliberate close persists to
+ * localStorage (keyed per conversation), switching away and back keeps a closed
+ * canvas collapsed, reopening / a fresh AI canvas edit clears the flag, and the
+ * transient source-canvas mutual-exclusion collapse does NOT persist.
+ *
+ * Canvas rendering is enabled here (the main ChatDetail.test.tsx disables it),
+ * so this lives in its own file with its own mock set: a stubbed CanvasPanel, a
+ * controllable source-canvas hook, a captured `onCanvasUpdated` SSE callback,
+ * and a fetch handler that serves `client.canvases.list` per conversation pid.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import React, { useEffect, type ReactNode } from 'react';
+import { AppProvider } from '../../../../src/server/spa/client/react/contexts/AppContext';
+import { QueueProvider } from '../../../../src/server/spa/client/react/contexts/QueueContext';
+import { ToastProvider } from '../../../../src/server/spa/client/react/contexts/ToastContext';
+import { NotificationProvider } from '../../../../src/server/spa/client/react/contexts/NotificationContext';
+import { TaskProvider } from '../../../../src/server/spa/client/react/contexts/TaskContext';
+import {
+    canvasClosedStorageKey,
+    readCanvasClosed,
+} from '../../../../src/server/spa/client/react/features/chat/canvasClosedPreference';
+import { toQueueProcessId } from '../../../../src/server/spa/client/react/utils/queue-process-id';
+
+// ── Hoisted mock state ──────────────────────────────────────────────────────
+
+const { mockState } = vi.hoisted(() => ({
+    mockState: {
+        sendFollowUp: vi.fn().mockResolvedValue(undefined),
+        closeFollowUpStream: vi.fn(),
+        onSendComplete: vi.fn(),
+        stopStreaming: vi.fn(),
+        handlePopOut: vi.fn(),
+        handleFloat: vi.fn(),
+        getDraft: vi.fn().mockReturnValue(null) as ReturnType<typeof vi.fn>,
+        setDraft: vi.fn(),
+        pruneExpired: vi.fn(),
+        clearDraft: vi.fn(),
+        clearAskUserDraftsForProcess: vi.fn(),
+        addFromPaste: vi.fn(),
+        removeAttachment: vi.fn(),
+        clearAttachments: vi.fn(),
+        richTextValue: '',
+        richTextSetValueCalls: [] as Array<[string, number?]>,
+        // Captured SSE options so a test can fire onCanvasUpdated.
+        sseOpts: null as any,
+        // Per-pid canvas descriptors served by the fetch handler for
+        // `client.canvases.list`.
+        canvasesByPid: {} as Record<string, Array<{ id: string }>>,
+    },
+}));
+
+// ── Module mocks (hoisted before imports) ──────────────────────────────────
+
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
+    getApiBase: () => '/api',
+    getWsPath: () => '/ws',
+    getWsUrl: () => 'ws://localhost/ws',
+    isRalphEnabled: () => true,
+    isRalphMultiAgentGrillEnabled: () => false,
+    isLoopsEnabled: () => false,
+    isForEachEnabled: () => false,
+    getDefaultProvider: () => 'copilot' as const,
+    getActiveProvider: () => 'copilot' as const,
+    isEffortLevelsEnabled: () => false,
+    isSessionContextAttachmentsEnabled: () => false,
+    getPrewarmDebounceMs: () => 500,
+    getWarmClientTtlMs: () => 300000,
+    isCanvasEnabled: () => true,
+    isRemoteShellEnabled: () => false,
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({
+    useDisplaySettings: () => ({ showReportIntent: false, toolCompactness: 0, taskCardDensity: 'compact', groupSingleLineMessages: false }),
+    invalidateDisplaySettings: vi.fn(),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/ChatPreferencesContext', () => ({
+    ChatPrefsSync: () => null,
+    useChatPrefs: () => ({
+        archivedChatIds: new Set<string>(),
+        pinnedChatIds: new Set<string>(),
+        pinChat: vi.fn(),
+        unpinChat: vi.fn(),
+        archiveChat: vi.fn(),
+        unarchiveChat: vi.fn(),
+        archiveChats: vi.fn(),
+        unarchiveChats: vi.fn(),
+        loaded: true,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/PopOutContext', () => ({
+    usePopOut: () => ({
+        poppedOutTasks: new Set<string>(),
+        markPoppedOut: vi.fn(),
+        markRestored: vi.fn(),
+        postMessage: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/FloatingChatsContext', () => ({
+    useFloatingChats: () => ({
+        floatingChats: new Map(),
+        floatChat: vi.fn(),
+        unfloatChat: vi.fn(),
+        isFloating: () => false,
+    }),
+}));
+
+// useChatSSE — capture the options object so tests can fire onCanvasUpdated.
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useChatSSE', () => ({
+    useChatSSE: (opts: any) => {
+        mockState.sseOpts = opts;
+        return { stopStreaming: mockState.stopStreaming };
+    },
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useSendMessage', () => ({
+    useSendMessage: (opts: any) => {
+        (globalThis as any).__useSendMessage_opts = opts;
+        return {
+            sendFollowUp: mockState.sendFollowUp,
+            closeFollowUpStream: mockState.closeFollowUpStream,
+            onSendComplete: mockState.onSendComplete,
+        };
+    },
+}));
+
+vi.mock('../../../../src/server/spa/client/react/queue/hooks/useQueuedTaskPoll', () => ({
+    useQueuedTaskPoll: () => {},
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useChatWindowActions', () => ({
+    useChatWindowActions: () => ({
+        handlePopOut: mockState.handlePopOut,
+        handleFloat: mockState.handleFloat,
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useFileAttachments', () => ({
+    useFileAttachments: () => ({
+        attachments: [],
+        images: [],
+        addFromPaste: mockState.addFromPaste,
+        addFromFileInput: vi.fn(),
+        removeAttachment: mockState.removeAttachment,
+        clearAttachments: mockState.clearAttachments,
+        error: null,
+        clearError: vi.fn(),
+        toPayload: () => [],
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
+    useBreakpoint: () => ({ isMobile: false, isTablet: false, isDesktop: true, breakpoint: 'desktop' as const }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/useModels', () => ({
+    useModels: () => ({ models: [], loading: false, error: null, reload: vi.fn() }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/hooks/useProviderEffortTiers', () => ({
+    useProviderEffortTiers: () => ({
+        tiers: {},
+        loading: false,
+        error: null,
+        saveError: null,
+        saving: false,
+        dirty: false,
+        setTier: vi.fn(),
+        clearTier: vi.fn(),
+        save: vi.fn(),
+        cancel: vi.fn(),
+        reload: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useContainerWidth', () => ({
+    useContainerWidth: () => ({ width: 800, tier: 'wide', isWide: true, isMedium: false, isNarrow: false }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useDraftStore', () => ({
+    getDraft: (...args: any[]) => mockState.getDraft(...args),
+    setDraft: (...args: any[]) => mockState.setDraft(...args),
+    clearDraft: (...args: any[]) => mockState.clearDraft(...args),
+    pruneExpired: () => mockState.pruneExpired(),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useAskUserDraftStore', () => ({
+    getAskUserDraft: () => null,
+    setAskUserDraft: vi.fn(),
+    clearAskUserDraft: vi.fn(),
+    clearOtherAskUserDraftsForProcess: vi.fn(),
+    pruneExpiredAskUserDrafts: vi.fn(),
+    clearAskUserDraftsForProcess: (...args: any[]) => mockState.clearAskUserDraftsForProcess(...args),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useSlashCommands', () => ({
+    useSlashCommands: () => ({
+        menuVisible: false,
+        menuFilter: '',
+        filteredSkills: [],
+        highlightIndex: 0,
+        handleInputChange: vi.fn(),
+        handleKeyDown: vi.fn(() => false),
+        selectSkill: vi.fn(),
+        parseAndExtract: vi.fn((t: string) => ({ skills: [], prompt: t })),
+        dismissMenu: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/shared/RichTextInput', async () => {
+    const R = await import('react');
+    return {
+        RichTextInput: R.forwardRef((props: any, ref: any) => {
+            R.useImperativeHandle(ref, () => ({
+                getValue: () => mockState.richTextValue,
+                setValue: (text: string, cursorPos?: number) => {
+                    mockState.richTextSetValueCalls.push([text, cursorPos]);
+                    mockState.richTextValue = text;
+                },
+                focus: () => {},
+            }), []);
+            return R.createElement('div', {
+                'data-testid': props['data-testid'] ?? 'activity-chat-input',
+                contentEditable: !props.disabled,
+                onKeyDown: props.onKeyDown,
+                onInput: (e: any) => props.onChange?.(e.currentTarget?.textContent ?? ''),
+                onPaste: props.onPaste,
+            });
+        }),
+    };
+});
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/conversation/ConversationMiniMap', () => ({
+    ConversationMiniMap: () => React.createElement('div', { 'data-testid': 'conversation-minimap' }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble', () => ({
+    ConversationTurnBubble: (props: any) => React.createElement('div', {
+        'data-testid': `turn-${props.turn?.role}`,
+    }, props.turn?.content ?? ''),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/QueuedBubble', () => ({
+    QueuedBubble: (props: any) => React.createElement('div', { 'data-testid': 'queued-bubble' }, props.msg?.content ?? ''),
+    QueuedFollowUps: (props: any) =>
+        React.createElement('div', { 'data-testid': 'queued-followups', 'data-count': props.queue?.length ?? 0 }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/BackgroundTasksIndicator', () => ({
+    BackgroundTasksIndicator: () => React.createElement('div', { 'data-testid': 'bg-tasks-indicator' }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/queue/PendingTaskInfoPanel', () => ({
+    PendingTaskInfoPanel: () => React.createElement('div', { 'data-testid': 'pending-task-info-panel' }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/chat/conversation/ConversationMetadataPopover', () => ({
+    getSessionIdFromProcess: (proc: any) => proc?.sdkSessionId ?? proc?.sessionId ?? proc?.metadata?.sessionId ?? null,
+    ConversationMetadataPopover: () => React.createElement('div', { 'data-testid': 'metadata-popover' }),
+}));
+
+// CanvasPanel — stub exposing the close affordance the persistence wiring calls.
+vi.mock('../../../../src/server/spa/client/react/features/canvas/CanvasPanel', () => ({
+    CanvasPanel: (props: any) => React.createElement('div', { 'data-testid': 'canvas-panel-mock' },
+        React.createElement('button', { 'data-testid': 'canvas-close', onClick: props.onClose }, 'Close'),
+    ),
+}));
+
+// source-canvas — controllable hook so a test can open the docked source canvas
+// (which collapses the agent canvas transiently) without rendering the real dock.
+vi.mock('../../../../src/server/spa/client/react/features/chat/source-canvas', async () => {
+    const R = await import('react');
+    return {
+        SourceCanvasDock: () => R.createElement('div', { 'data-testid': 'source-canvas-dock' }),
+        useSourceCanvasState: (opts: any) => {
+            const [fileRef, setFileRef] = R.useState<any>(null);
+            const onOpenRef = R.useRef(opts?.onOpen);
+            onOpenRef.current = opts?.onOpen;
+            const open = R.useCallback((ref: any) => {
+                onOpenRef.current?.();
+                setFileRef(ref ?? { fullPath: '/x.ts', kind: 'code' });
+            }, []);
+            const close = R.useCallback(() => setFileRef(null), []);
+            return { open, close, isOpen: !!fileRef, fileRef };
+        },
+        useSourceCanvasContent: () => null,
+        useSourceCanvasDirectory: () => null,
+    };
+});
+
+// Now import the component under test (after mocks)
+import { ChatDetail } from '../../../../src/server/spa/client/react/features/chat/ChatDetail';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const WS_ID = 'ws-1';
+
+function Wrap({ children }: { children: ReactNode }) {
+    return (
+        <AppProvider>
+            <QueueProvider>
+                <NotificationProvider>
+                    <TaskProvider>
+                        <ToastProvider value={{ addToast: vi.fn(), removeToast: vi.fn(), toasts: [] }}>
+                            {children}
+                        </ToastProvider>
+                    </TaskProvider>
+                </NotificationProvider>
+            </QueueProvider>
+        </AppProvider>
+    );
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: any): Response {
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    mockState.canvasesByPid = {};
+    mockState.sseOpts = null;
+    fetchMock = vi.fn(async (url: string) => {
+        const urlStr = typeof url === 'string' ? url : '';
+        if (urlStr.includes('/canvases')) {
+            const pid = new URL(urlStr, 'http://x').searchParams.get('processId') ?? '';
+            return jsonResponse({ canvases: mockState.canvasesByPid[pid] ?? [] });
+        }
+        if (urlStr.includes('/skills/all')) {
+            return jsonResponse({ merged: [] });
+        }
+        return jsonResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    Element.prototype.scrollIntoView = vi.fn();
+    mockState.sendFollowUp.mockReset().mockResolvedValue(undefined);
+    mockState.stopStreaming.mockReset();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).__useSendMessage_opts;
+});
+
+/** The conversation identity ChatDetail keys the canvas off of (task unloaded). */
+function pidFor(taskId: string): string {
+    return toQueueProcessId(taskId);
+}
+
+function renderChat(taskId: string) {
+    return render(<Wrap><ChatDetail taskId={taskId} workspaceId={WS_ID} /></Wrap>);
+}
+
+function rerenderChat(rerender: (ui: React.ReactElement) => void, taskId: string) {
+    rerender(<Wrap><ChatDetail taskId={taskId} workspaceId={WS_ID} /></Wrap>);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('ChatDetail — persisted canvas closed state (AC-02)', () => {
+    it('auto-opens a chat canvas on first visit', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        expect(screen.queryByTestId('canvas-collapsed-rail')).toBeNull();
+    });
+
+    it('(a) keeps a deliberately-closed canvas collapsed after switching away and back', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        // Deliberate close → collapsed rail + persisted flag.
+        fireEvent.click(screen.getByTestId('canvas-close'));
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(true);
+
+        // Switch to B, then back to A.
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+        rerenderChat(rerender, 'task-A');
+
+        // A settles into the collapsed rail — NOT the expanded panel.
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(screen.queryByTestId('canvas-panel-mock')).toBeNull();
+    });
+
+    it('(b) reopening clears persistence and auto-opens on the next switch-back', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('canvas-close'));
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(localStorage.getItem(canvasClosedStorageKey(WS_ID, pidFor('task-A'))!)).not.toBeNull();
+
+        // Reopen via the collapsed-rail « button.
+        fireEvent.click(screen.getByTestId('canvas-reopen'));
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(false);
+
+        // Switch away and back — now auto-opens.
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+        rerenderChat(rerender, 'task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        expect(screen.queryByTestId('canvas-collapsed-rail')).toBeNull();
+    });
+
+    it('(c) a fresh AI canvas edit auto-opens a closed chat and clears persistence', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('canvas-close'));
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(true);
+
+        // SSE delivers an AI canvas update for this chat.
+        act(() => {
+            mockState.sseOpts.onCanvasUpdated({ canvasId: 'canvas-A', title: 'A', revision: 2, editor: 'ai' });
+        });
+
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        expect(screen.queryByTestId('canvas-collapsed-rail')).toBeNull();
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(false);
+    });
+
+    it('(d) opening a source-file canvas collapses the agent canvas WITHOUT persisting closed', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        // Open the docked source-file canvas — mutual exclusion collapses the
+        // agent canvas, but this is transient and must NOT persist.
+        act(() => {
+            window.dispatchEvent(new CustomEvent('coc-open-source-canvas', { detail: { filePath: '/x.ts' } }));
+        });
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(false);
+
+        // Switch away and back — the agent canvas auto-opens again (no persisted close).
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+        rerenderChat(rerender, 'task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+    });
+
+    it('keeps a closed chat collapsed across a full reload (fresh mount)', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        const first = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        fireEvent.click(screen.getByTestId('canvas-close'));
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        first.unmount();
+
+        // Fresh mount (simulated reload) reads the persisted flag → stays collapsed.
+        renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(screen.queryByTestId('canvas-panel-mock')).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/repos/RepoChatTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoChatTab.test.tsx
@@ -1995,4 +1995,27 @@ describe('RepoChatTab: hover-to-float peek (collapsed rail)', () => {
         expect(screen.queryByTestId('activity-list-collapsed')).toBeNull();
         expect(screen.queryByTestId('activity-list-peek')).toBeNull();
     });
+
+    it('collapsed rail shows a + button that starts a new chat without expanding the rail', async () => {
+        setupFetchMock();
+        await renderTab();
+
+        // The + button is present in the collapsed rail.
+        const newChatBtn = screen.getByTestId('activity-list-collapsed-new-chat');
+        expect(newChatBtn).toBeTruthy();
+        expect(newChatBtn.getAttribute('aria-label')).toBe('Start a new conversation');
+
+        // Clicking it starts a new chat (the mock list pane's onNewChat fires, which
+        // the mock surfaces as a click on 'new-chat-btn').
+        // We trigger the button on the rail directly.
+        await act(async () => {
+            fireEvent.click(newChatBtn);
+        });
+
+        // The rail must NOT expand — listCollapsed stays true.
+        expect(screen.getByTestId('activity-list-collapsed')).toBeTruthy();
+        expect(screen.queryByTestId('activity-list-panel')).toBeNull();
+        // localStorage persisted state is unchanged (still collapsed).
+        expect(localStorage.getItem('activity-list-collapsed')).toBe('true');
+    });
 });

--- a/packages/coc/test/spa/react/repos/canvasClosedPreference.test.ts
+++ b/packages/coc/test/spa/react/repos/canvasClosedPreference.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the per-conversation agent-canvas "closed" persistence helper.
+ *
+ * Covers AC-01: a deliberately-closed canvas is remembered in localStorage,
+ * keyed per conversation, with sparse storage (only closed chats keep a key)
+ * and guarded access that never throws.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    canvasClosedStorageKey,
+    readCanvasClosed,
+    writeCanvasClosed,
+} from '../../../../src/server/spa/client/react/features/chat/canvasClosedPreference';
+
+describe('canvasClosedPreference', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+    afterEach(() => {
+        localStorage.clear();
+        vi.restoreAllMocks();
+    });
+
+    describe('canvasClosedStorageKey', () => {
+        it('mirrors the per-workspace width key shape, scoped per conversation', () => {
+            expect(canvasClosedStorageKey('ws-1', 'proc-9')).toBe(
+                'coc.canvasPanel.closed.ws-1.proc-9',
+            );
+        });
+
+        it('encodes workspace and pid components', () => {
+            expect(canvasClosedStorageKey('ws/a b', 'p.c#1')).toBe(
+                `coc.canvasPanel.closed.${encodeURIComponent('ws/a b')}.${encodeURIComponent('p.c#1')}`,
+            );
+        });
+
+        it('returns null when either identity is missing', () => {
+            expect(canvasClosedStorageKey(null, 'p')).toBeNull();
+            expect(canvasClosedStorageKey('ws', null)).toBeNull();
+            expect(canvasClosedStorageKey('', 'p')).toBeNull();
+            expect(canvasClosedStorageKey('ws', '')).toBeNull();
+            expect(canvasClosedStorageKey(undefined, undefined)).toBeNull();
+        });
+    });
+
+    describe('read/write round-trip', () => {
+        it('defaults to open (false) when nothing is persisted', () => {
+            expect(readCanvasClosed('ws-1', 'proc-9')).toBe(false);
+        });
+
+        it('persists a deliberate close and reads it back as closed', () => {
+            writeCanvasClosed('ws-1', 'proc-9', true);
+            expect(localStorage.getItem('coc.canvasPanel.closed.ws-1.proc-9')).not.toBeNull();
+            expect(readCanvasClosed('ws-1', 'proc-9')).toBe(true);
+        });
+
+        it('clears the flag on reopen and removes the key so storage stays sparse', () => {
+            writeCanvasClosed('ws-1', 'proc-9', true);
+            writeCanvasClosed('ws-1', 'proc-9', false);
+            expect(localStorage.getItem('coc.canvasPanel.closed.ws-1.proc-9')).toBeNull();
+            expect(readCanvasClosed('ws-1', 'proc-9')).toBe(false);
+        });
+
+        it('keeps the flag scoped per conversation', () => {
+            writeCanvasClosed('ws-1', 'proc-A', true);
+            expect(readCanvasClosed('ws-1', 'proc-A')).toBe(true);
+            expect(readCanvasClosed('ws-1', 'proc-B')).toBe(false);
+            expect(readCanvasClosed('ws-2', 'proc-A')).toBe(false);
+        });
+
+        it('survives a simulated reload (value remains in storage across reads)', () => {
+            writeCanvasClosed('ws-1', 'proc-9', true);
+            // No clear() — emulates a page reload reading the same backing store.
+            expect(readCanvasClosed('ws-1', 'proc-9')).toBe(true);
+        });
+    });
+
+    describe('no-op when identity is missing', () => {
+        it('write does nothing without workspace or pid', () => {
+            writeCanvasClosed(null, 'p', true);
+            writeCanvasClosed('ws', null, true);
+            expect(localStorage.length).toBe(0);
+        });
+
+        it('read returns false without workspace or pid', () => {
+            expect(readCanvasClosed(null, 'p')).toBe(false);
+            expect(readCanvasClosed('ws', null)).toBe(false);
+        });
+    });
+
+    describe('guarded access', () => {
+        it('read swallows storage errors and defaults to false', () => {
+            vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+                throw new Error('storage disabled');
+            });
+            expect(() => readCanvasClosed('ws-1', 'proc-9')).not.toThrow();
+            expect(readCanvasClosed('ws-1', 'proc-9')).toBe(false);
+        });
+
+        it('write swallows quota-exceeded errors', () => {
+            vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new Error('QuotaExceededError');
+            });
+            expect(() => writeCanvasClosed('ws-1', 'proc-9', true)).not.toThrow();
+        });
+
+        it('write swallows removeItem errors on clear', () => {
+            vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+                throw new Error('storage disabled');
+            });
+            expect(() => writeCanvasClosed('ws-1', 'proc-9', false)).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
- **feat(chat): add + new chat button to collapsed rail**
- **feat(coc/chat): add per-conversation canvas-closed localStorage helper (AC-01)**
- **feat(coc/chat): persist per-chat canvas closed state in ChatDetail (AC-02)**
