### PR TITLE
feat(coc): keep scheduled wakeups alive across Claude turn-end teardown

### DIFF
--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -33,6 +33,7 @@ import { ensureMyWorkWorkspace } from './workspaces/my-work-workspace';
 import { ensureMyLifeWorkspace } from './workspaces/my-life-workspace';
 import { createScheduleInfrastructure } from './infrastructure/schedule-infrastructure';
 import { createLoopInfrastructure } from './infrastructure/loop-infrastructure';
+import { createEnqueueWakeup } from './loops/enqueue-wakeup';
 import { createTriggerInfrastructure } from './infrastructure/trigger-infrastructure';
 import { createCiChecksFetcher } from './triggers/ci-checks-fetcher';
 import { createCiLogFetcher } from './triggers/ci-log-fetcher';
@@ -315,35 +316,12 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
                         return task?.repoId;
                     } catch { return undefined; }
                 },
-                enqueueWakeup: (opts) => {
-                    loopInfra!.timerRegistry.set(
-                        `wakeup:${opts.wakeupId}`,
-                        () => {
-                            const turnSource = { source: 'wakeup' as const, wakeupId: opts.wakeupId };
-                            void (async () => {
-                                try {
-                                    const { resolveFollowUpMode } = await import('./executors/follow-up-mode');
-                                    const mode = await resolveFollowUpMode(store, opts.processId);
-                                    await bridge.executeFollowUp(
-                                        opts.processId,
-                                        opts.prompt,
-                                        undefined,
-                                        mode,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        opts.model,
-                                        turnSource,
-                                    );
-                                } catch (err) {
-                                    const msg = err instanceof Error ? err.message : String(err);
-                                    process.stderr.write(`[Wakeup] Failed to execute wakeup ${opts.wakeupId}: ${msg}\n`);
-                                }
-                            })();
-                        },
-                        opts.delayMs,
-                    );
-                },
+                enqueueWakeup: createEnqueueWakeup({
+                    timerRegistry: loopInfra!.timerRegistry,
+                    store,
+                    executeFollowUp: (processId, message, attachments, mode, deliveryMode, images, selectedSkillNames, model, turnSource) =>
+                        bridge.executeFollowUp(processId, message, attachments, mode, deliveryMode, images, selectedSkillNames, model, turnSource),
+                }),
             };
         },
         () => mcpOauthInfra?.manager,

