### PR TITLE
fix(whisper): stop file-popover clicks from toggling the whisper group

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup.tsx
@@ -645,6 +645,7 @@ function FileHoverPopover({ files, anchorRef, popoverRef, onMouseEnter, onMouseL
             data-testid="file-hover-popover"
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            onClick={e => e.stopPropagation()}
         >
             {files.map(file => {
                 const display = shortenPath(file.path);
@@ -669,10 +670,11 @@ function FileHoverPopover({ files, anchorRef, popoverRef, onMouseEnter, onMouseL
                         tabIndex={interactive ? 0 : undefined}
                         aria-disabled={file.isDeleted ? true : undefined}
                         aria-label={interactive ? `Open diff for ${file.path}` : undefined}
-                        onClick={interactive ? () => onFileClick!(file) : undefined}
+                        onClick={interactive ? (e) => { e.stopPropagation(); onFileClick!(file); } : undefined}
                         onKeyDown={interactive ? (e) => {
                             if (e.key === 'Enter' || e.key === ' ') {
                                 e.preventDefault();
+                                e.stopPropagation();
                                 onFileClick!(file);
                             }
                         } : undefined}
@@ -770,6 +772,7 @@ function FileHoverSpan({ text, files, testId, showInlineTotals = true, onFileCli
             ref={anchorRef}
             onMouseEnter={showPopover}
             onMouseLeave={hidePopover}
+            onClick={e => e.stopPropagation()}
             className="underline decoration-dotted cursor-default"
             data-testid={testId}
         >

--- a/packages/coc/test/spa/react/WhisperCollapsedGroup-header.test.tsx
+++ b/packages/coc/test/spa/react/WhisperCollapsedGroup-header.test.tsx
@@ -999,4 +999,93 @@ describe('WhisperCollapsedGroup — actionable file rows', () => {
         fireEvent.click(row);
         expect(onOpenFileDiff).not.toHaveBeenCalled();
     });
+
+    // ── Click-propagation guard tests ─────────────────────────────────────────
+
+    function renderWithContainer(fileEdits: FileEdit[], onOpenFileDiff?: (ctx: unknown) => void) {
+        const { container } = render(
+            <WhisperCollapsedGroup
+                precedingChunks={[]}
+                summary={{
+                    toolCallCount: 3,
+                    messageCount: 0,
+                    fileEditCount: fileEdits.length,
+                    fileEdits,
+                } as WhisperSummary}
+                toolById={new Map()}
+                toolsWithChildren={new Set()}
+                toolParentById={new Map()}
+                isStreaming={false}
+                groupSingleLineMessages={false}
+                workspaceId="test-ws"
+                renderToolTree={() => null}
+                onOpenFileDiff={onOpenFileDiff}
+            />,
+        );
+        const span = container.querySelector('[data-testid="whisper-file-hover"]') as HTMLElement;
+        if (span) fireEvent.mouseEnter(span);
+        return container;
+    }
+
+    it('clicking a file row opens the diff without expanding the group', () => {
+        const onOpenFileDiff = vi.fn();
+        const container = renderWithContainer(
+            [{ path: 'src/a.ts', insertions: 4, deletions: 2, netInsertions: 4, netDeletions: 2, isCreate: false, isDeleted: false }],
+            onOpenFileDiff,
+        );
+        const row = document.body.querySelector('[data-testid="file-popover-row"]') as HTMLElement;
+        fireEvent.click(row);
+        expect(onOpenFileDiff).toHaveBeenCalledTimes(1);
+        const toggle = container.querySelector('[data-testid="whisper-toggle"]') as HTMLElement;
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(container.querySelector('[data-testid="whisper-expanded-content"]')).toBeNull();
+    });
+
+    it('Enter on a file row opens the diff without expanding the group', () => {
+        const onOpenFileDiff = vi.fn();
+        const container = renderWithContainer(
+            [{ path: 'src/a.ts', insertions: 4, deletions: 2, netInsertions: 4, netDeletions: 2, isCreate: false, isDeleted: false }],
+            onOpenFileDiff,
+        );
+        const row = document.body.querySelector('[data-testid="file-popover-row"]') as HTMLElement;
+        fireEvent.keyDown(row, { key: 'Enter' });
+        expect(onOpenFileDiff).toHaveBeenCalledTimes(1);
+        const toggle = container.querySelector('[data-testid="whisper-toggle"]') as HTMLElement;
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(container.querySelector('[data-testid="whisper-expanded-content"]')).toBeNull();
+    });
+
+    it('Space on a file row opens the diff without expanding the group', () => {
+        const onOpenFileDiff = vi.fn();
+        const container = renderWithContainer(
+            [{ path: 'src/a.ts', insertions: 4, deletions: 2, netInsertions: 4, netDeletions: 2, isCreate: false, isDeleted: false }],
+            onOpenFileDiff,
+        );
+        const row = document.body.querySelector('[data-testid="file-popover-row"]') as HTMLElement;
+        fireEvent.keyDown(row, { key: ' ' });
+        expect(onOpenFileDiff).toHaveBeenCalledTimes(1);
+        const toggle = container.querySelector('[data-testid="whisper-toggle"]') as HTMLElement;
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(container.querySelector('[data-testid="whisper-expanded-content"]')).toBeNull();
+    });
+
+    it('clicking the inline file-hover summary text does not expand the group', () => {
+        const container = renderWithContainer(
+            [{ path: 'src/a.ts', insertions: 4, deletions: 2, netInsertions: 4, netDeletions: 2, isCreate: false, isDeleted: false }],
+        );
+        const span = container.querySelector('[data-testid="whisper-file-hover"]') as HTMLElement;
+        fireEvent.click(span);
+        const toggle = container.querySelector('[data-testid="whisper-toggle"]') as HTMLElement;
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(container.querySelector('[data-testid="whisper-expanded-content"]')).toBeNull();
+    });
+
+    it('clicking the normal whisper-toggle still expands the group', () => {
+        const container = renderWithContainer(
+            [{ path: 'src/a.ts', insertions: 4, deletions: 2, netInsertions: 4, netDeletions: 2, isCreate: false, isDeleted: false }],
+        );
+        const toggle = container.querySelector('[data-testid="whisper-toggle"]') as HTMLElement;
+        fireEvent.click(toggle);
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    });
 });


### PR DESCRIPTION
React portal events bubble through the React component tree even when
the popover is mounted under document.body. Clicks on file rows and on
the inline "N files" span were reaching the whisper toggle button and
expanding/collapsing the group in the background.

Fix: stop propagation at the FileHoverPopover container, on each
interactive file row (onClick + onKeyDown Enter/Space), and on the
FileHoverSpan anchor. Header toggle behaviour is unchanged.

Adds five focused regression tests verifying click, Enter, and Space
activations leave the group collapsed, inline file-text clicks are
inert, and the normal toggle still works.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
