### PR TITLE
feat(coc): add create_conversation LLM tool to spawn new conversations

### DIFF
--- a/packages/coc/src/server/executors/autopilot-executor.ts
+++ b/packages/coc/src/server/executors/autopilot-executor.ts
@@ -69,6 +69,7 @@ export class AutopilotExecutor extends ChatBaseExecutor {
             broadcastWorkItem: this.getWsServerFn
                 ? (event) => this.getWsServerFn!()?.broadcastProcessEvent(event as any)
                 : undefined,
+            enqueueChat: this.getEnqueueChat?.(),
             scheduleWakeup: loopDeps.scheduleWakeup,
             loopTools: loopDeps.loopTools,
             includeMemoryV2: false,

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -165,6 +165,13 @@ export interface ChatModeExecutorOptions {
     resolveWorkspaceIdForPath: (rootPath: string) => Promise<string>;
     /** Late-bound loop infrastructure (getter because loop infra is created after executor registry). */
     getLoopInfra?: () => LoopInfraDeps | undefined;
+    /**
+     * Late-bound in-process enqueue capability (getter because the bound callback
+     * is constructed at the route layer — where the queue router + global state
+     * live — after the executor registry is created). Powers the opt-in
+     * `create_conversation` tool; absent → the tool is not offered.
+     */
+    getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
     /** Late-bound MCP OAuth manager (getter to allow optional/feature-flagged wiring). */
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     /** Active AI provider. Used to detect provider mismatches on follow-up resume. */
@@ -236,6 +243,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
     protected readonly resolveSkillConfigFn: (wsId: string | undefined, workDir?: string) => Promise<{ skillDirectories?: string[]; disabledSkills?: string[] }>;
     protected readonly resolveWorkspaceIdForPathFn: (rootPath: string) => Promise<string>;
     protected readonly getLoopInfra?: () => LoopInfraDeps | undefined;
+    protected readonly getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
     protected readonly getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     /** Active AI provider — used to guard against provider mismatches on follow-up resume. */
     protected readonly provider: 'copilot' | 'codex' | 'claude';
@@ -263,6 +271,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
         this.resolveSkillConfigFn = options.resolveSkillConfig;
         this.resolveWorkspaceIdForPathFn = options.resolveWorkspaceIdForPath;
         this.getLoopInfra = options.getLoopInfra;
+        this.getEnqueueChat = options.getEnqueueChat;
         this.getMcpOauthManager = options.getMcpOauthManager;
         this.provider = options.provider ?? 'copilot';
         this.ralphMultiAgentGrillEnabled = options.ralphMultiAgentGrillEnabled === true;
@@ -470,6 +479,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
             query: prompt,
             followUpSuggestions: this.followUpSuggestions,
             broadcastWorkItem,
+            enqueueChat: this.getEnqueueChat?.(),
             scheduleWakeup: loopDeps.scheduleWakeup,
             loopTools: loopDeps.loopTools,
             askUser: {

--- a/packages/coc/src/server/executors/chat-tool-builder.ts
+++ b/packages/coc/src/server/executors/chat-tool-builder.ts
@@ -1,6 +1,7 @@
 import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import type { Tool } from '@plusplusoneplusplus/coc-agent-sdk';
 import type { BroadcastWorkItemFn } from '../llm-tools/create-update-work-item-tool';
+import type { EnqueueChatFn } from '../llm-tools/create-conversation-tool';
 import type { AskUserToolDeps } from '../llm-tools/ask-user-tool';
 import type { WakeupToolDeps, LoopToolDeps } from '../llm-tools/loop-tools';
 import { DEFAULT_DISABLED_LLM_TOOLS } from '../llm-tools/llm-tool-registry';
@@ -10,6 +11,7 @@ import {
     applyLlmToolPreferences,
     buildAskUserAddon,
     buildCanvasToolsAddon,
+    buildCreateConversationAddon,
     buildCreateWorkItemAddon,
     buildExcalidrawToolsAddon,
     buildFollowUpSuggestionsAddon,
@@ -26,6 +28,12 @@ export interface ChatToolBundleOptions {
     dataDir?: string;
     store: ProcessStore;
     workspaceId?: string;
+    /**
+     * Bound in-process enqueue capability. When present (and the tool is enabled
+     * by preferences), the opt-in `create_conversation` tool is included so an
+     * agent can spawn a brand-new chat. Absent → the addon no-ops.
+     */
+    enqueueChat?: EnqueueChatFn;
     processId?: string;
     followUpSuggestions?: { enabled: boolean; count: number };
     askUser?: {
@@ -86,6 +94,14 @@ export function buildChatToolBundle(options: ChatToolBundleOptions): ChatToolBun
             options.store,
             options.workspaceId,
             options.processId,
+        ));
+    }
+
+    if (options.enqueueChat) {
+        addons.push(buildCreateConversationAddon(
+            options.store,
+            options.workspaceId,
+            options.enqueueChat,
         ));
     }
 

--- a/packages/coc/src/server/executors/chat-turn-context-builder.ts
+++ b/packages/coc/src/server/executors/chat-turn-context-builder.ts
@@ -18,6 +18,7 @@
 import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import type { Tool } from '@plusplusoneplusplus/coc-agent-sdk';
 import type { BroadcastWorkItemFn } from '../llm-tools/create-update-work-item-tool';
+import type { EnqueueChatFn } from '../llm-tools/create-conversation-tool';
 import type { AskUserToolDeps } from '../llm-tools/ask-user-tool';
 import type { WakeupToolDeps, LoopToolDeps } from '../llm-tools/loop-tools';
 import type { MemoryV2Addon } from './memory-v2-addon';
@@ -41,6 +42,12 @@ export interface ChatTurnContextInput {
     query?: string;
     followUpSuggestions?: { enabled: boolean; count: number };
     broadcastWorkItem?: BroadcastWorkItemFn;
+    /**
+     * Bound in-process enqueue capability. When present (and the opt-in
+     * `create_conversation` tool is enabled by preferences), an agent can spawn a
+     * brand-new chat. Absent → the addon no-ops and the tool is not offered.
+     */
+    enqueueChat?: EnqueueChatFn;
     scheduleWakeup?: WakeupToolDeps;
     loopTools?: LoopToolDeps;
     askUser?: {
@@ -149,6 +156,7 @@ export async function buildChatTurnContext(input: ChatTurnContextInput): Promise
         processId: input.processId,
         followUpSuggestions: input.followUpSuggestions,
         broadcastWorkItem: input.broadcastWorkItem,
+        enqueueChat: input.enqueueChat,
         memoryV2: includeMemoryV2 ? memoryV2 : undefined,
         scheduleWakeup: input.scheduleWakeup,
         loopTools: input.loopTools,

--- a/packages/coc/src/server/executors/executor-registry.ts
+++ b/packages/coc/src/server/executors/executor-registry.ts
@@ -53,6 +53,8 @@ export interface ExecutorRegistryOptions {
     onTitleNeeded: (processId: string, turns: ConversationTurn[]) => void;
     getWsServer?: () => import('../streaming/websocket').ProcessWebSocketServer | undefined;
     getLoopInfra?: () => import('./chat-base-executor').LoopInfraDeps | undefined;
+    /** Late-bound in-process enqueue capability for the opt-in `create_conversation` tool. */
+    getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     getDreamRunExecutor?: () => import('../dreams/dream-runner').DreamRunExecutor | undefined;
     cancelledTasks?: Set<string>;
@@ -104,6 +106,7 @@ export class ExecutorRegistry {
             resolveSkillConfig: options.resolveSkillConfig,
             resolveWorkspaceIdForPath: options.resolveWorkspaceIdForPath,
             getLoopInfra: options.getLoopInfra,
+            getEnqueueChat: options.getEnqueueChat,
             getMcpOauthManager: options.getMcpOauthManager,
             provider: options.provider,
             ralphMultiAgentGrillEnabled: options.ralphMultiAgentGrillEnabled,

--- a/packages/coc/src/server/executors/follow-up-executor.ts
+++ b/packages/coc/src/server/executors/follow-up-executor.ts
@@ -379,6 +379,7 @@ export class FollowUpExecutor extends ChatBaseExecutor {
                 broadcastWorkItem: this.getWsServerFn
                     ? (event) => this.getWsServerFn!()?.broadcastProcessEvent(event as any)
                     : undefined,
+                enqueueChat: this.getEnqueueChat?.(),
                 scheduleWakeup: loopDeps.scheduleWakeup,
                 loopTools: loopDeps.loopTools,
                 askUser: {

--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -32,6 +32,7 @@ import type { AskUserAnswerInput, AskUserAnswerValue, AskUserToolDeps } from '..
 import { createAskUserTool } from '../llm-tools/ask-user-tool';
 import { createCanvasTools } from '../llm-tools/canvas-tools';
 import { createCreateUpdateWorkItemTool, type BroadcastWorkItemFn, type CreateUpdateWorkItemToolDeps } from '../llm-tools/create-update-work-item-tool';
+import { createCreateConversationTool, type EnqueueChatFn } from '../llm-tools/create-conversation-tool';
 import { createExcalidrawTools } from '../llm-tools/excalidraw-tools';
 import { createGetConversationTool } from '../llm-tools/get-conversation-tool';
 import { createGetWorkItemTool } from '../llm-tools/get-work-item-tool';
@@ -497,6 +498,40 @@ export function buildSearchConversationsAddon(
     const { tool: getTool } = createGetConversationTool({ store, workspaceId });
 
     return { tools: [searchTool, getTool], suffix: '' };
+}
+
+// ============================================================================
+// Create Conversation
+// ============================================================================
+
+/**
+ * Builds the tools array for the `create_conversation` tool, which lets an agent
+ * spawn a brand-new chat (fire-and-forget) through the same in-process queue path
+ * `POST /api/queue` uses.
+ *
+ * No-ops (returns no tools) when the in-process enqueue capability is absent —
+ * the same defensive pattern {@link buildSearchConversationsAddon} uses when the
+ * store cannot search. The tool is opt-in: even when wired here it is filtered
+ * out unless the user enables it (see `DEFAULT_DISABLED_LLM_TOOLS` /
+ * {@link applyLlmToolPreferences}).
+ *
+ * @param store        ProcessStore — used to validate the target workspace exists.
+ * @param workspaceId  The caller's current workspace; the default enqueue target.
+ * @param enqueueChat  Bound in-process enqueue capability; when omitted, no tool.
+ */
+export function buildCreateConversationAddon(
+    store: ProcessStore | undefined,
+    workspaceId: string | undefined,
+    enqueueChat: EnqueueChatFn | undefined,
+): { tools: Tool<any>[]; suffix: string } {
+    if (!store || !enqueueChat) {
+        return { tools: [], suffix: '' };
+    }
+
+    const { tool } = createCreateConversationTool({ store, workspaceId, enqueueChat });
+
+    // No prose suffix — the create_conversation tool description carries its own guidance.
+    return { tools: [tool], suffix: '' };
 }
 
 // ============================================================================

--- a/packages/coc/src/server/executors/ralph-executor.ts
+++ b/packages/coc/src/server/executors/ralph-executor.ts
@@ -85,6 +85,7 @@ export class RalphExecutor extends ChatBaseExecutor {
             broadcastWorkItem: this.getWsServerFn
                 ? (event) => this.getWsServerFn!()?.broadcastProcessEvent(event as any)
                 : undefined,
+            enqueueChat: this.getEnqueueChat?.(),
             scheduleWakeup: loopDeps.scheduleWakeup,
             loopTools: loopDeps.loopTools,
         });

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -222,6 +222,13 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     // Forward declaration — trigger infra is created after queue infra
     let triggerInfra: TriggerInfrastructure | undefined;
 
+    // Forward declaration — the in-process enqueue capability for the opt-in
+    // `create_conversation` tool is bound at the route layer (where the queue
+    // global state + provider-default resolution live), which runs after the
+    // queue infra (and its executors) are created. The late-bound getter passed
+    // to createQueueInfrastructure reads this once routes finish registering.
+    let enqueueChatCapability: import('./llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
+
     // MCP OAuth infra — enabled by default when any MCP server may be configured.
     const mcpOauthEnabled = resolvedConfig.mcpOauth?.enabled ?? true;
     const mcpOauthInfra = mcpOauthEnabled
@@ -350,6 +357,9 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         // triggerInfra is created after queue infra (like loopInfra), so read it
         // lazily through this closure.
         () => triggerInfra ? { manager: triggerInfra.triggerManager } : undefined,
+        // Late-bound enqueue capability for the opt-in `create_conversation` tool;
+        // bound at the route layer below, read here once routes register.
+        () => enqueueChatCapability,
     );
 
     // Finalize any orphaned 'running' / 'cancelling' processes left behind by
@@ -604,6 +614,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         syncEngines,
         nativeCopilotSessionDbPath: options.nativeCopilotSessionDbPath,
         nativeCopilotSessionStateDir: options.nativeCopilotSessionStateDir,
+        setEnqueueChat: (fn) => { enqueueChatCapability = fn; },
     });
     // Restore auto-commit timers for all workspaces that had it enabled
     notesGitTimerManager.startAll(store, dataDir).catch(() => { /* best-effort */ });

--- a/packages/coc/src/server/infrastructure/queue-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/queue-infrastructure.ts
@@ -66,6 +66,7 @@ export function createQueueInfrastructure(
     ralphMultiAgentGrillEnabled?: boolean,
     getGlobalSystemPrompt?: () => string | undefined,
     getTriggerInfra?: () => { manager: import('../triggers/trigger-manager').TriggerManager } | undefined,
+    getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined,
 ): QueueInfrastructure {
     // Obtain SQLite DB handle: reuse from SqliteProcessStore, or create in-memory for tests.
     let db: Database.Database;
@@ -99,6 +100,7 @@ export function createQueueInfrastructure(
         initialDelayMs: options.queue?.restartPickupDelayMs,
         getLoopInfra,
         getTriggerInfra,
+        getEnqueueChat,
         getMcpOauthManager,
     });
 

--- a/packages/coc/src/server/llm-tools/create-conversation-tool.ts
+++ b/packages/coc/src/server/llm-tools/create-conversation-tool.ts
@@ -1,0 +1,262 @@
+/**
+ * Create Conversation Tool
+ *
+ * Factory that creates a `create_conversation` custom tool for the Copilot SDK.
+ * The model calls this tool to start a brand-new chat (its primary use case is
+ * an agent delegating / spawning a separate piece of work) with a small,
+ * simplified parameter set instead of the full `POST /api/queue` payload.
+ *
+ * The tool is fire-and-forget: it enqueues the new chat through the same
+ * in-process queue path that `POST /api/queue` uses (no HTTP self-call) so the
+ * conversation appears in the dashboard chat list and is picked up by the queue
+ * executor, then returns immediately with the queued task's identity.
+ *
+ * Per-invocation factory pattern: each AI call gets its own tool instance bound
+ * to the store + enqueue capability + the caller's current workspace, avoiding
+ * cross-request contamination.
+ *
+ * NOTE on `model` validation: the queue path already coerces a model that the
+ * resolved provider does not support (see `resolveModelForProvider` in
+ * `validateAndParseTask`). This tool therefore treats `model` as a pass-through
+ * string — it only rejects an empty / non-string value — and leaves
+ * provider-specific allow-listing to the shared enqueue machinery.
+ */
+
+import { defineTool } from '@plusplusoneplusplus/coc-agent-sdk';
+import type { CreateTaskInput, ProcessStore } from '@plusplusoneplusplus/forge';
+import { toQueueProcessId } from '@plusplusoneplusplus/forge';
+import { VALID_CHAT_PROVIDERS, type ChatProvider } from '../tasks/task-types';
+import { validateAndParseTask } from '../routes/queue-shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Chat modes this tool may start. `plan` and `ralph` are intentionally rejected. */
+export type CreateConversationMode = 'autopilot' | 'ask';
+
+export interface CreateConversationArgs {
+    /** First message of the new conversation. Required. */
+    prompt: string;
+    /** Target workspace/repo. Defaults to the caller's current workspace. */
+    workspaceId?: string;
+    /** Chat mode, restricted to `autopilot` | `ask`. Default `ask`. */
+    mode?: CreateConversationMode;
+    /** Display name for the new chat. Auto-generated from the prompt when omitted. */
+    title?: string;
+    /** Overrides the AI model. */
+    model?: string;
+    /** AI provider, validated against the supported chat providers. */
+    provider?: ChatProvider;
+    /** Queue priority. Default `normal`. */
+    priority?: 'high' | 'normal' | 'low';
+}
+
+/**
+ * Enqueue capability injected by the server/route layer where the
+ * `MultiRepoQueueRouter` and `QueueGlobalState` live. Returns the new task id.
+ *
+ * The bound callback is expected to run the same machinery `POST /api/queue`
+ * uses (`prepareTaskForEnqueue` + `enqueueViaBridge`) so the conversation shows
+ * up in the chat list and is executed by the queue executor.
+ */
+export type EnqueueChatFn = (input: CreateTaskInput) => Promise<string>;
+
+export interface CreateConversationToolOptions {
+    /** ProcessStore instance — used to validate the target workspace exists. */
+    store: ProcessStore;
+    /** The caller's current workspace ID; the default enqueue target. */
+    workspaceId?: string;
+    /** Bound in-process enqueue capability. */
+    enqueueChat: EnqueueChatFn;
+}
+
+export interface CreateConversationSuccess {
+    /** New process id, derived as `queue_<taskId>`. */
+    processId: string;
+    /** Resolved display name (explicit `title` or an auto-generated one). */
+    title: string;
+    /** Always `queued` — the tool is fire-and-forget. */
+    status: 'queued';
+    /** SPA deep-link to the new conversation. */
+    openLink: string;
+}
+
+export interface CreateConversationError {
+    error: string;
+}
+
+export type CreateConversationResult = CreateConversationSuccess | CreateConversationError;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Modes this tool may start — a strict subset of the queue's chat modes. */
+const ALLOWED_MODES: ReadonlySet<string> = new Set<CreateConversationMode>(['autopilot', 'ask']);
+const DEFAULT_MODE: CreateConversationMode = 'ask';
+
+const ALLOWED_PRIORITIES: ReadonlySet<string> = new Set(['high', 'normal', 'low']);
+const DEFAULT_PRIORITY = 'normal';
+
+// ============================================================================
+// Tool Factory
+// ============================================================================
+
+/**
+ * Create a `create_conversation` custom tool definition for the Copilot SDK.
+ *
+ * @param options Tool options (store + caller workspace + enqueue capability).
+ */
+export function createCreateConversationTool(options: CreateConversationToolOptions) {
+    const { store, workspaceId: callerWorkspaceId, enqueueChat } = options;
+
+    const tool = defineTool<CreateConversationArgs>('create_conversation', {
+        description:
+            'Start a brand-new, separate chat conversation (fire-and-forget). ' +
+            'Use this to delegate or spawn a distinct piece of work into its own conversation; ' +
+            'it does NOT continue or follow up the current chat. ' +
+            'The new chat appears in the dashboard chat list and is executed by the queue. ' +
+            'Returns immediately with the new conversation\'s processId and an open link — it does ' +
+            'not wait for the new chat to start or produce output. ' +
+            'Only `prompt` is required; `workspaceId` defaults to the current workspace and `mode` defaults to `ask`.',
+        parameters: {
+            type: 'object',
+            properties: {
+                prompt: {
+                    type: 'string',
+                    description: 'The first message of the new conversation. Required.',
+                },
+                workspaceId: {
+                    type: 'string',
+                    description:
+                        'Target workspace/repo ID. Any registered workspace may be targeted. ' +
+                        'Defaults to the current workspace when omitted.',
+                },
+                mode: {
+                    type: 'string',
+                    enum: ['autopilot', 'ask'],
+                    description: 'Chat mode: `ask` (read-only, default) or `autopilot` (can edit/run).',
+                },
+                title: {
+                    type: 'string',
+                    description: 'Display name for the new chat. Auto-generated from the prompt when omitted.',
+                },
+                model: {
+                    type: 'string',
+                    description: 'Overrides the AI model for the new chat.',
+                },
+                provider: {
+                    type: 'string',
+                    enum: [...VALID_CHAT_PROVIDERS],
+                    description: 'AI provider for the new chat (`copilot`, `codex`, or `claude`).',
+                },
+                priority: {
+                    type: 'string',
+                    enum: ['high', 'normal', 'low'],
+                    description: 'Queue priority for the new chat. Default `normal`.',
+                },
+            },
+            required: ['prompt'],
+        },
+        handler: async (args: CreateConversationArgs): Promise<CreateConversationResult> => {
+            // --- prompt (required, non-empty) ---------------------------------
+            if (typeof args.prompt !== 'string' || !args.prompt.trim()) {
+                return { error: 'Missing required field: prompt must be a non-empty string.' };
+            }
+            const prompt = args.prompt;
+
+            // --- workspace (default to caller's; must be registered) ----------
+            const requestedWorkspaceId =
+                typeof args.workspaceId === 'string' && args.workspaceId.trim()
+                    ? args.workspaceId.trim()
+                    : callerWorkspaceId;
+            if (!requestedWorkspaceId) {
+                return {
+                    error:
+                        'No target workspace: provide `workspaceId` or invoke this tool from a workspace context.',
+                };
+            }
+            const workspaces = await store.getWorkspaces();
+            if (!workspaces.some(ws => ws.id === requestedWorkspaceId)) {
+                return {
+                    error: `Unknown workspaceId: '${requestedWorkspaceId}' is not a registered workspace.`,
+                };
+            }
+
+            // --- mode (restricted to ask|autopilot) ---------------------------
+            const mode = args.mode ?? DEFAULT_MODE;
+            if (!ALLOWED_MODES.has(mode)) {
+                return {
+                    error:
+                        `Invalid mode: '${String(args.mode)}'. ` +
+                        `create_conversation only supports: ${[...ALLOWED_MODES].join(', ')}.`,
+                };
+            }
+
+            // --- provider (validated against the supported chat providers) ----
+            if (args.provider !== undefined && !VALID_CHAT_PROVIDERS.has(args.provider)) {
+                return {
+                    error:
+                        `Invalid provider: '${String(args.provider)}'. ` +
+                        `Valid providers: ${[...VALID_CHAT_PROVIDERS].join(', ')}.`,
+                };
+            }
+
+            // --- model (pass-through; reject empty/non-string) ----------------
+            if (args.model !== undefined && (typeof args.model !== 'string' || !args.model.trim())) {
+                return { error: 'Invalid model: must be a non-empty string when provided.' };
+            }
+            const model = args.model?.trim();
+
+            // --- priority (default normal) ------------------------------------
+            const priority = args.priority ?? DEFAULT_PRIORITY;
+            if (!ALLOWED_PRIORITIES.has(priority)) {
+                return {
+                    error:
+                        `Invalid priority: '${String(args.priority)}'. ` +
+                        `Valid priorities: ${[...ALLOWED_PRIORITIES].join(', ')}.`,
+                };
+            }
+
+            // --- build + validate the task spec, then enqueue in-process ------
+            const title = typeof args.title === 'string' && args.title.trim() ? args.title.trim() : undefined;
+            const taskSpec: Record<string, unknown> = {
+                type: 'chat',
+                priority,
+                workspaceId: requestedWorkspaceId,
+                ...(title ? { displayName: title } : {}),
+                payload: {
+                    kind: 'chat',
+                    mode,
+                    prompt,
+                    workspaceId: requestedWorkspaceId,
+                    ...(args.provider ? { provider: args.provider } : {}),
+                    ...(model ? { model } : {}),
+                },
+                ...(model ? { config: { model } } : {}),
+            };
+
+            // Reuse the canonical enqueue validation/normalization (config shape,
+            // model resolution, display-name generation). Our up-front checks
+            // above already reject the cases this path would silently coerce
+            // (unknown workspace, ralph/plan mode).
+            const validation = validateAndParseTask(taskSpec);
+            if (!validation.valid || !validation.input) {
+                return { error: validation.error ?? 'Failed to build the new conversation task.' };
+            }
+
+            const taskId = await enqueueChat(validation.input);
+            const processId = toQueueProcessId(taskId);
+
+            return {
+                processId,
+                title: validation.input.displayName ?? title ?? '',
+                status: 'queued',
+                openLink: `#/process/${processId}`,
+            };
+        },
+    });
+
+    return { tool };
+}

--- a/packages/coc/src/server/llm-tools/index.ts
+++ b/packages/coc/src/server/llm-tools/index.ts
@@ -11,6 +11,16 @@ export {
 } from './get-conversation-tool';
 export { createSuggestFollowUpsTool, type FollowUpSuggestion } from './suggest-follow-ups-tool';
 export {
+    createCreateConversationTool,
+    type CreateConversationArgs,
+    type CreateConversationMode,
+    type CreateConversationToolOptions,
+    type CreateConversationResult,
+    type CreateConversationSuccess,
+    type CreateConversationError,
+    type EnqueueChatFn,
+} from './create-conversation-tool';
+export {
     createGetWorkItemTool,
     type GetWorkItemArgs,
     type GetWorkItemToolDeps,

--- a/packages/coc/src/server/llm-tools/llm-tool-parameter-schemas.ts
+++ b/packages/coc/src/server/llm-tools/llm-tool-parameter-schemas.ts
@@ -66,6 +66,19 @@ export const LLM_TOOL_PARAMETER_SCHEMAS: Record<string, Record<string, unknown>>
         },
         required: ['processId'],
     },
+    create_conversation: {
+        type: 'object',
+        properties: {
+            prompt: { type: 'string' },
+            workspaceId: { type: 'string' },
+            mode: { type: 'string' },
+            title: { type: 'string' },
+            model: { type: 'string' },
+            provider: { type: 'string' },
+            priority: { type: 'string' },
+        },
+        required: ['prompt'],
+    },
     ask_user: {
         type: 'object',
         properties: {

--- a/packages/coc/src/server/llm-tools/llm-tool-registry.ts
+++ b/packages/coc/src/server/llm-tools/llm-tool-registry.ts
@@ -71,6 +71,12 @@ export const LLM_TOOL_REGISTRY: readonly LlmToolMeta[] = [
         enabledByDefault: true,
     },
     {
+        name: 'create_conversation',
+        label: 'Create Conversation',
+        description: 'Starts a brand-new, separate chat conversation (fire-and-forget) to delegate or spawn work. Opt-in.',
+        enabledByDefault: false,
+    },
+    {
         name: 'ask_user',
         label: 'Ask User',
         description: 'Poses interactive questions to the user during execution.',

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -47,6 +47,12 @@ export interface CLITaskExecutorOptions {
     getWsServer?: () => import('../streaming/websocket').ProcessWebSocketServer | undefined;
     getLoopInfra?: () => import('../executors/chat-base-executor').LoopInfraDeps | undefined;
     getTriggerInfra?: () => { manager: import('../triggers/trigger-manager').TriggerManager } | undefined;
+    /**
+     * Late-bound in-process enqueue capability supplied by the server/route layer
+     * (where the queue router + global state live). Powers the opt-in
+     * `create_conversation` tool so an agent can spawn a brand-new chat.
+     */
+    getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     onRalphSessionComplete?: (event: RalphSessionCompleteEvent) => void;
     dreamRunExecutor?: DreamRunExecutor;
@@ -148,6 +154,7 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
             onTitleNeeded: (pid: string, turns: ConversationTurn[]) => this.generateTitleIfNeeded(pid, turns),
             getWsServer: options.getWsServer,
             getLoopInfra: options.getLoopInfra,
+            getEnqueueChat: options.getEnqueueChat,
             getMcpOauthManager: options.getMcpOauthManager,
             getDreamRunExecutor: () => this.dreamRunExecutor,
             cancelledTasks: this.cancelledTasks,

--- a/packages/coc/src/server/queue/queue-handler.ts
+++ b/packages/coc/src/server/queue/queue-handler.ts
@@ -31,9 +31,16 @@ export function registerQueueRoutes(
         resolveDefaultProvider?: (options?: ResolveDefaultProviderOptions) => Promise<AutoProviderResolutionResult>;
         isAutoProviderRoutingActive?: () => boolean;
         getEffortTiersForProvider?: (provider: ChatProvider) => StoredEffortTiersMap | undefined;
+        /**
+         * Shared global queue state. When supplied (by the route layer), the HTTP
+         * enqueue path and any in-process enqueue capability (e.g. the
+         * `create_conversation` tool) observe the same global pause flags. When
+         * omitted, a fresh state is created (default for tests / standalone use).
+         */
+        state?: QueueGlobalState;
     } = {},
 ): void {
-    const state: QueueGlobalState = {
+    const state: QueueGlobalState = options.state ?? {
         globalPaused: false,
         globalPausedUntil: undefined,
         globalAutopilotPaused: false,

--- a/packages/coc/src/server/repos/classification-store.ts
+++ b/packages/coc/src/server/repos/classification-store.ts
@@ -551,16 +551,20 @@ function validateCriticalMetadata(raw: unknown, classificationIndex: number): Cr
 // ============================================================================
 
 /**
- * Remove classification files older than `maxAgeDays` for a single workspace.
- * Returns the number of files removed. Best-effort: errors are swallowed.
+ * Remove classification files older than `maxAgeDays` for a single storage
+ * scope. Pass `scope` to prune the canonical origin directory rather than the
+ * raw `workspaceId` directory. Returns the number of files removed.
+ * Best-effort: errors are swallowed.
  */
 export function pruneStaleClassifications(
     dataDir: string,
     workspaceId: string,
     maxAgeDays = 30,
+    scope?: PullRequestStorageScopeInput,
 ): number {
     if (maxAgeDays <= 0) return 0;
-    const dir = getRepoDataPath(dataDir, workspaceId, 'classifications');
+    const storageId = resolvePullRequestStorageId(workspaceId, scope);
+    const dir = getRepoDataPath(dataDir, storageId, 'classifications');
     let removed = 0;
     let entries: string[] = [];
     try {

--- a/packages/coc/src/server/repos/origin-scope.ts
+++ b/packages/coc/src/server/repos/origin-scope.ts
@@ -1,0 +1,132 @@
+/**
+ * Canonical origin-scope resolver — the single source of truth for mapping a
+ * caller-facing workspace/repo id to the canonical git-origin id that
+ * origin-scoped persistent state is stored under.
+ *
+ * Work Item storage, Work Item route scope, Pull Request storage scope, and PR
+ * classification cleanup all resolve multi-repo storage identity the same way:
+ *
+ *   1. Detect whether an id already looks canonical (`gh_`/`ado_`/`git_`/`local_`).
+ *   2. Resolve a workspace's remote URL, detecting it from the checkout and
+ *      backfilling the stored record when the workspace has none.
+ *   3. Map every registered workspace to its canonical origin id.
+ *   4. Enumerate the workspaces that resolve to the same origin.
+ *
+ * Centralizing these primitives keeps two clones of the same upstream repo from
+ * resolving to different storage directories.
+ *
+ * No VS Code dependencies — uses only Node.js + forge git helpers.
+ */
+
+import {
+    detectRemoteUrl,
+    resolveCanonicalOriginId,
+    type ProcessStore,
+} from '@plusplusoneplusplus/forge';
+
+/** Process-store surface needed to read workspaces and backfill remote URLs. */
+export type OriginScopeProcessStore = Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'>;
+
+/**
+ * Workspace fields the origin-scope resolver reads. Kept structural (and
+ * `null`-tolerant) so both `WorkspaceInfo` records and caller-supplied
+ * remote/root tuples satisfy it.
+ */
+export interface OriginScopeWorkspace {
+    id: string;
+    remoteUrl?: string | null;
+    rootPath?: string | null;
+}
+
+const CANONICAL_ORIGIN_PREFIX = /^(gh|ado|git|local)_/;
+
+/**
+ * True when `value` already looks like a canonical origin id
+ * (`gh_`/`ado_`/`git_`/`local_`) rather than a clone-specific workspace id.
+ */
+export function isCanonicalOriginId(value: string): boolean {
+    return CANONICAL_ORIGIN_PREFIX.test(value);
+}
+
+function trimNonEmpty(value: string | null | undefined): string | undefined {
+    const trimmed = value?.trim();
+    return trimmed || undefined;
+}
+
+/**
+ * Resolve the remote URL for a workspace, detecting it from the checkout when
+ * the stored record has none and backfilling the detected value via the process
+ * store. Returns `undefined` when no remote can be resolved.
+ */
+export async function resolveWorkspaceRemoteUrl(
+    workspace: OriginScopeWorkspace,
+    processStore?: Pick<ProcessStore, 'updateWorkspace'>,
+): Promise<string | undefined> {
+    const existing = trimNonEmpty(workspace.remoteUrl);
+    if (existing) return existing;
+    const root = trimNonEmpty(workspace.rootPath);
+    if (!root) return undefined;
+    const detected = trimNonEmpty(await detectRemoteUrl(root));
+    if (detected && typeof processStore?.updateWorkspace === 'function') {
+        await processStore.updateWorkspace(workspace.id, { remoteUrl: detected });
+    }
+    return detected;
+}
+
+/**
+ * Resolve the canonical origin id for a workspace record, detecting and
+ * backfilling its remote URL first. Falls back to a `local_<workspaceId>`
+ * canonical id when no remote is available.
+ */
+export async function resolveWorkspaceOriginId(
+    workspace: OriginScopeWorkspace,
+    processStore?: Pick<ProcessStore, 'updateWorkspace'>,
+): Promise<string> {
+    const remoteUrl = await resolveWorkspaceRemoteUrl(workspace, processStore);
+    return resolveCanonicalOriginId({ remoteUrl, workspaceId: workspace.id });
+}
+
+/**
+ * Build a map of registered `workspaceId` → canonical origin id, resolving (and
+ * backfilling) each workspace's remote exactly once. Insertion order matches
+ * `processStore.getWorkspaces()` so downstream enumeration stays deterministic.
+ */
+export async function mapWorkspaceOriginIds(
+    processStore: OriginScopeProcessStore,
+): Promise<Map<string, string>> {
+    const originIds = new Map<string, string>();
+    for (const workspace of await processStore.getWorkspaces()) {
+        originIds.set(workspace.id, await resolveWorkspaceOriginId(workspace, processStore));
+    }
+    return originIds;
+}
+
+/**
+ * Resolve the canonical origin id for a caller-facing id that may be either a
+ * registered workspace id or an already-canonical origin id. Returns
+ * `undefined` when the id is neither registered nor canonical.
+ */
+export async function resolveOriginIdForId(
+    processStore: OriginScopeProcessStore,
+    id: string,
+): Promise<string | undefined> {
+    const originIds = await mapWorkspaceOriginIds(processStore);
+    return originIds.get(id) ?? (isCanonicalOriginId(id) ? id : undefined);
+}
+
+/**
+ * List the registered workspace ids whose canonical origin id equals
+ * `originId`, in `getWorkspaces()` order. These are the clone-specific scopes
+ * that share one canonical origin.
+ */
+export async function sameOriginWorkspaceIds(
+    processStore: OriginScopeProcessStore,
+    originId: string,
+): Promise<string[]> {
+    const originIds = await mapWorkspaceOriginIds(processStore);
+    const workspaceIds: string[] = [];
+    for (const [workspaceId, resolved] of originIds) {
+        if (resolved === originId) workspaceIds.push(workspaceId);
+    }
+    return workspaceIds;
+}

--- a/packages/coc/src/server/repos/pr-origin-scope.ts
+++ b/packages/coc/src/server/repos/pr-origin-scope.ts
@@ -1,11 +1,14 @@
 import {
     type ProcessStore,
-    type WorkspaceInfo,
 } from '@plusplusoneplusplus/forge';
 import {
-    detectRemoteUrl,
     resolveCanonicalOriginId,
 } from '@plusplusoneplusplus/forge/git';
+import {
+    isCanonicalOriginId,
+    mapWorkspaceOriginIds,
+    resolveWorkspaceRemoteUrl,
+} from './origin-scope';
 
 export interface PullRequestLegacyStorageScope {
     workspaceId: string;
@@ -36,10 +39,6 @@ export interface ResolvePullRequestOriginStorageScopeOptions {
     processStore?: PullRequestScopeProcessStore;
 }
 
-function isCanonicalOriginId(value: string): boolean {
-    return /^(gh|ado|git|local)_/.test(value);
-}
-
 function trimNonEmpty(value: string | null | undefined): string | undefined {
     const trimmed = value?.trim();
     return trimmed || undefined;
@@ -58,36 +57,6 @@ function dedupeLegacyScopes(scopes: readonly PullRequestLegacyStorageScope[]): P
         out.push({ workspaceId, repoId });
     }
     return out;
-}
-
-async function resolveRemoteUrl(
-    workspaceId: string,
-    remoteUrl: string | null | undefined,
-    rootPath: string | null | undefined,
-    processStore?: Pick<ProcessStore, 'updateWorkspace'>,
-): Promise<string | undefined> {
-    const provided = trimNonEmpty(remoteUrl);
-    if (provided) return provided;
-    const root = trimNonEmpty(rootPath);
-    if (!root) return undefined;
-    const detected = await detectRemoteUrl(root);
-    if (detected && typeof processStore?.updateWorkspace === 'function') {
-        await processStore.updateWorkspace(workspaceId, { remoteUrl: detected });
-    }
-    return detected;
-}
-
-async function resolveWorkspaceOriginId(
-    workspace: WorkspaceInfo,
-    processStore: PullRequestScopeProcessStore,
-): Promise<string> {
-    const remoteUrl = await resolveRemoteUrl(
-        workspace.id,
-        workspace.remoteUrl,
-        workspace.rootPath,
-        processStore,
-    );
-    return resolveCanonicalOriginId({ remoteUrl, workspaceId: workspace.id });
 }
 
 export function resolvePullRequestStorageId(
@@ -133,10 +102,8 @@ export async function resolvePullRequestStorageScope(
         throw new Error('workspaceId and repoId are required to resolve pull-request storage scope');
     }
 
-    const remoteUrl = await resolveRemoteUrl(
-        workspaceId,
-        options.remoteUrl,
-        options.rootPath,
+    const remoteUrl = await resolveWorkspaceRemoteUrl(
+        { id: workspaceId, remoteUrl: options.remoteUrl, rootPath: options.rootPath },
         options.processStore,
     );
     const storageOriginId = resolveCanonicalOriginId({ remoteUrl, workspaceId });
@@ -151,12 +118,11 @@ export async function resolvePullRequestStorageScope(
         typeof processStore.updateWorkspace === 'function' &&
         !isCanonicalOriginId(repoId)
     ) {
-        const workspaces = await processStore.getWorkspaces();
-        for (const workspace of workspaces) {
-            const originId = await resolveWorkspaceOriginId(workspace, processStore);
+        const originIds = await mapWorkspaceOriginIds(processStore);
+        for (const [scopeWorkspaceId, originId] of originIds) {
             if (originId !== storageOriginId) continue;
-            legacyScopes.push({ workspaceId: workspace.id, repoId: workspace.id });
-            legacyScopes.push({ workspaceId: workspace.id, repoId });
+            legacyScopes.push({ workspaceId: scopeWorkspaceId, repoId: scopeWorkspaceId });
+            legacyScopes.push({ workspaceId: scopeWorkspaceId, repoId });
         }
     }
 
@@ -181,11 +147,10 @@ export async function resolvePullRequestOriginStorageScope(
         typeof processStore.getWorkspaces === 'function' &&
         typeof processStore.updateWorkspace === 'function'
     ) {
-        const workspaces = await processStore.getWorkspaces();
-        for (const workspace of workspaces) {
-            const originId = await resolveWorkspaceOriginId(workspace, processStore);
+        const originIds = await mapWorkspaceOriginIds(processStore);
+        for (const [scopeWorkspaceId, originId] of originIds) {
             if (originId !== storageOriginId) continue;
-            legacyScopes.push({ workspaceId: workspace.id, repoId: workspace.id });
+            legacyScopes.push({ workspaceId: scopeWorkspaceId, repoId: scopeWorkspaceId });
         }
     }
 

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -19,7 +19,9 @@ import type { WikiManager } from '../wiki';
 import { registerApiRoutes } from '../core/api-handler';
 import { registerQueueRoutes } from '../queue/queue-handler';
 import { prepareTaskForEnqueue } from './queue-enqueue';
-import { serializeTask } from './queue-shared';
+import { serializeTask, enqueueViaBridge } from './queue-shared';
+import type { QueueGlobalState } from './queue-shared';
+import type { EnqueueChatFn } from '../llm-tools/create-conversation-tool';
 import { registerTaskRoutes, registerTaskWriteRoutes } from '../tasks/tasks-handler';
 import { registerTaskGenerationRoutes } from '../tasks/task-generation-handler';
 import { registerPromptRoutes } from '../prompts/prompt-handler';
@@ -223,6 +225,15 @@ export interface RegisterRoutesOptions {
     nativeCopilotSessionDbPath?: string;
     /** Native Copilot CLI `session-state` base directory override (for tests). */
     nativeCopilotSessionStateDir?: string;
+    /**
+     * Publish the bound in-process enqueue capability back to the server layer so
+     * the late-bound getter passed to the queue infrastructure (created before
+     * routes) can hand it to executors. Powers the opt-in `create_conversation`
+     * tool. The callback runs the same machinery `POST /api/queue` uses
+     * (`prepareTaskForEnqueue` + `enqueueViaBridge`) against the shared global
+     * queue state.
+     */
+    setEnqueueChat?: (fn: EnqueueChatFn) => void;
 }
 
 export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions): { wikiManager: WikiManager | undefined; workItemGitHubPullPoller: WorkItemGitHubPullPoller; workItemAzureBoardsPullPoller: WorkItemAzureBoardsPullPoller; agentProvidersQuotaCache?: AgentProvidersQuotaCache; activeWorkspaceBackgroundRefresher: ActiveWorkspaceBackgroundRefresher; dreamIdleScheduler: DreamIdleScheduler } {
@@ -349,6 +360,27 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     });
     bridge.setResolveDefaultProvider(resolveDefaultProvider);
 
+    // Shared global queue state — passed to both the HTTP queue routes and the
+    // in-process `create_conversation` enqueue capability so they observe the
+    // same global pause flags. Created here (rather than inside
+    // `registerQueueRoutes`) so the tool path can reuse it.
+    const queueGlobalState: QueueGlobalState = {
+        globalPaused: false,
+        globalPausedUntil: undefined,
+        globalAutopilotPaused: false,
+        globalAutopilotPausedUntil: undefined,
+        resumeInProgress: new Set(),
+    };
+
+    // Publish the bound enqueue capability so executors (created before routes)
+    // can offer the opt-in `create_conversation` tool. Reuses the exact machinery
+    // `POST /api/queue` uses: provider/effort defaults resolution, then route +
+    // enqueue via the per-repo queue manager.
+    opts.setEnqueueChat?.(async (input: CreateTaskInput): Promise<string> => {
+        await prepareEnqueueTask(input);
+        return enqueueViaBridge(input, bridge, queueGlobalState, globalWorkspaceRootPath, store);
+    });
+
     // excalidrawEnabled uses a live getter via runtimeConfigService so admin
     // changes take effect without restart. loopsEnabled stays startup-captured
     // (restartRequired — loop executor infrastructure wires at startup).
@@ -414,6 +446,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
         resolveDefaultProvider,
         isAutoProviderRoutingActive,
         getEffortTiersForProvider,
+        state: queueGlobalState,
     });
     registerTaskRoutes(routes, store, dataDir, (workspaceId) => {
         getWsServer().broadcastProcessEvent({

--- a/packages/coc/src/server/routes/work-item-route-scope.ts
+++ b/packages/coc/src/server/routes/work-item-route-scope.ts
@@ -1,14 +1,31 @@
 import * as http from 'http';
 import * as url from 'url';
 import {
-    detectRemoteUrl,
-    resolveCanonicalOriginId,
     type ProcessStore,
     type WorkspaceInfo,
 } from '@plusplusoneplusplus/forge';
+import {
+    resolveWorkspaceOriginId,
+    sameOriginWorkspaceIds,
+} from '../repos/origin-scope';
 import { badRequest } from '../errors';
 
 export type WorkItemRouteScopeKind = 'workspaces' | 'origins';
+
+/**
+ * Build a route pattern for an origin-scoped persistent API. Both the
+ * `/api/workspaces/<id>/...` and `/api/origins/<id>/...` families are matched so
+ * new handlers do not hand-roll the `(workspaces|origins)` scope segment.
+ *
+ * Capture group 1 is the scope kind (`workspaces`/`origins`), group 2 is the
+ * scope id; any capture groups inside `tail` follow. `tail` is appended raw and
+ * the pattern is anchored at both ends.
+ *
+ * @example scopedRoutePattern('/work-items/([^/]+)') // → /api/(workspaces|origins)/<id>/work-items/<id>
+ */
+export function scopedRoutePattern(tail = ''): RegExp {
+    return new RegExp(`^/api/(workspaces|origins)/([^/]+)${tail}$`);
+}
 
 export interface WorkItemRouteScope {
     kind: WorkItemRouteScopeKind;
@@ -24,18 +41,16 @@ export function queryWorkspaceId(req: http.IncomingMessage): string | undefined 
     return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined;
 }
 
+/**
+ * Resolve a workspace record to its canonical origin id. Thin facade over the
+ * shared origin-scope resolver so route handlers and the binding store keep one
+ * import surface.
+ */
 export async function workspaceOriginId(
     workspace: WorkspaceInfo,
     processStore?: Pick<ProcessStore, 'updateWorkspace'>,
 ): Promise<string> {
-    let remoteUrl = workspace.remoteUrl;
-    if (!remoteUrl && workspace.rootPath) {
-        remoteUrl = await detectRemoteUrl(workspace.rootPath);
-        if (remoteUrl) {
-            await processStore?.updateWorkspace?.(workspace.id, { remoteUrl });
-        }
-    }
-    return resolveCanonicalOriginId({ remoteUrl, workspaceId: workspace.id });
+    return resolveWorkspaceOriginId(workspace, processStore);
 }
 
 export async function resolveWorkspaceWorkItemOriginId(
@@ -44,20 +59,14 @@ export async function resolveWorkspaceWorkItemOriginId(
 ): Promise<string> {
     const workspaces = await processStore.getWorkspaces();
     const workspace = workspaces.find(entry => entry.id === workspaceId);
-    return workspace ? workspaceOriginId(workspace, processStore) : workspaceId;
+    return workspace ? resolveWorkspaceOriginId(workspace, processStore) : workspaceId;
 }
 
 export async function legacyWorkspaceIdsForWorkItemOrigin(
     processStore: Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'>,
     originId: string,
 ): Promise<string[]> {
-    const legacyScopeIds: string[] = [];
-    for (const workspace of await processStore.getWorkspaces()) {
-        if (await workspaceOriginId(workspace, processStore) === originId) {
-            legacyScopeIds.push(workspace.id);
-        }
-    }
-    return legacyScopeIds;
+    return sameOriginWorkspaceIds(processStore, originId);
 }
 
 export async function resolveWorkItemRouteScope(

--- a/packages/coc/src/server/routes/work-item-routes.ts
+++ b/packages/coc/src/server/routes/work-item-routes.ts
@@ -26,6 +26,7 @@ import { handleAPIError, notFound, badRequest } from '../errors';
 import {
     queryWorkspaceId,
     resolveWorkItemRouteScope,
+    scopedRoutePattern,
     type WorkItemRouteScope,
     type WorkItemRouteScopeKind,
 } from './work-item-route-scope';
@@ -62,12 +63,12 @@ import {
 const VALID_SOURCES: Set<string> = new Set(['manual', 'chat', 'schedule']);
 const VALID_PRIORITIES: Set<string> = new Set(['high', 'normal', 'low']);
 const VALID_TRACKER_KINDS: Set<string> = new Set(WORK_ITEM_TRACKER_KINDS);
-const WORK_ITEM_COLLECTION_PATTERN = /^\/api\/(workspaces|origins)\/([^/]+)\/work-items$/;
-const WORK_ITEM_GROUPED_PATTERN = /^\/api\/(workspaces|origins)\/([^/]+)\/work-items\/grouped$/;
-const WORK_ITEM_DETAIL_PATTERN = /^\/api\/(workspaces|origins)\/([^/]+)\/work-items\/([^/]+)$/;
-const WORK_ITEM_REQUEST_CHANGES_PATTERN = /^\/api\/(workspaces|origins)\/([^/]+)\/work-items\/([^/]+)\/request-changes$/;
-const WORK_ITEM_PIN_PATTERN = /^\/api\/(workspaces|origins)\/([^/]+)\/work-items\/([^/]+)\/pin$/;
-const WORK_ITEM_ARCHIVE_PATTERN = /^\/api\/(workspaces|origins)\/([^/]+)\/work-items\/([^/]+)\/archive$/;
+const WORK_ITEM_COLLECTION_PATTERN = scopedRoutePattern('/work-items');
+const WORK_ITEM_GROUPED_PATTERN = scopedRoutePattern('/work-items/grouped');
+const WORK_ITEM_DETAIL_PATTERN = scopedRoutePattern('/work-items/([^/]+)');
+const WORK_ITEM_REQUEST_CHANGES_PATTERN = scopedRoutePattern('/work-items/([^/]+)/request-changes');
+const WORK_ITEM_PIN_PATTERN = scopedRoutePattern('/work-items/([^/]+)/pin');
+const WORK_ITEM_ARCHIVE_PATTERN = scopedRoutePattern('/work-items/([^/]+)/archive');
 
 export interface WorkItemRouteContext {
     routes: Route[];

--- a/packages/coc/src/server/work-items/work-item-store.ts
+++ b/packages/coc/src/server/work-items/work-item-store.ts
@@ -15,12 +15,14 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import {
-    detectRemoteUrl,
     getRepoDataPath,
-    resolveCanonicalOriginId,
     type ProcessStore,
-    type WorkspaceInfo,
 } from '@plusplusoneplusplus/forge';
+import {
+    isCanonicalOriginId,
+    mapWorkspaceOriginIds,
+    type OriginScopeProcessStore,
+} from '../repos/origin-scope';
 import type {
     WorkItem,
     WorkItemGitHubMirrorMetadata,
@@ -66,47 +68,21 @@ export type WorkItemStorageScopeResolver = (
     repoId: string,
 ) => WorkItemStorageScope | string | undefined | Promise<WorkItemStorageScope | string | undefined>;
 
-function isCanonicalOriginId(value: string): boolean {
-    return /^(gh|ado|git|local)_/.test(value);
-}
-
-async function resolveWorkspaceOriginId(
-    workspace: WorkspaceInfo,
-    processStore: Pick<ProcessStore, 'updateWorkspace'>,
-): Promise<string> {
-    let remoteUrl = workspace.remoteUrl;
-    if (!remoteUrl && workspace.rootPath) {
-        remoteUrl = await detectRemoteUrl(workspace.rootPath);
-        if (remoteUrl) {
-            await processStore.updateWorkspace(workspace.id, { remoteUrl });
-        }
-    }
-    return resolveCanonicalOriginId({ remoteUrl, workspaceId: workspace.id });
-}
-
 export function createWorkItemStorageScopeResolver(
-    processStore: Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'>,
+    processStore: OriginScopeProcessStore,
 ): WorkItemStorageScopeResolver {
     return async (repoId: string) => {
-        const workspaces = await processStore.getWorkspaces();
-        const originIdsByWorkspace = new Map<string, string>();
-        for (const workspace of workspaces) {
-            originIdsByWorkspace.set(
-                workspace.id,
-                await resolveWorkspaceOriginId(workspace, processStore),
-            );
-        }
+        const originIdsByWorkspace = await mapWorkspaceOriginIds(processStore);
 
         const storageRepoId = originIdsByWorkspace.get(repoId)
             ?? (isCanonicalOriginId(repoId) ? repoId : undefined);
         if (!storageRepoId) return undefined;
 
-        return {
-            storageRepoId,
-            legacyRepoIds: workspaces
-                .filter(workspace => originIdsByWorkspace.get(workspace.id) === storageRepoId)
-                .map(workspace => workspace.id),
-        };
+        const legacyRepoIds: string[] = [];
+        for (const [workspaceId, originId] of originIdsByWorkspace) {
+            if (originId === storageRepoId) legacyRepoIds.push(workspaceId);
+        }
+        return { storageRepoId, legacyRepoIds };
     };
 }
 

--- a/packages/coc/test/server/classification-store.test.ts
+++ b/packages/coc/test/server/classification-store.test.ts
@@ -406,6 +406,22 @@ describe('pruneStaleClassifications', () => {
         expect(removed).toBe(1);
         expect(fs.existsSync(pendingPath)).toBe(false);
     });
+
+    it('prunes the canonical origin directory when a storage scope is supplied', () => {
+        const scope = 'gh_owner_repo';
+        writeClassification(dataDir, 'ws-clone', 'repo', 'old', 'sha', validResult, { storageScope: scope });
+        const { resultPath } = classificationPaths(dataDir, 'ws-clone', 'repo', 'old', 'sha', scope);
+        const ancient = Date.now() - 40 * 24 * 60 * 60 * 1000;
+        fs.utimesSync(resultPath, ancient / 1000, ancient / 1000);
+
+        // Pruning with only the workspace id misses the origin directory.
+        expect(pruneStaleClassifications(dataDir, 'ws-clone', 30)).toBe(0);
+        expect(fs.existsSync(resultPath)).toBe(true);
+
+        // Supplying the origin scope targets the canonical directory.
+        expect(pruneStaleClassifications(dataDir, 'ws-clone', 30, scope)).toBe(1);
+        expect(fs.existsSync(resultPath)).toBe(false);
+    });
 });
 
 describe('pruneAllStaleClassifications', () => {

--- a/packages/coc/test/server/executors/chat-turn-context-builder.test.ts
+++ b/packages/coc/test/server/executors/chat-turn-context-builder.test.ts
@@ -327,4 +327,33 @@ describe('buildChatTurnContext', () => {
             }),
         );
     });
+
+    // -------------------------------------------------------------------------
+    // create_conversation enqueue capability passthrough (AC-02 Part 2)
+    // -------------------------------------------------------------------------
+
+    it('forwards the enqueueChat capability through to buildChatToolBundle', async () => {
+        const enqueueChat = vi.fn();
+
+        await buildChatTurnContext({
+            store: makeStore(),
+            workspaceId: 'ws-1',
+            enqueueChat,
+        });
+
+        expect(mockBuildChatToolBundle).toHaveBeenCalledWith(
+            expect.objectContaining({ enqueueChat }),
+        );
+    });
+
+    it('passes enqueueChat: undefined when the capability is absent', async () => {
+        await buildChatTurnContext({
+            store: makeStore(),
+            workspaceId: 'ws-1',
+        });
+
+        expect(mockBuildChatToolBundle).toHaveBeenCalledWith(
+            expect.objectContaining({ enqueueChat: undefined }),
+        );
+    });
 });

--- a/packages/coc/test/server/executors/create-conversation-addon.test.ts
+++ b/packages/coc/test/server/executors/create-conversation-addon.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildChatToolBundle } from '../../../src/server/executors/chat-tool-builder';
+import { buildCreateConversationAddon } from '../../../src/server/executors/prompt-builder';
+import { writeRepoPreferences } from '../../../src/server/preferences-handler';
+
+const WS_ID = 'ws-create-conversation';
+
+function makeStore() {
+    return {
+        searchConversations: vi.fn(),
+        getWorkspaces: vi.fn().mockResolvedValue([{ id: WS_ID }]),
+    } as any;
+}
+
+describe('buildCreateConversationAddon', () => {
+    it('no-ops (returns no tool) when the enqueue capability is absent', () => {
+        const addon = buildCreateConversationAddon(makeStore(), WS_ID, undefined);
+        expect(addon.tools).toEqual([]);
+        expect(addon.suffix).toBe('');
+    });
+
+    it('no-ops when the store is absent', () => {
+        const addon = buildCreateConversationAddon(undefined, WS_ID, vi.fn());
+        expect(addon.tools).toEqual([]);
+    });
+
+    it('builds the create_conversation tool when store + enqueue capability are present', () => {
+        const addon = buildCreateConversationAddon(makeStore(), WS_ID, vi.fn());
+        expect(addon.tools.map(t => t.name)).toEqual(['create_conversation']);
+    });
+});
+
+describe('buildChatToolBundle create_conversation wiring', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-conversation-bundle-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('includes create_conversation when the capability is provided AND the tool is enabled', () => {
+        // Explicit empty disabled list enables the otherwise opt-in tool.
+        writeRepoPreferences(tmpDir, WS_ID, { disabledLlmTools: [] });
+
+        const result = buildChatToolBundle({
+            dataDir: tmpDir,
+            store: makeStore(),
+            workspaceId: WS_ID,
+            enqueueChat: vi.fn(),
+        });
+
+        expect(result.tools.map(t => t.name)).toContain('create_conversation');
+    });
+
+    it('excludes create_conversation when the enqueue capability is absent (addon no-ops)', () => {
+        writeRepoPreferences(tmpDir, WS_ID, { disabledLlmTools: [] });
+
+        const result = buildChatToolBundle({
+            dataDir: tmpDir,
+            store: makeStore(),
+            workspaceId: WS_ID,
+            // no enqueueChat
+        });
+
+        expect(result.tools.map(t => t.name)).not.toContain('create_conversation');
+    });
+
+    it('excludes create_conversation by default (opt-in) even when the capability is present', () => {
+        // No repo preferences written → classic-mode defaults disable the opt-in tool.
+        const result = buildChatToolBundle({
+            dataDir: tmpDir,
+            store: makeStore(),
+            workspaceId: WS_ID,
+            enqueueChat: vi.fn(),
+        });
+
+        expect(result.tools.map(t => t.name)).not.toContain('create_conversation');
+    });
+
+    it('excludes create_conversation when explicitly disabled by repo preferences', () => {
+        writeRepoPreferences(tmpDir, WS_ID, { disabledLlmTools: ['create_conversation'] });
+
+        const result = buildChatToolBundle({
+            dataDir: tmpDir,
+            store: makeStore(),
+            workspaceId: WS_ID,
+            enqueueChat: vi.fn(),
+        });
+
+        expect(result.tools.map(t => t.name)).not.toContain('create_conversation');
+    });
+
+    it('defaults the create_conversation target workspace to options.workspaceId', async () => {
+        writeRepoPreferences(tmpDir, WS_ID, { disabledLlmTools: [] });
+
+        const enqueueChat = vi.fn().mockResolvedValue('task-123');
+        const result = buildChatToolBundle({
+            dataDir: tmpDir,
+            store: makeStore(),
+            workspaceId: WS_ID,
+            enqueueChat,
+        });
+
+        const tool = result.tools.find(t => t.name === 'create_conversation');
+        expect(tool).toBeDefined();
+
+        // Invoking with no workspaceId should fall back to options.workspaceId and
+        // enqueue a chat task scoped to that workspace.
+        await (tool as any).handler({ prompt: 'hello' });
+        expect(enqueueChat).toHaveBeenCalledTimes(1);
+        const input = enqueueChat.mock.calls[0][0];
+        expect(input.type).toBe('chat');
+        expect((input.payload as any).workspaceId).toBe(WS_ID);
+    });
+});

--- a/packages/coc/test/server/executors/create-conversation-enqueue-binding.test.ts
+++ b/packages/coc/test/server/executors/create-conversation-enqueue-binding.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration test for the create_conversation enqueue binding (AC-02 Part 2).
+ *
+ * Proves the tool is functional end-to-end against the *real* enqueue machinery
+ * that `POST /api/queue` uses: `createCreateConversationTool` wired to an
+ * `enqueueChat` callback that runs `enqueueViaBridge` against a real
+ * `MultiRepoQueueRouter`. Calling the handler with `{ prompt }` routes a
+ * `type:'chat'` task into the per-repo queue (so it appears in the chat list) and
+ * returns the queued task's identity.
+ *
+ * Mirrors the binding built at the route layer in `registerAllRoutes`:
+ *   enqueueChat = (input) => enqueueViaBridge(input, bridge, state, root, store)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { RepoQueueRegistry } from '@plusplusoneplusplus/forge';
+import type { CreateTaskInput } from '@plusplusoneplusplus/forge';
+
+// SDK mock — MultiRepoQueueRouter → CLITaskExecutor → getCopilotSDKService.
+import { createMockSDKService } from '../../helpers/mock-sdk-service';
+import { createMockProcessStore } from '../../helpers/mock-process-store';
+
+const sdkMocks = createMockSDKService();
+
+vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
+    return {
+        ...actual,
+        sdkServiceRegistry: { getOrThrow: () => sdkMocks.service },
+    };
+});
+
+import { MultiRepoQueueRouter } from '../../../src/server/queue/multi-repo-queue-router';
+import { createCreateConversationTool } from '../../../src/server/llm-tools/create-conversation-tool';
+import { enqueueViaBridge, type QueueGlobalState } from '../../../src/server/routes/queue-shared';
+
+const WS_ID = 'ws-spawn';
+const ROOT = '/repo/spawn';
+
+function freshState(): QueueGlobalState {
+    return {
+        globalPaused: false,
+        globalPausedUntil: undefined,
+        globalAutopilotPaused: false,
+        globalAutopilotPausedUntil: undefined,
+        resumeInProgress: new Set(),
+    };
+}
+
+function setup(state: QueueGlobalState = freshState()) {
+    const registry = new RepoQueueRegistry();
+    const store = createMockProcessStore();
+    (store.getWorkspaces as any).mockResolvedValue([{ id: WS_ID, rootPath: ROOT }]);
+    // autoStart:false → enqueued tasks stay queued (no SDK execution in the test).
+    const bridge = new MultiRepoQueueRouter(registry, store, { autoStart: false });
+
+    const enqueueChat = (input: CreateTaskInput): Promise<string> =>
+        enqueueViaBridge(input, bridge, state, ROOT, store);
+
+    const { tool } = createCreateConversationTool({ store: store as any, workspaceId: WS_ID, enqueueChat });
+    return { bridge, store, tool };
+}
+
+describe('create_conversation enqueue binding (real enqueueViaBridge path)', () => {
+    beforeEach(() => {
+        sdkMocks.resetAll();
+    });
+
+    it('enqueues a type:chat task that appears in the queue and returns its identity', async () => {
+        const { bridge, tool } = setup();
+
+        const result = await tool.handler({ prompt: 'spawn me a helper chat' }) as any;
+
+        // Returned identity is queue_<taskId> with an openable deep link.
+        expect(result.status).toBe('queued');
+        expect(result.processId).toMatch(/^queue_/);
+        expect(result.openLink).toBe(`#/process/${result.processId}`);
+
+        // The conversation is actually in the queue (chat-list visible).
+        const taskId = result.processId.slice('queue_'.length);
+        const task = bridge.getTask(taskId);
+        expect(task).toBeDefined();
+        expect(task!.type).toBe('chat');
+        expect((task!.payload as any).prompt).toBe('spawn me a helper chat');
+        expect((task!.payload as any).mode).toBe('ask');
+    });
+
+    it('routes an explicit autopilot mode + title through the real path', async () => {
+        const { bridge, tool } = setup();
+
+        const result = await tool.handler({
+            prompt: 'do the thing',
+            mode: 'autopilot',
+            title: 'Helper task',
+        }) as any;
+
+        expect(result.status).toBe('queued');
+        expect(result.title).toBe('Helper task');
+
+        const task = bridge.getTask(result.processId.slice('queue_'.length));
+        expect((task!.payload as any).mode).toBe('autopilot');
+        expect(task!.displayName).toBe('Helper task');
+    });
+
+    it('does not enqueue when validation fails (unknown workspace)', async () => {
+        const { bridge, tool } = setup();
+
+        const result = await tool.handler({ prompt: 'x', workspaceId: 'nope' }) as any;
+
+        expect(result.error).toMatch(/Unknown workspaceId/);
+        expect(bridge.createAggregateQueueFacade().getQueued()).toHaveLength(0);
+    });
+});

--- a/packages/coc/test/server/llm-tool-parameter-schemas.test.ts
+++ b/packages/coc/test/server/llm-tool-parameter-schemas.test.ts
@@ -20,6 +20,7 @@ import { LLM_TOOL_REGISTRY, type LlmToolMeta } from '../../src/server/llm-tools/
 import { createSuggestFollowUpsTool } from '../../src/server/llm-tools/suggest-follow-ups-tool';
 import { createSearchConversationsTool } from '../../src/server/llm-tools/search-conversations-tool';
 import { createGetConversationTool } from '../../src/server/llm-tools/get-conversation-tool';
+import { createCreateConversationTool } from '../../src/server/llm-tools/create-conversation-tool';
 import { createScheduleWakeupTool } from '../../src/server/llm-tools/loop-tools';
 import { createAskUserTool } from '../../src/server/llm-tools/ask-user-tool';
 import { createMemoryStoreFactTool, createMemoryRecallTool } from '../../src/server/llm-tools/memory-v2-tools';
@@ -110,6 +111,7 @@ describe('schema mirror drift guard', () => {
         { name: 'suggest_follow_ups', parameters: createSuggestFollowUpsTool().parameters },
         { name: 'search_conversations', parameters: createSearchConversationsTool({} as any).tool.parameters },
         { name: 'get_conversation', parameters: createGetConversationTool({} as any).tool.parameters },
+        { name: 'create_conversation', parameters: createCreateConversationTool({} as any).tool.parameters },
         { name: 'scheduleWakeup', parameters: createScheduleWakeupTool({} as any).tool.parameters },
         { name: 'ask_user', parameters: createAskUserTool({} as any).tool.parameters },
         { name: 'save_memory', parameters: createMemoryStoreFactTool({} as any).tool.parameters },

--- a/packages/coc/test/server/llm-tools/create-conversation-tool.test.ts
+++ b/packages/coc/test/server/llm-tools/create-conversation-tool.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Create Conversation Tool Tests
+ *
+ * Unit tests for createCreateConversationTool: defaults, explicit mode/provider,
+ * validation error paths (unknown workspace, bad provider, rejected modes,
+ * bad model, missing prompt), workspace defaulting, and the rich result shape.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createCreateConversationTool } from '../../../src/server/llm-tools/create-conversation-tool';
+import type { CreateConversationResult, CreateConversationSuccess } from '../../../src/server/llm-tools/create-conversation-tool';
+import type { CreateTaskInput, ProcessStore } from '@plusplusoneplusplus/forge';
+
+// Minimal invocation stub for handler calls (matches the SDK invocation arg).
+const invocationStub = {
+    sessionId: 'session-1',
+    toolCallId: 'call-1',
+    toolName: 'create_conversation',
+    arguments: {},
+};
+
+function makeStore(workspaceIds: string[] = ['ws-1']): ProcessStore {
+    const store: Partial<ProcessStore> = {
+        getWorkspaces: vi.fn().mockResolvedValue(
+            workspaceIds.map(id => ({ id, name: id, rootPath: `/repo/${id}` })),
+        ),
+    };
+    return store as ProcessStore;
+}
+
+/** Build a tool wired to a stub enqueue that captures the CreateTaskInput it receives. */
+function makeTool(opts?: { workspaceId?: string; storeWorkspaces?: string[]; taskId?: string }) {
+    const captured: { input?: CreateTaskInput } = {};
+    const enqueueChat = vi.fn(async (input: CreateTaskInput) => {
+        captured.input = input;
+        return opts?.taskId ?? 'task-123';
+    });
+    const { tool } = createCreateConversationTool({
+        store: makeStore(opts?.storeWorkspaces),
+        workspaceId: opts?.workspaceId ?? 'ws-1',
+        enqueueChat,
+    });
+    return { tool, enqueueChat, captured };
+}
+
+function asSuccess(result: CreateConversationResult): CreateConversationSuccess {
+    if ('error' in result) {
+        throw new Error(`Expected success but got error: ${result.error}`);
+    }
+    return result;
+}
+
+describe('createCreateConversationTool', () => {
+    it('returns a valid Tool shape with prompt required', () => {
+        const { tool } = makeTool();
+        expect(tool.name).toBe('create_conversation');
+        expect(typeof tool.handler).toBe('function');
+        expect(tool.parameters).toMatchObject({
+            type: 'object',
+            required: ['prompt'],
+        });
+    });
+
+    it('applies defaults (ask mode, normal priority, caller workspace) for { prompt } only', async () => {
+        const { tool, enqueueChat, captured } = makeTool({ workspaceId: 'ws-1' });
+
+        const result = asSuccess(await tool.handler({ prompt: 'hello' }, invocationStub));
+
+        expect(enqueueChat).toHaveBeenCalledTimes(1);
+        const input = captured.input!;
+        expect(input.type).toBe('chat');
+        expect(input.priority).toBe('normal');
+        const payload = input.payload as Record<string, unknown>;
+        expect(payload.kind).toBe('chat');
+        expect(payload.mode).toBe('ask');
+        expect(payload.prompt).toBe('hello');
+        expect(payload.workspaceId).toBe('ws-1');
+
+        expect(result.processId).toBe('queue_task-123');
+        expect(result.status).toBe('queued');
+        expect(result.openLink).toBe('#/process/queue_task-123');
+        expect(result.title).toContain('hello');
+    });
+
+    it('honors explicit mode:autopilot', async () => {
+        const { tool, captured } = makeTool();
+        await tool.handler({ prompt: 'do work', mode: 'autopilot' }, invocationStub);
+        const payload = captured.input!.payload as Record<string, unknown>;
+        expect(payload.mode).toBe('autopilot');
+    });
+
+    it('uses an explicit title as the display name', async () => {
+        const { tool, captured } = makeTool();
+        const result = asSuccess(await tool.handler({ prompt: 'hello', title: 'My Spawned Chat' }, invocationStub));
+        expect(captured.input!.displayName).toBe('My Spawned Chat');
+        expect(result.title).toBe('My Spawned Chat');
+    });
+
+    it('passes provider and model through to the task', async () => {
+        const { tool, captured } = makeTool();
+        await tool.handler({ prompt: 'hi', provider: 'claude', model: 'claude-opus-4-8' }, invocationStub);
+        const payload = captured.input!.payload as Record<string, unknown>;
+        expect(payload.provider).toBe('claude');
+        expect(captured.input!.config?.model).toBe('claude-opus-4-8');
+    });
+
+    it('targets a different registered workspace when workspaceId is provided', async () => {
+        const { tool, captured } = makeTool({ workspaceId: 'ws-1', storeWorkspaces: ['ws-1', 'ws-2'] });
+        await tool.handler({ prompt: 'hi', workspaceId: 'ws-2' }, invocationStub);
+        const payload = captured.input!.payload as Record<string, unknown>;
+        expect(payload.workspaceId).toBe('ws-2');
+    });
+
+    it('honors a high priority', async () => {
+        const { tool, captured } = makeTool();
+        await tool.handler({ prompt: 'urgent', priority: 'high' }, invocationStub);
+        expect(captured.input!.priority).toBe('high');
+    });
+
+    // ---- error paths ------------------------------------------------------
+
+    it('errors on missing/blank prompt', async () => {
+        const { tool, enqueueChat } = makeTool();
+        const result = await tool.handler({ prompt: '   ' }, invocationStub);
+        expect('error' in result && result.error).toMatch(/prompt/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('errors on an unknown workspaceId', async () => {
+        const { tool, enqueueChat } = makeTool({ workspaceId: 'ws-1', storeWorkspaces: ['ws-1'] });
+        const result = await tool.handler({ prompt: 'hi', workspaceId: 'ws-missing' }, invocationStub);
+        expect('error' in result && result.error).toMatch(/unknown workspaceid/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('errors when no workspace can be resolved', async () => {
+        const captured: { input?: CreateTaskInput } = {};
+        const enqueueChat = vi.fn(async (input: CreateTaskInput) => {
+            captured.input = input;
+            return 'task-x';
+        });
+        const { tool } = createCreateConversationTool({
+            store: makeStore(['ws-1']),
+            workspaceId: undefined,
+            enqueueChat,
+        });
+        const result = await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect('error' in result && result.error).toMatch(/no target workspace/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('errors on an invalid provider', async () => {
+        const { tool, enqueueChat } = makeTool();
+        const result = await tool.handler(
+            { prompt: 'hi', provider: 'gemini' as never },
+            invocationStub,
+        );
+        expect('error' in result && result.error).toMatch(/invalid provider/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('rejects mode:plan', async () => {
+        const { tool, enqueueChat } = makeTool();
+        const result = await tool.handler({ prompt: 'hi', mode: 'plan' as never }, invocationStub);
+        expect('error' in result && result.error).toMatch(/invalid mode/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('rejects mode:ralph', async () => {
+        const { tool, enqueueChat } = makeTool();
+        const result = await tool.handler({ prompt: 'hi', mode: 'ralph' as never }, invocationStub);
+        expect('error' in result && result.error).toMatch(/invalid mode/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('errors on an empty model string', async () => {
+        const { tool, enqueueChat } = makeTool();
+        const result = await tool.handler({ prompt: 'hi', model: '   ' }, invocationStub);
+        expect('error' in result && result.error).toMatch(/invalid model/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('errors on an invalid priority', async () => {
+        const { tool, enqueueChat } = makeTool();
+        const result = await tool.handler(
+            { prompt: 'hi', priority: 'urgent' as never },
+            invocationStub,
+        );
+        expect('error' in result && result.error).toMatch(/invalid priority/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+});

--- a/packages/coc/test/server/llm-tools/llm-tool-registry.test.ts
+++ b/packages/coc/test/server/llm-tools/llm-tool-registry.test.ts
@@ -24,6 +24,7 @@ describe('LLM_TOOL_REGISTRY', () => {
         expect(names).toContain('ask_user');
         expect(names).toContain('get_work_item');
         expect(names).toContain('create_update_work_item');
+        expect(names).toContain('create_conversation');
         expect(names).not.toContain('create_work_item');
         expect(names).not.toContain('update_work_item');
         expect(names).not.toContain('create_bug');
@@ -51,9 +52,18 @@ describe('LLM_TOOL_REGISTRY', () => {
         expect(tavily!.enabledByDefault).toBe(false);
     });
 
+    it('create_conversation is opt-in (disabled by default)', () => {
+        const entry = LLM_TOOL_REGISTRY.find(t => t.name === 'create_conversation');
+        expect(entry).toBeDefined();
+        expect(entry!.enabledByDefault).toBe(false);
+        // Exactly one registry entry named create_conversation.
+        expect(LLM_TOOL_REGISTRY.filter(t => t.name === 'create_conversation')).toHaveLength(1);
+    });
+
     it('all other tools are enabled by default', () => {
-        const nonTavily = LLM_TOOL_REGISTRY.filter(t => t.name !== 'tavily_web_search');
-        for (const tool of nonTavily) {
+        const optIn = new Set(['tavily_web_search', 'create_conversation']);
+        const enabledByDefaultTools = LLM_TOOL_REGISTRY.filter(t => !optIn.has(t.name));
+        for (const tool of enabledByDefaultTools) {
             expect(tool.enabledByDefault).toBe(true);
         }
     });
@@ -62,6 +72,10 @@ describe('LLM_TOOL_REGISTRY', () => {
 describe('DEFAULT_DISABLED_LLM_TOOLS', () => {
     it('contains tavily_web_search', () => {
         expect(DEFAULT_DISABLED_LLM_TOOLS).toContain('tavily_web_search');
+    });
+
+    it('contains the opt-in create_conversation tool', () => {
+        expect(DEFAULT_DISABLED_LLM_TOOLS).toContain('create_conversation');
     });
 
     it('does not contain enabled-by-default tools', () => {
@@ -109,6 +123,14 @@ describe('isLlmToolEnabled', () => {
 
     it('returns false for tavily_web_search when disabledList is undefined (default)', () => {
         expect(isLlmToolEnabled('tavily_web_search', undefined)).toBe(false);
+    });
+
+    it('returns false for opt-in create_conversation when disabledList is undefined (default)', () => {
+        expect(isLlmToolEnabled('create_conversation', undefined)).toBe(false);
+    });
+
+    it('returns true for create_conversation when explicitly enabled (empty disabled list)', () => {
+        expect(isLlmToolEnabled('create_conversation', [])).toBe(true);
     });
 
     it('returns true for tavily_web_search when explicitly enabled (empty disabled list)', () => {

--- a/packages/coc/test/server/repos/origin-scope.test.ts
+++ b/packages/coc/test/server/repos/origin-scope.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { detectRemoteUrl, type ProcessStore, type WorkspaceInfo } from '@plusplusoneplusplus/forge';
+import {
+    isCanonicalOriginId,
+    mapWorkspaceOriginIds,
+    resolveOriginIdForId,
+    resolveWorkspaceOriginId,
+    resolveWorkspaceRemoteUrl,
+    sameOriginWorkspaceIds,
+} from '../../../src/server/repos/origin-scope';
+
+// Keep the real canonical-id resolution; only stub remote detection so the
+// detect-and-backfill path is deterministic without a real git checkout.
+vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@plusplusoneplusplus/forge')>();
+    return { ...actual, detectRemoteUrl: vi.fn() };
+});
+
+const mockedDetectRemoteUrl = vi.mocked(detectRemoteUrl);
+
+function workspace(overrides: Partial<WorkspaceInfo> & { id: string }): WorkspaceInfo {
+    return {
+        name: overrides.id,
+        rootPath: `/repos/${overrides.id}`,
+        ...overrides,
+    } as WorkspaceInfo;
+}
+
+function makeProcessStore(workspaces: WorkspaceInfo[]): {
+    store: Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'>;
+    updates: Array<{ id: string; updates: Partial<WorkspaceInfo> }>;
+} {
+    const updates: Array<{ id: string; updates: Partial<WorkspaceInfo> }> = [];
+    const store: Pick<ProcessStore, 'getWorkspaces' | 'updateWorkspace'> = {
+        getWorkspaces: async () => workspaces,
+        updateWorkspace: async (id, patch) => {
+            updates.push({ id, updates: patch as Partial<WorkspaceInfo> });
+            const ws = workspaces.find(entry => entry.id === id);
+            if (!ws) return undefined;
+            Object.assign(ws, patch);
+            return ws;
+        },
+    };
+    return { store, updates };
+}
+
+beforeEach(() => {
+    mockedDetectRemoteUrl.mockReset();
+});
+
+describe('isCanonicalOriginId', () => {
+    it('recognizes canonical origin prefixes', () => {
+        expect(isCanonicalOriginId('gh_owner_repo')).toBe(true);
+        expect(isCanonicalOriginId('ado_org_project')).toBe(true);
+        expect(isCanonicalOriginId('git_abc123')).toBe(true);
+        expect(isCanonicalOriginId('local_ws-1')).toBe(true);
+    });
+
+    it('rejects clone-specific workspace ids', () => {
+        expect(isCanonicalOriginId('ws-xjvuoc')).toBe(false);
+        expect(isCanonicalOriginId('clone-a')).toBe(false);
+        expect(isCanonicalOriginId('github_owner_repo')).toBe(false);
+    });
+});
+
+describe('resolveWorkspaceRemoteUrl', () => {
+    it('returns the stored remote without detecting when present', async () => {
+        const ws = workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' });
+        const remote = await resolveWorkspaceRemoteUrl(ws);
+        expect(remote).toBe('https://github.com/owner/repo.git');
+        expect(mockedDetectRemoteUrl).not.toHaveBeenCalled();
+    });
+
+    it('detects and backfills the remote when the record has none', async () => {
+        mockedDetectRemoteUrl.mockResolvedValue('git@github.com:owner/repo.git');
+        const ws = workspace({ id: 'clone-a', remoteUrl: undefined });
+        const { store, updates } = makeProcessStore([ws]);
+
+        const remote = await resolveWorkspaceRemoteUrl(ws, store);
+
+        expect(remote).toBe('git@github.com:owner/repo.git');
+        expect(mockedDetectRemoteUrl).toHaveBeenCalledWith('/repos/clone-a');
+        expect(updates).toEqual([{ id: 'clone-a', updates: { remoteUrl: 'git@github.com:owner/repo.git' } }]);
+    });
+
+    it('returns undefined and does not backfill when detection finds no remote', async () => {
+        mockedDetectRemoteUrl.mockResolvedValue(undefined);
+        const ws = workspace({ id: 'clone-a', remoteUrl: undefined });
+        const { store, updates } = makeProcessStore([ws]);
+
+        const remote = await resolveWorkspaceRemoteUrl(ws, store);
+
+        expect(remote).toBeUndefined();
+        expect(updates).toEqual([]);
+    });
+
+    it('does not detect when there is no root path', async () => {
+        const ws = workspace({ id: 'clone-a', remoteUrl: undefined, rootPath: undefined });
+        const remote = await resolveWorkspaceRemoteUrl(ws);
+        expect(remote).toBeUndefined();
+        expect(mockedDetectRemoteUrl).not.toHaveBeenCalled();
+    });
+});
+
+describe('resolveWorkspaceOriginId', () => {
+    it('resolves a canonical origin id from the stored remote', async () => {
+        const ws = workspace({ id: 'clone-a', remoteUrl: 'https://github.com/Owner/Repo.git' });
+        expect(await resolveWorkspaceOriginId(ws)).toBe('gh_owner_repo');
+    });
+
+    it('detects + backfills, then resolves the canonical origin id', async () => {
+        mockedDetectRemoteUrl.mockResolvedValue('git@github.com:owner/repo.git');
+        const ws = workspace({ id: 'clone-a', remoteUrl: undefined });
+        const { store, updates } = makeProcessStore([ws]);
+
+        expect(await resolveWorkspaceOriginId(ws, store)).toBe('gh_owner_repo');
+        expect(updates).toHaveLength(1);
+    });
+
+    it('falls back to a local origin id when no remote is available', async () => {
+        mockedDetectRemoteUrl.mockResolvedValue(undefined);
+        const ws = workspace({ id: 'ws-solo', remoteUrl: undefined });
+        expect(await resolveWorkspaceOriginId(ws)).toBe('local_ws-solo');
+    });
+});
+
+describe('mapWorkspaceOriginIds', () => {
+    it('maps every workspace to its canonical origin in getWorkspaces order', async () => {
+        const workspaces = [
+            workspace({ id: 'clone-a', remoteUrl: 'https://github.com/Owner/Repo.git' }),
+            workspace({ id: 'clone-b', remoteUrl: 'git@github.com:owner/repo.git' }),
+            workspace({ id: 'other', remoteUrl: 'https://github.com/owner/other.git' }),
+        ];
+        const { store } = makeProcessStore(workspaces);
+
+        const map = await mapWorkspaceOriginIds(store);
+
+        expect([...map.entries()]).toEqual([
+            ['clone-a', 'gh_owner_repo'],
+            ['clone-b', 'gh_owner_repo'],
+            ['other', 'gh_owner_other'],
+        ]);
+    });
+});
+
+describe('sameOriginWorkspaceIds', () => {
+    it('lists all clones sharing one canonical origin in order', async () => {
+        const workspaces = [
+            workspace({ id: 'clone-a', remoteUrl: 'https://github.com/Owner/Repo.git' }),
+            workspace({ id: 'other', remoteUrl: 'https://github.com/owner/other.git' }),
+            workspace({ id: 'clone-b', remoteUrl: 'git@github.com:owner/repo.git' }),
+        ];
+        const { store } = makeProcessStore(workspaces);
+
+        expect(await sameOriginWorkspaceIds(store, 'gh_owner_repo')).toEqual(['clone-a', 'clone-b']);
+    });
+
+    it('returns an empty list when no workspace resolves to the origin', async () => {
+        const { store } = makeProcessStore([
+            workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' }),
+        ]);
+        expect(await sameOriginWorkspaceIds(store, 'gh_owner_other')).toEqual([]);
+    });
+});
+
+describe('resolveOriginIdForId', () => {
+    it('resolves a registered workspace id to its origin', async () => {
+        const { store } = makeProcessStore([
+            workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' }),
+        ]);
+        expect(await resolveOriginIdForId(store, 'clone-a')).toBe('gh_owner_repo');
+    });
+
+    it('passes through an already-canonical origin id that is not registered', async () => {
+        const { store } = makeProcessStore([]);
+        expect(await resolveOriginIdForId(store, 'gh_owner_repo')).toBe('gh_owner_repo');
+    });
+
+    it('returns undefined for an unregistered, non-canonical id', async () => {
+        const { store } = makeProcessStore([
+            workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' }),
+        ]);
+        expect(await resolveOriginIdForId(store, 'ws-unknown')).toBeUndefined();
+    });
+});

--- a/packages/coc/test/server/routes/work-item-route-scope.test.ts
+++ b/packages/coc/test/server/routes/work-item-route-scope.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import type { ProcessStore, WorkspaceInfo } from '@plusplusoneplusplus/forge';
+import {
+    resolveWorkItemRouteScope,
+    scopedRoutePattern,
+} from '../../../src/server/routes/work-item-route-scope';
+
+function makeCtx(workspaces: WorkspaceInfo[]): { processStore: ProcessStore } {
+    const store = {
+        getWorkspaces: async () => workspaces,
+        updateWorkspace: async (id: string, patch: Partial<WorkspaceInfo>) => {
+            const ws = workspaces.find(entry => entry.id === id);
+            if (!ws) return undefined;
+            Object.assign(ws, patch);
+            return ws;
+        },
+    } as unknown as ProcessStore;
+    return { processStore: store };
+}
+
+function workspace(overrides: Partial<WorkspaceInfo> & { id: string }): WorkspaceInfo {
+    return { name: overrides.id, rootPath: `/repos/${overrides.id}`, ...overrides } as WorkspaceInfo;
+}
+
+describe('scopedRoutePattern', () => {
+    it('matches both the workspaces and origins families and captures kind + id', () => {
+        const pattern = scopedRoutePattern('/work-items');
+        expect('/api/workspaces/ws-1/work-items'.match(pattern)?.slice(1)).toEqual(['workspaces', 'ws-1']);
+        expect('/api/origins/gh_owner_repo/work-items'.match(pattern)?.slice(1)).toEqual(['origins', 'gh_owner_repo']);
+    });
+
+    it('anchors both ends and exposes tail capture groups', () => {
+        const pattern = scopedRoutePattern('/work-items/([^/]+)');
+        expect(pattern.test('/api/workspaces/ws-1/work-items')).toBe(false);
+        expect(pattern.test('/api/workspaces/ws-1/work-items/wi-9/extra')).toBe(false);
+        expect('/api/origins/gh_o_r/work-items/wi-9'.match(pattern)?.slice(1)).toEqual([
+            'origins',
+            'gh_o_r',
+            'wi-9',
+        ]);
+    });
+
+    it('rejects unknown scope families', () => {
+        const pattern = scopedRoutePattern('/work-items');
+        expect(pattern.test('/api/repos/ws-1/work-items')).toBe(false);
+    });
+});
+
+describe('resolveWorkItemRouteScope', () => {
+    it('resolves the workspaces family to a canonical storage id with the workspace as command repo', async () => {
+        const ctx = makeCtx([workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' })]);
+        const scope = await resolveWorkItemRouteScope(ctx, 'workspaces', 'clone-a');
+        expect(scope).toEqual({
+            kind: 'workspaces',
+            routeScopeId: 'clone-a',
+            storageRepoId: 'gh_owner_repo',
+            commandRepoId: 'clone-a',
+            workspaceId: 'clone-a',
+        });
+    });
+
+    it('keeps an unregistered workspaces id as its own storage id', async () => {
+        const ctx = makeCtx([]);
+        const scope = await resolveWorkItemRouteScope(ctx, 'workspaces', 'gh_owner_repo');
+        expect(scope.storageRepoId).toBe('gh_owner_repo');
+        expect(scope.commandRepoId).toBe('gh_owner_repo');
+    });
+
+    it('uses the origin id directly when the origins family has no selected workspace', async () => {
+        const ctx = makeCtx([workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' })]);
+        const scope = await resolveWorkItemRouteScope(ctx, 'origins', 'gh_owner_repo');
+        expect(scope).toEqual({
+            kind: 'origins',
+            routeScopeId: 'gh_owner_repo',
+            storageRepoId: 'gh_owner_repo',
+            commandRepoId: 'gh_owner_repo',
+        });
+    });
+
+    it('binds the selected workspace as command repo when it resolves to the origin', async () => {
+        const ctx = makeCtx([workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/repo.git' })]);
+        const scope = await resolveWorkItemRouteScope(ctx, 'origins', 'gh_owner_repo', 'clone-a');
+        expect(scope).toEqual({
+            kind: 'origins',
+            routeScopeId: 'gh_owner_repo',
+            storageRepoId: 'gh_owner_repo',
+            commandRepoId: 'clone-a',
+            workspaceId: 'clone-a',
+        });
+    });
+
+    it('rejects an unregistered selected workspace', async () => {
+        const ctx = makeCtx([]);
+        await expect(resolveWorkItemRouteScope(ctx, 'origins', 'gh_owner_repo', 'missing'))
+            .rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('rejects a selected workspace that resolves to a different origin', async () => {
+        const ctx = makeCtx([workspace({ id: 'clone-a', remoteUrl: 'https://github.com/owner/other.git' })]);
+        await expect(resolveWorkItemRouteScope(ctx, 'origins', 'gh_owner_repo', 'clone-a'))
+            .rejects.toMatchObject({ statusCode: 400 });
+    });
+});


### PR DESCRIPTION
Adds a `create_conversation` LLM tool that lets the assistant spawn a brand-new, separate chat conversation (fire-and-forget) into the dashboard queue.

- **AC-01** — `create-conversation-tool` factory + handler.
- **AC-03** — registered as an opt-in tool (parameter schemas + registry).
- **AC-02** — wired into the chat tool bundle and the enqueue capability end-to-end (executors, queue bridge, routes).
- Extracts a shared canonical origin-scope resolver (`repos/origin-scope.ts`) reused by classification/PR/work-item scoping.

Note: this PR is the prerequisite for the excalidraw native-canvas PR, which will be submitted as a follow-up once this merges.