--- a/packages/coc/src/server/loops/enqueue-wakeup.ts
+++ b/packages/coc/src/server/loops/enqueue-wakeup.ts
@@ -1,0 +1,97 @@
+/**
+ * Scheduled-wakeup timer wiring.
+ *
+ * A `scheduleWakeup` tool call arms a one-shot timer in the loop
+ * infrastructure's {@link ScheduleTimerRegistry}. When the timer fires it
+ * resolves the follow-up mode and runs a wakeup-sourced follow-up turn on the
+ * same process via the queue bridge.
+ *
+ * The timer is keyed by `wakeup:<wakeupId>` — deliberately NOT keyed by
+ * processId and NOT owned by the per-turn executor session. That decoupling is
+ * what lets a wakeup survive turn-end teardown
+ * (`BaseExecutor.cleanupSession`, the executor `finally` blocks): the executor
+ * never touches this registry, so a wakeup scheduled mid-turn still fires after
+ * the turn completes. The registry only drops timers on cancel (loop/trigger
+ * ids) or on server shutdown (`clear()`).
+ */
+
+import type { ProcessStore, TurnSource } from '@plusplusoneplusplus/forge';
+import type { ChatMode } from '../tasks/task-types';
+import type { ScheduleTimerRegistry } from '../schedule/schedule-timer-registry';
+
+/** Options passed when arming a scheduled wakeup. */
+export interface WakeupEnqueueOptions {
+    processId: string;
+    prompt: string;
+    delayMs: number;
+    wakeupId: string;
+    model?: string;
+    workspaceId?: string;
+}
+
+/**
+ * Minimal follow-up runner the wakeup timer invokes when it fires. Matches the
+ * leading arguments of the queue bridge's `executeFollowUp`.
+ */
+export type WakeupExecuteFollowUp = (
+    processId: string,
+    message: string,
+    attachments: undefined,
+    mode: ChatMode,
+    deliveryMode: undefined,
+    images: undefined,
+    selectedSkillNames: undefined,
+    model: string | undefined,
+    turnSource: TurnSource,
+) => Promise<void>;
+
+export interface EnqueueWakeupDeps {
+    timerRegistry: ScheduleTimerRegistry;
+    store: ProcessStore;
+    executeFollowUp: WakeupExecuteFollowUp;
+}
+
+/** Timer-registry key prefix for one-shot scheduled wakeups. */
+export const WAKEUP_TIMER_KEY_PREFIX = 'wakeup:';
+
+/** The {@link ScheduleTimerRegistry} key under which a wakeup's timer is armed. */
+export function wakeupTimerKey(wakeupId: string): string {
+    return `${WAKEUP_TIMER_KEY_PREFIX}${wakeupId}`;
+}
+
+/**
+ * Build the `enqueueWakeup` callback handed to the scheduleWakeup tool. The
+ * returned function arms a one-shot timer that, when it fires, resolves the
+ * follow-up mode and runs a wakeup-sourced follow-up turn on the process.
+ */
+export function createEnqueueWakeup(deps: EnqueueWakeupDeps): (opts: WakeupEnqueueOptions) => void {
+    return (opts: WakeupEnqueueOptions) => {
+        deps.timerRegistry.set(
+            wakeupTimerKey(opts.wakeupId),
+            () => {
+                const turnSource: TurnSource = { source: 'wakeup', wakeupId: opts.wakeupId };
+                void (async () => {
+                    try {
+                        const { resolveFollowUpMode } = await import('../executors/follow-up-mode');
+                        const mode = await resolveFollowUpMode(deps.store, opts.processId);
+                        await deps.executeFollowUp(
+                            opts.processId,
+                            opts.prompt,
+                            undefined,
+                            mode,
+                            undefined,
+                            undefined,
+                            undefined,
+                            opts.model,
+                            turnSource,
+                        );
+                    } catch (err) {
+                        const msg = err instanceof Error ? err.message : String(err);
+                        process.stderr.write(`[Wakeup] Failed to execute wakeup ${opts.wakeupId}: ${msg}\n`);
+                    }
+                })();
+            },
+            opts.delayMs,
+        );
+    };
+}

