### PR TITLE
feat(git): add Discard All bulk action to Local Tree working changes

### DIFF
--- a/packages/coc-client/src/contracts/git.ts
+++ b/packages/coc-client/src/contracts/git.ts
@@ -241,6 +241,14 @@ export interface GitWorkingTreeChangesResponse {
   repoState: GitRepoState;
 }
 
+export interface GitDiscardAllResponse {
+  success: boolean;
+  /** Number of files successfully discarded/deleted. */
+  discarded: number;
+  /** Per-file/phase error messages; empty when fully successful. */
+  errors: string[];
+}
+
 export interface GitCommitChatBinding {
   commitHash: string;
   taskId: string;

--- a/packages/coc-client/src/domains/git.ts
+++ b/packages/coc-client/src/domains/git.ts
@@ -19,6 +19,7 @@ import type {
   GitDiffCommentResponse,
   GitDiffCommentsResponse,
   GitDiffCommentTotalsResponse,
+  GitDiscardAllResponse,
   GitFileContentResponse,
   GitPatchApplyRequest,
   GitPatchApplyResponse,
@@ -417,6 +418,11 @@ export class GitClient {
 
   deleteUntrackedFile(workspaceId: string, filePath: string): Promise<GitOperationResult> {
     return this.transport.request<GitOperationResult>(workspaceGitPath(workspaceId, '/changes/untracked'), jsonRequest('DELETE', { filePath }));
+  }
+
+  /** Discard every working-tree change (staged, unstaged, and untracked) in one call. */
+  discardAllChanges(workspaceId: string): Promise<GitDiscardAllResponse> {
+    return this.transport.request<GitDiscardAllResponse>(workspaceGitPath(workspaceId, '/changes/discard-all'), { method: 'POST' });
   }
 
   stageFiles(workspaceId: string, filePaths: string[]): Promise<GitOperationResult> {

--- a/packages/coc-client/test/domains/git.test.ts
+++ b/packages/coc-client/test/domains/git.test.ts
@@ -134,6 +134,7 @@ describe('GitClient', () => {
     await client.deleteUntrackedFile('repo/a', 'src/a.ts');
     await client.stageFiles('repo/a', ['src/a.ts', 'src/b.ts']);
     await client.unstageFiles('repo/a', ['src/a.ts', 'src/b.ts']);
+    await client.discardAllChanges('repo/a');
 
     expect(adapter.calls.map(c => c.path)).toEqual([
       '/workspaces/repo%2Fa/git/repo-state',
@@ -161,6 +162,7 @@ describe('GitClient', () => {
       '/workspaces/repo%2Fa/git/changes/untracked',
       '/workspaces/repo%2Fa/git/changes/stage-batch',
       '/workspaces/repo%2Fa/git/changes/unstage-batch',
+      '/workspaces/repo%2Fa/git/changes/discard-all',
     ]);
     expect(adapter.calls[1].options?.query).toEqual({ op: 'pull' });
     expect(adapter.calls[3].options).toMatchObject({ method: 'POST', body: { remote: 'origin' } });
@@ -184,6 +186,7 @@ describe('GitClient', () => {
     });
     expect(adapter.calls[22].options).toMatchObject({ method: 'DELETE', body: { filePath: 'src/a.ts' } });
     expect(adapter.calls[23].options).toMatchObject({ method: 'POST', body: { filePaths: ['src/a.ts', 'src/b.ts'] } });
+    expect(adapter.calls[25].options).toMatchObject({ method: 'POST' });
   });
 
   it('calls diff-comment and commit-chat routes with encoded identifiers', async () => {

--- a/packages/coc/src/server/routes/api-git-working-tree-routes.ts
+++ b/packages/coc/src/server/routes/api-git-working-tree-routes.ts
@@ -138,6 +138,21 @@ export function registerGitWorkingTreeRoutes(ctx: ApiRouteContext): void {
         },
     }));
 
+    // POST /api/workspaces/:id/git/changes/discard-all — Discard ALL working-tree changes
+    routes.push(createRoute({
+        method: 'POST',
+        pattern: /^\/api\/workspaces\/([^/]+)\/git\/changes\/discard-all$/,
+        handler: async ({ res, match }) => {
+            const ws = await resolveWorkspaceOrFail(store, match, res);
+            if (!ws) return;
+            const id = ws.id;
+
+            const result = await workingTreeService.discardAll(ws.rootPath);
+            getWsServer?.()?.broadcastGitChanged(id, 'discard-all');
+            return result;
+        },
+    }));
+
     // DELETE /api/workspaces/:id/git/changes/untracked — Delete an untracked file
     routes.push(createRoute({
         method: 'DELETE',

--- a/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTree.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/working-tree/WorkingTree.tsx
@@ -262,6 +262,7 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
     /** Set of filePaths currently being acted on */
     const [busyFiles, setBusyFiles] = useState<Set<string>>(new Set());
     const [stagingAll, setStagingAll] = useState(false);
+    const [discardingAll, setDiscardingAll] = useState(false);
     const [workingChangesExpanded, setWorkingChangesExpanded] = useState(false);
     const [allWorkingComments, setAllWorkingComments] = useState<DiffComment[]>([]);
 
@@ -372,6 +373,27 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
             setActionError(err.message || 'Unstage all failed');
         } finally {
             setStagingAll(false);
+        }
+    }, [workspaceId, cloneClient, fetchChanges, onRefresh]);
+
+    // Discard every visible change (staged, unstaged, untracked) in one server call.
+    // On failure we still refresh so the tree reflects any partial completion, then
+    // surface the error — partial failures must not look like success (AC-03).
+    const handleDiscardAll = useCallback(async () => {
+        setDiscardingAll(true);
+        setActionError(null);
+        try {
+            const result = await cloneClient.git.discardAllChanges(workspaceId);
+            if (result.success === false) {
+                setActionError(result.errors?.length ? result.errors.join('; ') : 'Discard all failed');
+            }
+        } catch (err: any) {
+            setActionError(err.message || 'Discard all failed');
+        } finally {
+            // Always re-read so the tree reflects any partial completion, even on error.
+            await fetchChanges();
+            onRefresh?.();
+            setDiscardingAll(false);
         }
     }, [workspaceId, cloneClient, fetchChanges, onRefresh]);
 
@@ -509,6 +531,23 @@ export function WorkingTree({ workspaceId, onRefresh, onFileSelect, selectedFile
                 </div>
                 {workingChangesExpanded && (
                     <div className="border-t border-[#e0e0e0] dark:border-[#3c3c3c]" data-testid="working-changes-content">
+                        {totalCount > 0 && (
+                            <div
+                                className="flex items-center justify-end gap-1.5 pl-7 pr-4 py-1.5 border-b border-[#e0e0e0] dark:border-[#3c3c3c]"
+                                data-testid="working-tree-bulk-actions"
+                            >
+                                <button
+                                    className="text-[10px] px-1.5 py-0.5 rounded border border-[#d32f2f] text-[#d32f2f] hover:bg-[#d32f2f] hover:text-white dark:border-[#f48771] dark:text-[#f48771] dark:hover:bg-[#f48771] dark:hover:text-[#1e1e1e] transition-colors disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1 flex-shrink-0"
+                                    onClick={(e) => { e.stopPropagation(); handleDiscardAll(); }}
+                                    disabled={discardingAll || stagingAll}
+                                    title="Discard all changes — staged, unstaged, and untracked. This is irreversible."
+                                    data-testid="working-tree-discard-all"
+                                >
+                                    {discardingAll && <Spinner size="sm" />}
+                                    {discardingAll ? 'Discarding…' : '↩ Discard All'}
+                                </button>
+                            </div>
+                        )}
                         <Section
                             title="Staged"
                             count={staged.length}

--- a/packages/coc/test/server/git-working-tree-edge.test.ts
+++ b/packages/coc/test/server/git-working-tree-edge.test.ts
@@ -32,6 +32,7 @@ const mockGetAllChanges = vi.fn();
 const mockStageFile = vi.fn();
 const mockUnstageFile = vi.fn();
 const mockDiscardChanges = vi.fn();
+const mockDiscardAll = vi.fn();
 const mockDeleteUntrackedFile = vi.fn();
 const mockGetFileDiff = vi.fn();
 const mockStageFiles = vi.fn();
@@ -46,6 +47,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
             stageFile: mockStageFile,
             unstageFile: mockUnstageFile,
             discardChanges: mockDiscardChanges,
+            discardAll: mockDiscardAll,
             deleteUntrackedFile: mockDeleteUntrackedFile,
             getFileDiff: mockGetFileDiff,
             stageFiles: mockStageFiles,
@@ -134,6 +136,7 @@ describe('Git Working Tree Edge Cases', () => {
         mockStageFile.mockReset();
         mockUnstageFile.mockReset();
         mockDiscardChanges.mockReset();
+        mockDiscardAll.mockReset();
         mockDeleteUntrackedFile.mockReset();
         mockGetFileDiff.mockReset();
         mockStageFiles.mockReset();
@@ -226,6 +229,49 @@ deleted file mode 100644
             });
 
             expect(res.status).toBe(400);
+        });
+    });
+
+    describe('POST /api/workspaces/:id/git/changes/discard-all', () => {
+        it('discards the whole working tree and reports the count', async () => {
+            mockDiscardAll.mockResolvedValue({ success: true, discarded: 4, errors: [] });
+
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/git/changes/discard-all`, {
+                method: 'POST',
+            });
+
+            expect(res.status).toBe(200);
+            expect(res.json()).toEqual({ success: true, discarded: 4, errors: [] });
+            expect(mockDiscardAll).toHaveBeenCalledWith(WORKSPACE_ROOT);
+        });
+
+        it('passes through partial failures without hiding them', async () => {
+            mockDiscardAll.mockResolvedValue({
+                success: false,
+                discarded: 2,
+                errors: ['delete /repo/locked.log: EPERM: operation not permitted'],
+            });
+
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/git/changes/discard-all`, {
+                method: 'POST',
+            });
+
+            // Service result is returned verbatim (200) so the UI can surface the error.
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.success).toBe(false);
+            expect(data.discarded).toBe(2);
+            expect(data.errors).toHaveLength(1);
+            expect(data.errors[0]).toContain('EPERM');
+        });
+
+        it('returns 404 for unknown workspace', async () => {
+            const res = await request(`${base()}/api/workspaces/ws-does-not-exist/git/changes/discard-all`, {
+                method: 'POST',
+            });
+
+            expect(res.status).toBe(404);
+            expect(mockDiscardAll).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/coc/test/spa/react/WorkingTree.test.ts
+++ b/packages/coc/test/spa/react/WorkingTree.test.ts
@@ -239,4 +239,49 @@ describe('WorkingTree', () => {
             expect(unstageAllBody).not.toContain('for (const f of files)');
         });
     });
+
+    describe('Discard All bulk action', () => {
+        it('renders a visible Discard All control (not in an overflow menu)', () => {
+            expect(source).toContain('data-testid="working-tree-discard-all"');
+            expect(source).toContain('Discard All');
+        });
+
+        it('places the control in a bulk-actions area inside the expanded content', () => {
+            expect(source).toContain('data-testid="working-tree-bulk-actions"');
+            const contentIdx = source.indexOf('working-changes-content');
+            const bulkIdx = source.indexOf('working-tree-bulk-actions');
+            const stagedIdx = source.indexOf('working-tree-staged');
+            // Bulk actions sit between the content wrapper and the first section.
+            expect(bulkIdx).toBeGreaterThan(contentIdx);
+            expect(stagedIdx).toBeGreaterThan(bulkIdx);
+        });
+
+        it('only shows the control when there are changes', () => {
+            expect(source).toContain('totalCount > 0 &&');
+        });
+
+        it('discards through the typed clone-routed git client', () => {
+            expect(source).toContain('cloneClient.git.discardAllChanges(workspaceId)');
+        });
+
+        it('tracks an in-progress state and disables the control while running', () => {
+            expect(source).toContain('discardingAll');
+            expect(source).toContain('setDiscardingAll');
+            expect(source).toContain('disabled={discardingAll || stagingAll}');
+        });
+
+        it('refreshes the working tree even on failure so partial failures are not hidden', () => {
+            const start = source.indexOf('handleDiscardAll');
+            const end = source.indexOf('const staged', start);
+            const body = source.substring(start, end);
+            // catch block still refreshes before surfacing the error
+            expect(body).toContain('catch');
+            expect(body).toContain('fetchChanges()');
+            expect(body).toContain('setActionError');
+        });
+
+        it('surfaces discard errors so it cannot look like success', () => {
+            expect(source).toContain('result.errors');
+        });
+    });
 });

--- a/packages/forge/src/git/working-tree-service.ts
+++ b/packages/forge/src/git/working-tree-service.ts
@@ -304,6 +304,83 @@ export class WorkingTreeService {
     }
 
     /**
+     * Discard tracked modifications/deletions for multiple files
+     * (`git checkout -- <files>`), falling back to per-file checkout on batch
+     * error so a single bad path does not abort the rest.
+     */
+    private async discardPaths(repoRoot: string, filePaths: string[]): Promise<{ discarded: number; errors: string[] }> {
+        if (filePaths.length === 0) return { discarded: 0, errors: [] };
+        const errors: string[] = [];
+        const executionContext = resolveWorkspaceExecutionContext(repoRoot);
+        try {
+            await execGitAsync(
+                ['-C', translatePathForExecution(repoRoot, executionContext), 'checkout', '--', ...filePaths.map(f => translatePathForExecution(f, executionContext))],
+                { cwd: repoRoot },
+            );
+        } catch {
+            for (const filePath of filePaths) {
+                try {
+                    await execGitAsync(
+                        ['-C', translatePathForExecution(repoRoot, executionContext), 'checkout', '--', translatePathForExecution(filePath, executionContext)],
+                        { cwd: repoRoot },
+                    );
+                } catch (e) {
+                    errors.push(`${filePath}: ${e instanceof Error ? e.message : 'Unknown error'}`);
+                }
+            }
+        }
+        return { discarded: filePaths.length - errors.length, errors };
+    }
+
+    /**
+     * Discard ALL working-tree changes, returning the repo to a clean state.
+     *
+     * Runs three phases and reports each independently so partial failures
+     * surface with enough detail to tell which step failed:
+     *   1. Unstage every staged path (so its contents can then be discarded).
+     *   2. Discard tracked modifications/deletions via `git checkout -- <paths>`.
+     *   3. Delete untracked files/directories from disk.
+     *
+     * A newly-added staged file becomes untracked once unstaged, so the
+     * working-tree state is re-read after phase 1 to classify what remains.
+     *
+     * Destructive and irreversible. Error strings are prefixed with the failing
+     * phase (`unstage`/`discard`/`delete`).
+     */
+    async discardAll(repoRoot: string): Promise<{ success: boolean; discarded: number; errors: string[] }> {
+        const initial = await this.getAllChanges(repoRoot);
+        if (initial.length === 0) return { success: true, discarded: 0, errors: [] };
+
+        const errors: string[] = [];
+
+        // Phase 1 — unstage every staged path so worktree contents can be reset.
+        const stagedPaths = [...new Set(initial.filter(c => c.stage === 'staged').map(c => c.filePath))];
+        if (stagedPaths.length > 0) {
+            const unstaged = await this.unstageFiles(repoRoot, stagedPaths);
+            for (const e of unstaged.errors) errors.push(`unstage ${e}`);
+        }
+
+        // Re-read after unstaging: staged "added" files are now untracked.
+        const remaining = stagedPaths.length > 0 ? await this.getAllChanges(repoRoot) : initial;
+        const trackedPaths = [...new Set(remaining.filter(c => c.stage === 'unstaged').map(c => c.filePath))];
+        const untrackedPaths = [...new Set(remaining.filter(c => c.stage === 'untracked').map(c => c.filePath))];
+
+        // Phase 2 — discard tracked modifications/deletions.
+        const discardResult = await this.discardPaths(repoRoot, trackedPaths);
+        for (const e of discardResult.errors) errors.push(`discard ${e}`);
+
+        // Phase 3 — delete untracked files/directories.
+        let deleted = 0;
+        for (const filePath of untrackedPaths) {
+            const result = await this.deleteUntrackedFile(repoRoot, filePath);
+            if (result.success) deleted++;
+            else errors.push(`delete ${filePath}: ${result.error ?? 'Unknown error'}`);
+        }
+
+        return { success: errors.length === 0, discarded: discardResult.discarded + deleted, errors };
+    }
+
+    /**
      * Get the diff for a single file in the working tree.
      * - staged=true  → `git diff --staged -- <file>`
      * - staged=false → `git diff -- <file>`

--- a/packages/forge/test/git/working-tree-service.test.ts
+++ b/packages/forge/test/git/working-tree-service.test.ts
@@ -421,3 +421,99 @@ describe('WorkingTreeService.deleteUntrackedFile', () => {
         expect(result.error).toContain('permission denied');
     });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkingTreeService.discardAll
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('WorkingTreeService.discardAll', () => {
+    const service = new WorkingTreeService();
+    const repoRoot = ROOT;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('returns success with discarded=0 when there are no changes', async () => {
+        mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' } as any);
+        const result = await service.discardAll(repoRoot);
+        expect(result).toEqual({ success: true, discarded: 0, errors: [] });
+        // Only the initial status query runs; nothing to unstage/discard/delete.
+        expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('unstages, discards, and deletes a mixed working tree', async () => {
+        // Call order: status → unstage(reset) batch → re-read status → discard(checkout) batch.
+        mockExecFileAsync
+            .mockResolvedValueOnce({ stdout: 'M  staged.ts\n M unstaged.ts\n?? untracked.txt\n', stderr: '' } as any)
+            .mockResolvedValueOnce({ stdout: '', stderr: '' } as any)
+            .mockResolvedValueOnce({ stdout: ' M staged.ts\n M unstaged.ts\n?? untracked.txt\n', stderr: '' } as any)
+            .mockResolvedValueOnce({ stdout: '', stderr: '' } as any);
+        mockFs.existsSync.mockReturnValue(true);
+        mockFs.statSync.mockReturnValue({ isDirectory: () => false } as any);
+
+        const result = await service.discardAll(repoRoot);
+
+        expect(result.success).toBe(true);
+        expect(result.errors).toEqual([]);
+        // 2 tracked files reverted + 1 untracked deleted.
+        expect(result.discarded).toBe(3);
+        const commands = mockExecFileAsync.mock.calls.map(c => (c[1] as string[]).join(' '));
+        expect(commands.some(c => c.includes('reset HEAD'))).toBe(true);
+        expect(commands.some(c => c.includes('checkout --'))).toBe(true);
+        expect(mockFs.unlinkSync).toHaveBeenCalledWith(path.join(ROOT, 'untracked.txt'));
+    });
+
+    it('deletes a staged-added file after unstaging turns it untracked', async () => {
+        // A staged "added" file becomes untracked once unstaged, so it is deleted, not checked out.
+        mockExecFileAsync
+            .mockResolvedValueOnce({ stdout: 'A  brand-new.ts\n', stderr: '' } as any) // status: staged add
+            .mockResolvedValueOnce({ stdout: '', stderr: '' } as any)                   // unstage(reset) batch
+            .mockResolvedValueOnce({ stdout: '?? brand-new.ts\n', stderr: '' } as any);  // re-read: now untracked
+        mockFs.existsSync.mockReturnValue(true);
+        mockFs.statSync.mockReturnValue({ isDirectory: () => false } as any);
+
+        const result = await service.discardAll(repoRoot);
+
+        expect(result.success).toBe(true);
+        expect(result.discarded).toBe(1);
+        // No checkout needed — nothing tracked remained after unstaging.
+        const commands = mockExecFileAsync.mock.calls.map(c => (c[1] as string[]).join(' '));
+        expect(commands.some(c => c.includes('checkout --'))).toBe(false);
+        expect(mockFs.unlinkSync).toHaveBeenCalledWith(path.join(ROOT, 'brand-new.ts'));
+    });
+
+    it('surfaces a phase-prefixed error when discarding a tracked file fails', async () => {
+        // No staged paths → no re-read. status → checkout batch (fail) → per-file checkout (fail).
+        mockExecFileAsync
+            .mockResolvedValueOnce({ stdout: ' M a.ts\n?? b.txt\n', stderr: '' } as any)
+            .mockRejectedValueOnce(new Error('batch checkout failed'))
+            .mockRejectedValueOnce(new Error('checkout: pathspec error'));
+        mockFs.existsSync.mockReturnValue(true);
+        mockFs.statSync.mockReturnValue({ isDirectory: () => false } as any);
+
+        const result = await service.discardAll(repoRoot);
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain('discard');
+        expect(result.errors[0]).toContain('pathspec');
+        // Untracked file is still deleted despite the discard failure (no hidden partial failure).
+        expect(result.discarded).toBe(1);
+        expect(mockFs.unlinkSync).toHaveBeenCalledWith(path.join(ROOT, 'b.txt'));
+    });
+
+    it('surfaces a delete-phase error when an untracked file cannot be removed', async () => {
+        mockExecFileAsync.mockResolvedValueOnce({ stdout: '?? c.txt\n', stderr: '' } as any);
+        mockFs.existsSync.mockReturnValue(false); // delete fails: file does not exist
+
+        const result = await service.discardAll(repoRoot);
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain('delete');
+        expect(result.discarded).toBe(0);
+        // Only the status query ran — no tracked files to checkout.
+        expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Adds a "Discard All" bulk action to the Local Tree working-changes view, letting users discard all uncommitted working-tree changes at once.

- Adds the bulk-discard capability to the working-tree service (`forge`) and the `api-git-working-tree-routes` endpoint.
- Wires the `coc-client` git contract/domain method and the `WorkingTree.tsx` SPA action.
- Adds working-tree service, route edge-case, client domain, and SPA tests.