### PR TITLE
feat(agent-canvas): group top-level sub-agents by spawning turn

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/AgentCanvas.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/AgentCanvas.tsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { useZoomPan } from '../../../hooks/ui/useZoomPan';
-import { buildLayout, edgePath, spineVars, PAD, type PositionedNode } from './layout';
+import { buildLayout, edgePath, spineVars, COLW, NODEW, PAD, type PositionedNode } from './layout';
 import type { AgentRunNode } from './types';
 import { AcIcons, roleIcon } from './icons';
 import { formatRunDuration } from './format';
@@ -201,6 +201,25 @@ export function AgentCanvas({ root, onOpenAgentDetail }: AgentCanvasProps) {
             style={{ cursor: state.isDragging ? 'grabbing' : 'grab' }}
         >
             <div className="world" style={{ transform: worldTransform }}>
+                {layout.groups.map((g, i) => (
+                    typeof g.turn === 'number' && (
+                        <div
+                            key={`turn-divider-${i}`}
+                            className={'turn-divider' + (g.hasLine ? '' : ' no-line')}
+                            data-testid="agent-canvas-turn-divider"
+                            data-turn={g.turn}
+                            data-has-line={g.hasLine}
+                            style={{
+                                left: COLW + PAD,
+                                top: g.y + PAD,
+                                width: Math.max(NODEW, layout.worldW - COLW - PAD * 2),
+                            }}
+                        >
+                            <span className="turn-divider-label">turn <strong>{g.turn}</strong></span>
+                            {g.hasLine && <span className="turn-divider-rule" />}
+                        </div>
+                    )
+                ))}
                 <svg className="canvas-edges" width={layout.worldW} height={layout.worldH}>
                     {layout.edges.map((e) => {
                         const a = layout.pos[e.from];

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/agent-canvas.css
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/agent-canvas.css
@@ -419,6 +419,40 @@
     padding-left: 12px;
 }
 
+/* Turn dividers — group the orchestrator's top-level sub-agents by the user
+   turn that spawned them. Lives inside `.world`, so the label + dotted rule
+   pan/zoom with the nodes. Typography mirrors the thread's model/mode divider
+   (mono, uppercase, tracking); the rule is dotted and theme-aware. */
+.agent-canvas .turn-divider {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.agent-canvas .turn-divider-label {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    white-space: nowrap;
+}
+
+.agent-canvas .turn-divider-label strong {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.agent-canvas .turn-divider-rule {
+    flex: 1;
+    height: 0;
+    border-top: 1px dotted var(--border-strong);
+}
+
 /* Empty state — no sub-agents in this conversation. */
 .agent-canvas .canvas-empty {
     position: absolute;

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/buildAgentRunTree.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/buildAgentRunTree.ts
@@ -175,6 +175,16 @@ export function buildAgentRunTreeFromTurns(
     }
     rootChildren.sort(byStartedAt);
 
+    // Tag each top-level run with the human turn ordinal that spawned it, so the
+    // canvas can group depth-1 runs by turn and label its dividers. Only depth-1
+    // runs carry this; nested (L2+) runs inherit their top-level ancestor's group.
+    for (const child of rootChildren) {
+        const ordinal = turnOrdinalForRun(turns, child.id);
+        if (ordinal !== null) {
+            child.turn = ordinal;
+        }
+    }
+
     // Root status reflects the whole subtree: any descendant still running/queued
     // keeps the orchestrator "live" when no explicit process status is given.
     const anyActive = Array.from(nodeById.values())
@@ -216,6 +226,37 @@ export function findTurnIndexForRun(
         const inTimeline = (turn.timeline || []).some((item) => item.toolCall?.id === runId);
         if (inToolCalls || inTimeline) {
             return turn.turnIndex ?? i;
+        }
+    }
+    return null;
+}
+
+/**
+ * The human-visible 1-based turn ordinal that spawned a run: the count of `user`
+ * turns at or before the assistant turn carrying the run's `Task` tool-call.
+ * Returns null when the run isn't found (or no turns).
+ *
+ * Unlike `findTurnIndexForRun` — which yields the raw `turnIndex` counting every
+ * turn (user + assistant) — this reads as the turn ordinal a human sees in the
+ * thread. Turns that spawned no agents therefore leave gaps in the sequence
+ * (e.g. … `turn 1`, `turn 4` …), which is exactly what the canvas labels show.
+ */
+export function turnOrdinalForRun(
+    turns: ClientConversationTurn[] | undefined,
+    runId: string,
+): number | null {
+    if (!turns) {
+        return null;
+    }
+    let userTurns = 0;
+    for (const turn of turns) {
+        if (turn.role === 'user') {
+            userTurns++;
+        }
+        const inToolCalls = Array.isArray(turn.toolCalls) && turn.toolCalls.some((tc) => tc.id === runId);
+        const inTimeline = (turn.timeline || []).some((item) => item.toolCall?.id === runId);
+        if (inToolCalls || inTimeline) {
+            return userTurns;
         }
     }
     return null;

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/index.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/index.ts
@@ -6,7 +6,7 @@ export { AgentCascadeMenu } from './AgentCascadeMenu';
 export { SubAgentDetailView } from './SubAgentDetailView';
 export { readChatViewFromHash, applyChatViewToHash } from './chatViewHash';
 export { readAgentFromHash, applyAgentToHash } from './chatAgentHash';
-export { buildAgentRunTreeFromTurns, countRuns, findTurnIndexForRun } from './buildAgentRunTree';
+export { buildAgentRunTreeFromTurns, countRuns, findTurnIndexForRun, turnOrdinalForRun } from './buildAgentRunTree';
 export type { AgentRunRootMeta } from './buildAgentRunTree';
 export { flattenAgentLevels, findAgentNode, pathToAgent } from './agentLevels';
 export type { AgentLevel } from './agentLevels';

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/layout.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/layout.ts
@@ -11,6 +11,11 @@ export const ROWH = 78;
 export const NODEW = 202;
 export const NODEH = 56;
 export const PAD = 60;
+// Extra vertical space inserted between two adjacent turn groups, giving the
+// dotted divider line room to sit clear of either group's nodes.
+export const TURN_GAP = 64;
+// How far above the first group's first node its (line-less) turn label rises.
+export const TURN_LABEL_RISE = 30;
 
 export interface PositionedNode {
     x: number;
@@ -25,6 +30,24 @@ export interface CanvasEdge {
     depth: number;
 }
 
+/** A contiguous run of top-level (depth-1) nodes sharing one spawning turn. */
+export interface TurnGroup {
+    /** The 1-based human turn ordinal, or undefined when the turn is unknown. */
+    turn: number | undefined;
+    runs: AgentRunNode[];
+}
+
+/**
+ * A turn divider placed in world coordinates (pre-PAD, like node positions).
+ * `y` is the vertical centerline of the label/rule row; `hasLine` is false for
+ * the first (topmost) group, which shows its label but no dividing rule above it.
+ */
+export interface TurnGroupMarker {
+    turn: number | undefined;
+    y: number;
+    hasLine: boolean;
+}
+
 export interface CanvasLayout {
     /** Positioned node keyed by node id. */
     pos: Record<string, PositionedNode>;
@@ -32,9 +55,37 @@ export interface CanvasLayout {
     order: string[];
     /** Parent→child connectors. */
     edges: CanvasEdge[];
+    /** Per-turn-group divider markers (label + optional dotted rule). */
+    groups: TurnGroupMarker[];
     /** Intrinsic world size for fit-to-view. */
     worldW: number;
     worldH: number;
+}
+
+/**
+ * Partition top-level runs into contiguous groups by spawning turn. Distinct
+ * turns are ordered ascending (unknown turns sort last); within each group the
+ * runs keep their incoming (startedAt) order. Grouping by turn value — rather
+ * than relying on startedAt contiguity — guarantees each turn forms exactly one
+ * contiguous block even if start times happen to interleave across turns.
+ */
+export function groupRunsByTurn(runs: AgentRunNode[]): TurnGroup[] {
+    const byTurn = new Map<number | undefined, AgentRunNode[]>();
+    const seen: (number | undefined)[] = [];
+    for (const run of runs) {
+        if (!byTurn.has(run.turn)) {
+            byTurn.set(run.turn, []);
+            seen.push(run.turn);
+        }
+        byTurn.get(run.turn)!.push(run);
+    }
+    seen.sort((a, b) => {
+        if (a === b) return 0;
+        if (a === undefined) return 1;
+        if (b === undefined) return -1;
+        return a - b;
+    });
+    return seen.map((turn) => ({ turn, runs: byTurn.get(turn)! }));
 }
 
 /**
@@ -48,7 +99,8 @@ export function buildLayout(root: AgentRunNode): CanvasLayout {
     const edges: CanvasEdge[] = [];
     let cursorY = 0;
 
-    function rec(node: AgentRunNode, depth: number, parentId: string | null): number {
+    // Lay out a subtree rooted at a non-root node (depth >= 1), post-order.
+    function rec(node: AgentRunNode, depth: number, parentId: string): number {
         const x = depth * COLW;
         const kids = node.children || [];
         let y: number;
@@ -61,12 +113,46 @@ export function buildLayout(root: AgentRunNode): CanvasLayout {
         }
         pos[node.id] = { x, y, depth, node };
         order.push(node.id);
-        if (parentId !== null) {
-            edges.push({ from: parentId, to: node.id, depth });
-        }
+        edges.push({ from: parentId, to: node.id, depth });
         return y;
     }
-    rec(root, 0, null);
+
+    // The orchestrator's direct children are partitioned into turn groups; an
+    // extra gap + dotted divider separates adjacent groups, and every group
+    // carries a `turn N` label. Deeper levels are laid out inside each subtree
+    // (no turn boundaries below depth 1).
+    const groups = groupRunsByTurn(root.children || []);
+    const markers: TurnGroupMarker[] = [];
+    const childYs: number[] = [];
+    groups.forEach((group, gi) => {
+        let dividerY: number;
+        let hasLine: boolean;
+        if (gi === 0) {
+            // First group: label only, riding just above its first node row.
+            dividerY = -TURN_LABEL_RISE;
+            hasLine = false;
+        } else {
+            // Boundary divider sits in the middle of the inserted gap.
+            dividerY = cursorY + TURN_GAP / 2;
+            hasLine = true;
+            cursorY += TURN_GAP;
+        }
+        for (const run of group.runs) {
+            childYs.push(rec(run, 1, root.id));
+        }
+        markers.push({ turn: group.turn, y: dividerY, hasLine });
+    });
+
+    // Place the orchestrator root (depth 0), centered over its children.
+    let rootY: number;
+    if (childYs.length) {
+        rootY = (childYs[0] + childYs[childYs.length - 1]) / 2;
+    } else {
+        rootY = cursorY;
+        cursorY += ROWH;
+    }
+    pos[root.id] = { x: 0, y: rootY, depth: 0, node: root };
+    order.push(root.id);
 
     let maxX = 0;
     let maxY = 0;
@@ -78,6 +164,7 @@ export function buildLayout(root: AgentRunNode): CanvasLayout {
         pos,
         order,
         edges,
+        groups: markers,
         worldW: maxX + NODEW + PAD * 2,
         worldH: maxY + NODEH + PAD * 2,
     };

--- a/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/types.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/agent-canvas/types.ts
@@ -34,6 +34,13 @@ export interface AgentRunNode {
     prompt?: string;
     /** Full result/output the run produced, if available. */
     result?: string;
+    /**
+     * 1-based human turn ordinal of the user turn that spawned this run. Set only
+     * on the orchestrator's direct (depth-1) children by
+     * `buildAgentRunTreeFromTurns`; it drives the canvas's per-turn grouping and
+     * dividers. Undefined for the root, nested (L2+) runs, and synthetic nodes.
+     */
+    turn?: number;
     /** Recursively spawned child runs. */
     children: AgentRunNode[];
 }

--- a/packages/coc/test/server/spa/client/agent-canvas-data.test.ts
+++ b/packages/coc/test/server/spa/client/agent-canvas-data.test.ts
@@ -3,6 +3,7 @@ import {
     buildAgentRunTreeFromTurns,
     countRuns,
     findTurnIndexForRun,
+    turnOrdinalForRun,
 } from '../../../../src/server/spa/client/react/features/chat/agent-canvas/buildAgentRunTree';
 import type { AgentRunNode } from '../../../../src/server/spa/client/react/features/chat/agent-canvas/types';
 import type { ClientConversationTurn, ClientToolCall } from '../../../../src/server/spa/client/react/types/dashboard';
@@ -16,6 +17,10 @@ function assistantTurn(
     timeline: ClientConversationTurn['timeline'] = [],
 ): ClientConversationTurn {
     return { role: 'assistant', content: '', timeline, toolCalls };
+}
+
+function userTurn(content = 'go'): ClientConversationTurn {
+    return { role: 'user', content, timeline: [] };
 }
 
 describe('buildAgentRunTreeFromTurns', () => {
@@ -400,6 +405,76 @@ describe('buildAgentRunTreeFromTurns', () => {
         ])];
         const parent = buildAgentRunTreeFromTurns(turns).children[0];
         expect(parent.children.map((c) => c.id)).toEqual(['early', 'late']);
+    });
+
+    it('tags each top-level run with the spawning turn ordinal, leaving gaps (AC-01/AC-03)', () => {
+        // user→agent, then two agent-less turns, then user→agent: ordinals 1 and 4.
+        const turns = [
+            userTurn('u1'),
+            assistantTurn([tc({ id: 'a', args: { description: 'first' }, startTime: '2026-06-13T10:00:00.000Z' })]),
+            userTurn('u2'),
+            assistantTurn([]),
+            userTurn('u3'),
+            assistantTurn([]),
+            userTurn('u4'),
+            assistantTurn([tc({ id: 'b', args: { description: 'fourth' }, startTime: '2026-06-13T10:10:00.000Z' })]),
+        ];
+        const root = buildAgentRunTreeFromTurns(turns);
+        const byId = new Map(root.children.map((c) => [c.id, c]));
+        expect(byId.get('a')?.turn).toBe(1);
+        expect(byId.get('b')?.turn).toBe(4);
+    });
+
+    it('does not tag nested (L2+) runs with a turn', () => {
+        const turns = [
+            userTurn('go'),
+            assistantTurn([
+                tc({ id: 'l1', args: { name: 'parent' } }),
+                tc({ id: 'l2', parentToolCallId: 'l1', args: { name: 'child' } }),
+            ]),
+        ];
+        const root = buildAgentRunTreeFromTurns(turns);
+        expect(root.children[0].turn).toBe(1);
+        expect(root.children[0].children[0].turn).toBeUndefined();
+    });
+});
+
+describe('turnOrdinalForRun', () => {
+    it('counts user turns up to the spawning assistant turn (human ordinal)', () => {
+        const turns = [
+            userTurn('go'),
+            assistantTurn([tc({ id: 't1', args: { description: 'x' } })]),
+        ];
+        expect(turnOrdinalForRun(turns, 't1')).toBe(1);
+    });
+
+    it('produces real-position ordinals with gaps when turns spawn no agents', () => {
+        const turns = [
+            userTurn('u1'),
+            assistantTurn([tc({ id: 'a', args: { description: 'first' } })]),
+            userTurn('u2'),
+            assistantTurn([]),
+            userTurn('u3'),
+            assistantTurn([]),
+            userTurn('u4'),
+            assistantTurn([tc({ id: 'b', args: { description: 'fourth' } })]),
+        ];
+        expect(turnOrdinalForRun(turns, 'a')).toBe(1);
+        expect(turnOrdinalForRun(turns, 'b')).toBe(4);
+    });
+
+    it('matches a run found only in the timeline', () => {
+        const turns = [userTurn('go'), assistantTurn([], [{
+            type: 'tool-complete',
+            timestamp: '2026-06-13T10:00:00.000Z',
+            toolCall: tc({ id: 't9', args: {}, status: 'completed' }),
+        }])];
+        expect(turnOrdinalForRun(turns, 't9')).toBe(1);
+    });
+
+    it('returns null when the run is absent or turns are missing', () => {
+        expect(turnOrdinalForRun(undefined, 'x')).toBeNull();
+        expect(turnOrdinalForRun([assistantTurn([tc({ id: 't1', args: {} })])], 'missing')).toBeNull();
     });
 });
 

--- a/packages/coc/test/server/spa/client/agent-canvas-layout.test.ts
+++ b/packages/coc/test/server/spa/client/agent-canvas-layout.test.ts
@@ -3,16 +3,23 @@ import {
     buildLayout,
     edgePath,
     spineVars,
+    groupRunsByTurn,
     COLW,
     ROWH,
     NODEW,
     NODEH,
     PAD,
+    TURN_GAP,
+    TURN_LABEL_RISE,
 } from '../../../../src/server/spa/client/react/features/chat/agent-canvas/layout';
 import type { AgentRunNode } from '../../../../src/server/spa/client/react/features/chat/agent-canvas/types';
 
 function node(id: string, children: AgentRunNode[] = []): AgentRunNode {
     return { id, name: id, role: 'agent', status: 'done', children };
+}
+
+function turnNode(id: string, turn: number, children: AgentRunNode[] = []): AgentRunNode {
+    return { ...node(id, children), turn };
 }
 
 describe('buildLayout', () => {
@@ -59,6 +66,74 @@ describe('buildLayout', () => {
         expect(layout.edges).toContainEqual({ from: 'a', to: 'a2', depth: 2 });
         expect(layout.edges).toContainEqual({ from: 'root', to: 'a', depth: 1 });
         expect(layout.worldW).toBe(COLW * 2 + NODEW + PAD * 2);
+    });
+});
+
+describe('groupRunsByTurn (AC-01)', () => {
+    it('partitions top-level runs into contiguous groups ordered by turn, preserving within-group order', () => {
+        const groups = groupRunsByTurn([
+            turnNode('a', 1),
+            turnNode('b', 1),
+            turnNode('c', 2),
+        ]);
+        expect(groups).toHaveLength(2);
+        expect(groups[0].turn).toBe(1);
+        expect(groups[0].runs.map((r) => r.id)).toEqual(['a', 'b']);
+        expect(groups[1].turn).toBe(2);
+        expect(groups[1].runs.map((r) => r.id)).toEqual(['c']);
+    });
+
+    it('yields exactly one group when every run shares a turn', () => {
+        const groups = groupRunsByTurn([turnNode('a', 3), turnNode('b', 3)]);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].turn).toBe(3);
+        expect(groups[0].runs.map((r) => r.id)).toEqual(['a', 'b']);
+    });
+
+    it('keeps each turn contiguous and ascending even when input start order interleaves turns', () => {
+        const groups = groupRunsByTurn([
+            turnNode('a', 2),
+            turnNode('b', 1),
+            turnNode('c', 2),
+        ]);
+        expect(groups.map((g) => g.turn)).toEqual([1, 2]);
+        expect(groups[0].runs.map((r) => r.id)).toEqual(['b']);
+        // both turn-2 runs collapse into one contiguous group, original order kept
+        expect(groups[1].runs.map((r) => r.id)).toEqual(['a', 'c']);
+    });
+
+    it('sorts unknown-turn runs into a trailing group', () => {
+        const groups = groupRunsByTurn([node('x'), turnNode('a', 1)]);
+        expect(groups.map((g) => g.turn)).toEqual([1, undefined]);
+    });
+});
+
+describe('buildLayout turn dividers (AC-02)', () => {
+    it('emits one label marker with no line for a single-turn root', () => {
+        const layout = buildLayout(node('root', [turnNode('a', 1), turnNode('b', 1)]));
+        expect(layout.groups).toHaveLength(1);
+        expect(layout.groups[0]).toMatchObject({ turn: 1, hasLine: false, y: -TURN_LABEL_RISE });
+        // no extra gap is inserted for a lone group: rows stack one ROWH apart
+        expect(layout.pos.a.y).toBe(0);
+        expect(layout.pos.b.y).toBe(ROWH);
+    });
+
+    it('inserts a gap and a lined divider between two turn groups', () => {
+        const layout = buildLayout(node('root', [turnNode('a', 1), turnNode('b', 2)]));
+        expect(layout.groups).toHaveLength(2);
+        expect(layout.groups[0]).toMatchObject({ turn: 1, hasLine: false });
+        expect(layout.groups[1]).toMatchObject({ turn: 2, hasLine: true });
+        // the second group's leaf is pushed down by the inserted gap
+        expect(layout.pos.b.y).toBe(ROWH + TURN_GAP);
+        // the boundary divider sits in the middle of that gap
+        expect(layout.groups[1].y).toBe(ROWH + TURN_GAP / 2);
+        // root stays centered over its (now further-apart) children
+        expect(layout.pos.root.y).toBe((ROWH + TURN_GAP) / 2);
+    });
+
+    it('has no group markers for a lone root with no sub-agents', () => {
+        const layout = buildLayout(node('root'));
+        expect(layout.groups).toEqual([]);
     });
 });
 

--- a/packages/coc/test/spa/react/AgentCanvas.test.tsx
+++ b/packages/coc/test/spa/react/AgentCanvas.test.tsx
@@ -12,6 +12,10 @@ function sub(id: string, overrides: Partial<AgentRunNode> = {}): AgentRunNode {
     return { id, name: id, role: 'Explore', status: 'done', children: [], ...overrides };
 }
 
+function subT(id: string, turn: number, overrides: Partial<AgentRunNode> = {}): AgentRunNode {
+    return sub(id, { turn, ...overrides });
+}
+
 describe('AgentCanvas', () => {
     it('renders the orchestrator root and every sub-agent node', () => {
         render(<AgentCanvas root={tree([sub('explore'), sub('review', { role: 'reviewer' })])} />);
@@ -98,5 +102,37 @@ describe('AgentCanvas', () => {
         fireEvent.click(screen.getByTestId('agent-canvas-zoom-label'));
         fireEvent.click(within(screen.getByTestId('agent-canvas-zoom-menu')).getByText('50%'));
         expect(screen.queryByTestId('agent-canvas-zoom-menu')).toBeNull();
+    });
+});
+
+describe('AgentCanvas turn dividers', () => {
+    it('shows a single turn label and no dividing line when all sub-agents share a turn (AC-02)', () => {
+        render(<AgentCanvas root={tree([subT('a', 1), subT('b', 1)])} />);
+        const dividers = screen.getAllByTestId('agent-canvas-turn-divider');
+        expect(dividers).toHaveLength(1);
+        expect(dividers[0].textContent).toContain('turn 1');
+        expect(dividers[0].querySelector('.turn-divider-rule')).toBeNull();
+    });
+
+    it('draws a dotted line + label between groups, with no line above the first (AC-02/AC-03)', () => {
+        // turns 1 and 4 spawn agents → real-ordinal labels with a gap
+        render(<AgentCanvas root={tree([subT('a', 1), subT('b', 4)])} />);
+        const dividers = screen.getAllByTestId('agent-canvas-turn-divider');
+        expect(dividers).toHaveLength(2);
+        expect(dividers[0].textContent).toContain('turn 1');
+        expect(dividers[0].querySelector('.turn-divider-rule')).toBeNull(); // first: label only
+        expect(dividers[1].textContent).toContain('turn 4');
+        expect(dividers[1].querySelector('.turn-divider-rule')).not.toBeNull(); // boundary: dotted rule
+    });
+
+    it('renders no turn dividers when there are no sub-agents (AC-02)', () => {
+        render(<AgentCanvas root={tree([])} />);
+        expect(screen.queryAllByTestId('agent-canvas-turn-divider')).toHaveLength(0);
+    });
+
+    it('renders the dividers inside the zoom/pan world layer so they pan/zoom with nodes (AC-02)', () => {
+        const { container } = render(<AgentCanvas root={tree([subT('a', 1), subT('b', 2)])} />);
+        const world = container.querySelector('.agent-canvas .world');
+        expect(world?.querySelectorAll('.turn-divider')).toHaveLength(2);
     });
 });


### PR DESCRIPTION
Groups top-level sub-agents in the agent canvas by the conversation turn that spawned them, with dotted dividers between turn groups, making it easier to see which sub-agents belong to which turn.

- Updates `AgentCanvas.tsx`, `buildAgentRunTree.ts`, `layout.ts`, `types.ts`, and `agent-canvas.css`.
- Adds/updates agent-canvas data + layout tests and the `AgentCanvas` SPA test.