--- a/packages/coc/test/server/loops/wakeup-survives-turn-end.test.ts
+++ b/packages/coc/test/server/loops/wakeup-survives-turn-end.test.ts
@@ -1,0 +1,128 @@
+/**
+ * AC-04 regression: a scheduled wakeup created during a turn must survive
+ * turn-end teardown.
+ *
+ * A `scheduleWakeup` tool call arms a one-shot timer in the loop
+ * infrastructure's ScheduleTimerRegistry (keyed `wakeup:<id>`). The per-turn
+ * executor session is a *separate* structure: both executor `finally` blocks
+ * (FollowUpExecutor, process-lifecycle-runner) tear the turn down through
+ * `BaseExecutor.cleanupSession`, which only touches the `sessions` map. These
+ * tests lock in that the teardown never disarms a pending wakeup, so a wakeup
+ * scheduled mid-turn still fires after the turn completes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ScheduleTimerRegistry } from '../../../src/server/schedule/schedule-timer-registry';
+import { createEnqueueWakeup, wakeupTimerKey } from '../../../src/server/loops/enqueue-wakeup';
+import { createScheduleWakeupTool } from '../../../src/server/llm-tools/loop-tools';
+import type { WakeupToolDeps } from '../../../src/server/llm-tools/loop-tools';
+import { BaseExecutor } from '../../../src/server/executors/base-executor';
+import { createMockProcessStore, type MockProcessStore } from '../helpers/mock-process-store';
+// Warm the module cache so the dynamic import() inside the wakeup timer
+// callback resolves on a microtask while fake timers are installed.
+import '../../../src/server/executors/follow-up-mode';
+
+/** Concrete executor exposing the protected turn-lifecycle hooks for the test. */
+class TestExecutor extends BaseExecutor {
+    public startTurn(processId: string): void {
+        this.getOrCreateSession(processId);
+    }
+    /** Mirror what both executor `finally` blocks run at turn end. */
+    public endTurn(processId: string): void {
+        this.cleanupSession(processId);
+    }
+}
+
+function makeWakeupDeps(
+    processId: string,
+    enqueueWakeup: WakeupToolDeps['enqueueWakeup'],
+): WakeupToolDeps {
+    return {
+        executor: { armTimer: vi.fn(), disarmTimer: vi.fn() } as any,
+        processId,
+        resolveWorkspaceId: vi.fn().mockResolvedValue('ws-1'),
+        enqueueWakeup,
+    };
+}
+
+describe('AC-04: scheduled wakeup survives turn-end teardown', () => {
+    let store: MockProcessStore;
+    let timerRegistry: ScheduleTimerRegistry;
+    let executeFollowUp: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        store = createMockProcessStore();
+        timerRegistry = new ScheduleTimerRegistry();
+        executeFollowUp = vi.fn().mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        timerRegistry.clear();
+        vi.useRealTimers();
+    });
+
+    async function scheduleWakeup(processId: string, prompt: string, delay: string) {
+        const enqueueWakeup = createEnqueueWakeup({
+            timerRegistry,
+            store,
+            executeFollowUp: executeFollowUp as any,
+        });
+        const { tool } = createScheduleWakeupTool(makeWakeupDeps(processId, enqueueWakeup));
+        return (tool.handler as (a: any) => Promise<any>)({ prompt, delay });
+    }
+
+    it('keeps the wakeup timer armed after cleanupSession runs at turn end', async () => {
+        const processId = 'proc-wakeup-1';
+        const result = await scheduleWakeup(processId, 'resume me', '60s');
+        expect(result.scheduled).toBe(true);
+
+        const key = wakeupTimerKey(result.wakeupId);
+        expect(timerRegistry.has(key)).toBe(true);
+
+        // The turn for this process ends — executor teardown runs.
+        const executor = new TestExecutor(store);
+        executor.startTurn(processId);
+        executor.endTurn(processId);
+
+        // Teardown must not have disarmed the wakeup.
+        expect(timerRegistry.has(key)).toBe(true);
+    });
+
+    it('fires the follow-up after the turn ended', async () => {
+        const processId = 'proc-wakeup-2';
+        const result = await scheduleWakeup(processId, 'resume me', '60s');
+        const key = wakeupTimerKey(result.wakeupId);
+
+        const executor = new TestExecutor(store);
+        executor.startTurn(processId);
+        executor.endTurn(processId);
+        expect(timerRegistry.has(key)).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect(executeFollowUp).toHaveBeenCalledTimes(1);
+        const callArgs = executeFollowUp.mock.calls[0];
+        expect(callArgs[0]).toBe(processId);          // processId
+        expect(callArgs[1]).toBe('resume me');         // prompt
+        expect(callArgs[8]).toEqual({ source: 'wakeup', wakeupId: result.wakeupId }); // turnSource
+        // The registry drops one-shot timers once they fire.
+        expect(timerRegistry.has(key)).toBe(false);
+    });
+
+    it('cleanupSession only clears executor session state, never the timer registry', async () => {
+        const processId = 'proc-wakeup-3';
+        const result = await scheduleWakeup(processId, 'resume me', '90s');
+        const key = wakeupTimerKey(result.wakeupId);
+
+        const executor = new TestExecutor(store);
+        // Two back-to-back turns each tear down; the wakeup must outlive both.
+        executor.startTurn(processId);
+        executor.endTurn(processId);
+        executor.startTurn(processId);
+        executor.endTurn(processId);
+
+        expect(timerRegistry.has(key)).toBe(true);
+        expect(executeFollowUp).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
AC-04 of the Claude-SDK background-resume work: a scheduleWakeup armed
during a turn must still fire after the turn ends. Verified the current
behavior is correct — the wakeup timer lives in the loop
ScheduleTimerRegistry keyed by `wakeup:<id>`, decoupled from the per-turn
executor session that cleanupSession (both executor finally blocks) tears
down — and locked it in with a regression test.

Extracted the inline enqueueWakeup wiring from server/index.ts into a
testable createEnqueueWakeup helper (loops/enqueue-wakeup.ts) so the
regression test exercises the real timer-arming path rather than a copy.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
