### PR TITLE
feat(coc-agent-sdk): keep Claude session alive for background-task resume

### DIFF
--- a/packages/coc-agent-sdk/src/claude-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/claude-sdk-service.ts
@@ -171,8 +171,8 @@ interface ClaudeStreamingUserMessage {
     type: 'user';
     message: {
         role: 'user';
-        // A plain string for text-only turns (matches the SDK's MessageParam.content),
-        // or a block array when image attachments are present.
+        // Text-only turns keep the SDK's plain-string content shape; image turns
+        // use a block array so text and images can be sent together.
         content: string | Array<ClaudeTextBlock | ClaudeImageBlock>;
     };
     parent_tool_use_id: null;
@@ -182,10 +182,7 @@ interface ClaudeStreamingUserMessage {
 /**
  * Task-lifecycle messages the SDK emits over the `type:'system'` channel while a
  * backgrounded task (Bash `run_in_background`, native `Agent`/`Task` subagent, or
- * `backgroundTasks()`) runs. `task_started` marks a task in flight; the terminal
- * `task_notification` reports its outcome. `task_updated`/`task_progress` are
- * informational only and must NOT drive the in-flight counter (they would
- * double-count). See {@link applyClaudeTaskInflight}.
+ * `backgroundTasks()`) runs.
  */
 export interface ClaudeTaskSystemMessage {
     type: 'system';
@@ -193,23 +190,6 @@ export interface ClaudeTaskSystemMessage {
     task_id?: string;
     status?: 'completed' | 'failed' | 'stopped';
     [key: string]: unknown;
-}
-
-/**
- * A controllable streaming-input channel for a single Claude turn.
- *
- * The Claude turn is driven in streaming-input mode (an `AsyncIterable` prompt)
- * rather than single-shot (a bare string). A bare string EOFs stdin as soon as
- * the SDK reads it, so the SDK applies an end-of-session grace deadline (~5s) and
- * kills any longer-running background task — dropping the model re-invocation.
- * Holding the input stream open keeps the session "active" so long background
- * tasks complete and the SDK re-invokes the model; closing the stream (EOF) lets
- * the session end once all background tasks have drained.
- */
-interface ClaudeInputChannel {
-    stream: AsyncIterable<ClaudeStreamingUserMessage>;
-    /** EOF the input stream so the SDK session can end. Idempotent. */
-    close: () => void;
 }
 
 export interface ClaudeRateLimitInfo {
@@ -229,7 +209,75 @@ interface ClaudeRateLimitEvent {
     session_id?: string;
 }
 
-type ClaudeSDKMessage = ClaudeAssistantMessage | ClaudeUserMessage | ClaudeResultMessage | ClaudeSystemMessage | ClaudeRateLimitEvent | Record<string, unknown>;
+/**
+ * Authoritative turn-over signal. `state: 'idle'` fires after the SDK's
+ * held-back result flushes and its background-agent drain loop exits — i.e. the
+ * turn is genuinely done with no pending background work. Mirrors Copilot's
+ * `session.idle`; the keep-alive loop settles the turn on it.
+ */
+interface ClaudeSessionStateChangedMessage {
+    type: 'system';
+    subtype: 'session_state_changed';
+    state: 'idle' | 'running' | 'requires_action';
+    session_id?: string;
+}
+
+/** A background/foreground task was registered with the session. */
+interface ClaudeTaskStartedMessage {
+    type: 'system';
+    subtype: 'task_started';
+    task_id: string;
+    tool_use_id?: string;
+    description?: string;
+    /** Subagent type name; present for subagent tasks. */
+    subagent_type?: string;
+    task_type?: string;
+    session_id?: string;
+}
+
+/** A background task settled (the async notification that resumes the turn). */
+interface ClaudeTaskNotificationMessage {
+    type: 'system';
+    subtype: 'task_notification';
+    task_id: string;
+    tool_use_id?: string;
+    status: 'completed' | 'failed' | 'stopped';
+    summary?: string;
+    session_id?: string;
+}
+
+/** Wire-safe patch of changed task fields (status / backgrounded flag). */
+interface ClaudeTaskUpdatedMessage {
+    type: 'system';
+    subtype: 'task_updated';
+    task_id: string;
+    patch?: {
+        status?: 'pending' | 'running' | 'completed' | 'failed' | 'killed' | 'paused';
+        is_backgrounded?: boolean;
+    };
+    session_id?: string;
+}
+
+/** Maps an SDK `system` message `subtype` to its concrete message shape. */
+interface ClaudeSystemSubtypeMap {
+    task_started: ClaudeTaskStartedMessage;
+    task_updated: ClaudeTaskUpdatedMessage;
+    task_notification: ClaudeTaskNotificationMessage;
+    session_state_changed: ClaudeSessionStateChangedMessage;
+}
+
+/** Terminal task-update statuses that drain a tracked background task. */
+const CLAUDE_TERMINAL_TASK_STATUSES: ReadonlySet<string> = new Set(['completed', 'failed', 'killed']);
+
+/** Active background task tracked for keep-alive + `onBackgroundTasksChanged`. */
+interface ClaudeBackgroundTaskEntry {
+    id: string;
+    kind: 'agent' | 'shell';
+    type?: string;
+    description?: string;
+}
+
+type ClaudeSDKMessage = ClaudeAssistantMessage | ClaudeUserMessage | ClaudeResultMessage | ClaudeSystemMessage | ClaudeRateLimitEvent | ClaudeSessionStateChangedMessage | ClaudeTaskStartedMessage | ClaudeTaskNotificationMessage | ClaudeTaskUpdatedMessage | Record<string, unknown>;
 type ClaudePermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto';
 
 /**
@@ -329,6 +377,51 @@ interface ClaudeSDKModule {
 interface ActiveClaudeSession {
     sessionId: string;
     abortController: AbortController;
+}
+
+/**
+ * Controllable streaming-input source for a Claude `query()` turn.
+ *
+ * A plain string prompt (or a single-yield generator) tells the SDK the turn is
+ * single-shot: it closes the session right after the first `result`, killing the
+ * `claude-code` subprocess and any background jobs it owns. Instead we hand the
+ * SDK an async-iterable that yields the initial user message(s) and then stays
+ * open — the session (and its background work) stays alive until {@link close}
+ * is called, at which point the SDK observes end-of-input and settles the turn.
+ */
+class ClaudeInputGate {
+    private readonly closeSignal: Promise<void>;
+    private resolveClose!: () => void;
+    private closed = false;
+
+    constructor(private readonly initialMessages: ClaudeStreamingUserMessage[]) {
+        this.closeSignal = new Promise<void>((resolve) => {
+            this.resolveClose = resolve;
+        });
+    }
+
+    get isClosed(): boolean {
+        return this.closed;
+    }
+
+    /** Signal end-of-input so the SDK settles the turn. Idempotent. */
+    close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        this.resolveClose();
+    }
+
+    /** Async-iterable input: yields the initial message(s), then blocks until {@link close}. */
+    stream(): AsyncGenerator<ClaudeStreamingUserMessage> {
+        const initialMessages = this.initialMessages;
+        const closeSignal = this.closeSignal;
+        return (async function* () {
+            for (const message of initialMessages) {
+                yield message;
+            }
+            await closeSignal;
+        })();
+    }
 }
 
 interface ClaudeDiagnosticLogContext {
@@ -686,13 +779,6 @@ export class ClaudeSDKService implements ISDKService {
         let currentSessionId = sessionId;
         const abortController = new AbortController();
 
-        // EOF the streaming-input channel (assigned once the channel is built).
-        // Any abort — caller signal, abortSession(), or the background-drain cap —
-        // closes the input so the SDK session can wind down instead of blocking
-        // the loop on the next message while the input stream is still held open.
-        let closeClaudeInput: () => void = () => {};
-        abortController.signal.addEventListener('abort', () => closeClaudeInput());
-
         // Propagate caller's AbortSignal into our internal controller.
         let signalCleanup: (() => void) | undefined;
         if (options.signal) {
@@ -740,6 +826,53 @@ export class ClaudeSDKService implements ISDKService {
         const permissionOptions = this.resolveClaudePermissionOptions(options.mode);
         let mcpServerNames = inferClaudeMcpServerNamesFromOptions(options);
 
+        // Streaming-input gate that keeps the query() session alive past the
+        // first `result` while SDK-native background work is still pending. The
+        // `finally` closes it so a thrown/aborted turn never leaks the generator.
+        let inputGate: ClaudeInputGate | undefined;
+        const closeClaudeInput = () => inputGate?.close();
+        abortController.signal.addEventListener('abort', closeClaudeInput);
+
+        // Background tasks (background Bash, backgrounded subagents) tracked for
+        // keep-alive settlement and the `onBackgroundTasksChanged` UI callback.
+        const backgroundTasks = new Map<string, ClaudeBackgroundTaskEntry>();
+        const emitBackgroundTasksChanged = () => {
+            if (!options.onBackgroundTasksChanged) return;
+            const toSummary = (entry: ClaudeBackgroundTaskEntry) => ({
+                id: entry.id,
+                ...(entry.type ? { type: entry.type } : {}),
+                ...(entry.description ? { description: entry.description } : {}),
+            });
+            const entries = Array.from(backgroundTasks.values());
+            try {
+                options.onBackgroundTasksChanged({
+                    backgroundAgents: entries.filter(e => e.kind === 'agent').map(toSummary),
+                    backgroundShells: entries.filter(e => e.kind === 'shell').map(toSummary),
+                    backgroundTotalActive: backgroundTasks.size,
+                    backgroundWaitingForDrain: backgroundTasks.size > 0,
+                });
+            } catch {
+                // Observational only; never fail the turn on a renderer error.
+            }
+        };
+        const registerBackgroundTask = (
+            id: string | undefined,
+            kind: ClaudeBackgroundTaskEntry['kind'],
+            type?: string,
+            description?: string,
+        ) => {
+            if (!id || backgroundTasks.has(id)) return;
+            backgroundTasks.set(id, { id, kind, ...(type ? { type } : {}), ...(description ? { description } : {}) });
+            emitBackgroundTasksChanged();
+        };
+        const settleBackgroundTasks = (...ids: Array<string | undefined>) => {
+            let changed = false;
+            for (const id of ids) {
+                if (id && backgroundTasks.delete(id)) changed = true;
+            }
+            if (changed) emitBackgroundTasksChanged();
+        };
+
         try {
             const effort = this.normalizeClaudeEffort(options.reasoningEffort);
             const { servers: mcpServers, allowedTools, cleanup } = await this.buildClaudeMcpServers(options);
@@ -752,22 +885,19 @@ export class ClaudeSDKService implements ISDKService {
                     ? [...ASK_MODE_AUTO_APPROVED_TOOLS]
                     : [];
             const effectiveAllowedTools = [...allowedTools, ...askModeAllowed];
-
-            // Streaming-input transport: hold stdin open until background tasks
-            // drain, then EOF to let the session end (see ClaudeInputChannel).
-            const inputChannel = this.buildClaudeInputChannel(options);
-            closeClaudeInput = inputChannel.close;
-            // task_id set of background tasks currently in flight. A `result` is
-            // only allowed to settle the turn when this is empty (AC-02).
-            const inflightTasks = new Set<string>();
             const drainCapMs = this.resolveBackgroundDrainCapMs(options);
             // Arm the drain cap lazily — only when a `result` defers settle with
-            // tasks still in flight. A no-background turn never arms it (AC-04).
+            // background work still tracked. A no-background turn never arms it.
             const armDrainCap = () => {
                 if (drainCapTimer || drainCapMs <= 0) return;
                 drainCapTimer = setTimeout(() => {
                     getSDKLogger().warn(
-                        { provider: CLAUDE_PROVIDER, event: 'claude_background_drain_timeout', drainCapMs, inflight: inflightTasks.size },
+                        {
+                            provider: CLAUDE_PROVIDER,
+                            event: 'claude_background_drain_timeout',
+                            drainCapMs,
+                            backgroundTaskCount: backgroundTasks.size,
+                        },
                         'Claude background-task drain exceeded the wall-clock cap; closing input and aborting',
                     );
                     closeClaudeInput();
@@ -776,8 +906,9 @@ export class ClaudeSDKService implements ISDKService {
                 drainCapTimer.unref?.();
             };
 
+            inputGate = new ClaudeInputGate(this.buildClaudeInitialMessages(options));
             const queryOptions: ClaudeQueryOptions = {
-                prompt: inputChannel.stream,
+                prompt: inputGate.stream(),
                 abortController,
                 options: {
                     ...(options.workingDirectory ? { cwd: options.workingDirectory } : {}),
@@ -805,6 +936,12 @@ export class ClaudeSDKService implements ISDKService {
                             options.onStreamingChunk?.(block.text);
                         } else if (this.isClaudeToolUseBlock(block)) {
                             this.handleClaudeToolUse(block, options, toolCalls, startedToolCalls, msg.parent_tool_use_id ?? undefined);
+                            // A tool launched with run_in_background keeps the
+                            // session alive until its task_notification settles.
+                            if (isClaudeBackgroundToolUse(block)) {
+                                const toolName = normalizeClaudeToolName(block.name ?? '');
+                                registerBackgroundTask(block.id, toolName === 'task' ? 'agent' : 'shell', toolName);
+                            }
                         }
                     }
                 } else if (this.isUserMessage(msg)) {
@@ -835,14 +972,13 @@ export class ClaudeSDKService implements ISDKService {
                         chunks.push(msg.result);
                         options.onStreamingChunk?.(msg.result);
                     }
-                    // Settle decision: with no background task in flight, EOF the
-                    // input so the session ends now (no-background turns close at
-                    // their first result — parity with single-shot). Otherwise keep
-                    // stdin open and keep iterating; the SDK will deliver the task's
-                    // terminal notification and re-invoke the model (AC-02).
-                    if (inflightTasks.size === 0) {
+                    // Fast path / common case: no background work pending, so close
+                    // the input stream and let the SDK settle the turn immediately.
+                    // When background work is pending, keep the gate open until the
+                    // SDK reports idle, bounded by the drain cap.
+                    if (backgroundTasks.size === 0) {
                         clearDrainCap();
-                        inputChannel.close();
+                        inputGate.close();
                     } else {
                         armDrainCap();
                     }
@@ -855,10 +991,29 @@ export class ClaudeSDKService implements ISDKService {
                     );
                     latestRateLimitInfo = msg.rate_limit_info;
                     this.lastRateLimitInfo = msg.rate_limit_info;
-                } else if (this.isClaudeTaskSystemMessage(msg)) {
-                    // task_started/task_notification drive the in-flight counter
-                    // (AC-03); previously every type:'system' message was dropped.
-                    applyClaudeTaskInflight(inflightTasks, msg);
+                } else if (this.isClaudeSystemSubtype(msg, 'task_started')) {
+                    registerBackgroundTask(
+                        msg.task_id,
+                        msg.subagent_type ? 'agent' : 'shell',
+                        msg.task_type ?? msg.subagent_type,
+                        msg.description,
+                    );
+                } else if (this.isClaudeSystemSubtype(msg, 'task_updated')) {
+                    const status = msg.patch?.status;
+                    if (status && CLAUDE_TERMINAL_TASK_STATUSES.has(status)) {
+                        settleBackgroundTasks(msg.task_id);
+                    } else if (msg.patch?.is_backgrounded === true) {
+                        registerBackgroundTask(msg.task_id, 'shell');
+                    }
+                } else if (this.isClaudeSystemSubtype(msg, 'task_notification')) {
+                    settleBackgroundTasks(msg.task_id, msg.tool_use_id);
+                } else if (this.isClaudeSystemSubtype(msg, 'session_state_changed')) {
+                    // Authoritative turn-over signal: the SDK's background drain
+                    // loop has exited. Settle regardless of our local tracking.
+                    if (msg.state === 'idle') {
+                        clearDrainCap();
+                        inputGate.close();
+                    }
                 }
             }
 
@@ -887,7 +1042,9 @@ export class ClaudeSDKService implements ISDKService {
             return { success: false, error: message, sessionId: currentSessionId, effectiveModel: model };
         } finally {
             clearDrainCap();
-            closeClaudeInput();
+            // Idempotent: unblocks the streaming-input generator if the turn
+            // ended via abort/throw before a settle signal closed it.
+            inputGate?.close();
             signalCleanup?.();
             mcpCleanup();
             this.sessions.delete(currentSessionId);
@@ -919,38 +1076,14 @@ export class ClaudeSDKService implements ISDKService {
     }
 
     /**
-     * Build the controllable streaming-input channel for a turn. The stream
-     * yields exactly one initial user message (text and/or image blocks), then
-     * stays open — awaiting an internal close — so the SDK treats the session as
-     * active while background tasks run. Calling `close()` EOFs the stream.
+     * Build the initial streaming-input user message(s) for a turn.
+     *
+     * Always returns streaming `user` messages (never a bare string) so the turn
+     * runs through {@link ClaudeInputGate}: the gate yields these, then keeps the
+     * SDK session open for background-work resume until the turn settles. The
+     * text-only case keeps a plain string content value; images use block content.
      */
-    private buildClaudeInputChannel(options: SendMessageOptions): ClaudeInputChannel {
-        const message = this.buildInitialClaudeUserMessage(options);
-        let resolveClosed!: () => void;
-        const closed = new Promise<void>((resolve) => { resolveClosed = resolve; });
-        let closeCalled = false;
-        const stream = (async function* (): AsyncGenerator<ClaudeStreamingUserMessage> {
-            yield message;
-            await closed;
-        })();
-        return {
-            stream,
-            close: () => {
-                if (closeCalled) return;
-                closeCalled = true;
-                resolveClosed();
-            },
-        };
-    }
-
-    /**
-     * Build the single initial user message for a turn. Text-only turns use a
-     * plain string `content`; attachments are converted to base64 image blocks
-     * (oversized/malformed supported images are dropped with a sanitized skip
-     * diagnostic; unsupported extensions are ignored so text-only behavior is
-     * preserved).
-     */
-    private buildInitialClaudeUserMessage(options: SendMessageOptions): ClaudeStreamingUserMessage {
+    private buildClaudeInitialMessages(options: SendMessageOptions): ClaudeStreamingUserMessage[] {
         const text = options.prompt ?? '';
         const images: ClaudeImageSource[] = [];
         for (const attachment of options.attachments ?? []) {
@@ -978,15 +1111,15 @@ export class ClaudeSDKService implements ISDKService {
                 })),
             ];
 
-        return {
+        return [{
             type: 'user',
             message: { role: 'user', content },
             parent_tool_use_id: null,
-        };
+        }];
     }
 
     /**
-     * Resolve the wall-clock ceiling for holding the input channel open while
+     * Resolve the wall-clock ceiling for holding the input gate open while
      * background tasks drain. Honors a smaller caller `timeoutMs` budget when
      * given, but never exceeds {@link CLAUDE_BACKGROUND_DRAIN_TIMEOUT_MS}.
      */
@@ -1141,20 +1274,16 @@ export class ClaudeSDKService implements ISDKService {
         );
     }
 
-    /**
-     * A `type:'system'` task-lifecycle message (`task_started`/`task_updated`/
-     * `task_progress`/`task_notification`). Other system messages (`init`, etc.)
-     * are not task messages and have no counter effect.
-     */
-    private isClaudeTaskSystemMessage(msg: ClaudeSDKMessage): msg is ClaudeTaskSystemMessage {
-        if (typeof msg !== 'object' || msg === null) return false;
-        const record = msg as Record<string, unknown>;
-        if (record.type !== 'system') return false;
+    /** Narrow an SDK `system` message by its `subtype` discriminant. */
+    private isClaudeSystemSubtype<K extends keyof ClaudeSystemSubtypeMap>(
+        msg: ClaudeSDKMessage,
+        subtype: K,
+    ): msg is ClaudeSystemSubtypeMap[K] {
         return (
-            record.subtype === 'task_started' ||
-            record.subtype === 'task_updated' ||
-            record.subtype === 'task_progress' ||
-            record.subtype === 'task_notification'
+            typeof msg === 'object' &&
+            msg !== null &&
+            (msg as Record<string, unknown>).type === 'system' &&
+            (msg as Record<string, unknown>).subtype === subtype
         );
     }
 
@@ -1654,6 +1783,22 @@ function normalizeBridgedToolName(name: string): string {
     return name.startsWith(prefix) ? name.slice(prefix.length) : name;
 }
 
+/**
+ * True when a tool_use block requests background execution
+ * (`run_in_background: true`) — e.g. background Bash or a backgrounded subagent.
+ * Such tools return immediately and keep running after the turn's `result`, so
+ * the keep-alive loop must not settle until they report back.
+ */
+function isClaudeBackgroundToolUse(block: ClaudeToolUseBlock): boolean {
+    const input = block.input;
+    return (
+        typeof input === 'object' &&
+        input !== null &&
+        !Array.isArray(input) &&
+        (input as Record<string, unknown>).run_in_background === true
+    );
+}
+
 function normalizeClaudeToolName(name: string): string {
     const normalized = normalizeBridgedToolName(name);
     switch (normalized) {
@@ -1994,14 +2139,10 @@ function addClaudeUsage(current: TokenUsage | undefined, msg: Pick<ClaudeResultM
 }
 
 /**
- * Apply a `type:'system'` task-lifecycle message to the in-flight background-task
- * set. `task_started` marks a task in flight; the terminal `task_notification`
- * (status `completed`/`failed`/`stopped`) clears it. `task_updated`/
- * `task_progress` are informational status pings and intentionally have NO effect
- * — counting them would double-count a single task. A message without a
- * `task_id` is ignored.
- *
- * Exported for direct unit testing of the counter rule (AC-03).
+ * Apply a `type:'system'` task-lifecycle message to an in-flight background-task
+ * set. `task_started` marks a task in flight; terminal `task_notification`
+ * messages clear it. `task_updated`/`task_progress` are informational pings and
+ * intentionally have no effect so they cannot double-count a single task.
  */
 export function applyClaudeTaskInflight(inflight: Set<string>, msg: ClaudeTaskSystemMessage): void {
     const taskId = typeof msg.task_id === 'string' && msg.task_id ? msg.task_id : undefined;

--- a/packages/coc-agent-sdk/test/ai/claude-sdk-image.test.ts
+++ b/packages/coc-agent-sdk/test/ai/claude-sdk-image.test.ts
@@ -32,6 +32,22 @@ async function drainAsyncIterable(iterable: AsyncIterable<unknown>): Promise<unk
     return values;
 }
 
+/**
+ * Text of the first user message in a streaming-input prompt. The provider now
+ * always hands the SDK an open async-iterable input (the keep-alive gate), so a
+ * text-only prompt may be plain string content while image prompts use content
+ * blocks. Safe to drain after sendMessage resolves: the turn settles and closes
+ * the gate.
+ */
+async function firstUserText(prompt: unknown): Promise<string> {
+    if (typeof prompt === 'string') return prompt;
+    const messages = await drainAsyncIterable(prompt as AsyncIterable<unknown>);
+    const content = (messages[0] as any)?.message?.content;
+    if (typeof content === 'string') return content;
+    const textBlock = Array.isArray(content) ? content.find((b: any) => b?.type === 'text') : undefined;
+    return typeof textBlock?.text === 'string' ? textBlock.text : '';
+}
+
 /** Minimal pino-shaped logger that records every call for assertions. */
 function createCapturingLogger() {
     const logs: Array<{ level: string; fields: Record<string, unknown>; message: string }> = [];
@@ -116,17 +132,10 @@ describe('ClaudeSDKService image attachments', () => {
         ]);
     });
 
-    it('streams a plain text user message when no attachments are provided', async () => {
+    it('wraps a no-attachment prompt as a single streaming text message', async () => {
         await svc.sendMessage({ prompt: 'Text only' });
 
-        // Streaming-input transport: a text-only turn yields one user message
-        // whose content is the plain prompt string (no image blocks).
-        const prompt = queryFn.mock.calls[0][0].prompt;
-        expect(typeof prompt).not.toBe('string');
-        const messages = await drainAsyncIterable(prompt);
-        expect(messages).toEqual([
-            { type: 'user', message: { role: 'user', content: 'Text only' }, parent_tool_use_id: null },
-        ]);
+        expect(await firstUserText(queryFn.mock.calls[0][0].prompt)).toBe('Text only');
     });
 
     it('skips unsupported image and non-image attachments', async () => {
@@ -139,10 +148,7 @@ describe('ClaudeSDKService image attachments', () => {
             ],
         });
 
-        const messages = await drainAsyncIterable(queryFn.mock.calls[0][0].prompt);
-        expect(messages).toEqual([
-            { type: 'user', message: { role: 'user', content: 'Skip unsupported' }, parent_tool_use_id: null },
-        ]);
+        expect(await firstUserText(queryFn.mock.calls[0][0].prompt)).toBe('Skip unsupported');
     });
 
     it('forwards an image whose byte size is exactly at the limit', async () => {
@@ -175,10 +181,7 @@ describe('ClaudeSDKService image attachments', () => {
         });
 
         // Oversized image dropped; request still runs as a plain text prompt.
-        const messages = await drainAsyncIterable(queryFn.mock.calls[0][0].prompt);
-        expect(messages).toEqual([
-            { type: 'user', message: { role: 'user', content: 'Too large' }, parent_tool_use_id: null },
-        ]);
+        expect(await firstUserText(queryFn.mock.calls[0][0].prompt)).toBe('Too large');
     });
 
     it('records a sanitized skip diagnostic for an oversized image (no payload/prompt leak)', async () => {
@@ -262,10 +265,7 @@ describe('ClaudeSDKService image attachments', () => {
         });
 
         // No Claude-supported image → request still runs as a plain text prompt.
-        const messages = await drainAsyncIterable(queryFn.mock.calls[0][0].prompt);
-        expect(messages).toEqual([
-            { type: 'user', message: { role: 'user', content: 'Look at this photo' }, parent_tool_use_id: null },
-        ]);
+        expect(await firstUserText(queryFn.mock.calls[0][0].prompt)).toBe('Look at this photo');
 
         const skip = logs.find(l => l.fields.event === 'claude_image_skipped');
         expect(skip).toBeDefined();

--- a/packages/coc-agent-sdk/test/ai/claude-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/ai/claude-sdk-service.test.ts
@@ -66,24 +66,57 @@ async function* makeMessages(messages: object[]): AsyncIterable<object> {
 }
 
 /**
- * Drain the streaming-input prompt channel and return the single initial user
- * message. The Claude provider drives turns in streaming-input mode, so
- * `queryFn.mock.calls[i][0].prompt` is an AsyncIterable, not a bare string.
+ * Reads the text of the first user message yielded by a streaming-input prompt.
+ * The Claude provider now always hands the SDK an open async-iterable input
+ * (the keep-alive gate) instead of a bare string prompt, so prompt assertions
+ * read the first message's text from either plain string or block content.
  */
-async function firstStreamedUserMessage(prompt: unknown): Promise<{
-    type: string;
-    message: { role: string; content: unknown };
-    parent_tool_use_id: unknown;
-}> {
-    if (typeof prompt === 'string' || prompt == null) {
-        throw new Error(`expected an async-iterable prompt, got ${typeof prompt}`);
+async function firstUserText(prompt: unknown): Promise<string> {
+    if (typeof prompt === 'string') return prompt;
+    for await (const message of prompt as AsyncIterable<any>) {
+        const content = (message as any)?.message?.content;
+        if (typeof content === 'string') return content;
+        if (Array.isArray(content)) {
+            const textBlock = content.find((b: any) => b?.type === 'text');
+            return typeof textBlock?.text === 'string' ? textBlock.text : '';
+        }
+        return '';
     }
-    const values: unknown[] = [];
-    for await (const value of prompt as AsyncIterable<unknown>) values.push(value);
-    if (values.length !== 1) {
-        throw new Error(`expected exactly one streamed user message, got ${values.length}`);
-    }
-    return values[0] as { type: string; message: { role: string; content: unknown }; parent_tool_use_id: unknown };
+    return '';
+}
+
+/**
+ * Builds an input-aware query handle that faithfully models the keep-alive
+ * contract: the SDK only delivers the post-`result` continuation while the
+ * streaming-input session stays open. A single-shot input (a bare string, the
+ * pre-fix behavior) yields just `beforeResult` and ends; an open async-iterable
+ * input also yields `continuation`, then drains the input until the provider
+ * closes the gate. `onInput` lets a test observe provider state mid-window.
+ */
+function makeKeepAliveQuery(
+    beforeResult: object[],
+    continuation: object[] = [],
+    onInput?: () => void,
+) {
+    return (queryOptions: { prompt: unknown }) => {
+        const input = queryOptions.prompt;
+        const inputOpen =
+            !!input &&
+            typeof input !== 'string' &&
+            typeof (input as any)[Symbol.asyncIterator] === 'function';
+        return {
+            async *[Symbol.asyncIterator]() {
+                for (const msg of beforeResult) yield msg;
+                if (!inputOpen) return; // single-shot input -> no async resume
+                onInput?.();
+                for (const msg of continuation) yield msg;
+                // Block until the provider settles the turn by closing the gate.
+                for await (const _ of input as AsyncIterable<unknown>) { void _; }
+            },
+            accountInfo: async () => ({}),
+            return: async (value?: unknown) => ({ done: true as const, value }),
+        };
+    };
 }
 
 /** Wraps a message array as a query handle with optional control-method spies. */
@@ -620,7 +653,7 @@ describe('ClaudeSDKService.sendMessage', () => {
 
         expect(result.success).toBe(true);
         const call = queryFn.mock.calls[0][0];
-        expect((await firstStreamedUserMessage(call.prompt)).message.content).toBe('user prompt');
+        expect(await firstUserText(call.prompt)).toBe('user prompt');
         expect(call.options?.systemPrompt).toEqual({
             type: 'preset',
             preset: 'claude_code',
@@ -643,7 +676,7 @@ describe('ClaudeSDKService.sendMessage', () => {
 
         expect(result.success).toBe(true);
         const call = queryFn.mock.calls[0][0];
-        expect((await firstStreamedUserMessage(call.prompt)).message.content).toBe('generator prompt');
+        expect(await firstUserText(call.prompt)).toBe('generator prompt');
         expect(call.options?.systemPrompt).toBe('Strict generator system prompt');
         expect(call.options).not.toHaveProperty('appendSystemPrompt');
         expect(call.options).not.toHaveProperty('customSystemPrompt');
@@ -698,7 +731,7 @@ describe('ClaudeSDKService.sendMessage', () => {
             preset: 'claude_code',
             append: 'history plus CoC system prompt',
         });
-        expect((await firstStreamedUserMessage(call.prompt)).message.content).toBe('follow-up prompt');
+        expect(await firstUserText(call.prompt)).toBe('follow-up prompt');
     });
 
     it('maps Claude result usage into the shared TokenUsage shape', async () => {
@@ -1610,6 +1643,159 @@ describe('ClaudeSDKService.sendMessage', () => {
         expect(result.success).toBe(false);
         expect(result.error).toMatch(/npm install/);
     });
+
+    // ── Background-task keep-alive (async resume) ───────────────────────────
+
+    it('keeps the session open past the first result and surfaces the background resume (AC-01/AC-02)', async () => {
+        queryFn.mockImplementationOnce(makeKeepAliveQuery(
+            [
+                { type: 'assistant', message: { content: [{ type: 'text', text: 'Starting background work.' }] } },
+                {
+                    type: 'assistant',
+                    message: { content: [{ type: 'tool_use', id: 'bash-bg', name: 'Bash', input: { command: 'sleep 8 && echo done', run_in_background: true } }] },
+                },
+                { type: 'result', subtype: 'success', result: 'started' },
+            ],
+            [
+                // Background completion arrives later in the SAME open session.
+                { type: 'system', subtype: 'task_notification', task_id: 'task-1', tool_use_id: 'bash-bg', status: 'completed', summary: 'done' },
+                { type: 'assistant', message: { content: [{ type: 'text', text: ' Background finished: done.' }] } },
+                { type: 'result', subtype: 'success', result: 'all done' },
+                { type: 'system', subtype: 'session_state_changed', state: 'idle' },
+            ],
+        ));
+
+        const chunks: string[] = [];
+        const toolEvents: object[] = [];
+        const result = await svc.sendMessage({
+            prompt: 'run a background command',
+            onStreamingChunk: (c) => { if (c) chunks.push(c); },
+            onToolEvent: (e) => toolEvents.push(e),
+        });
+
+        expect(result.success).toBe(true);
+        // The post-result continuation is consumed and surfaced through callbacks.
+        expect(chunks).toEqual(['Starting background work.', ' Background finished: done.']);
+        expect(result.response).toBe('Starting background work. Background finished: done.');
+        expect(toolEvents).toContainEqual(expect.objectContaining({ type: 'tool-start', toolName: 'Bash', toolCallId: 'bash-bg' }));
+    }, 5000);
+
+    it('fires onBackgroundTasksChanged with active>0 then active==0 (AC-05)', async () => {
+        queryFn.mockImplementationOnce(makeKeepAliveQuery(
+            [
+                {
+                    type: 'assistant',
+                    message: { content: [{ type: 'tool_use', id: 'bash-bg', name: 'Bash', input: { command: 'sleep 5', run_in_background: true } }] },
+                },
+                { type: 'result', subtype: 'success', result: 'started' },
+            ],
+            [
+                { type: 'system', subtype: 'task_notification', task_id: 'task-1', tool_use_id: 'bash-bg', status: 'completed' },
+                { type: 'result', subtype: 'success', result: 'done' },
+                { type: 'system', subtype: 'session_state_changed', state: 'idle' },
+            ],
+        ));
+
+        const bgEvents: Array<{ backgroundTotalActive: number; backgroundWaitingForDrain: boolean; backgroundShells: Array<{ id: string }> }> = [];
+        const result = await svc.sendMessage({
+            prompt: 'bg',
+            onBackgroundTasksChanged: (t) => bgEvents.push({
+                backgroundTotalActive: t.backgroundTotalActive,
+                backgroundWaitingForDrain: t.backgroundWaitingForDrain,
+                backgroundShells: t.backgroundShells.map(s => ({ id: s.id })),
+            }),
+        });
+
+        expect(result.success).toBe(true);
+        const active = bgEvents.find(e => e.backgroundTotalActive > 0);
+        expect(active).toBeDefined();
+        expect(active!.backgroundWaitingForDrain).toBe(true);
+        expect(active!.backgroundShells).toContainEqual({ id: 'bash-bg' });
+        expect(bgEvents[bgEvents.length - 1]).toMatchObject({ backgroundTotalActive: 0, backgroundWaitingForDrain: false });
+    }, 5000);
+
+    it('settles exactly once at genuine idle and keeps the session alive meanwhile (AC-03)', async () => {
+        let activeDuringWindow = -1;
+        queryFn.mockImplementationOnce(makeKeepAliveQuery(
+            [
+                {
+                    type: 'assistant',
+                    message: { content: [{ type: 'tool_use', id: 'bash-bg', name: 'Bash', input: { command: 'sleep 5', run_in_background: true } }] },
+                },
+                { type: 'result', subtype: 'success', result: 'started' },
+            ],
+            [
+                { type: 'system', subtype: 'task_notification', task_id: 't', tool_use_id: 'bash-bg', status: 'completed' },
+                { type: 'result', subtype: 'success', result: 'done' },
+                { type: 'system', subtype: 'session_state_changed', state: 'idle' },
+            ],
+            // Fires mid-window, after the first result but before the resume.
+            () => { activeDuringWindow = svc.getActiveSessionCount(); },
+        ));
+
+        expect(svc.getActiveSessionCount()).toBe(0);
+        const result = await svc.sendMessage({ prompt: 'bg' });
+
+        expect(result.success).toBe(true);
+        // The session (and its subprocess) stayed alive through the keep-alive window.
+        expect(activeDuringWindow).toBeGreaterThanOrEqual(1);
+        // Teardown ran exactly once at genuine idle: the session is now cleared.
+        expect(svc.getActiveSessionCount()).toBe(0);
+    }, 5000);
+
+    it('aborts and tears down promptly during the keep-alive window (AC-03)', async () => {
+        const controller = new AbortController();
+        let sessionId = '';
+        queryFn.mockImplementationOnce((opts: { abortController?: AbortController }) => {
+            const ac = opts.abortController;
+            return {
+                async *[Symbol.asyncIterator]() {
+                    yield {
+                        type: 'assistant',
+                        message: { content: [{ type: 'tool_use', id: 'bash-bg', name: 'Bash', input: { command: 'sleep 30', run_in_background: true } }] },
+                    };
+                    yield { type: 'result', subtype: 'success', result: 'started' };
+                    // Background still pending → gate stays open. Block until aborted.
+                    await new Promise<void>((_, reject) => {
+                        if (ac?.signal.aborted) { reject(new Error('Aborted')); return; }
+                        ac?.signal.addEventListener('abort', () => reject(new Error('Aborted')));
+                    });
+                },
+                accountInfo: async () => ({}),
+                return: async (value?: unknown) => ({ done: true as const, value }),
+            };
+        });
+
+        const sendPromise = svc.sendMessage({
+            prompt: 'bg',
+            signal: controller.signal,
+            onSessionCreated: (id) => { sessionId = id; },
+        });
+
+        await new Promise((r) => setTimeout(r, 0));
+        expect(sessionId).toBeTruthy();
+        expect(svc.hasActiveSession(sessionId)).toBe(true);
+
+        controller.abort();
+        const result = await sendPromise;
+        expect(result).toBeDefined();
+        expect(svc.hasActiveSession(sessionId)).toBe(false);
+    }, 5000);
+
+    it('settles promptly on the single result with no background work (AC-06)', async () => {
+        // The input-aware mock blocks on the streaming input until the gate is
+        // closed; if the no-background turn failed to settle on the result this
+        // would hang and time out.
+        queryFn.mockImplementationOnce(makeKeepAliveQuery([
+            { type: 'assistant', message: { content: [{ type: 'text', text: 'Quick answer.' }] } },
+            { type: 'result', subtype: 'success', result: 'Quick answer.' },
+        ]));
+
+        const result = await svc.sendMessage({ prompt: 'hello' });
+        expect(result.success).toBe(true);
+        expect(result.response).toBe('Quick answer.');
+        expect(svc.getActiveSessionCount()).toBe(0);
+    }, 5000);
 
     it('passes workingDirectory through to the query options', async () => {
         queryFn.mockReturnValueOnce(makeMessages([

--- a/packages/coc-agent-sdk/test/ai/global-system-prompt-provider-parity.test.ts
+++ b/packages/coc-agent-sdk/test/ai/global-system-prompt-provider-parity.test.ts
@@ -121,6 +121,22 @@ async function* makeMessages(messages: object[]): AsyncIterable<object> {
     for (const msg of messages) yield msg;
 }
 
+/**
+ * Text of the first user message in a Claude streaming-input prompt. The Claude
+ * provider hands the SDK an open async-iterable input (keep-alive gate), so the
+ * prompt is a streaming user message rather than a bare string prompt.
+ */
+async function firstUserText(prompt: unknown): Promise<string> {
+    if (typeof prompt === 'string') return prompt;
+    for await (const message of prompt as AsyncIterable<any>) {
+        const content = (message as any)?.message?.content;
+        if (typeof content === 'string') return content;
+        const textBlock = Array.isArray(content) ? content.find((b: any) => b?.type === 'text') : undefined;
+        return typeof textBlock?.text === 'string' ? textBlock.text : '';
+    }
+    return '';
+}
+
 /** Claude: returns the `ClaudeQueryOptions` passed to the SDK `query` fn. */
 async function sendViaClaude(systemMessage?: SystemMessageConfig): Promise<any> {
     const svc = new ClaudeSDKService();
@@ -183,14 +199,7 @@ describe('global system prompt provider parity (AC-04)', () => {
     it('Claude maps the global systemMessage to the claude_code preset systemPrompt without mutating the prompt', async () => {
         const queryOptions = await sendViaClaude(GLOBAL_SYSTEM_MESSAGE);
 
-        // Streaming-input transport: the prompt is an async-iterable user message
-        // whose content is the unmutated user prompt.
-        expect(typeof queryOptions.prompt).not.toBe('string');
-        const streamed: unknown[] = [];
-        for await (const m of queryOptions.prompt as AsyncIterable<unknown>) streamed.push(m);
-        expect(streamed).toEqual([
-            { type: 'user', message: { role: 'user', content: USER_PROMPT }, parent_tool_use_id: null },
-        ]);
+        expect(await firstUserText(queryOptions.prompt)).toBe(USER_PROMPT);
         expect(queryOptions.options.systemPrompt).toEqual({
             type: 'preset',
             preset: 'claude_code',


### PR DESCRIPTION
The Claude provider ran each turn as a one-shot query() whose string/single-
yield input closed after the first message. When the model scheduled SDK-native
background work (background Bash, backgrounded subagents), the SDK emitted the
turn's `result` while the job was still running, the input stream had already
closed, so the session ended and the claude-code subprocess (owning the job) was
torn down — the conversation just stopped.

Mirror Copilot's drain-until-idle behavior for the Claude provider only:

- ClaudeInputGate: a controllable streaming-input source that yields the initial
  user message(s) and stays open until the turn settles, so query() (and the
  subprocess) stays alive past the first result (AC-01).
- Track background tasks from run_in_background tool_use, `task_started`, and
  `task_updated.is_backgrounded`; drain them on `task_notification` /
  `task_updated` terminal status. The post-result continuation (resume assistant
  output + tool events) is consumed in the same session and surfaced through the
  existing callbacks (AC-02).
- Settle (close the gate) on the authoritative `session_state_changed: idle`
  signal, or — fast path — on a success `result` with no background work pending,
  so the no-background common case settles immediately with no added latency
  (AC-03, AC-06). finally closes the gate so abort/throw never leaks it.
- Fire onBackgroundTasksChanged while background work is active and again when it
  drains, for UI parity with Copilot (AC-05).

Pinned SDK signal (the goal's [open] item): the installed
@anthropic-ai/claude-agent-sdk exposes `session_state_changed` (state idle =
authoritative turn-over after the bg-agent drain loop exits) plus the
task_started/task_updated/task_notification lifecycle; no fallback suspend/resume
path is needed.

Tests: input-aware mock query handle whose post-result continuation is delivered
only while the streaming input stays open, covering keep-alive resume, settle-
once-at-idle, abort-during-window teardown, background-tasks events, and the
no-background fast path. Existing prompt-shape assertions updated for the new
streaming-input prompt.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
