### PR TITLE
feat(coc): make excalidraw a native canvas type

### DIFF
--- a/packages/coc/src/server/canvas/canvas-store.ts
+++ b/packages/coc/src/server/canvas/canvas-store.ts
@@ -32,9 +32,9 @@ import { getRepoDataPath } from '../paths';
 
 export type CanvasEditor = 'ai' | 'user';
 
-export type CanvasType = 'markdown' | 'code' | 'extension';
+export type CanvasType = 'markdown' | 'code' | 'extension' | 'excalidraw';
 
-export const CANVAS_TYPES: readonly CanvasType[] = ['markdown', 'code', 'extension'];
+export const CANVAS_TYPES: readonly CanvasType[] = ['markdown', 'code', 'extension', 'excalidraw'];
 
 export interface CanvasDescriptor {
     id: string;
@@ -237,7 +237,9 @@ export class CanvasStore {
     createCanvas(input: CreateCanvasInput): CanvasRecord {
         const id = generateCanvasId(input.title);
         const now = new Date().toISOString();
-        const type: CanvasType = input.type === 'code' || input.type === 'extension' ? input.type : 'markdown';
+        const type: CanvasType = input.type === 'code' || input.type === 'extension' || input.type === 'excalidraw'
+            ? input.type
+            : 'markdown';
         const language = type === 'code' ? normalizeCanvasLanguage(input.language) : undefined;
         const record: CanvasRecord = {
             id,

--- a/packages/coc/src/server/canvas/excalidraw-scene.ts
+++ b/packages/coc/src/server/canvas/excalidraw-scene.ts
@@ -1,0 +1,196 @@
+/**
+ * Excalidraw scene validation + normalization for the canvas write path.
+ *
+ * `excalidraw` canvases store an Excalidraw scene (`{ elements, appState }`) as
+ * their artifact content — a JSON string. The AI emits a "skeleton" scene:
+ * elements that carry only the visible attributes (id/type/x/y/width/height/
+ * text/points/...) but omit Excalidraw's internal bookkeeping fields
+ * (`version`, `versionNonce`, `groupIds`, `isDeleted`, `seed`, default style
+ * fields, ...). We complete those fields here, server-side, before persisting
+ * so the stored scene is a renderable `{ elements, appState }`.
+ *
+ * Why this normalizer is pure and dependency-free:
+ *   The richer client-side completion in
+ *   `spa/client/react/features/diagrams/diagram-scene.ts` pipes elements
+ *   through `convertToExcalidrawElements` / `restoreElements` from
+ *   `@excalidraw/excalidraw`. That package cannot be imported in Node — it
+ *   imports `open-color.json` without a JSON import attribute, which throws on
+ *   Node ≥ 24 (`needs an import attribute of "type: json"`). So the server
+ *   write path uses this self-contained normalizer instead. The browser viewer
+ *   still runs the full Excalidraw normalization at render time, so no render
+ *   fidelity is lost — server normalization is the persisted floor, client
+ *   normalization is the render ceiling.
+ *
+ * No VS Code dependencies — uses only Node.js built-in modules.
+ * Cross-platform compatible (Linux/Mac/Windows).
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ExcalidrawScene {
+    elements: any[];
+    appState: Record<string, any>;
+    files?: Record<string, any>;
+    [key: string]: any;
+}
+
+export type NormaliseSceneResult =
+    | { ok: true; scene: ExcalidrawScene; content: string }
+    | { ok: false; error: string };
+
+// ============================================================================
+// Element completion
+// ============================================================================
+
+/**
+ * Deterministic positive integer per element index. Excalidraw uses random
+ * `seed` / `versionNonce` integers; we derive stable ones (no `Math.random`)
+ * so normalization stays pure and test output is reproducible.
+ */
+function pseudoNonce(index: number, salt = 0): number {
+    return ((index + 1) * 1_000_003 + salt * 97) % 2_147_483_647;
+}
+
+/** Set keys on `target` only when the existing value is `undefined`. */
+function fillDefaults(target: Record<string, any>, defaults: Record<string, any>): void {
+    for (const key of Object.keys(defaults)) {
+        if (target[key] === undefined) target[key] = defaults[key];
+    }
+}
+
+/**
+ * Complete a single skeleton element with the bookkeeping + default-style
+ * fields Excalidraw expects, without overwriting any field the author set.
+ */
+function completeElement(raw: any, index: number): any {
+    const el: Record<string, any> = { ...raw };
+
+    fillDefaults(el, {
+        id: `el-${index}`,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        angle: 0,
+        strokeColor: '#1e1e1e',
+        backgroundColor: 'transparent',
+        fillStyle: 'solid',
+        strokeWidth: 2,
+        strokeStyle: 'solid',
+        roughness: 1,
+        opacity: 100,
+        groupIds: [],
+        frameId: null,
+        roundness: null,
+        seed: pseudoNonce(index, 1),
+        version: 1,
+        versionNonce: pseudoNonce(index, 2),
+        isDeleted: false,
+        boundElements: null,
+        updated: 1,
+        link: null,
+        locked: false,
+    });
+
+    if (el.type === 'text') {
+        fillDefaults(el, {
+            text: '',
+            fontSize: 20,
+            fontFamily: 1,
+            textAlign: 'left',
+            verticalAlign: 'top',
+            containerId: null,
+            lineHeight: 1.25,
+            autoResize: true,
+        });
+        if (el.originalText === undefined) el.originalText = el.text;
+    }
+
+    if (el.type === 'arrow' || el.type === 'line') {
+        fillDefaults(el, {
+            points: [[0, 0], [el.width ?? 0, el.height ?? 0]],
+            lastCommittedPoint: null,
+            startBinding: null,
+            endBinding: null,
+            startArrowhead: null,
+            endArrowhead: el.type === 'arrow' ? 'arrow' : null,
+        });
+    }
+
+    return el;
+}
+
+/**
+ * Normalise skeleton scene elements into renderable Excalidraw elements.
+ *
+ * Pure server-side counterpart of the client viewer's `normaliseSceneElements`
+ * (which uses `@excalidraw/excalidraw`, unavailable in Node). Fills the common
+ * bookkeeping + style defaults LLM-emitted elements omit, preserving every
+ * field the author already supplied. Non-object entries are dropped.
+ */
+export function normaliseSceneElements(elements: any[]): any[] {
+    if (!Array.isArray(elements) || elements.length === 0) return [];
+    const out: any[] = [];
+    elements.forEach((el, index) => {
+        if (el && typeof el === 'object' && !Array.isArray(el)) {
+            out.push(completeElement(el, index));
+        }
+    });
+    return out;
+}
+
+// ============================================================================
+// Scene validation + normalization
+// ============================================================================
+
+function parseSceneInput(raw: unknown): { ok: true; value: Record<string, any> } | { ok: false; error: string } {
+    let value: unknown = raw;
+    if (typeof raw === 'string') {
+        try {
+            value = JSON.parse(raw);
+        } catch {
+            return { ok: false, error: 'Excalidraw canvas content must be valid scene JSON ({ elements, appState }).' };
+        }
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return { ok: false, error: 'Excalidraw scene must be a JSON object with "elements" and "appState".' };
+    }
+    return { ok: true, value: value as Record<string, any> };
+}
+
+/**
+ * Validate + normalise an Excalidraw scene for persistence.
+ *
+ * Accepts the raw scene as a JSON string (how `write_canvas` receives it) or a
+ * pre-parsed object. Validates the `{ elements, appState }` shape, completes
+ * skeleton elements via `normaliseSceneElements`, and returns the pretty-printed
+ * JSON string to store as the canvas artifact.
+ */
+export function normaliseExcalidrawScene(raw: unknown): NormaliseSceneResult {
+    const parsed = parseSceneInput(raw);
+    if (!parsed.ok) return parsed;
+    const value = parsed.value;
+
+    if (value.elements !== undefined && !Array.isArray(value.elements)) {
+        return { ok: false, error: 'Excalidraw scene "elements" must be an array.' };
+    }
+    if (value.appState !== undefined && (typeof value.appState !== 'object' || value.appState === null || Array.isArray(value.appState))) {
+        return { ok: false, error: 'Excalidraw scene "appState" must be an object.' };
+    }
+
+    const elements = normaliseSceneElements(Array.isArray(value.elements) ? value.elements : []);
+    const appState: Record<string, any> = (value.appState && typeof value.appState === 'object' && !Array.isArray(value.appState))
+        ? value.appState
+        : {};
+
+    const scene: ExcalidrawScene = {
+        ...value,
+        type: typeof value.type === 'string' ? value.type : 'excalidraw',
+        elements,
+        appState,
+    };
+
+    return { ok: true, scene, content: JSON.stringify(scene, null, 2) };
+}

--- a/packages/coc/src/server/executors/chat-tool-builder.ts
+++ b/packages/coc/src/server/executors/chat-tool-builder.ts
@@ -13,7 +13,6 @@ import {
     buildCanvasToolsAddon,
     buildCreateConversationAddon,
     buildCreateWorkItemAddon,
-    buildExcalidrawToolsAddon,
     buildFollowUpSuggestionsAddon,
     buildLoopToolsAddon,
     buildScheduleWakeupAddon,
@@ -50,7 +49,6 @@ export interface ChatToolBundleOptions {
     includeWorkItemTools?: boolean;
     includeTavilyWebSearch?: boolean;
     includeScheduleWakeup?: boolean;
-    includeExcalidrawTools?: boolean;
     includeCanvasTools?: boolean;
     /** Overrides the `canvas.enabled` config flag (used by tests). */
     canvasToolsEnabled?: boolean;
@@ -131,10 +129,6 @@ export function buildChatToolBundle(options: ChatToolBundleOptions): ChatToolBun
 
     if (options.loopTools) {
         addons.push(buildLoopToolsAddon(options.loopTools));
-    }
-
-    if (options.includeExcalidrawTools !== false) {
-        addons.push(buildExcalidrawToolsAddon(options.dataDir, options.workspaceId));
     }
 
     if (options.includeCanvasTools !== false) {

--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -33,7 +33,6 @@ import { createAskUserTool } from '../llm-tools/ask-user-tool';
 import { createCanvasTools } from '../llm-tools/canvas-tools';
 import { createCreateUpdateWorkItemTool, type BroadcastWorkItemFn, type CreateUpdateWorkItemToolDeps } from '../llm-tools/create-update-work-item-tool';
 import { createCreateConversationTool, type EnqueueChatFn } from '../llm-tools/create-conversation-tool';
-import { createExcalidrawTools } from '../llm-tools/excalidraw-tools';
 import { createGetConversationTool } from '../llm-tools/get-conversation-tool';
 import { createGetWorkItemTool } from '../llm-tools/get-work-item-tool';
 import { filterDisabledLlmTools } from '../llm-tools/llm-tool-registry';
@@ -703,23 +702,6 @@ export function buildLoopToolsAddon(
     const { tool: listTool } = createListLoopsTool(deps);
 
     return { tools: [createTool, cancelTool, listTool], suffix: '' };
-}
-
-// ============================================================================
-// Excalidraw Tools
-// ============================================================================
-
-export function buildExcalidrawToolsAddon(
-    dataDir: string | undefined,
-    workspaceId: string | undefined,
-): { tools: Tool<any>[]; suffix: string } {
-    if (!dataDir || !workspaceId) {
-        return { tools: [], suffix: '' };
-    }
-
-    const { createOrUpdate, read } = createExcalidrawTools({ dataDir, workspaceId });
-
-    return { tools: [createOrUpdate, read], suffix: '' };
 }
 
 // ============================================================================

--- a/packages/coc/src/server/llm-tools/canvas-tools.ts
+++ b/packages/coc/src/server/llm-tools/canvas-tools.ts
@@ -24,6 +24,7 @@ import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import { CanvasStore, MAX_EXTENSION_UI_BYTES, MAX_EXTENSION_CAPABILITIES_BYTES } from '../canvas/canvas-store';
 import type { CanvasEdit, CanvasType, CanvasCapabilityMeta, CanvasExtensionManifest } from '../canvas/canvas-store';
 import { runCanvasCapability, isValidCapabilityName } from '../canvas/canvas-capability-runner';
+import { normaliseExcalidrawScene } from '../canvas/excalidraw-scene';
 import { emitCanvasUpdated } from '../streaming/sse-handler';
 
 // ============================================================================
@@ -130,11 +131,14 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
     // ------------------------------------------------------------------
     const write = defineTool<WriteCanvasArgs>('write_canvas', {
         description:
-            'Create or update a markdown/code canvas — a live document beside the chat the user iterates on. '
+            'Create or update a canvas — a live document beside the chat the user iterates on. '
             + 'Markdown renders Mermaid blocks as diagrams. Omit canvasId to create (needs title + content; '
-            + 'set type "code" + language for code). To update, pass canvasId + expectedRevision and either '
-            + 'edits (exact-match, one per match) or content (full rewrite). On a revision conflict the user '
-            + 'edited it — read_canvas and retry. Keep chat replies short; reference the canvas, don\'t repeat it.',
+            + 'set type "code" + language for code). For an Excalidraw diagram, set type "excalidraw" and pass '
+            + 'the scene JSON ({ elements, appState }) as content — it renders inline in chat and in the panel; '
+            + 'updates must pass the full scene as content (edits are rejected for excalidraw). To update, pass '
+            + 'canvasId + expectedRevision and either edits (exact-match, one per match) or content (full rewrite). '
+            + 'On a revision conflict the user edited it — read_canvas and retry. Keep chat replies short; '
+            + 'reference the canvas, don\'t repeat it.',
         parameters: {
             type: 'object',
             properties: {
@@ -153,7 +157,7 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
                         required: ['oldText', 'newText'],
                     },
                 },
-                type: { type: 'string', enum: ['markdown', 'code'], description: 'Create only. Default "markdown".' },
+                type: { type: 'string', enum: ['markdown', 'code', 'excalidraw'], description: 'Create only. Default "markdown". Use "excalidraw" for a diagram whose content is the scene JSON.' },
                 language: { type: 'string', description: 'Create only, for type "code" (e.g. "typescript").' },
                 purpose: {
                     type: 'string',
@@ -171,10 +175,34 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
                 if (a.content === undefined && (!a.edits || a.edits.length === 0) && a.title === undefined) {
                     return { success: false, error: 'To update, provide edits, content, or title' };
                 }
+
+                // Excalidraw canvases store a JSON scene — text edits are not
+                // meaningful, so reject them and normalize full-content rewrites.
+                let content = a.content;
+                const existing = store.getCanvas(deps.workspaceId, a.canvasId);
+                if (!existing) {
+                    return { success: false, error: `Canvas not found: ${a.canvasId}` };
+                }
+                if (existing.type === 'excalidraw') {
+                    if (a.edits && a.edits.length > 0) {
+                        return {
+                            success: false,
+                            error: 'Excalidraw canvases do not support targeted edits — pass the full scene JSON as content (a full rewrite).',
+                        };
+                    }
+                    if (a.content !== undefined) {
+                        const normalised = normaliseExcalidrawScene(a.content);
+                        if (!normalised.ok) {
+                            return { success: false, error: normalised.error };
+                        }
+                        content = normalised.content;
+                    }
+                }
+
                 try {
                     const result = store.updateCanvas(deps.workspaceId, a.canvasId, {
                         edits: a.edits,
-                        content: a.content,
+                        content,
                         expectedRevision: a.expectedRevision,
                         title: a.title,
                         editor: 'ai',
@@ -207,14 +235,25 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
             if (typeof a.content !== 'string') {
                 return { success: false, error: 'content is required to create a canvas' };
             }
-            if (a.type !== undefined && a.type !== 'markdown' && a.type !== 'code') {
-                return { success: false, error: 'type must be "markdown" or "code"' };
+            if (a.type !== undefined && a.type !== 'markdown' && a.type !== 'code' && a.type !== 'excalidraw') {
+                return { success: false, error: 'type must be "markdown", "code", or "excalidraw"' };
             }
+
+            // Excalidraw canvases persist a validated, normalized scene JSON.
+            let createContent = a.content;
+            if (a.type === 'excalidraw') {
+                const normalised = normaliseExcalidrawScene(a.content);
+                if (!normalised.ok) {
+                    return { success: false, error: normalised.error };
+                }
+                createContent = normalised.content;
+            }
+
             try {
                 const canvas = store.createCanvas({
                     workspaceId: deps.workspaceId,
                     title: a.title.trim(),
-                    content: a.content,
+                    content: createContent,
                     type: a.type,
                     language: a.language,
                     purpose: a.purpose,
@@ -265,6 +304,9 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
                 ...(extension ? {
                     extensionManifest: extension.manifest,
                     note: 'Extension canvas: content is its JSON shared state. Prefer extension_canvas with a capability over raw edits.',
+                } : {}),
+                ...(canvas.type === 'excalidraw' ? {
+                    note: 'Excalidraw canvas: content is the scene JSON ({ elements, appState }). To change it, write_canvas with the full scene as content — targeted edits are not supported.',
                 } : {}),
             };
         },

--- a/packages/coc/src/server/llm-tools/canvas-tools.ts
+++ b/packages/coc/src/server/llm-tools/canvas-tools.ts
@@ -134,8 +134,9 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
             'Create or update a canvas — a live document beside the chat the user iterates on. '
             + 'Markdown renders Mermaid blocks as diagrams. Omit canvasId to create (needs title + content; '
             + 'set type "code" + language for code). For an Excalidraw diagram, set type "excalidraw" and pass '
-            + 'the scene JSON ({ elements, appState }) as content — it renders inline in chat and in the panel; '
-            + 'updates must pass the full scene as content (edits are rejected for excalidraw). To update, pass '
+            + 'the scene JSON ({ elements, appState }) as content — the result carries an `embed` reference '
+            + '(canvas://<id>); put that marker in your chat reply to render the diagram inline (it also shows in '
+            + 'the panel). Updates must pass the full scene as content (edits are rejected for excalidraw). To update, pass '
             + 'canvasId + expectedRevision and either edits (exact-match, one per match) or content (full rewrite). '
             + 'On a revision conflict the user edited it — read_canvas and retry. Keep chat replies short; '
             + 'reference the canvas, don\'t repeat it.',
@@ -222,7 +223,12 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
                         return { success: false, error: result.error };
                     }
                     emitUpdate(result.canvas.id, result.canvas.title, result.canvas.revision);
-                    return { success: true, canvasId: result.canvas.id, revision: result.canvas.revision };
+                    return {
+                        success: true,
+                        canvasId: result.canvas.id,
+                        revision: result.canvas.revision,
+                        ...(result.canvas.type === 'excalidraw' ? { embed: `canvas://${result.canvas.id}` } : {}),
+                    };
                 } catch (err) {
                     return { success: false, error: err instanceof Error ? err.message : String(err) };
                 }
@@ -261,7 +267,7 @@ export function createCanvasTools(deps: CanvasToolsDeps): {
                     editor: 'ai',
                 });
                 emitUpdate(canvas.id, canvas.title, canvas.revision);
-                return { success: true, canvasId: canvas.id, title: canvas.title, type: canvas.type, ...(canvas.language ? { language: canvas.language } : {}), revision: canvas.revision, created: true };
+                return { success: true, canvasId: canvas.id, title: canvas.title, type: canvas.type, ...(canvas.language ? { language: canvas.language } : {}), ...(canvas.type === 'excalidraw' ? { embed: `canvas://${canvas.id}` } : {}), revision: canvas.revision, created: true };
             } catch (err) {
                 return { success: false, error: err instanceof Error ? err.message : String(err) };
             }

--- a/packages/coc/src/server/llm-tools/index.ts
+++ b/packages/coc/src/server/llm-tools/index.ts
@@ -75,15 +75,6 @@ export {
     type ScheduleWakeupArgs,
 } from './loop-tools';
 export {
-    createExcalidrawTools,
-    normaliseFilename as normaliseExcalidrawFilename,
-    type ExcalidrawToolsDeps,
-    type CreateOrUpdateExcalidrawArgs,
-    type CreateOrUpdateExcalidrawResult,
-    type ReadExcalidrawArgs,
-    type ReadExcalidrawResult,
-} from './excalidraw-tools';
-export {
     createCanvasTools,
     type CanvasToolsDeps,
     type WriteCanvasArgs,

--- a/packages/coc/src/server/llm-tools/llm-tool-parameter-schemas.ts
+++ b/packages/coc/src/server/llm-tools/llm-tool-parameter-schemas.ts
@@ -142,21 +142,6 @@ export const LLM_TOOL_PARAMETER_SCHEMAS: Record<string, Record<string, unknown>>
         },
         required: ['prompt', 'delay'],
     },
-    create_or_update_excalidraw: {
-        type: 'object',
-        properties: {
-            filename: { type: 'string' },
-            content: { type: 'object' },
-        },
-        required: ['filename', 'content'],
-    },
-    read_excalidraw: {
-        type: 'object',
-        properties: {
-            filename: { type: 'string' },
-        },
-        required: ['filename'],
-    },
     write_canvas: {
         type: 'object',
         properties: {

--- a/packages/coc/src/server/llm-tools/llm-tool-registry.ts
+++ b/packages/coc/src/server/llm-tools/llm-tool-registry.ts
@@ -119,18 +119,6 @@ export const LLM_TOOL_REGISTRY: readonly LlmToolMeta[] = [
         enabledByDefault: true,
     },
     {
-        name: 'create_or_update_excalidraw',
-        label: 'Create/Update Excalidraw',
-        description: 'Creates or updates an Excalidraw diagram file.',
-        enabledByDefault: true,
-    },
-    {
-        name: 'read_excalidraw',
-        label: 'Read Excalidraw',
-        description: 'Reads an existing Excalidraw diagram file.',
-        enabledByDefault: true,
-    },
-    {
         name: 'write_canvas',
         label: 'Write Canvas',
         description: 'Creates or updates a markdown/code canvas in a side panel next to the chat.',
@@ -166,13 +154,10 @@ export const CANVAS_LLM_TOOL_NAMES = ['write_canvas', 'read_canvas', 'extension_
  * the dashboard tool list and per-workspace settings do not advertise a tool
  * the executor will not register.
  */
-export function getEffectiveLlmToolRegistry(opts: { loopsEnabled?: boolean; excalidrawEnabled?: boolean; canvasEnabled?: boolean } = {}): readonly LlmToolMeta[] {
+export function getEffectiveLlmToolRegistry(opts: { loopsEnabled?: boolean; canvasEnabled?: boolean } = {}): readonly LlmToolMeta[] {
     let registry = [...LLM_TOOL_REGISTRY];
     if (!opts.loopsEnabled) {
         registry = registry.filter(t => t.name !== 'scheduleWakeup');
-    }
-    if (!opts.excalidrawEnabled) {
-        registry = registry.filter(t => t.name !== 'create_or_update_excalidraw' && t.name !== 'read_excalidraw');
     }
     if (!opts.canvasEnabled) {
         registry = registry.filter(t => !(CANVAS_LLM_TOOL_NAMES as readonly string[]).includes(t.name));

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -769,7 +769,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
             const ws = await resolveWorkspaceOrFail(store, match!, res);
             if (!ws) return;
             const liveFlags = ctx.getLiveFeatureFlags?.() ?? { excalidrawEnabled: false, canvasEnabled: false };
-            const effectiveRegistry = withToolParameterMetadata(getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, excalidrawEnabled: liveFlags.excalidrawEnabled, canvasEnabled: liveFlags.canvasEnabled }));
+            const effectiveRegistry = withToolParameterMetadata(getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, canvasEnabled: liveFlags.canvasEnabled }));
             const conversationRetrievalAvailable = typeof ctx.store.searchConversations === 'function';
             if (!ctx.dataDir) {
                 sendJSON(res, 200, {
@@ -816,7 +816,7 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
             writeRepoPreferences(ctx.dataDir, ws.id, merged);
             const globalPrefs = readGlobalPreferences(ctx.dataDir);
             sendJSON(res, 200, {
-                tools: withToolParameterMetadata(getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, excalidrawEnabled: ctx.getLiveFeatureFlags?.()?.excalidrawEnabled ?? false, canvasEnabled: ctx.getLiveFeatureFlags?.()?.canvasEnabled ?? false })),
+                tools: withToolParameterMetadata(getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, canvasEnabled: ctx.getLiveFeatureFlags?.()?.canvasEnabled ?? false })),
                 disabledLlmTools: merged.disabledLlmTools ?? getEffectiveDefaultDisabledTools(globalPrefs.uiLayoutMode),
                 conversationRetrievalAvailable: typeof ctx.store.searchConversations === 'function',
             });

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -136,7 +136,6 @@ import { registerAgentProvidersRoutes } from '../agent-providers/agent-providers
 import { AgentProvidersQuotaCache } from '../agent-providers/quota-cache';
 import { resolveAutoAgentProvider, type AutoProviderAvailabilityMap, type AutoProviderResolutionResult } from '../agent-providers/auto-provider-router';
 import { registerProviderInstallRoutes } from '../providers/provider-install-routes';
-import { registerDiagramRoutes } from '../diagrams/diagrams-handler';
 import { registerRuntimeConfigRoutes } from '../config/runtime-config-handler';
 import { registerSyncRoutes } from '../sync/sync-handler';
 import type { SyncEngine } from '../sync/sync-engine';
@@ -467,10 +466,6 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     registerNotesEditsRoutes(routes, store, dataDir);
     registerNotesRootsRoutes(routes, store, dataDir);
 
-    // Diagram routes — always registered so excalidraw.enabled (classified
-    // as live) can be toggled via admin config without restart. The SPA
-    // gates the UI via runtime config.
-    registerDiagramRoutes(routes, store, dataDir);
     registerWorkflowRoutes(routes, store);
     registerWorkspaceSummaryRoutes(routes, store, dataDir);
     registerWorkflowWriteRoutes(routes, store, (workspaceId) => {

--- a/packages/coc/src/server/spa/client/react/features/canvas/CanvasPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/canvas/CanvasPanel.tsx
@@ -28,13 +28,14 @@
  *    mode exposes the raw state JSON with the normal autosave.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CocApiError } from '@plusplusoneplusplus/coc-client';
 import type { Canvas, CanvasComment, CanvasVersion, CanvasVersionMeta } from '@plusplusoneplusplus/coc-client';
 import { useCocClient } from '../../repos/cloneRouting';
 import { useMarkdownPreview } from '../../hooks/ui/useMarkdownPreview';
 import { MonacoFileEditor, getMonacoLanguage } from '../repo-detail/explorer/MonacoFileEditor';
 import { ExtensionCanvasView } from './ExtensionCanvasView';
+import { ExcalidrawSceneView, parseSceneContent } from '../diagrams';
 import type { CanvasUpdatedEvent } from '../chat/hooks/useChatSSE';
 
 const AUTOSAVE_DELAY_MS = 800;
@@ -125,6 +126,7 @@ const LANGUAGE_TO_FILE_EXT: Record<string, string> = {
 function downloadFilenameFor(canvas: Canvas): string {
     const slug = canvas.id.replace(/-[0-9a-f]{6}$/, '') || 'canvas';
     if (canvas.type === 'extension') return `${slug}.json`;
+    if (canvas.type === 'excalidraw') return `${slug}.excalidraw`;
     if (canvas.type !== 'code') return `${slug}.md`;
     const language = canvas.language ?? '';
     return `${slug}.${LANGUAGE_TO_FILE_EXT[language] ?? (language || 'txt')}`;
@@ -444,15 +446,25 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
     const displayedContent = viewingVersion ? viewingVersion.content : (canvas?.content ?? '');
     const isCodeCanvas = canvas?.type === 'code';
     const isExtensionCanvas = canvas?.type === 'extension';
+    const isExcalidrawCanvas = canvas?.type === 'excalidraw';
+    // Excalidraw canvases are host-rendered (view-only) straight from their
+    // scene JSON content — including history views — so they never go through
+    // the markdown pipeline.
+    const excalidrawScene = useMemo(
+        () => (isExcalidrawCanvas ? parseSceneContent(displayedContent) : null),
+        [isExcalidrawCanvas, displayedContent],
+    );
     // Extension canvases render their own iframe UI; the markdown pipeline is
     // only used for history views of their JSON state.
-    const previewMarkdown = isExtensionCanvas
+    const previewMarkdown = isExcalidrawCanvas
+        ? ''
+        : isExtensionCanvas
         ? (viewingVersion ? fenceCode(displayedContent, 'json') : '')
         : isCodeCanvas ? fenceCode(displayedContent, canvas?.language) : displayedContent;
     const { html } = useMarkdownPreview({
         content: previewMarkdown,
         containerRef: previewRef,
-        loading: loading || (isExtensionCanvas && !viewingVersion) || (!viewingVersion && mode !== 'preview'),
+        loading: loading || isExcalidrawCanvas || (isExtensionCanvas && !viewingVersion) || (!viewingVersion && mode !== 'preview'),
     });
 
     const handleExtensionCanvasSaved = useCallback((saved: Canvas) => {
@@ -491,6 +503,11 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
                         extension
                     </span>
                 )}
+                {isExcalidrawCanvas && (
+                    <span className="text-[9px] uppercase px-1 py-0.5 rounded border border-sky-300 dark:border-sky-700 text-sky-600 dark:text-sky-300 shrink-0" data-testid="canvas-panel-excalidraw-badge">
+                        diagram
+                    </span>
+                )}
                 {canvas && (
                     <span className="flex items-center gap-0.5 text-[10px] text-[#848484] shrink-0">
                         <button
@@ -524,7 +541,8 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
                         {statusLabel}
                     </span>
                 )}
-                {!viewingVersion && (
+                {/* Excalidraw canvases are view-only in v1 — no Edit affordance. */}
+                {!viewingVersion && !isExcalidrawCanvas && (
                     <div className="flex rounded-md border border-[#e0e0e0] dark:border-[#3c3c3c] overflow-hidden shrink-0">
                         <button
                             type="button"
@@ -706,6 +724,12 @@ export function CanvasPanel({ workspaceId, canvasId, liveEvent, onClose, onAskAi
                     <div className="text-xs text-[#848484] py-6 text-center">Loading canvas…</div>
                 ) : loadError ? (
                     <div className="text-xs text-red-500 py-6 text-center" data-testid="canvas-panel-error">{loadError}</div>
+                ) : isExcalidrawCanvas && excalidrawScene ? (
+                    <ExcalidrawSceneView
+                        scene={excalidrawScene}
+                        className="h-full min-h-[200px]"
+                        data-testid="canvas-panel-excalidraw"
+                    />
                 ) : !viewingVersion && mode === 'preview' && isExtensionCanvas && canvas ? (
                     <ExtensionCanvasView
                         workspaceId={workspaceId}

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble.tsx
@@ -15,7 +15,7 @@ import { LoopIcon } from '../icons/LoopIcon';
 import { Marked } from 'marked';
 import { useDisplaySettings } from '../../../hooks/preferences/useDisplaySettings';
 import { useHtmlEmbedPreference } from '../../../hooks/preferences/useHtmlEmbedPreference';
-import { isExcalidrawEnabled } from '../../../utils/config';
+import { isExcalidrawEnabled, isCanvasEnabled } from '../../../utils/config';
 import { SHOW_EXCALIDRAW_DIAGRAMS } from '../../../featureFlags';
 import { getSpaCocClient } from '../../../api/cocClient';
 import { copyToClipboard, copyHtmlToClipboard, copyImageToClipboard, splitMarkdownSections } from '../../../utils/format';
@@ -79,6 +79,47 @@ export function parseExcalidrawLink(url: string): { workspaceId: string; diagram
 }
 
 /**
+ * Parse a `canvas://<canvasId>` reference marker.
+ *
+ * Excalidraw diagrams are canvases, so `write_canvas` returns this marker for
+ * an excalidraw canvas; placing it in a chat reply renders the diagram inline.
+ * Returns null if the marker doesn't match a valid canvas id.
+ */
+export function parseCanvasEmbedLink(url: string): { canvasId: string } | null {
+    const match = url.match(/^canvas:\/\/([a-z0-9][a-z0-9-]{0,127})$/i);
+    if (!match) return null;
+    return { canvasId: match[1] };
+}
+
+/**
+ * Post-processing: convert bare `canvas://<id>` text in HTML (not already
+ * inside a tag attribute) into excalidraw embed divs. The workspace id is
+ * injected separately by `injectCanvasEmbedWorkspace` once it is known.
+ */
+function rewriteBareCanvasEmbedLinks(html: string): string {
+    return html.replace(
+        /(?<!="|=')canvas:\/\/([a-z0-9][a-z0-9-]{0,127})/gi,
+        (match) => {
+            const parsed = parseCanvasEmbedLink(match);
+            if (!parsed) return match;
+            return `<div class="md-excalidraw-embed" data-canvas-id="${escapeAttr(parsed.canvasId)}"></div>`;
+        },
+    );
+}
+
+/**
+ * Stamp the workspace id onto canvas embed placeholders. The `link`/bare-link
+ * rewriters emit `data-canvas-id` only (they don't know the workspace), so this
+ * pass adds `data-ws-id` from the render context once it is available.
+ */
+function injectCanvasEmbedWorkspace(html: string, wsId: string): string {
+    return html.replace(
+        /<div class="md-excalidraw-embed" data-canvas-id="([^"]*)"><\/div>/g,
+        (_match, canvasId) => `<div class="md-excalidraw-embed" data-canvas-id="${canvasId}" data-ws-id="${escapeAttr(wsId)}"></div>`,
+    );
+}
+
+/**
  * Post-processing: convert bare `excalidraw://...` text in HTML (not already
  * inside a tag attribute or an existing placeholder) into embed divs.
  */
@@ -132,6 +173,13 @@ function createChatMarked(htmlEmbedEnabled: boolean, excalidrawEmbedEnabled: boo
                     const parsed = parseExcalidrawLink(href);
                     if (parsed) {
                         return `<div class="md-excalidraw-embed" data-ws-id="${escapeAttr(parsed.workspaceId)}" data-diagram-path="${escapeAttr(parsed.diagramPath)}"></div>`;
+                    }
+                }
+                // Canvas reference markers → inline excalidraw embed (ws id stamped later)
+                if (excalidrawEmbedEnabled && href && /^canvas:\/\//i.test(href)) {
+                    const parsed = parseCanvasEmbedLink(href);
+                    if (parsed) {
+                        return `<div class="md-excalidraw-embed" data-canvas-id="${escapeAttr(parsed.canvasId)}"></div>`;
                     }
                 }
                 const isExternal = /^https?:\/\/|^mailto:/i.test(href ?? '');
@@ -218,9 +266,15 @@ export function chatMarkdownToHtml(content: string, wsId?: string, options?: { h
     if (wsId) {
         html = rewriteLocalImagePaths(html, wsId);
     }
-    // Post-process: convert bare excalidraw:// URLs to embed divs
+    // Post-process: convert bare excalidraw:// / canvas:// URLs to embed divs,
+    // then stamp the workspace id onto canvas embeds so the viewer can read the
+    // scene from the canvas store.
     if (excalidrawEnabled) {
         html = rewriteBareExcalidrawLinks(html);
+        html = rewriteBareCanvasEmbedLinks(html);
+        if (wsId) {
+            html = injectCanvasEmbedWorkspace(html, wsId);
+        }
     }
     return html;
 }
@@ -1220,7 +1274,9 @@ export function ConversationTurnBubble({ turn, taskId, onRetry, onContinueInterr
     const isScript = !isUser && processType === TaskDefs.runScript.kind;
     const { showReportIntent, toolCompactness, groupSingleLineMessages } = useDisplaySettings();
     const htmlEmbedEnabled = useHtmlEmbedPreference(wsId) && !turn.streaming;
-    const excalidrawEmbedEnabled = SHOW_EXCALIDRAW_DIAGRAMS && isExcalidrawEnabled() && !turn.streaming;
+    // Excalidraw diagrams are now canvases, so enable inline embeds whenever the
+    // canvas feature is on (the legacy excalidraw flag still enables it too).
+    const excalidrawEmbedEnabled = SHOW_EXCALIDRAW_DIAGRAMS && (isExcalidrawEnabled() || isCanvasEnabled()) && !turn.streaming;
     const assistantRender = useMemo(
         () => isUser ? null : buildAssistantRender(turn, wsId, { htmlEmbedEnabled, excalidrawEmbedEnabled }),
         // turn.timeline + turn.content drive the markdown HTML; embed flags toggle inline-HTML/excalidraw rendering.

--- a/packages/coc/src/server/spa/client/react/features/diagrams/DiagramViewerShell.tsx
+++ b/packages/coc/src/server/spa/client/react/features/diagrams/DiagramViewerShell.tsx
@@ -2,19 +2,21 @@
  * DiagramViewerShell — full-page view-only Excalidraw viewer.
  *
  * Rendered when `window.location.pathname` starts with `/diagram/`.
- * URL format: `/diagram/<workspaceId>/<diagramPath>`
+ * URL format: `/diagram/<workspaceId>/<canvasId>`
  *
- * Fetches diagram data from the REST API and renders a full-viewport
- * read-only Excalidraw canvas with pan/zoom. A top bar shows the diagram
- * name and a back button.
+ * Excalidraw diagrams are canvases, so this reads the scene straight from the
+ * canvas store (`GET /api/workspaces/:wsId/canvases/:canvasId`) — the legacy
+ * `/api/diagrams` endpoint was removed in the canvas cutover. It renders a
+ * full-viewport read-only Excalidraw canvas with pan/zoom; a top bar shows the
+ * canvas title and a back button.
  */
 
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { Excalidraw } from '@excalidraw/excalidraw';
 import { ThemeProvider } from '../../layout/ThemeProvider';
-import { getApiBase, isExcalidrawEnabled } from '../../utils/config';
+import { getApiBase, isExcalidrawEnabled, isCanvasEnabled } from '../../utils/config';
 import { SHOW_EXCALIDRAW_DIAGRAMS } from '../../featureFlags';
-import { unwrapDiagramResponse, buildViewerInitialData, type ExcalidrawScene } from './diagram-scene';
+import { parseSceneContent, buildViewerInitialData, type ExcalidrawScene } from './diagram-scene';
 
 // Minimal subset of Excalidraw's imperative API that we actually consume.
 // Avoids pulling the real (extremely heavy) type into the module signature,
@@ -27,30 +29,28 @@ interface ExcalidrawApiLike {
 
 export interface DiagramViewerParams {
     workspaceId: string;
-    diagramPath: string;
+    canvasId: string;
 }
 
 /**
- * Parse `/diagram/:wsId/:path` from `window.location.pathname`.
- * Returns null if the pathname doesn't match.
+ * Parse `/diagram/:wsId/:canvasId` from `window.location.pathname`.
+ * Returns null if the pathname doesn't match. Both segments are single path
+ * components — canvas IDs are slugs (no slashes), so filename-style nested
+ * paths no longer match (filename addressing was dropped in the cutover).
  */
 export function parseDiagramViewerRoute(pathname: string): DiagramViewerParams | null {
-    const match = pathname.match(/^\/diagram\/([^/]+)\/(.+)$/);
+    const match = pathname.match(/^\/diagram\/([^/]+)\/([^/]+)$/);
     if (!match) return null;
     return {
         workspaceId: decodeURIComponent(match[1]),
-        diagramPath: decodeURIComponent(match[2]),
+        canvasId: decodeURIComponent(match[2]),
     };
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function diagramApiUrl(wsId: string, filename: string): string {
-    return `${getApiBase()}/workspaces/${encodeURIComponent(wsId)}/diagrams/${encodeURIComponent(filename)}`;
-}
-
-function displayName(p: string): string {
-    return p.replace(/\.excalidraw$/i, '');
+function canvasApiUrl(wsId: string, canvasId: string): string {
+    return `${getApiBase()}/workspaces/${encodeURIComponent(wsId)}/canvases/${encodeURIComponent(canvasId)}`;
 }
 
 // ── Viewer content ─────────────────────────────────────────────────────────────
@@ -60,10 +60,11 @@ type LoadState = 'loading' | 'loaded' | 'error';
 function DiagramViewerContent({ params }: { params: DiagramViewerParams }) {
     const [state, setState] = useState<LoadState>('loading');
     const [sceneData, setSceneData] = useState<ExcalidrawScene | null>(null);
+    const [title, setTitle] = useState('');
     const [errorMsg, setErrorMsg] = useState('');
     const apiRef = useRef<ExcalidrawApiLike | null>(null);
 
-    const name = useMemo(() => displayName(params.diagramPath), [params.diagramPath]);
+    const name = title || params.canvasId;
 
     const initialData = useMemo(
         () => (sceneData ? buildViewerInitialData(sceneData) : null),
@@ -104,7 +105,7 @@ function DiagramViewerContent({ params }: { params: DiagramViewerParams }) {
         let cancelled = false;
         setState('loading');
 
-        fetch(diagramApiUrl(params.workspaceId, params.diagramPath))
+        fetch(canvasApiUrl(params.workspaceId, params.canvasId))
             .then(async (res) => {
                 if (cancelled) return;
                 if (res.status === 404) {
@@ -115,7 +116,9 @@ function DiagramViewerContent({ params }: { params: DiagramViewerParams }) {
                 }
                 const data = await res.json();
                 if (cancelled) return;
-                setSceneData(unwrapDiagramResponse(data));
+                const canvas = data?.canvas;
+                setSceneData(parseSceneContent(canvas?.content));
+                setTitle(typeof canvas?.title === 'string' ? canvas.title : '');
                 setState('loaded');
             })
             .catch((err) => {
@@ -125,7 +128,7 @@ function DiagramViewerContent({ params }: { params: DiagramViewerParams }) {
             });
 
         return () => { cancelled = true; };
-    }, [params.workspaceId, params.diagramPath]);
+    }, [params.workspaceId, params.canvasId]);
 
     const handleBack = useCallback(() => {
         if (window.history.length > 1) {
@@ -150,7 +153,7 @@ function DiagramViewerContent({ params }: { params: DiagramViewerParams }) {
                 <span
                     className="text-sm font-semibold text-[#1e1e1e] dark:text-[#cccccc] truncate"
                     data-testid="diagram-viewer-title"
-                    title={params.diagramPath}
+                    title={name}
                 >
                     📐 {name}
                 </span>
@@ -209,8 +212,10 @@ function DiagramViewerContent({ params }: { params: DiagramViewerParams }) {
 export function DiagramViewerShell() {
     const params = parseDiagramViewerRoute(window.location.pathname);
 
-    // Feature flag off → show 404
-    if (!SHOW_EXCALIDRAW_DIAGRAMS || !isExcalidrawEnabled()) {
+    // Feature flag off → show 404. Excalidraw diagrams are now canvases, so the
+    // viewer is reachable whenever either the canvas feature or the vestigial
+    // excalidraw flag is on (matches the inline-render call-site gate).
+    if (!SHOW_EXCALIDRAW_DIAGRAMS || !(isExcalidrawEnabled() || isCanvasEnabled())) {
         return (
             <ThemeProvider>
                 <div className="flex items-center justify-center h-screen text-sm text-[#848484]">

--- a/packages/coc/src/server/spa/client/react/features/diagrams/ExcalidrawSceneView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/diagrams/ExcalidrawSceneView.tsx
@@ -1,0 +1,92 @@
+/**
+ * ExcalidrawSceneView — view-only Excalidraw renderer for an in-memory scene.
+ *
+ * The shared presentational half of the diagram rendering stack: given an
+ * already-parsed `ExcalidrawScene` it mounts `@excalidraw/excalidraw` in
+ * view-only mode (no editing affordances) and fits the content into the
+ * viewport. Consumers (the canvas panel, inline chat preview) read the scene
+ * from the canvas store and hand it here, so there is a single place that owns
+ * the view-only Excalidraw configuration and the fit-to-content behaviour.
+ *
+ * View-only is enforced via `viewModeEnabled` + `zenModeEnabled` and by
+ * disabling every canvas action in `UIOptions`, mirroring the standalone
+ * DiagramViewerShell viewer.
+ */
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Excalidraw } from '@excalidraw/excalidraw';
+import { buildViewerInitialData, type ExcalidrawScene } from './diagram-scene';
+
+// Minimal subset of Excalidraw's imperative API we actually consume — also what
+// the test-time stub of `@excalidraw/excalidraw` exposes.
+interface ExcalidrawApiLike {
+    scrollToContent?: (target?: readonly any[], opts?: { fitToContent?: boolean }) => void;
+}
+
+export interface ExcalidrawSceneViewProps {
+    /** Already-parsed Excalidraw scene to render. */
+    scene: ExcalidrawScene;
+    /** Optional className for the wrapping element. */
+    className?: string;
+    /** Optional test id for the wrapping element. */
+    'data-testid'?: string;
+}
+
+export function ExcalidrawSceneView({ scene, className, 'data-testid': testId }: ExcalidrawSceneViewProps) {
+    const apiRef = useRef<ExcalidrawApiLike | null>(null);
+    const initialData = useMemo(() => buildViewerInitialData(scene), [scene]);
+
+    // After the scene mounts, ask Excalidraw to fit the content into the
+    // viewport. Without this, view-mode canvases stay parked at scroll (0,0)
+    // and elements positioned off the origin (which the LLM happily does)
+    // render as a blank canvas. Retry a few frames because the API ref is set
+    // before the canvas is fully sized.
+    useEffect(() => {
+        const elements = initialData.elements as readonly any[];
+        if (!Array.isArray(elements) || elements.length === 0) return;
+        let cancelled = false;
+        let attempts = 0;
+        const tick = () => {
+            if (cancelled) return;
+            const api = apiRef.current;
+            if (api?.scrollToContent) {
+                try {
+                    api.scrollToContent(elements, { fitToContent: true });
+                    return;
+                } catch {
+                    // fall through to retry
+                }
+            }
+            if (attempts++ < 20) {
+                requestAnimationFrame(tick);
+            }
+        };
+        requestAnimationFrame(tick);
+        return () => { cancelled = true; };
+    }, [initialData]);
+
+    return (
+        <div className={className} data-testid={testId}>
+            <Excalidraw
+                initialData={initialData}
+                excalidrawAPI={(api: any) => { apiRef.current = api as ExcalidrawApiLike; }}
+                viewModeEnabled={true}
+                zenModeEnabled={true}
+                gridModeEnabled={false}
+                UIOptions={{
+                    canvasActions: {
+                        changeViewBackgroundColor: false,
+                        clearCanvas: false,
+                        export: false,
+                        loadScene: false,
+                        saveToActiveFile: false,
+                        toggleTheme: false,
+                        saveAsImage: false,
+                    },
+                    tools: { image: false },
+                }}
+                renderTopRightUI={() => null}
+            />
+        </div>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/diagrams/diagram-scene.ts
+++ b/packages/coc/src/server/spa/client/react/features/diagrams/diagram-scene.ts
@@ -44,6 +44,25 @@ export function unwrapDiagramResponse(data: any): ExcalidrawScene {
 }
 
 /**
+ * Parse a canvas-store `content` string (an Excalidraw scene serialized as JSON)
+ * into a renderable `ExcalidrawScene`.
+ *
+ * `excalidraw` canvases persist the server-normalized scene as their UTF-8
+ * artifact content, so the viewer reads it straight from the canvas store
+ * rather than the (removed) `/api/diagrams` endpoint. Malformed or empty
+ * content degrades to an empty scene so the viewer renders blank instead of
+ * crashing.
+ */
+export function parseSceneContent(content: string | null | undefined): ExcalidrawScene {
+    if (!content || !content.trim()) return { elements: [], appState: {} };
+    try {
+        return unwrapDiagramResponse(JSON.parse(content));
+    } catch {
+        return { elements: [], appState: {} };
+    }
+}
+
+/**
  * Normalise raw scene elements so Excalidraw can render them.
  *
  * LLM-generated diagrams come in a "skeleton" shape — they carry the visible

--- a/packages/coc/src/server/spa/client/react/features/diagrams/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/diagrams/index.ts
@@ -1,2 +1,6 @@
 export { DiagramViewerShell, parseDiagramViewerRoute } from './DiagramViewerShell';
 export type { DiagramViewerParams } from './DiagramViewerShell';
+export { ExcalidrawSceneView } from './ExcalidrawSceneView';
+export type { ExcalidrawSceneViewProps } from './ExcalidrawSceneView';
+export { parseSceneContent } from './diagram-scene';
+export type { ExcalidrawScene } from './diagram-scene';

--- a/packages/coc/src/server/spa/client/react/shared/ExcalidrawPreview.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/ExcalidrawPreview.tsx
@@ -1,17 +1,18 @@
 /**
  * ExcalidrawPreview — read-only Excalidraw canvas for inline chat previews.
  *
- * Fetches diagram data from the diagrams REST API and renders using
- * @excalidraw/excalidraw in view-only mode.  Pan/zoom are enabled;
- * clicking navigates to the full viewer page.
+ * Reads the scene from the canvas store (`GET /api/workspaces/:wsId/canvases/:id`)
+ * and renders it with @excalidraw/excalidraw in view-only mode. Pan/zoom are
+ * enabled. Excalidraw diagrams are canvases, so this shares the canvas store and
+ * the scene-normalization stack with the side panel.
  */
 
-import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { Excalidraw } from '@excalidraw/excalidraw';
 import { getApiBase } from '../utils/config';
 import { SHOW_EXCALIDRAW_DIAGRAMS } from '../featureFlags';
 import {
-    unwrapDiagramResponse,
+    parseSceneContent,
     buildViewerInitialData,
     type ExcalidrawScene,
 } from '../features/diagrams/diagram-scene';
@@ -25,10 +26,10 @@ interface ExcalidrawApiLike {
 // ---------------------------------------------------------------------------
 
 export interface ExcalidrawPreviewProps {
-    /** Workspace ID that owns the diagram. */
+    /** Workspace ID that owns the canvas. */
     workspaceId: string;
-    /** Diagram filename (e.g. "architecture.excalidraw"). */
-    diagramPath: string;
+    /** Canvas ID of the excalidraw canvas to render. */
+    canvasId: string;
     /** Height of the preview canvas in pixels. */
     height?: number;
 }
@@ -45,25 +46,18 @@ const DEFAULT_HEIGHT = 400;
 // Helpers
 // ---------------------------------------------------------------------------
 
-function diagramApiUrl(wsId: string, filename: string): string {
-    return `${getApiBase()}/workspaces/${encodeURIComponent(wsId)}/diagrams/${encodeURIComponent(filename)}`;
-}
-
-function viewerUrl(wsId: string, diagramPath: string): string {
-    return `/diagram/${encodeURIComponent(wsId)}/${encodeURIComponent(diagramPath)}`;
-}
-
-function displayName(path: string): string {
-    return path.replace(/\.excalidraw$/i, '');
+function canvasApiUrl(wsId: string, canvasId: string): string {
+    return `${getApiBase()}/workspaces/${encodeURIComponent(wsId)}/canvases/${encodeURIComponent(canvasId)}`;
 }
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-export function ExcalidrawPreview({ workspaceId, diagramPath, height = DEFAULT_HEIGHT }: ExcalidrawPreviewProps) {
+export function ExcalidrawPreview({ workspaceId, canvasId, height = DEFAULT_HEIGHT }: ExcalidrawPreviewProps) {
     const [state, setState] = useState<LoadState>('loading');
     const [sceneData, setSceneData] = useState<ExcalidrawScene | null>(null);
+    const [title, setTitle] = useState('');
     const [errorMsg, setErrorMsg] = useState('');
     const containerRef = useRef<HTMLDivElement>(null);
     const apiRef = useRef<ExcalidrawApiLike | null>(null);
@@ -101,14 +95,14 @@ export function ExcalidrawPreview({ workspaceId, diagramPath, height = DEFAULT_H
         return () => { cancelled = true; };
     }, [state, initialData]);
 
-    // Fetch diagram content
+    // Fetch the excalidraw canvas scene from the canvas store.
     useEffect(() => {
         if (!SHOW_EXCALIDRAW_DIAGRAMS) return;
 
         let cancelled = false;
         setState('loading');
 
-        fetch(diagramApiUrl(workspaceId, diagramPath))
+        fetch(canvasApiUrl(workspaceId, canvasId))
             .then(async (res) => {
                 if (cancelled) return;
                 if (!res.ok) {
@@ -116,7 +110,9 @@ export function ExcalidrawPreview({ workspaceId, diagramPath, height = DEFAULT_H
                 }
                 const data = await res.json();
                 if (cancelled) return;
-                setSceneData(unwrapDiagramResponse(data));
+                const canvas = data?.canvas;
+                setSceneData(parseSceneContent(canvas?.content));
+                setTitle(typeof canvas?.title === 'string' ? canvas.title : '');
                 setState('loaded');
             })
             .catch((err) => {
@@ -126,28 +122,18 @@ export function ExcalidrawPreview({ workspaceId, diagramPath, height = DEFAULT_H
             });
 
         return () => { cancelled = true; };
-    }, [workspaceId, diagramPath]);
-
-    // Navigate to viewer on click
-    const handleClick = useCallback(() => {
-        window.open(viewerUrl(workspaceId, diagramPath), '_blank', 'noopener');
-    }, [workspaceId, diagramPath]);
+    }, [workspaceId, canvasId]);
 
     if (!SHOW_EXCALIDRAW_DIAGRAMS) return null;
 
-    const name = displayName(diagramPath);
+    const name = title || 'Diagram';
 
     return (
-        <div className="md-excalidraw-preview" ref={containerRef}>
+        <div className="md-excalidraw-preview" ref={containerRef} data-canvas-id={canvasId}>
             {/* Toolbar */}
             <div className="md-excalidraw-preview-toolbar">
-                <span className="md-excalidraw-preview-title" title={diagramPath}>
+                <span className="md-excalidraw-preview-title" title={name}>
                     📐 {name}
-                </span>
-                <span className="md-excalidraw-preview-actions">
-                    <button type="button" onClick={handleClick} title="Open in viewer">
-                        Open
-                    </button>
                 </span>
             </div>
 

--- a/packages/coc/src/server/spa/client/react/shared/MarkdownView.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/MarkdownView.tsx
@@ -44,7 +44,7 @@ export interface MarkdownViewProps {
 interface ExcalidrawPortal {
     mountEl: HTMLElement;
     workspaceId: string;
-    diagramPath: string;
+    canvasId: string;
     key: string;
 }
 
@@ -165,10 +165,13 @@ export function MarkdownView({ html, sectionMarkdown, fullMarkdown, hideSectionC
         for (let i = 0; i < placeholders.length; i++) {
             const el = placeholders[i];
             const wsId = el.dataset.wsId;
-            const diagramPath = el.dataset.diagramPath;
-            if (!wsId || !diagramPath) continue;
+            // Diagrams are canvases now — render from the canvas store via data-canvas-id.
+            // Legacy excalidraw:// embeds (data-diagram-path only) point at the removed
+            // /api/diagrams endpoint, so they are intentionally not mounted.
+            const canvasId = el.dataset.canvasId;
+            if (!wsId || !canvasId) continue;
 
-            const embedKey = `excalidraw-${wsId}-${diagramPath}-${i}`;
+            const embedKey = `excalidraw-${wsId}-${canvasId}-${i}`;
 
             // Re-render guard
             const existingMount = el.querySelector('.excalidraw-preview-mount');
@@ -176,7 +179,7 @@ export function MarkdownView({ html, sectionMarkdown, fullMarkdown, hideSectionC
                 portals.push({
                     mountEl: existingMount as HTMLElement,
                     workspaceId: wsId,
-                    diagramPath,
+                    canvasId,
                     key: embedKey,
                 });
                 continue;
@@ -186,7 +189,7 @@ export function MarkdownView({ html, sectionMarkdown, fullMarkdown, hideSectionC
             mountEl.className = 'excalidraw-preview-mount';
             el.appendChild(mountEl);
 
-            portals.push({ mountEl, workspaceId: wsId, diagramPath, key: embedKey });
+            portals.push({ mountEl, workspaceId: wsId, canvasId, key: embedKey });
         }
 
         setExcalidrawPortals(portals);
@@ -221,12 +224,12 @@ export function MarkdownView({ html, sectionMarkdown, fullMarkdown, hideSectionC
                     mountEl
                 )
             )}
-            {excalidrawPortals.map(({ mountEl, workspaceId, diagramPath, key }) =>
+            {excalidrawPortals.map(({ mountEl, workspaceId, canvasId, key }) =>
                 createPortal(
                     <ExcalidrawPreview
                         key={key}
                         workspaceId={workspaceId}
-                        diagramPath={diagramPath}
+                        canvasId={canvasId}
                     />,
                     mountEl
                 )

--- a/packages/coc/test/server/canvas/canvas-routes.test.ts
+++ b/packages/coc/test/server/canvas/canvas-routes.test.ts
@@ -248,4 +248,63 @@ describe('canvas routes', () => {
         const res = await request(handler, 'PUT', `/api/workspaces/${WS}/canvases/${c.id}`, {});
         expect(res.status).toBe(400);
     });
+
+    describe('excalidraw canvases inherit canvas features (AC-06)', () => {
+        const scene = (boxId: string): string => JSON.stringify({
+            type: 'excalidraw',
+            elements: [{ id: boxId, type: 'rectangle', x: 0, y: 0, width: 100, height: 40 }],
+            appState: {},
+        });
+
+        it('lists an excalidraw canvas filtered by processId', async () => {
+            const diagram = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw', processId: 'p-diagram' });
+            store.createCanvas({ workspaceId: WS, title: 'Notes', content: '# notes', processId: 'p-other' });
+
+            const res = await request(handler, 'GET', `/api/workspaces/${WS}/canvases?processId=p-diagram`);
+            expect(res.status).toBe(200);
+            expect(res.body.canvases).toHaveLength(1);
+            expect(res.body.canvases[0].id).toBe(diagram.id);
+            expect(res.body.canvases[0].type).toBe('excalidraw');
+        });
+
+        it('versions and revision-checks an excalidraw canvas like any other', async () => {
+            const c = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw' });
+
+            const second = await request(handler, 'PUT', `/api/workspaces/${WS}/canvases/${c.id}`, {
+                content: scene('box2'),
+                expectedRevision: 1,
+            });
+            expect(second.status).toBe(200);
+            expect(second.body.canvas.revision).toBe(2);
+            expect(second.body.canvas.type).toBe('excalidraw');
+
+            const versions = await request(handler, 'GET', `/api/workspaces/${WS}/canvases/${c.id}/versions`);
+            expect(versions.body.versions.map((v: any) => v.revision)).toEqual([2, 1]);
+
+            const v1 = await request(handler, 'GET', `/api/workspaces/${WS}/canvases/${c.id}/versions/1`);
+            expect(JSON.parse(v1.body.version.content).elements[0].id).toBe('box1');
+
+            const stale = await request(handler, 'PUT', `/api/workspaces/${WS}/canvases/${c.id}`, {
+                content: scene('box3'),
+                expectedRevision: 1,
+            });
+            expect(stale.status).toBe(409);
+            expect(stale.body.error).toBe('revision-conflict');
+            expect(stale.body.currentRevision).toBe(2);
+        });
+
+        it('round-trips comments on an excalidraw canvas', async () => {
+            const c = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw' });
+
+            const created = await request(handler, 'POST', `/api/workspaces/${WS}/canvases/${c.id}/comments`, {
+                anchorText: 'box1',
+                body: 'tweak this box',
+            });
+            expect(created.status).toBe(201);
+
+            const listed = await request(handler, 'GET', `/api/workspaces/${WS}/canvases/${c.id}/comments`);
+            expect(listed.body.comments).toHaveLength(1);
+            expect(listed.body.comments[0].body).toBe('tweak this box');
+        });
+    });
 });

--- a/packages/coc/test/server/canvas/canvas-store.test.ts
+++ b/packages/coc/test/server/canvas/canvas-store.test.ts
@@ -406,6 +406,72 @@ describe('extension canvases', () => {
     });
 });
 
+describe('excalidraw canvases inherit canvas features (AC-06)', () => {
+    let dataDir: string;
+    let store: CanvasStore;
+
+    beforeEach(() => {
+        dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coc-canvas-excalidraw-'));
+        store = new CanvasStore(dataDir);
+    });
+
+    afterEach(() => {
+        fs.rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    const scene = (boxId: string): string => JSON.stringify({
+        type: 'excalidraw',
+        elements: [{ id: boxId, type: 'rectangle', x: 0, y: 0, width: 100, height: 40 }],
+        appState: { viewBackgroundColor: '#ffffff' },
+    });
+
+    it('writes a versions/<rev>.json snapshot on a second write', () => {
+        const c = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw' });
+        const result = store.updateCanvas(WS, c.id, { content: scene('box2'), editor: 'ai', expectedRevision: 1 });
+        expect(result.ok).toBe(true);
+
+        // The second write must drop a per-revision snapshot on disk, not just bump revision.
+        const versionsDir = path.join(dataDir, 'repos', WS, 'canvases', c.id, 'versions');
+        expect(fs.existsSync(path.join(versionsDir, '1.json'))).toBe(true);
+        expect(fs.existsSync(path.join(versionsDir, '2.json'))).toBe(true);
+
+        const v2 = JSON.parse(fs.readFileSync(path.join(versionsDir, '2.json'), 'utf-8'));
+        expect(JSON.parse(v2.content).elements[0].id).toBe('box2');
+        expect(store.listVersions(WS, c.id).map(v => v.revision)).toEqual([2, 1]);
+        expect(store.getVersion(WS, c.id, 1)?.content).toBe(scene('box1'));
+    });
+
+    it('returns a revision conflict on a stale expectedRevision', () => {
+        const c = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw' });
+        store.updateCanvas(WS, c.id, { content: scene('box2'), editor: 'ai' }); // -> revision 2
+
+        const stale = store.updateCanvas(WS, c.id, { content: scene('box3'), editor: 'ai', expectedRevision: 1 });
+        expect(stale).toEqual({ ok: false, reason: 'revision-conflict', currentRevision: 2 });
+        // Content unchanged by the rejected write.
+        expect(JSON.parse(store.getCanvas(WS, c.id)!.content).elements[0].id).toBe('box2');
+    });
+
+    it('supports anchored comments on an excalidraw canvas', () => {
+        const c = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw' });
+        const comment = store.addComment(WS, c.id, { anchorText: 'box1', body: 'rename this box' });
+
+        expect(comment).not.toBeNull();
+        expect(comment!.status).toBe('open');
+        expect(store.listComments(WS, c.id)).toHaveLength(1);
+        expect(store.setCommentStatus(WS, c.id, comment!.id, 'resolved')?.status).toBe('resolved');
+    });
+
+    it('lists an excalidraw canvas filtered by processId', () => {
+        const diagram = store.createCanvas({ workspaceId: WS, title: 'Arch', content: scene('box1'), type: 'excalidraw', processId: 'p-diagram' });
+        store.createCanvas({ workspaceId: WS, title: 'Notes', content: '# notes', processId: 'p-other' });
+
+        const list = store.listCanvases(WS, { processId: 'p-diagram' });
+        expect(list).toHaveLength(1);
+        expect(list[0].id).toBe(diagram.id);
+        expect(list[0].type).toBe('excalidraw');
+    });
+});
+
 describe('canvas id helpers', () => {
     it('generateCanvasId produces valid filesystem-safe ids', () => {
         expect(isValidCanvasId(generateCanvasId('Hello World'))).toBe(true);

--- a/packages/coc/test/server/canvas/canvas-tools.test.ts
+++ b/packages/coc/test/server/canvas/canvas-tools.test.ts
@@ -221,6 +221,26 @@ describe('canvas LLM tools', () => {
             expect(scene.elements[0].isDeleted).toBe(false);
         });
 
+        it('returns a canvas:// embed marker on create and update', async () => {
+            const { write } = buildTools();
+            const created = await write.handler({ title: 'Arch', content: SKELETON_SCENE, type: 'excalidraw' }) as any;
+            expect(created.embed).toBe(`canvas://${created.canvasId}`);
+
+            const updated = await write.handler({
+                canvasId: created.canvasId,
+                content: JSON.stringify({ elements: [], appState: {} }),
+                expectedRevision: 1,
+            }) as any;
+            expect(updated.success).toBe(true);
+            expect(updated.embed).toBe(`canvas://${created.canvasId}`);
+        });
+
+        it('does not return an embed marker for non-excalidraw canvases', async () => {
+            const { write } = buildTools();
+            const md = await write.handler({ title: 'Doc', content: '# hi' }) as any;
+            expect(md.embed).toBeUndefined();
+        });
+
         it('rejects an invalid scene on create', async () => {
             const { write } = buildTools();
             const badJson = await write.handler({ title: 'Bad', content: '{ not json', type: 'excalidraw' }) as any;

--- a/packages/coc/test/server/canvas/canvas-tools.test.ts
+++ b/packages/coc/test/server/canvas/canvas-tools.test.ts
@@ -152,6 +152,90 @@ describe('canvas LLM tools', () => {
         });
     });
 
+    describe('write_canvas — excalidraw', () => {
+        const SKELETON_SCENE = JSON.stringify({
+            type: 'excalidraw',
+            elements: [{ id: 'box1', type: 'rectangle', x: 0, y: 0, width: 120, height: 60 }],
+            appState: { viewBackgroundColor: '#ffffff' },
+        });
+
+        it('creates an excalidraw canvas and persists a normalized complete scene', async () => {
+            const { write, read } = buildTools();
+            const created = await write.handler({ title: 'Arch', content: SKELETON_SCENE, type: 'excalidraw' }) as any;
+
+            expect(created.success).toBe(true);
+            expect(created.type).toBe('excalidraw');
+            expect(store.getCanvas(WS, created.canvasId)?.type).toBe('excalidraw');
+
+            const result = await read.handler({ canvasId: created.canvasId }) as any;
+            expect(result.success).toBe(true);
+            const scene = JSON.parse(result.content);
+            expect(Array.isArray(scene.elements)).toBe(true);
+            expect(typeof scene.appState).toBe('object');
+            // Skeleton element completed with Excalidraw bookkeeping fields.
+            const el = scene.elements[0];
+            expect(el.id).toBe('box1');
+            expect(el.isDeleted).toBe(false);
+            expect(el.groupIds).toEqual([]);
+            expect(typeof el.versionNonce).toBe('number');
+            expect(typeof el.seed).toBe('number');
+            // read_canvas flags excalidraw canvases so the model uses full rewrites.
+            expect(result.note).toMatch(/scene JSON/i);
+        });
+
+        it('rejects targeted edits on an excalidraw canvas with a clear error', async () => {
+            const { write } = buildTools();
+            const created = await write.handler({ title: 'Arch', content: SKELETON_SCENE, type: 'excalidraw' }) as any;
+
+            const result = await write.handler({
+                canvasId: created.canvasId,
+                edits: [{ oldText: 'rectangle', newText: 'ellipse' }],
+                expectedRevision: 1,
+            }) as any;
+
+            expect(result.success).toBe(false);
+            expect(result.error).toMatch(/excalidraw/i);
+            expect(result.error).toMatch(/full scene|content|rewrite/i);
+            // Unchanged on disk.
+            expect(store.getCanvas(WS, created.canvasId)?.revision).toBe(1);
+        });
+
+        it('normalizes a full-scene content rewrite on update', async () => {
+            const { write, read } = buildTools();
+            const created = await write.handler({ title: 'Arch', content: SKELETON_SCENE, type: 'excalidraw' }) as any;
+
+            const next = JSON.stringify({
+                elements: [{ id: 'circle1', type: 'ellipse', x: 10, y: 10, width: 40, height: 40 }],
+                appState: {},
+            });
+            const updated = await write.handler({
+                canvasId: created.canvasId,
+                content: next,
+                expectedRevision: 1,
+            }) as any;
+
+            expect(updated.success).toBe(true);
+            expect(updated.revision).toBe(2);
+            const scene = JSON.parse(store.getCanvas(WS, created.canvasId)!.content);
+            expect(scene.elements[0].id).toBe('circle1');
+            expect(scene.elements[0].isDeleted).toBe(false);
+        });
+
+        it('rejects an invalid scene on create', async () => {
+            const { write } = buildTools();
+            const badJson = await write.handler({ title: 'Bad', content: '{ not json', type: 'excalidraw' }) as any;
+            expect(badJson.success).toBe(false);
+
+            const notArray = await write.handler({
+                title: 'Bad2',
+                content: JSON.stringify({ elements: 'nope', appState: {} }),
+                type: 'excalidraw',
+            }) as any;
+            expect(notArray.success).toBe(false);
+            expect(notArray.error).toMatch(/elements/i);
+        });
+    });
+
     describe('read_canvas', () => {
         it('returns content and revision', async () => {
             const { write, read } = buildTools();

--- a/packages/coc/test/server/canvas/excalidraw-scene.test.ts
+++ b/packages/coc/test/server/canvas/excalidraw-scene.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the server-side Excalidraw scene normalizer used on the canvas
+ * write path. This module is intentionally pure and dependency-free (it does
+ * NOT import `@excalidraw/excalidraw`, which cannot load in Node ≥ 24), so it
+ * runs in a plain Node test environment without the `@excalidraw` mock.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    normaliseSceneElements,
+    normaliseExcalidrawScene,
+} from '../../../src/server/canvas/excalidraw-scene';
+
+describe('normaliseSceneElements', () => {
+    it('completes a skeleton element with Excalidraw bookkeeping defaults', () => {
+        const [el] = normaliseSceneElements([
+            { id: 'box1', type: 'rectangle', x: 0, y: 0, width: 100, height: 40 },
+        ]);
+        expect(el.id).toBe('box1');
+        expect(el.type).toBe('rectangle');
+        expect(el.isDeleted).toBe(false);
+        expect(el.groupIds).toEqual([]);
+        expect(typeof el.version).toBe('number');
+        expect(typeof el.versionNonce).toBe('number');
+        expect(typeof el.seed).toBe('number');
+        expect(el.strokeColor).toBe('#1e1e1e');
+        expect(el.opacity).toBe(100);
+    });
+
+    it('preserves fields the author already supplied', () => {
+        const [el] = normaliseSceneElements([
+            { id: 'a', type: 'rectangle', strokeColor: '#ff0000', opacity: 50, version: 7 },
+        ]);
+        expect(el.strokeColor).toBe('#ff0000');
+        expect(el.opacity).toBe(50);
+        expect(el.version).toBe(7);
+    });
+
+    it('fills text-specific defaults and mirrors originalText', () => {
+        const [el] = normaliseSceneElements([{ id: 't', type: 'text', text: 'Hello' }]);
+        expect(el.fontSize).toBe(20);
+        expect(el.textAlign).toBe('left');
+        expect(el.containerId).toBeNull();
+        expect(el.originalText).toBe('Hello');
+        expect(el.lineHeight).toBe(1.25);
+    });
+
+    it('fills arrow-specific defaults including an arrowhead', () => {
+        const [el] = normaliseSceneElements([
+            { id: 'arr', type: 'arrow', x: 0, y: 0, width: 50, height: 0 },
+        ]);
+        expect(Array.isArray(el.points)).toBe(true);
+        expect(el.endArrowhead).toBe('arrow');
+        expect(el.startBinding).toBeNull();
+    });
+
+    it('returns an empty array for empty / invalid input', () => {
+        expect(normaliseSceneElements([])).toEqual([]);
+        expect(normaliseSceneElements(null as any)).toEqual([]);
+        expect(normaliseSceneElements(undefined as any)).toEqual([]);
+    });
+
+    it('drops non-object entries', () => {
+        const out = normaliseSceneElements([{ id: 'a', type: 'rectangle' }, 'nope' as any, 42 as any, null as any]);
+        expect(out).toHaveLength(1);
+        expect(out[0].id).toBe('a');
+    });
+
+    it('is deterministic (no Math.random)', () => {
+        const input = [{ id: 'a', type: 'rectangle' }, { id: 'b', type: 'ellipse' }];
+        expect(normaliseSceneElements(input)).toEqual(normaliseSceneElements(input));
+    });
+});
+
+describe('normaliseExcalidrawScene', () => {
+    it('parses a JSON string scene and normalizes elements + appState on the way out', () => {
+        const raw = JSON.stringify({
+            type: 'excalidraw',
+            elements: [{ id: 'box', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 }],
+            appState: { viewBackgroundColor: '#fafafa' },
+        });
+        const result = normaliseExcalidrawScene(raw);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const parsed = JSON.parse(result.content);
+        expect(parsed.type).toBe('excalidraw');
+        expect(parsed.appState.viewBackgroundColor).toBe('#fafafa');
+        expect(parsed.elements).toHaveLength(1);
+        expect(parsed.elements[0].isDeleted).toBe(false);
+        expect(typeof parsed.elements[0].versionNonce).toBe('number');
+    });
+
+    it('accepts a pre-parsed object scene', () => {
+        const result = normaliseExcalidrawScene({ elements: [{ id: 'a', type: 'rectangle' }], appState: {} });
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.scene.elements[0].groupIds).toEqual([]);
+    });
+
+    it('defaults a missing appState to an empty object', () => {
+        const result = normaliseExcalidrawScene({ elements: [] });
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.scene.appState).toEqual({});
+    });
+
+    it('defaults a missing type to "excalidraw"', () => {
+        const result = normaliseExcalidrawScene({ elements: [], appState: {} });
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.scene.type).toBe('excalidraw');
+    });
+
+    it('rejects invalid JSON', () => {
+        const result = normaliseExcalidrawScene('{ not json');
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toMatch(/valid scene JSON/i);
+    });
+
+    it('rejects a non-object scene (array / primitive)', () => {
+        expect(normaliseExcalidrawScene('[]').ok).toBe(false);
+        expect(normaliseExcalidrawScene('42').ok).toBe(false);
+        expect(normaliseExcalidrawScene('"hi"').ok).toBe(false);
+    });
+
+    it('rejects elements that are not an array', () => {
+        const result = normaliseExcalidrawScene({ elements: 'nope', appState: {} });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toMatch(/elements.*array/i);
+    });
+
+    it('rejects an appState that is not an object', () => {
+        const result = normaliseExcalidrawScene({ elements: [], appState: 'nope' });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toMatch(/appState.*object/i);
+    });
+
+    it('preserves a passthrough files dictionary', () => {
+        const files = { img1: { dataURL: 'data:...', mimeType: 'image/png' } };
+        const result = normaliseExcalidrawScene({ elements: [], appState: {}, files });
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.scene.files).toEqual(files);
+    });
+});

--- a/packages/coc/test/server/config/runtime-config-handler.test.ts
+++ b/packages/coc/test/server/config/runtime-config-handler.test.ts
@@ -668,16 +668,16 @@ describe('forEach.enabled live enablement end-to-end', () => {
 });
 
 describe('AC-08: live-classified route registration', () => {
-    it('diagram routes are always registered (not gated by excalidraw.enabled at startup)', async () => {
+    it('diagram routes are removed after the canvas-consolidation hard cutover', async () => {
         const routesSrc = await import('fs').then(fs =>
             fs.readFileSync(
                 require('path').resolve(__dirname, '../../../src/server/routes/index.ts'),
                 'utf-8',
             ),
         );
-        // registerDiagramRoutes must be called unconditionally
-        expect(routesSrc).toContain('registerDiagramRoutes(routes');
-        expect(routesSrc).not.toMatch(/if\s*\(.*excalidraw.*\)\s*\{?\s*registerDiagramRoutes/);
+        // The /api/diagrams routes were deleted; diagrams are now canvases.
+        expect(routesSrc).not.toContain('registerDiagramRoutes');
+        expect(routesSrc).not.toContain('diagrams-handler');
     });
 
     it('focused-diff classification routes are always registered (not gated by features.focusedDiff at startup)', async () => {
@@ -691,14 +691,14 @@ describe('AC-08: live-classified route registration', () => {
         expect(routesSrc).not.toMatch(/if\s*\(.*focusedDiff.*\)\s*\{?\s*registerGenericClassificationRoutes/);
     });
 
-    it('excalidraw LLM tool visibility uses live getter (not startup boolean)', async () => {
+    it('canvas LLM tool visibility uses live getter (not startup boolean)', async () => {
         const routesSrc = await import('fs').then(fs =>
             fs.readFileSync(
                 require('path').resolve(__dirname, '../../../src/server/routes/api-workspace-routes.ts'),
                 'utf-8',
             ),
         );
-        // Workspace routes should call getLiveFeatureFlags, not read a static excalidrawEnabled
+        // Workspace routes should call getLiveFeatureFlags, not read a static flag off ctx.
         expect(routesSrc).toContain('getLiveFeatureFlags');
         expect(routesSrc).not.toMatch(/ctx\.excalidrawEnabled/);
     });

--- a/packages/coc/test/server/diagrams-handler.test.ts
+++ b/packages/coc/test/server/diagrams-handler.test.ts
@@ -1,11 +1,13 @@
 /**
- * Diagrams Handler Tests
+ * Diagrams Routes Removed — Hard Cutover Regression Test
  *
- * Integration tests for the Excalidraw diagram CRUD REST API:
- *   GET    /api/workspaces/:id/diagrams            — list
- *   GET    /api/workspaces/:id/diagrams/:filename   — read
- *   PUT    /api/workspaces/:id/diagrams/:filename   — create/update
- *   DELETE /api/workspaces/:id/diagrams/:filename   — delete
+ * The dedicated `/api/diagrams` CRUD routes were deleted when diagrams were
+ * folded into the unified Canvas system (one tool family, one store). This test
+ * locks in the cutover: GET/PUT/DELETE on `/api/workspaces/:id/diagrams*` must
+ * no longer be registered and therefore fall through to the API 404 handler.
+ *
+ * Pre-existing `excalidraw://<workspaceId>/<filename>` links and on-disk
+ * `diagrams/*.excalidraw` files are intentionally not migrated.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -13,7 +15,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { FileProcessStore, getRepoDataPath } from '@plusplusoneplusplus/forge';
+import { FileProcessStore } from '@plusplusoneplusplus/forge';
 import { createExecutionServer } from '../../src/server/index';
 import type { ExecutionServer } from '../../src/server/types';
 import { safeRm } from '../helpers/safe-rm';
@@ -66,25 +68,10 @@ function jsonRequest(
     });
 }
 
-// ============================================================================
-// Sample Excalidraw scene
-// ============================================================================
-
 const SAMPLE_SCENE = {
     type: 'excalidraw',
     version: 2,
-    elements: [
-        {
-            type: 'rectangle',
-            id: 'rect1',
-            x: 100,
-            y: 100,
-            width: 200,
-            height: 100,
-            strokeColor: '#000000',
-            backgroundColor: '#ffffff',
-        },
-    ],
+    elements: [],
     appState: { viewBackgroundColor: '#ffffff' },
 };
 
@@ -92,15 +79,15 @@ const SAMPLE_SCENE = {
 // Tests
 // ============================================================================
 
-describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
+describe('Diagrams routes removed (canvas-consolidation hard cutover)', { timeout: 30_000 }, () => {
     let server: ExecutionServer | undefined;
     let dataDir: string;
     let workspaceDir: string;
     let wsId: string;
 
     beforeEach(() => {
-        dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagrams-handler-'));
-        workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagrams-ws-'));
+        dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagrams-removed-'));
+        workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagrams-removed-ws-'));
         wsId = 'test-ws-' + Date.now();
     });
 
@@ -120,6 +107,7 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
             host: '127.0.0.1',
             store,
             dataDir,
+            // excalidraw.enabled was the old gate; the routes are gone regardless.
             fileConfig: { excalidraw: { enabled: true } },
         });
         return server;
@@ -139,208 +127,36 @@ describe('Diagrams Handler — CRUD API', { timeout: 30_000 }, () => {
         return filename ? `${base}/${encodeURIComponent(filename)}` : base;
     }
 
-    // -------------------------------------------------------------------------
-    // LIST
-    // -------------------------------------------------------------------------
-
-    it('returns empty list when no diagrams exist', async () => {
+    it('GET list endpoint is no longer registered (404)', async () => {
         const srv = await startServer();
         await registerWorkspace(srv);
 
         const res = await request(diagramUrl(srv));
-        expect(res.status).toBe(200);
-        const data = JSON.parse(res.body);
-        expect(data.diagrams).toEqual([]);
+        expect(res.status).toBe(404);
+        expect(JSON.parse(res.body).error).toMatch(/route not found/i);
     });
 
-    it('lists diagrams after creation', async () => {
+    it('GET single-diagram endpoint is no longer registered (404)', async () => {
         const srv = await startServer();
         await registerWorkspace(srv);
-
-        await jsonRequest(diagramUrl(srv, 'arch.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
-        await jsonRequest(diagramUrl(srv, 'flow.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
-
-        const res = await request(diagramUrl(srv));
-        expect(res.status).toBe(200);
-        const data = JSON.parse(res.body);
-        expect(data.diagrams).toHaveLength(2);
-        expect(data.diagrams[0].filename).toBe('arch.excalidraw');
-        expect(data.diagrams[1].filename).toBe('flow.excalidraw');
-        expect(data.diagrams[0].sizeBytes).toBeGreaterThan(0);
-    });
-
-    // -------------------------------------------------------------------------
-    // CREATE (PUT)
-    // -------------------------------------------------------------------------
-
-    it('creates a new diagram with 201', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        const res = await jsonRequest(diagramUrl(srv, 'new-diagram'), 'PUT', { content: SAMPLE_SCENE });
-        expect(res.status).toBe(201);
-        const data = JSON.parse(res.body);
-        expect(data.filename).toBe('new-diagram.excalidraw');
-        expect(data.created).toBe(true);
-    });
-
-    it('auto-appends .excalidraw extension when missing', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        const res = await jsonRequest(diagramUrl(srv, 'my-flow'), 'PUT', { content: SAMPLE_SCENE });
-        expect(res.status).toBe(201);
-        const data = JSON.parse(res.body);
-        expect(data.filename).toBe('my-flow.excalidraw');
-    });
-
-    it('accepts raw Excalidraw JSON without content wrapper', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        const res = await jsonRequest(diagramUrl(srv, 'raw.excalidraw'), 'PUT', SAMPLE_SCENE);
-        expect(res.status).toBe(201);
-
-        // Verify by reading back
-        const readRes = await request(diagramUrl(srv, 'raw.excalidraw'));
-        expect(readRes.status).toBe(200);
-        const readData = JSON.parse(readRes.body);
-        expect(readData.content.type).toBe('excalidraw');
-    });
-
-    it('updates an existing diagram with 200', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        // Create
-        const createRes = await jsonRequest(diagramUrl(srv, 'diagram.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
-        expect(createRes.status).toBe(201);
-
-        // Update
-        const updatedScene = { ...SAMPLE_SCENE, version: 3 };
-        const updateRes = await jsonRequest(diagramUrl(srv, 'diagram.excalidraw'), 'PUT', { content: updatedScene });
-        expect(updateRes.status).toBe(200);
-        const data = JSON.parse(updateRes.body);
-        expect(data.created).toBe(false);
-    });
-
-    // -------------------------------------------------------------------------
-    // READ (GET)
-    // -------------------------------------------------------------------------
-
-    it('reads a created diagram', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        await jsonRequest(diagramUrl(srv, 'arch.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
 
         const res = await request(diagramUrl(srv, 'arch.excalidraw'));
-        expect(res.status).toBe(200);
-        const data = JSON.parse(res.body);
-        expect(data.filename).toBe('arch.excalidraw');
-        expect(data.content.type).toBe('excalidraw');
-        expect(data.content.elements).toHaveLength(1);
-        expect(data.sizeBytes).toBeGreaterThan(0);
-        expect(data.createdAt).toBeDefined();
-        expect(data.updatedAt).toBeDefined();
-    });
-
-    it('returns 404 for a non-existent diagram', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        const res = await request(diagramUrl(srv, 'does-not-exist.excalidraw'));
         expect(res.status).toBe(404);
     });
 
-    // -------------------------------------------------------------------------
-    // DELETE
-    // -------------------------------------------------------------------------
-
-    it('deletes an existing diagram', async () => {
+    it('PUT create/update endpoint is no longer registered (404)', async () => {
         const srv = await startServer();
         await registerWorkspace(srv);
 
-        await jsonRequest(diagramUrl(srv, 'to-delete.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
-
-        const delRes = await jsonRequest(diagramUrl(srv, 'to-delete.excalidraw'), 'DELETE');
-        expect(delRes.status).toBe(200);
-        const data = JSON.parse(delRes.body);
-        expect(data.deleted).toBe(true);
-
-        // Verify it's gone
-        const readRes = await request(diagramUrl(srv, 'to-delete.excalidraw'));
-        expect(readRes.status).toBe(404);
-    });
-
-    it('returns 404 when deleting a non-existent diagram', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        const res = await jsonRequest(diagramUrl(srv, 'ghost.excalidraw'), 'DELETE');
+        const res = await jsonRequest(diagramUrl(srv, 'arch.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
         expect(res.status).toBe(404);
     });
 
-    // -------------------------------------------------------------------------
-    // Validation / edge cases
-    // -------------------------------------------------------------------------
-
-    it('rejects path traversal in filename', async () => {
+    it('DELETE endpoint is no longer registered (404)', async () => {
         const srv = await startServer();
         await registerWorkspace(srv);
 
-        const res = await jsonRequest(diagramUrl(srv, '..%2F..%2Fetc%2Fpasswd'), 'PUT', { content: SAMPLE_SCENE });
-        expect(res.status).toBe(400);
-    });
-
-    it('rejects empty filename', async () => {
-        const srv = await startServer();
-        await registerWorkspace(srv);
-
-        const res = await jsonRequest(diagramUrl(srv, '.excalidraw'), 'PUT', { content: SAMPLE_SCENE });
-        expect(res.status).toBe(400);
-    });
-
-    it('returns 404 for non-existent workspace', async () => {
-        const srv = await startServer();
-        const res = await request(`${srv.url}/api/workspaces/nonexistent/diagrams`);
+        const res = await jsonRequest(diagramUrl(srv, 'arch.excalidraw'), 'DELETE');
         expect(res.status).toBe(404);
-    });
-
-    // -------------------------------------------------------------------------
-    // Feature flag — routes always registered (live-togglable), but runtime
-    // config reports excalidraw as disabled so the SPA gates the UI.
-    // -------------------------------------------------------------------------
-
-    it('routes remain accessible when excalidraw is disabled (SPA gates UI)', async () => {
-        const store = new FileProcessStore({ dataDir });
-        server = await createExecutionServer({
-            port: 0,
-            host: '127.0.0.1',
-            store,
-            dataDir,
-            fileConfig: { excalidraw: { enabled: false } },
-        });
-        const srv = server;
-
-        // Register workspace
-        const wsRes = await jsonRequest(`${srv.url}/api/workspaces`, 'POST', {
-            id: wsId,
-            name: 'Test Workspace',
-            rootPath: workspaceDir,
-        });
-        expect(wsRes.status).toBe(201);
-
-        // Diagram routes are always registered so the feature can be toggled
-        // live via admin config. The endpoint responds normally; the SPA
-        // checks runtime config to decide whether to show the UI.
-        const res = await request(`${srv.url}/api/workspaces/${wsId}/diagrams`);
-        expect(res.status).toBe(200);
-
-        // Runtime config should report excalidraw as disabled
-        const configRes = await request(`${srv.url}/api/config/runtime`);
-        expect(configRes.status).toBe(200);
-        const configBody = JSON.parse(configRes.body);
-        expect(configBody.features.excalidrawEnabled).toBe(false);
     });
 });

--- a/packages/coc/test/server/executors/chat-tool-builder.test.ts
+++ b/packages/coc/test/server/executors/chat-tool-builder.test.ts
@@ -44,11 +44,9 @@ describe('buildChatToolBundle', () => {
 
         expect(result.tools.map(t => t.name).sort()).toEqual([
             'ask_user',
-            'create_or_update_excalidraw',
             'create_update_work_item',
             'get_conversation',
             'get_work_item',
-            'read_excalidraw',
             'search_conversations',
             'suggest_follow_ups',
             'tavily_web_search',

--- a/packages/coc/test/server/llm-tool-parameter-schemas.test.ts
+++ b/packages/coc/test/server/llm-tool-parameter-schemas.test.ts
@@ -85,12 +85,12 @@ describe('withToolParameterMetadata', () => {
 
     it('preserves all existing contract fields and does not mutate the input', () => {
         const input: LlmToolMeta[] = [
-            { name: 'read_excalidraw', label: 'Read Excalidraw', description: 'd', enabledByDefault: false },
+            { name: 'example_tool', label: 'Example Tool', description: 'd', enabledByDefault: false },
         ];
         const frozenSnapshot = JSON.stringify(input);
         const [result] = withToolParameterMetadata(input);
-        expect(result.name).toBe('read_excalidraw');
-        expect(result.label).toBe('Read Excalidraw');
+        expect(result.name).toBe('example_tool');
+        expect(result.label).toBe('Example Tool');
         expect(result.description).toBe('d');
         expect(result.enabledByDefault).toBe(false);
         // Input is untouched (no params field added in place).

--- a/packages/coc/test/server/llm-tools/llm-tool-registry.test.ts
+++ b/packages/coc/test/server/llm-tools/llm-tool-registry.test.ts
@@ -221,30 +221,23 @@ describe('getEffectiveLlmToolRegistry', () => {
 
     it('includes scheduleWakeup when loopsEnabled is true', async () => {
         const { getEffectiveLlmToolRegistry } = await import('../../../src/server/llm-tools/llm-tool-registry');
-        const names = getEffectiveLlmToolRegistry({ loopsEnabled: true, excalidrawEnabled: true, canvasEnabled: true }).map(t => t.name);
+        const names = getEffectiveLlmToolRegistry({ loopsEnabled: true, canvasEnabled: true }).map(t => t.name);
         expect(names).toContain('scheduleWakeup');
         // Should equal the full registry length when all flags on
-        expect(getEffectiveLlmToolRegistry({ loopsEnabled: true, excalidrawEnabled: true, canvasEnabled: true })).toHaveLength(LLM_TOOL_REGISTRY.length);
+        expect(getEffectiveLlmToolRegistry({ loopsEnabled: true, canvasEnabled: true })).toHaveLength(LLM_TOOL_REGISTRY.length);
     });
 
-    it('filters out excalidraw tools when excalidrawEnabled is false', async () => {
+    it('no longer advertises the removed excalidraw tools regardless of flags', async () => {
         const { getEffectiveLlmToolRegistry } = await import('../../../src/server/llm-tools/llm-tool-registry');
-        const names = getEffectiveLlmToolRegistry({ excalidrawEnabled: false }).map(t => t.name);
+        const names = getEffectiveLlmToolRegistry({ loopsEnabled: true, canvasEnabled: true }).map(t => t.name);
         expect(names).not.toContain('create_or_update_excalidraw');
         expect(names).not.toContain('read_excalidraw');
     });
 
-    it('includes excalidraw tools when excalidrawEnabled is true', async () => {
-        const { getEffectiveLlmToolRegistry } = await import('../../../src/server/llm-tools/llm-tool-registry');
-        const names = getEffectiveLlmToolRegistry({ excalidrawEnabled: true }).map(t => t.name);
-        expect(names).toContain('create_or_update_excalidraw');
-        expect(names).toContain('read_excalidraw');
-    });
-
     it('returns registry minus feature-gated entries when all off', async () => {
         const { getEffectiveLlmToolRegistry } = await import('../../../src/server/llm-tools/llm-tool-registry');
-        // scheduleWakeup + 2 excalidraw tools + 3 canvas tools = 6 filtered
-        expect(getEffectiveLlmToolRegistry({ loopsEnabled: false, excalidrawEnabled: false, canvasEnabled: false })).toHaveLength(LLM_TOOL_REGISTRY.length - 6);
+        // scheduleWakeup + 3 canvas tools = 4 filtered
+        expect(getEffectiveLlmToolRegistry({ loopsEnabled: false, canvasEnabled: false })).toHaveLength(LLM_TOOL_REGISTRY.length - 4);
     });
 
     it('filters out canvas tools when canvasEnabled is false', async () => {

--- a/packages/coc/test/server/spa/client/canvas/CanvasPanel.test.tsx
+++ b/packages/coc/test/server/spa/client/canvas/CanvasPanel.test.tsx
@@ -54,6 +54,22 @@ vi.mock('../../../../../src/server/spa/client/react/hooks/ui/useMarkdownPreview'
     useMarkdownPreview: ({ content }: { content: string }) => ({ html: content }),
 }));
 
+// @excalidraw/excalidraw can't load in Node; the global setup stubs it to
+// render nothing. Override locally so the excalidraw render branch is
+// observable: surface the element count handed to the viewer so the test can
+// assert the canvas scene actually reached <Excalidraw>. The companion
+// normalizers are identity passthroughs, mirroring the global setup mock.
+vi.mock('@excalidraw/excalidraw', () => ({
+    Excalidraw: ({ initialData }: { initialData: { elements?: unknown[] } }) => (
+        <div
+            data-testid="mock-excalidraw"
+            data-element-count={Array.isArray(initialData?.elements) ? initialData.elements.length : 0}
+        />
+    ),
+    restoreElements: (elements: unknown) => (Array.isArray(elements) ? elements : []),
+    convertToExcalidrawElements: (elements: unknown) => (Array.isArray(elements) ? elements : []),
+}));
+
 import { CanvasPanel } from '../../../../../src/server/spa/client/react/features/canvas/CanvasPanel';
 
 function makeCanvas(overrides: Record<string, unknown> = {}) {
@@ -449,6 +465,42 @@ describe('CanvasPanel', () => {
         expect(screen.getByTestId('mock-extension-view')).toBeTruthy();
         // Extension canvases do not show the markdown preview pane
         expect(screen.queryByTestId('canvas-panel-preview')).toBeNull();
+    });
+
+    it('renders excalidraw canvases through the view-only Excalidraw viewer with a diagram badge', async () => {
+        const scene = JSON.stringify({
+            type: 'excalidraw',
+            elements: [
+                { id: 'r1', type: 'rectangle', x: 10, y: 10, width: 100, height: 60 },
+                { id: 't1', type: 'text', x: 20, y: 30, width: 80, height: 20, text: 'Hi' },
+            ],
+            appState: {},
+        });
+        mocks.get.mockResolvedValue(makeCanvas({ type: 'excalidraw', content: scene }));
+
+        render(<CanvasPanel workspaceId="ws-1" canvasId="doc-abc123" liveEvent={null} />);
+
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-excalidraw-badge')).toBeTruthy());
+        // The Excalidraw viewer mounts and receives the parsed scene elements.
+        const viewer = screen.getByTestId('canvas-panel-excalidraw');
+        expect(viewer).toBeTruthy();
+        expect(screen.getByTestId('mock-excalidraw').getAttribute('data-element-count')).toBe('2');
+        // Diagrams never go through the markdown preview pane.
+        expect(screen.queryByTestId('canvas-panel-preview')).toBeNull();
+    });
+
+    it('exposes no edit affordance for excalidraw canvases (view-only)', async () => {
+        const scene = JSON.stringify({ type: 'excalidraw', elements: [], appState: {} });
+        mocks.get.mockResolvedValue(makeCanvas({ type: 'excalidraw', content: scene }));
+
+        render(<CanvasPanel workspaceId="ws-1" canvasId="doc-abc123" liveEvent={null} />);
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-excalidraw-badge')).toBeTruthy());
+
+        // No Preview/Edit toggle and no editor surfaces for a view-only diagram.
+        expect(screen.queryByTestId('canvas-panel-mode-edit')).toBeNull();
+        expect(screen.queryByTestId('canvas-panel-mode-preview')).toBeNull();
+        expect(screen.queryByTestId('canvas-panel-editor')).toBeNull();
+        expect(screen.queryByTestId('mock-monaco')).toBeNull();
     });
 
     it('saves markdown canvases to Notes and hides the option for code canvases', async () => {

--- a/packages/coc/test/spa/DiagramViewerShell.test.ts
+++ b/packages/coc/test/spa/DiagramViewerShell.test.ts
@@ -10,19 +10,19 @@ import { parseDiagramViewerRoute } from '../../src/server/spa/client/react/featu
 // ── parseDiagramViewerRoute ────────────────────────────────────────────────────
 
 describe('parseDiagramViewerRoute', () => {
-    it('parses a valid diagram path', () => {
-        const result = parseDiagramViewerRoute('/diagram/ws-abc123/architecture.excalidraw');
+    it('parses a valid /diagram/<wsId>/<canvasId> route', () => {
+        const result = parseDiagramViewerRoute('/diagram/ws-abc123/architecture');
         expect(result).toEqual({
             workspaceId: 'ws-abc123',
-            diagramPath: 'architecture.excalidraw',
+            canvasId: 'architecture',
         });
     });
 
     it('decodes URL-encoded components', () => {
-        const result = parseDiagramViewerRoute('/diagram/ws%2Dabc/my%20diagram.excalidraw');
+        const result = parseDiagramViewerRoute('/diagram/ws%2Dabc/my%2Dcanvas');
         expect(result).toEqual({
             workspaceId: 'ws-abc',
-            diagramPath: 'my diagram.excalidraw',
+            canvasId: 'my-canvas',
         });
     });
 
@@ -30,7 +30,7 @@ describe('parseDiagramViewerRoute', () => {
         expect(parseDiagramViewerRoute('/')).toBeNull();
     });
 
-    it('returns null for missing diagram path segment', () => {
+    it('returns null for missing canvasId segment', () => {
         expect(parseDiagramViewerRoute('/diagram/ws-abc')).toBeNull();
     });
 
@@ -42,19 +42,17 @@ describe('parseDiagramViewerRoute', () => {
         expect(parseDiagramViewerRoute('/api/workspaces')).toBeNull();
     });
 
-    it('handles path with subdirectory', () => {
-        const result = parseDiagramViewerRoute('/diagram/ws-123/subdir/file.excalidraw');
-        expect(result).toEqual({
-            workspaceId: 'ws-123',
-            diagramPath: 'subdir/file.excalidraw',
-        });
+    // Filename addressing was dropped in the canvas cutover — canvas IDs are
+    // single-segment slugs, so a nested filename-style path no longer matches.
+    it('returns null for a nested filename-style path', () => {
+        expect(parseDiagramViewerRoute('/diagram/ws-123/subdir/file.excalidraw')).toBeNull();
     });
 
-    it('handles diagram name without .excalidraw extension', () => {
+    it('parses a slug canvasId', () => {
         const result = parseDiagramViewerRoute('/diagram/ws-x/my-diagram');
         expect(result).toEqual({
             workspaceId: 'ws-x',
-            diagramPath: 'my-diagram',
+            canvasId: 'my-diagram',
         });
     });
 });
@@ -205,5 +203,49 @@ describe('DiagramViewerShell component source', () => {
         expect(source).toContain('loadScene: false');
         expect(source).toContain('saveToActiveFile: false');
         expect(source).toContain('saveAsImage: false');
+    });
+});
+
+// ── Canvas-store repoint regression ──────────────────────────────────────────────
+//
+// Excalidraw diagrams became canvases in the cutover and the `/api/diagrams`
+// endpoint was removed. The standalone viewer must read the scene from the
+// canvas store, not the dead diagrams endpoint — these assertions guard against
+// a regression back to the removed endpoint or the old filename addressing.
+describe('DiagramViewerShell canvas-store repoint', () => {
+    function readSource(): string {
+        return fs.readFileSync(
+            path.join(
+                __dirname, '..', '..', 'src', 'server', 'spa', 'client', 'react',
+                'features', 'diagrams', 'DiagramViewerShell.tsx',
+            ),
+            'utf-8',
+        );
+    }
+
+    it('fetches the canvas-store endpoint, not the removed /api/diagrams route', () => {
+        const source = readSource();
+        expect(source).toContain('/canvases/');
+        expect(source).not.toContain('/diagrams/');
+    });
+
+    it('parses the scene from canvas.content via parseSceneContent', () => {
+        const source = readSource();
+        expect(source).toContain('parseSceneContent');
+        expect(source).toContain('canvas?.content');
+        // The legacy /api/diagrams response unwrapper is gone post-repoint.
+        expect(source).not.toContain('unwrapDiagramResponse');
+    });
+
+    it('keys the viewer on a canvasId, not a filename path', () => {
+        const source = readSource();
+        expect(source).toContain('canvasId: string');
+        expect(source).not.toContain('diagramPath');
+    });
+
+    it('shows the viewer whenever the canvas or excalidraw feature is enabled', () => {
+        const source = readSource();
+        expect(source).toContain('isCanvasEnabled');
+        expect(source).toContain('isExcalidrawEnabled');
     });
 });

--- a/packages/coc/test/spa/diagram-scene.test.ts
+++ b/packages/coc/test/spa/diagram-scene.test.ts
@@ -11,6 +11,7 @@ import {
     unwrapDiagramResponse,
     buildViewerInitialData,
     normaliseSceneElements,
+    parseSceneContent,
 } from '../../src/server/spa/client/react/features/diagrams/diagram-scene';
 import * as ExcalidrawMod from '@excalidraw/excalidraw';
 
@@ -62,6 +63,26 @@ describe('unwrapDiagramResponse', () => {
     it('omits files when not an object', () => {
         const scene = unwrapDiagramResponse({ content: { ...SAMPLE_SCENE, files: 'oops' } });
         expect(scene.files).toBeUndefined();
+    });
+});
+
+describe('parseSceneContent', () => {
+    it('parses a canvas-store scene JSON string into a scene', () => {
+        const content = JSON.stringify(SAMPLE_SCENE);
+        const scene = parseSceneContent(content);
+        expect(scene.elements).toEqual([{ id: 'a', type: 'rectangle' }]);
+        expect(scene.appState).toEqual({ viewBackgroundColor: '#fafafa', gridSize: null });
+    });
+
+    it('returns an empty scene for empty/blank content', () => {
+        expect(parseSceneContent('')).toEqual({ elements: [], appState: {} });
+        expect(parseSceneContent('   ')).toEqual({ elements: [], appState: {} });
+        expect(parseSceneContent(null)).toEqual({ elements: [], appState: {} });
+        expect(parseSceneContent(undefined)).toEqual({ elements: [], appState: {} });
+    });
+
+    it('degrades malformed JSON to an empty scene instead of throwing', () => {
+        expect(parseSceneContent('{not valid json')).toEqual({ elements: [], appState: {} });
     });
 });
 

--- a/packages/coc/test/spa/react/canvasEmbedInline.test.tsx
+++ b/packages/coc/test/spa/react/canvasEmbedInline.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * AC-05 — inline-in-chat Excalidraw rendering via the canvas:// marker.
+ *
+ * Verifies the full round-trip: the marker that `write_canvas` returns for an
+ * excalidraw canvas (`canvas://<id>`) is rewritten by `chatMarkdownToHtml` into
+ * an embed placeholder, `MarkdownView` mounts `ExcalidrawPreview` on it, and the
+ * preview reads the scene from the canvas store endpoint and renders it.
+ */
+
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+// @excalidraw/excalidraw can't load in Node; the global setup stubs it to
+// render nothing. Override locally so the rendered scene is observable.
+vi.mock('@excalidraw/excalidraw', () => ({
+    Excalidraw: ({ initialData }: { initialData: { elements?: unknown[] } }) => (
+        <div
+            data-testid="mock-excalidraw"
+            data-element-count={Array.isArray(initialData?.elements) ? initialData.elements.length : 0}
+        />
+    ),
+    restoreElements: (elements: unknown) => (Array.isArray(elements) ? elements : []),
+    convertToExcalidrawElements: (elements: unknown) => (Array.isArray(elements) ? elements : []),
+}));
+
+import { MarkdownView } from '../../../src/server/spa/client/react/shared/MarkdownView';
+import { chatMarkdownToHtml } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
+
+const SCENE = JSON.stringify({
+    elements: [
+        { id: 'a', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'b', type: 'ellipse', x: 20, y: 0, width: 10, height: 10 },
+    ],
+    appState: { viewBackgroundColor: '#ffffff' },
+});
+
+describe('inline canvas:// excalidraw embed', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ canvas: { id: 'arch', title: 'Architecture', type: 'excalidraw', content: SCENE } }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it('renders the diagram inline from the canvas store endpoint', async () => {
+        // The marker is exactly what write_canvas returns for an excalidraw canvas.
+        const html = chatMarkdownToHtml('Here it is: canvas://arch', 'ws-1', { excalidrawEmbedEnabled: true });
+        expect(html).toContain('data-canvas-id="arch"');
+
+        render(<MarkdownView html={html} />);
+
+        // The preview fetches the scene from the canvas store, not /api/diagrams.
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        expect(fetchMock.mock.calls[0][0]).toContain('/workspaces/ws-1/canvases/arch');
+        expect(fetchMock.mock.calls[0][0]).not.toContain('/diagrams');
+
+        const viewer = await screen.findByTestId('mock-excalidraw');
+        expect(viewer.getAttribute('data-element-count')).toBe('2');
+    });
+
+    it('does not mount a preview for legacy excalidraw:// embeds (no canvas id)', async () => {
+        const html = chatMarkdownToHtml('Old: excalidraw://ws-1/old.excalidraw', 'ws-1', { excalidrawEmbedEnabled: true });
+        // The legacy placeholder is still emitted, but it carries no canvas id...
+        expect(html).toContain('data-diagram-path="old.excalidraw"');
+
+        render(<MarkdownView html={html} />);
+
+        // ...so nothing is fetched and no viewer mounts (the removed /api/diagrams
+        // endpoint is intentionally unsupported after the hard cutover).
+        await new Promise(r => setTimeout(r, 20));
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('mock-excalidraw')).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/chatMarkdownToHtml.test.ts
+++ b/packages/coc/test/spa/react/chatMarkdownToHtml.test.ts
@@ -6,7 +6,7 @@ import React from 'react';
 import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { MarkdownView } from '../../../src/server/spa/client/react/shared/MarkdownView';
-import { chatMarkdownToHtml, toContentHtml, normalizeMarkdownLinkUrls, parseExcalidrawLink } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
+import { chatMarkdownToHtml, toContentHtml, normalizeMarkdownLinkUrls, parseExcalidrawLink, parseCanvasEmbedLink } from '../../../src/server/spa/client/react/features/chat/conversation/ConversationTurnBubble';
 
 afterEach(() => {
     cleanup();
@@ -655,5 +655,90 @@ describe('chatMarkdownToHtml — excalidraw embeds', () => {
         expect(matches).toHaveLength(2);
         expect(html).toContain('data-diagram-path="a.excalidraw"');
         expect(html).toContain('data-diagram-path="b.excalidraw"');
+    });
+});
+
+// =====================================================================
+// parseCanvasEmbedLink
+// =====================================================================
+
+describe('parseCanvasEmbedLink', () => {
+    it('parses a valid canvas marker', () => {
+        expect(parseCanvasEmbedLink('canvas://arch-1a2b3c')).toEqual({ canvasId: 'arch-1a2b3c' });
+    });
+
+    it('is case-insensitive for the protocol', () => {
+        expect(parseCanvasEmbedLink('CANVAS://diagram-42')).toEqual({ canvasId: 'diagram-42' });
+    });
+
+    it('returns null for other URL schemes', () => {
+        expect(parseCanvasEmbedLink('https://example.com/foo')).toBeNull();
+        expect(parseCanvasEmbedLink('excalidraw://ws-1/a.excalidraw')).toBeNull();
+    });
+
+    it('returns null for malformed markers', () => {
+        expect(parseCanvasEmbedLink('canvas://')).toBeNull();
+        expect(parseCanvasEmbedLink('canvas://has/slash')).toBeNull();
+        expect(parseCanvasEmbedLink('canvas://-bad-start')).toBeNull();
+        expect(parseCanvasEmbedLink('canvas://has space')).toBeNull();
+    });
+});
+
+// =====================================================================
+// Canvas (excalidraw) embed markers in chatMarkdownToHtml
+// =====================================================================
+
+describe('chatMarkdownToHtml — canvas embeds', () => {
+    it('converts a markdown link with canvas:// to a placeholder div stamped with the workspace', () => {
+        const html = chatMarkdownToHtml(
+            'Here is the diagram: [Architecture](canvas://arch-1)',
+            'ws-1',
+            { excalidrawEmbedEnabled: true },
+        );
+        expect(html).toContain('class="md-excalidraw-embed"');
+        expect(html).toContain('data-canvas-id="arch-1"');
+        expect(html).toContain('data-ws-id="ws-1"');
+    });
+
+    it('converts a bare canvas:// marker in text to a placeholder div', () => {
+        const html = chatMarkdownToHtml(
+            'I created the diagram: canvas://flow-2',
+            'ws-9',
+            { excalidrawEmbedEnabled: true },
+        );
+        expect(html).toContain('class="md-excalidraw-embed"');
+        expect(html).toContain('data-canvas-id="flow-2"');
+        expect(html).toContain('data-ws-id="ws-9"');
+    });
+
+    it('does not create a placeholder when the embed feature is disabled', () => {
+        const html = chatMarkdownToHtml(
+            'See canvas://arch-1 here',
+            'ws-1',
+            { excalidrawEmbedEnabled: false },
+        );
+        expect(html).not.toContain('md-excalidraw-embed');
+        expect(html).toContain('canvas://arch-1');
+    });
+
+    it('round-trips the write_canvas embed marker into an inline placeholder', () => {
+        // Mirrors what write_canvas returns for an excalidraw canvas: canvas://<id>.
+        const canvasId = 'sequence-diagram-7';
+        const embed = `canvas://${canvasId}`;
+        const html = chatMarkdownToHtml(`Done — ${embed}`, 'ws-1', { excalidrawEmbedEnabled: true });
+        expect(html).toContain(`data-canvas-id="${canvasId}"`);
+        expect(html).toContain('data-ws-id="ws-1"');
+    });
+
+    it('handles multiple canvas markers in the same message', () => {
+        const html = chatMarkdownToHtml(
+            'First: [A](canvas://a-1) and second: [B](canvas://b-2)',
+            'ws-1',
+            { excalidrawEmbedEnabled: true },
+        );
+        const matches = html.match(/md-excalidraw-embed/g);
+        expect(matches).toHaveLength(2);
+        expect(html).toContain('data-canvas-id="a-1"');
+        expect(html).toContain('data-canvas-id="b-2"');
     });
 });


### PR DESCRIPTION
Migrates Excalidraw diagrams from the dedicated LLM tools + `/api/diagrams` routes onto the unified canvas system, so excalidraw scenes are first-class canvases.

- **AC-01** — add excalidraw as a native canvas type with server-side scene normalization (canvas store + `excalidraw-scene` + canvas tools).
- **AC-02/AC-03** — remove the dedicated Excalidraw LLM tools and `/api/diagrams` routes.
- **AC-04** — render excalidraw canvases view-only in `CanvasPanel`.
- **AC-05** — preserve inline-in-chat excalidraw rendering via the `canvas://` marker.
- **AC-06** — tests verifying excalidraw canvases inherit canvas features.
- Refactor: repoint `DiagramViewerShell` at the canvas store.

Builds on #411 (create_conversation LLM tool), which is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)