### PR TITLE
perf(coc): cut chat-load request traffic via static-config cache + deferred fetches

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -337,6 +337,77 @@ present.
 | `useDiffComments` | Inline diff comment state |
 | `useUnseenChat` | Read/unread tracking |
 
+## Chat load performance (per-conversation request budget)
+
+Opening a chat used to fan out ~11 separate requests
+(`pull-request-chat-bindings`, `models`, `reasoning-efforts`, `effort-tiers`,
+`loops`, `llm-tools-config`, `canvases`, the sidebar `all`, the process detail
+`queue_<id>`, `stream?warm=1`, and the unseen `count`). Most were redundant —
+static provider/workspace config is identical across conversations, and several
+workspace-scoped calls refetched on every conversation switch. The target is a
+**warm** second open (same SPA session, same workspace, provider already seen)
+that issues **≤3** fetch round-trips — process detail, `canvases?processId=`,
+and `pull-request-chat-bindings?taskId=` — excluding the persistent
+`stream?warm=1` SSE EventSource (which opens only for running conversations).
+The sidebar `all` list is left untouched and there is no new server
+aggregation/bootstrap endpoint; the wins are all client caching, re-keying,
+deferral, and additive cache headers.
+
+- **Static config client cache** — `react/api/staticConfigCache.ts` is a
+  module-level singleton mirroring the AppContext `ConversationCacheEntry`
+  `{value, cachedAt}` + 60-min-TTL pattern (deliberately **not** React-Query/SWR).
+  `getOrFetchConfig(key, fetcher, ttlMs?)` returns a cache hit, fetches once on a
+  miss, dedupes concurrent same-key fetches, and does **not** cache failures;
+  `peekConfig(key)` is a synchronous seed used so a warm reopen paints with no
+  loading flash; `invalidateConfig(key)` drops one key; `configCacheKey` builds
+  the keys (`.models`/`.reasoningEfforts`/`.effortTiers(provider)` per **provider**,
+  `.llmToolsConfig(workspaceId)` per **workspace**). The provider-config hooks
+  (`hooks/useModels.ts`, `hooks/useProviderModels.ts`,
+  `hooks/useProviderReasoningEfforts.ts`, `hooks/useProviderEffortTiers.ts`) and
+  the two llm-tools-config consumers (`features/repo-settings/LlmToolsPanel.tsx`
+  `loadConfig`, `features/chat/sessionContextDrop.ts`
+  `useConversationRetrievalCapability`) all read through this cache, so a
+  conversation whose provider/workspace was already seen this session triggers
+  **zero** config calls. `test/setup.ts` clears the singleton in a global
+  `beforeEach` so it stays transparent to consumer tests.
+- **Invalidate-on-mutate** — each settings mutation drops only its own key so the
+  next read refetches without a page reload: `setEnabledModels` →
+  `models:<provider>`, `setReasoningEffort` → `reasoning-efforts:<provider>`,
+  `effortTiers.save()` → `effort-tiers:<provider>`, and `LlmToolsPanel`'s toggle
+  → `llm-tools-config:<workspaceId>` after a successful `updateLlmToolsConfig`.
+- **Workspace-scoped data is not refetched per conversation** —
+  `features/chat/hooks/useLoops.ts` fetches `loops.list` keyed by
+  `[workspaceId, cloneClient]` only (processId is dropped from the fetch dep); the
+  per-process view is a `useMemo([allLoops, processId])`, so a conversation switch
+  re-derives the filtered list with no round-trip and only a workspace change
+  refetches. The unseen `count` refresh is gated on a real seen-state change:
+  `useUnseenChat`'s `markSeen`/`markAllSeen`/`markTasksSeen`/`markUnseen` now
+  return whether they changed seen-state (detected synchronously via a
+  `seenMapRef`), and `RepoChatTab` only calls `scheduleUnseenRefresh()` when that
+  boolean is true — so reopening an already-seen conversation issues no `count`
+  call.
+- **Deferral past first paint** — the conversation process-detail fetch + message
+  render is the critical path; the two remaining non-critical per-conversation
+  fetches run after first paint via `utils/runWhenIdle.ts`
+  (`requestIdleCallback` with a `{timeout}` bound so the data still loads
+  automatically on a busy page, `setTimeout(cb, 0)` fallback for Safari/jsdom;
+  returns a disposer). `ChatDetail` keeps
+  `setCanvasPanelClosed(readCanvasClosed(...))` synchronous (no collapse-rail
+  flash) and defers only `client.canvases.list`; `usePrChatStatusItems` keeps its
+  synchronous resets immediate and defers only the async binding IIFE
+  (`listChatBindingsForOrigin` + association build + detail fan-out), guarding the
+  idle fire with `generationRef` so an A→B switch never fires a stale fetch. Both
+  effects `cancelIdle()` in cleanup.
+- **Short-lived HTTP cache headers** — the four static-config GET routes carry
+  `Cache-Control: private, max-age=60` (so a cold reload within the window skips
+  the round-trip) via `setStaticConfigCacheHeaders(res)` in
+  `src/server/shared/router.ts`, applied on the 200 path only:
+  `agent-providers/agent-providers-routes.ts` (`reasoning-efforts`, `effort-tiers`),
+  `routes/queue-enqueue.ts` (`models`), and `routes/api-workspace-routes.ts`
+  (`llm-tools-config`). The 60s TTL is conservative because client-side
+  invalidate-on-mutate already covers same-session edits, so the header only
+  bounds cross-reload staleness.
+
 ## Work Items UI
 
 The hierarchy tree uses `WorkItemHierarchyTree` and `WorkItemHierarchyNode`.

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -127,6 +127,32 @@ all have their own `references/*.md`.
   follow-up send paths pass `warmKey: processId` whenever `keepWarm: true`;
   `/api/processes/:id/prewarm` and warm-only SSE status use that same process id.
   `workingDirectory` remains provider execution context only, not the warm key.
+- **Per-conversation request budget** keeps opening a chat lean. A **warm**
+  second open of a conversation (same SPA session, same workspace, provider
+  already seen) must stay at **≤3** fetch round-trips — process detail,
+  `canvases?processId=`, and `pull-request-chat-bindings?taskId=` — excluding the
+  `stream?warm=1` SSE. Static provider/workspace config is cached client-side in
+  the module-level singleton
+  `src/server/spa/client/react/api/staticConfigCache.ts` (mirrors the AppContext
+  `ConversationCacheEntry` 60-min-TTL pattern, **not** React-Query/SWR): `models`
+  / `reasoning-efforts` / `effort-tiers` keyed by **provider**, `llm-tools-config`
+  keyed by **workspace**; the provider/workspace config hooks read through
+  `getOrFetchConfig` and seed from `peekConfig` (no loading flash), and every
+  mutation site `invalidateConfig`s its own key (invalidate-on-mutate, no reload).
+  Workspace-scoped data must not refetch per conversation: `useLoops` fetches
+  keyed by `[workspaceId, cloneClient]` only (processId drives a `useMemo` view,
+  never a round-trip) and the unseen `count` refresh fires only when a `markSeen`
+  family call actually changes seen-state. The two remaining non-critical
+  per-conversation fetches (`canvases.list`, `listChatBindingsForOrigin`) are
+  deferred past first paint through `utils/runWhenIdle.ts` (requestIdleCallback
+  with a timeout bound, setTimeout fallback for Safari/jsdom) so messages render
+  first; synchronous panel/reset state stays immediate, and a generation/cancel
+  guard drops a stale deferred fetch on an A→B switch. The four static-config GET
+  routes also carry `Cache-Control: private, max-age=60` via
+  `setStaticConfigCacheHeaders` in `src/server/shared/router.ts` (200-path only).
+  Do not reintroduce a per-conversation refetch of cached config or
+  workspace-scoped data, and do not add a new server aggregation/bootstrap
+  endpoint — keep these as separate cached/deferred client calls.
 - **Implement-plan target routing** (`ImplementPlanCard` + `implementTargets.ts`)
   keeps local runs path-based and remote runs content-embedded: a **local**
   target enqueues `Read and implement the plan file at <path>` + `context.files`

--- a/packages/coc/src/server/agent-providers/agent-providers-routes.ts
+++ b/packages/coc/src/server/agent-providers/agent-providers-routes.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Route } from '../types';
-import { sendJson, send400, send500 } from '../shared/router';
+import { sendJson, send400, send500, setStaticConfigCacheHeaders } from '../shared/router';
 import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import type { AgentProviderStatus, AgentProvidersResponse } from '@plusplusoneplusplus/coc-client';
 import type { CopilotSDKService, IAvailabilityResult, CodexSDKService, ClaudeSDKService, ModelInfo, ISDKService } from '@plusplusoneplusplus/forge';
@@ -378,6 +378,7 @@ export function registerAgentProvidersRoutes(routes: Route[], ctx: AgentProvider
             try {
                 const cfg = ctx.loadConfigFile(ctx.configPath);
                 const settings = getProviderModelSettings(cfg, provider);
+                setStaticConfigCacheHeaders(res);
                 sendJson(res, { provider, reasoningEfforts: settings.reasoningEfforts });
             } catch (err) {
                 send500(res, err instanceof Error ? err.message : 'Failed to retrieve reasoning efforts');
@@ -443,6 +444,7 @@ export function registerAgentProvidersRoutes(routes: Route[], ctx: AgentProvider
                 const settings = getProviderModelSettings(cfg, provider);
                 const effortTiers: MergedEffortTiersMap = mergeEffortTiersWithDefaults(provider, settings.effortTiers);
                 const defaults: EffortTierDefaultsMap | Record<string, never> = getDefaultEffortTiers(provider) ?? {};
+                setStaticConfigCacheHeaders(res);
                 sendJson(res, { provider, effortTiers, defaults });
             } catch (err) {
                 send500(res, err instanceof Error ? err.message : 'Failed to retrieve effort tiers');

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -13,6 +13,7 @@ import type { MCPServerConfig, ProcessStore, WorkspaceInfo } from '@plusplusonep
 import { BranchService, loadDefaultMcpConfig, loadWorkspaceMcpConfig, detectRemoteUrl, resolvePathForHostFilesystem, computeWorkspaceId } from '@plusplusoneplusplus/forge';
 import type { Route } from '../types';
 import { sendJSON } from '../core/api-handler';
+import { setStaticConfigCacheHeaders } from '../shared/router';
 import { handleAPIError, missingFields, notFound, badRequest } from '../errors';
 import { gitCache } from '../git/git-cache';
 import { gitInfoCache, type GitInfoResult } from '../git/git-info-cache';
@@ -768,6 +769,8 @@ export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
         handler: async (_req, res, match) => {
             const ws = await resolveWorkspaceOrFail(store, match!, res);
             if (!ws) return;
+            // Static config — short-lived private cache (both branches below are 200s).
+            setStaticConfigCacheHeaders(res);
             const liveFlags = ctx.getLiveFeatureFlags?.() ?? { excalidrawEnabled: false, canvasEnabled: false };
             const effectiveRegistry = withToolParameterMetadata(getEffectiveLlmToolRegistry({ loopsEnabled: ctx.loopsEnabled, canvasEnabled: liveFlags.canvasEnabled }));
             const conversationRetrievalAvailable = typeof ctx.store.searchConversations === 'function';

--- a/packages/coc/src/server/routes/queue-enqueue.ts
+++ b/packages/coc/src/server/routes/queue-enqueue.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import { getActiveModels, modelMetadataStore, ensureQueueProcessId, toQueueProcessId, isQueueProcessId, toTaskId, SqliteProcessStore, sdkServiceRegistry, mergeEffortTiersWithDefaults, resolveModelForProvider, getLogger, LogCategory } from '@plusplusoneplusplus/forge';
 import type { CreateTaskInput, QueuedTask } from '@plusplusoneplusplus/forge';
 import { sendJSON, sendError, parseBody } from '../core/api-handler';
+import { setStaticConfigCacheHeaders } from '../shared/router';
 import {
     isWireAttachmentArray,
     processMessageAttachments,
@@ -93,6 +94,9 @@ export function registerQueueEnqueueRoutes(routes: Route[], ctx: QueueRouteConte
                 return sendError(res, 500, err instanceof Error ? err.message : 'Failed to resolve default provider');
             }
             const activeProvider = resolution.provider;
+            // Static config — short-lived private cache (resolution succeeded; all
+            // branches below are 200s). Skipped on the 500 early-return above.
+            setStaticConfigCacheHeaders(res);
             if (activeProvider === 'copilot') {
                 const live = modelMetadataStore.getCachedModels()
                     .filter(m => m.policy?.state !== 'disabled');

--- a/packages/coc/src/server/shared/router.ts
+++ b/packages/coc/src/server/shared/router.ts
@@ -335,6 +335,29 @@ export function sendJson(res: http.ServerResponse, data: unknown, statusCode = 2
     res.end(bodyBuf);
 }
 
+/**
+ * Short-lived TTL (seconds) for the static provider/workspace config endpoints
+ * (`models`, `reasoning-efforts`, `effort-tiers`, `llm-tools-config`). These
+ * change rarely and are also invalidated client-side on mutation, so 60s is a
+ * conservative window: a cold page reload within it can skip the round-trip
+ * entirely while a settings edit still shows within at most a minute even
+ * without the client-side invalidate-on-mutate.
+ */
+export const STATIC_CONFIG_CACHE_MAX_AGE_SECONDS = 60;
+
+/** Cache-Control value for the static config endpoints. `private` keeps it out
+ * of shared proxy caches (responses are per-provider/per-workspace). */
+export const STATIC_CONFIG_CACHE_CONTROL = `private, max-age=${STATIC_CONFIG_CACHE_MAX_AGE_SECONDS}`;
+
+/**
+ * Tag a response as short-lived private cache for static config. Call this
+ * BEFORE the success `sendJson`/`sendJSON` so the header survives `writeHead`'s
+ * merge, and only on the 200 path — never cache a 4xx/5xx.
+ */
+export function setStaticConfigCacheHeaders(res: http.ServerResponse): void {
+    res.setHeader('Cache-Control', STATIC_CONFIG_CACHE_CONTROL);
+}
+
 /** Send a 404 Not Found response. */
 export function send404(res: http.ServerResponse, message = 'Not Found'): void {
     sendJson(res, { error: message }, 404);

--- a/packages/coc/src/server/spa/client/react/api/staticConfigCache.ts
+++ b/packages/coc/src/server/spa/client/react/api/staticConfigCache.ts
@@ -1,0 +1,140 @@
+/**
+ * staticConfigCache — session-scoped, in-memory cache for static
+ * provider/workspace configuration that the dashboard SPA otherwise refetches
+ * on every conversation switch.
+ *
+ * Today, opening a single conversation fans out ~11 RPCs. Several of those are
+ * provider-scoped (`models`, `reasoning-efforts`, `effort-tiers`) or
+ * workspace-scoped (`llm-tools-config`) static config that is identical across
+ * conversations. This module caches each response keyed by provider/workspace
+ * so the second-and-later reads in the same app session resolve without a
+ * network round-trip.
+ *
+ * Pattern: this mirrors the AppContext conversation cache
+ * (`ConversationCacheEntry` — a `{ value, cachedAt }` entry behind a TTL) but
+ * lives at module scope rather than in the reducer. The provider hooks that
+ * consume this (`useModels`, `useProviderReasoningEfforts`,
+ * `useProviderEffortTiers`, and the llm-tools-config call sites) are mounted in
+ * many places across the app — chat picker, queue/schedule dialogs, admin
+ * panels — so a module singleton is shared by all of them without threading
+ * `appDispatch`/`appState` through every call site. The established in-repo
+ * precedent for this is `features/git/hooks/useCommitsCache.ts`. No new
+ * data-fetching library (React-Query/SWR) is introduced.
+ *
+ * Two maps back the cache:
+ *  - `cache`     — resolved values with a `cachedAt` timestamp for TTL expiry.
+ *  - `inflight`  — in-flight fetch promises so concurrent reads of the same key
+ *                  (e.g. the chat picker and a queue dialog both mounting and
+ *                  calling `useModels`) dedupe to a single network call. A
+ *                  rejected fetch drops its in-flight entry so the next read
+ *                  retries instead of caching the failure.
+ *
+ * Invalidation (AC-05) is invalidate-on-mutate: a mutating settings call drops
+ * the specific key via `invalidateConfig(...)` so the next read refetches.
+ */
+
+/** A cached config value plus the time it was stored. Mirrors `ConversationCacheEntry`. */
+export interface ConfigCacheEntry<T = unknown> {
+    value: T;
+    /** `Date.now()` when the value was stored; drives TTL expiry. */
+    cachedAt: number;
+}
+
+/**
+ * Default time-to-live for a cached config entry. Matches the 60-minute TTL of
+ * the AppContext conversation cache. Static config changes rarely and is also
+ * dropped client-side on mutation (AC-05), so this is a backstop against
+ * unbounded staleness rather than the primary freshness mechanism — within a
+ * single session, reuse-for-the-session is the intended behaviour.
+ */
+export const DEFAULT_CONFIG_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Builders for the cache keys so every call site keys consistently. Static
+ * config is per-provider (`models`/`reasoning-efforts`/`effort-tiers`) and
+ * per-workspace (`llm-tools-config`); keying MUST follow that so a conversation
+ * using a different provider/workspace still sees the correct config.
+ */
+export const configCacheKey = {
+    models: (provider: string): string => `models:${provider}`,
+    reasoningEfforts: (provider: string): string => `reasoning-efforts:${provider}`,
+    effortTiers: (provider: string): string => `effort-tiers:${provider}`,
+    llmToolsConfig: (workspaceId: string): string => `llm-tools-config:${workspaceId}`,
+} as const;
+
+const cache = new Map<string, ConfigCacheEntry>();
+const inflight = new Map<string, Promise<unknown>>();
+
+/**
+ * Returns the cached value for `key` if present and not past `ttlMs`, otherwise
+ * invokes `fetcher` exactly once (deduping concurrent callers) and caches the
+ * resolved value. A second read of an already-cached key returns from cache
+ * with no call to `fetcher`.
+ *
+ * @param key     Stable cache key — build with `configCacheKey`.
+ * @param fetcher Performs the network read when the cache misses.
+ * @param ttlMs   Entry lifetime; defaults to {@link DEFAULT_CONFIG_TTL_MS}.
+ */
+export function getOrFetchConfig<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    ttlMs: number = DEFAULT_CONFIG_TTL_MS,
+): Promise<T> {
+    const entry = cache.get(key);
+    if (entry && Date.now() - entry.cachedAt < ttlMs) {
+        return Promise.resolve(entry.value as T);
+    }
+    // Stale entry — drop it so a slow refetch never serves the old value below.
+    if (entry) cache.delete(key);
+
+    const pending = inflight.get(key);
+    if (pending) return pending as Promise<T>;
+
+    const promise = fetcher().then(
+        (value) => {
+            cache.set(key, { value, cachedAt: Date.now() });
+            inflight.delete(key);
+            return value;
+        },
+        (err) => {
+            // Do not cache failures — drop the in-flight entry so the next read retries.
+            inflight.delete(key);
+            throw err;
+        },
+    );
+    inflight.set(key, promise);
+    return promise as Promise<T>;
+}
+
+/**
+ * Synchronously returns the cached value for `key` if present and fresh,
+ * otherwise `undefined`. Does not trigger a fetch. Useful for seeding a hook's
+ * initial state so a cache hit paints without a loading flash.
+ */
+export function peekConfig<T>(key: string, ttlMs: number = DEFAULT_CONFIG_TTL_MS): T | undefined {
+    const entry = cache.get(key);
+    if (entry && Date.now() - entry.cachedAt < ttlMs) {
+        return entry.value as T;
+    }
+    return undefined;
+}
+
+/**
+ * Drops the cached value and any in-flight fetch for `key` so the next read
+ * refetches. Call this right after a mutating settings call (AC-05).
+ */
+export function invalidateConfig(key: string): void {
+    cache.delete(key);
+    inflight.delete(key);
+}
+
+/** Test/reset helper: empties the entire cache (values and in-flight promises). */
+export function _clearConfigCache(): void {
+    cache.clear();
+    inflight.clear();
+}
+
+/** Test helper: number of resolved entries currently cached. */
+export function _getConfigCacheSize(): number {
+    return cache.size;
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -24,6 +24,7 @@ import { useModelCommand, selectPickableModels } from './hooks/useModelCommand';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
 import { getMetaSkillItems, mergeSkillsWithMeta, type SkillItem } from './SlashCommandMenu';
 import { scanTurnsForCreatedFiles, scanTurnsForPlanCanvas } from '../../utils/conversationScan';
+import { runWhenIdle } from '../../utils/runWhenIdle';
 import { toQueueProcessId, isQueueProcessId, toTaskId } from '../../utils/queue-process-id';
 import type { ClientConversationTurn } from '../../types/dashboard';
 import { getDraft, setDraft, pruneExpired } from './hooks/useDraftStore';
@@ -1115,14 +1116,20 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         // straight into the collapsed rail without flashing the expanded panel.
         setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid));
         let cancelled = false;
-        client.canvases.list(workspaceId, { processId: canvasPid })
-            .then(canvases => {
-                if (!cancelled && canvases.length > 0) {
-                    setActiveCanvasId(prev => prev ?? canvases[0].id);
-                }
-            })
-            .catch(() => { /* canvas discovery is best-effort */ });
-        return () => { cancelled = true; };
+        // Canvas discovery is non-critical: defer the round-trip to browser idle
+        // so the conversation messages paint first (AC-03). The persisted close
+        // flag above still applies synchronously; only the network probe waits.
+        const cancelIdle = runWhenIdle(() => {
+            if (cancelled) return;
+            client.canvases.list(workspaceId, { processId: canvasPid })
+                .then(canvases => {
+                    if (!cancelled && canvases.length > 0) {
+                        setActiveCanvasId(prev => prev ?? canvases[0].id);
+                    }
+                })
+                .catch(() => { /* canvas discovery is best-effort */ });
+        });
+        return () => { cancelled = true; cancelIdle(); };
     }, [workspaceId, canvasPid]);
 
     const canvasResize = useResizablePanel({

--- a/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RepoChatTab.tsx
@@ -500,24 +500,23 @@ export function RepoChatTab({ workspaceId, mode }: RepoChatTabProps) {
         setTimeout(() => refreshUnseenCounts([workspaceId]), 300);
     }, [refreshUnseenCounts, workspaceId]);
 
+    // Only refresh the workspace-scoped unseen count when the seen-state
+    // actually changed. Reopening an already-seen conversation (a warm A→B→A
+    // switch) no-ops the raw mark, so we skip the redundant `count` round-trip.
     const markSeen = useCallback((processId: string) => {
-        rawMarkSeen(processId);
-        scheduleUnseenRefresh();
+        if (rawMarkSeen(processId)) scheduleUnseenRefresh();
     }, [rawMarkSeen, scheduleUnseenRefresh]);
 
     const markAllSeen = useCallback(() => {
-        rawMarkAllSeen();
-        scheduleUnseenRefresh();
+        if (rawMarkAllSeen()) scheduleUnseenRefresh();
     }, [rawMarkAllSeen, scheduleUnseenRefresh]);
 
     const markTasksSeen = useCallback((tasks: any[]) => {
-        rawMarkTasksSeen(tasks);
-        scheduleUnseenRefresh();
+        if (rawMarkTasksSeen(tasks)) scheduleUnseenRefresh();
     }, [rawMarkTasksSeen, scheduleUnseenRefresh]);
 
     const markUnseen = useCallback((processId: string) => {
-        rawMarkUnseen(processId);
-        scheduleUnseenRefresh();
+        if (rawMarkUnseen(processId)) scheduleUnseenRefresh();
     }, [rawMarkUnseen, scheduleUnseenRefresh]);
     // Activity-specific selectTask: chat tasks stay inline instead of navigating away
     const selectTask = useCallback((id: string, task?: any) => {

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/usePrChatStatusItems.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/usePrChatStatusItems.ts
@@ -28,6 +28,7 @@ import type { ClientConversationTurn } from '../../../types/dashboard';
 import { getSpaCocClientErrorMessage } from '../../../api/cocClient';
 import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 import { resolveCanonicalOriginId } from '../../../repos/originScope';
+import { runWhenIdle } from '../../../utils/runWhenIdle';
 import { buildCheckRowsFromChecks } from '../../pull-requests/pr-derived-data';
 import type { PullRequestCheck, PullRequestDiffStats, Reviewer } from '../../pull-requests/pr-utils';
 import {
@@ -395,7 +396,14 @@ export function usePrChatStatusItems(options: UsePrChatStatusItemsOptions): UseP
         const generation = ++generationRef.current;
         const client = getCocClientForWorkspace(workspaceId);
 
-        (async () => {
+        // The bindings round-trip is non-critical chrome (the PR status card),
+        // not the message-render path: defer it to browser idle so the
+        // conversation paints first (AC-03). The synchronous reset above still
+        // clears stale items immediately; the generation guard invalidates this
+        // run if the deps change before idle fires.
+        const cancelIdle = runWhenIdle(() => {
+            if (generationRef.current !== generation) return;
+            void (async () => {
             const detected = detectedRef.current;
             let bindings: PrChatBindingLike[] = [];
             try {
@@ -432,11 +440,14 @@ export function usePrChatStatusItems(options: UsePrChatStatusItemsOptions): UseP
             for (const association of associations) {
                 fetchDetailForAssociation(association, workspaceId, generation);
             }
-        })();
+            })();
+        });
 
         return () => {
-            // Invalidate this generation on dep change / unmount.
+            // Invalidate this generation on dep change / unmount, and drop the
+            // deferred bindings probe if idle has not fired yet.
             generationRef.current++;
+            cancelIdle();
         };
     }, [workspaceId, chatOriginId, taskId, detectedKey, fetchDetailForAssociation]);
 

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useLoops.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useLoops.ts
@@ -4,7 +4,7 @@
  * Fetches loops associated with the current process, listens for WebSocket
  * loop events to keep state up to date in real time.
  */
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useCocClient } from '../../../repos/cloneRouting';
 import { isLoopsEnabled } from '../../../utils/config';
 import type { LoopEntry } from '@plusplusoneplusplus/coc-client';
@@ -31,7 +31,11 @@ export interface UseLoopsResult {
 }
 
 export function useLoops(workspaceId: string | undefined, processId: string | null): UseLoopsResult {
-    const [loops, setLoops] = useState<LoopEntry[]>([]);
+    // AC-02: loops are workspace-scoped, so we fetch the full workspace list and
+    // keep it keyed by workspace only. The per-process view is derived client-side
+    // (below) so switching conversations within the same workspace never re-issues
+    // `loops.list` — the fetch dependency intentionally omits processId.
+    const [allLoops, setAllLoops] = useState<LoopEntry[]>([]);
     const [loading, setLoading] = useState(false);
     const mountedRef = useRef(true);
     // AC-07: loop list/pause/resume/cancel target the selected clone's server.
@@ -41,24 +45,27 @@ export function useLoops(workspaceId: string | undefined, processId: string | nu
         if (!workspaceId) return;
         // Skip network calls when loops feature is disabled — REST routes are not registered.
         if (!isLoopsEnabled()) {
-            setLoops([]);
+            setAllLoops([]);
             return;
         }
         setLoading(true);
         cloneClient.loops.list(workspaceId)
             .then((all) => {
                 if (!mountedRef.current) return;
-                // Filter to loops for this process
-                const filtered = processId
-                    ? all.filter(l => l.processId === processId)
-                    : all;
-                setLoops(filtered);
+                setAllLoops(all);
             })
             .catch(() => { /* ignore — loops panel is best-effort */ })
             .finally(() => {
                 if (mountedRef.current) setLoading(false);
             });
-    }, [workspaceId, processId, cloneClient]);
+    }, [workspaceId, cloneClient]);
+
+    // Per-process view, derived from the workspace-scoped list. Re-deriving on a
+    // processId change is cheap and never triggers a network round-trip.
+    const loops = useMemo(
+        () => (processId ? allLoops.filter(l => l.processId === processId) : allLoops),
+        [allLoops, processId],
+    );
 
     useEffect(() => {
         mountedRef.current = true;

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useUnseenChat.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useUnseenChat.ts
@@ -28,14 +28,26 @@ export interface useUnseenChatResult {
     unseenProcessIds: Set<string>;
     /** Number of tasks with unseen activity. */
     unseenCount: number;
-    /** Mark a process as seen (call when user selects a task). */
-    markSeen: (processId: string) => void;
-    /** Mark all history tasks as seen. */
-    markAllSeen: () => void;
-    /** Mark a specific subset of tasks as seen (e.g. the currently filtered list). */
-    markTasksSeen: (tasks: any[]) => void;
-    /** Mark a process as unseen/unread (removes it from the seen map). */
-    markUnseen: (processId: string) => void;
+    /**
+     * Mark a process as seen (call when user selects a task).
+     * Returns `true` when the seen-state actually changed (a real transition),
+     * `false` when it was already seen — callers gate workspace-scoped side
+     * effects (e.g. the unseen-count refetch) on this so a warm reopen of an
+     * already-seen conversation does not re-fire the count request.
+     */
+    markSeen: (processId: string) => boolean;
+    /** Mark all history tasks as seen. Returns `true` if anything changed. */
+    markAllSeen: () => boolean;
+    /**
+     * Mark a specific subset of tasks as seen (e.g. the currently filtered list).
+     * Returns `true` if anything changed.
+     */
+    markTasksSeen: (tasks: any[]) => boolean;
+    /**
+     * Mark a process as unseen/unread (removes it from the seen map).
+     * Returns `true` if an entry was actually removed.
+     */
+    markUnseen: (processId: string) => boolean;
 }
 
 export function useUnseenChat(
@@ -44,6 +56,14 @@ export function useUnseenChat(
     selectedTaskId: string | null,
 ): useUnseenChatResult {
     const [seenMap, setSeenMap] = useState<Record<string, string>>({});
+    // Synchronous mirror of seenMap. The mutators below run inside event
+    // handlers and must report whether they actually changed state *before* the
+    // next render commits, so they read/update this ref instead of relying on
+    // the async `setSeenMap` updater closure. Kept in sync with `seenMap` after
+    // every commit (incl. async effects) and eagerly updated inside each mutator
+    // so back-to-back synchronous calls in one tick stay correct.
+    const seenMapRef = useRef<Record<string, string>>({});
+    useEffect(() => { seenMapRef.current = seenMap; }, [seenMap]);
     const initializedRef = useRef(false);
     const seededRef = useRef(false);
     const prevSelectedRef = useRef<string | null>(null);
@@ -181,66 +201,65 @@ export function useUnseenChat(
         return unseen;
     }, [history, seenMap]);
 
-    // Mark a specific task as seen.
-    const markSeen = useCallback((processId: string) => {
+    // Mark a specific task as seen. Returns whether the state actually changed.
+    const markSeen = useCallback((processId: string): boolean => {
         const task = history.find(t => t.id === processId);
         const completedAt = task ? getTaskCompletedAtIso(task) : undefined;
-        if (completedAt) {
-            setSeenMap(prev => {
-                if (prev[processId] === completedAt) return prev;
-                schedulePatch([{ processId, seenAt: completedAt }]);
-                return { ...prev, [processId]: completedAt };
-            });
-        }
+        if (!completedAt) return false;
+        if (seenMapRef.current[processId] === completedAt) return false;
+        const updated = { ...seenMapRef.current, [processId]: completedAt };
+        seenMapRef.current = updated;
+        schedulePatch([{ processId, seenAt: completedAt }]);
+        setSeenMap(updated);
+        return true;
     }, [history, schedulePatch]);
 
-    // Mark all history tasks as seen.
-    const markAllSeen = useCallback(() => {
-        setSeenMap(prev => {
-            const updated = { ...prev };
-            const entries: Array<{ processId: string; seenAt: string }> = [];
-            let changed = false;
-            for (const task of history) {
-                const completedAt = getTaskCompletedAtIso(task);
-                if (completedAt && updated[task.id] !== completedAt) {
-                    updated[task.id] = completedAt;
-                    entries.push({ processId: task.id, seenAt: completedAt });
-                    changed = true;
-                }
+    // Mark all history tasks as seen. Returns whether anything changed.
+    const markAllSeen = useCallback((): boolean => {
+        const updated = { ...seenMapRef.current };
+        const entries: Array<{ processId: string; seenAt: string }> = [];
+        for (const task of history) {
+            const completedAt = getTaskCompletedAtIso(task);
+            if (completedAt && updated[task.id] !== completedAt) {
+                updated[task.id] = completedAt;
+                entries.push({ processId: task.id, seenAt: completedAt });
             }
-            if (entries.length > 0) schedulePatch(entries);
-            return changed ? updated : prev;
-        });
+        }
+        if (entries.length === 0) return false;
+        seenMapRef.current = updated;
+        schedulePatch(entries);
+        setSeenMap(updated);
+        return true;
     }, [history, schedulePatch]);
 
     // Mark a specific subset of tasks as seen (e.g. the currently filtered list).
-    const markTasksSeen = useCallback((tasks: any[]) => {
-        setSeenMap(prev => {
-            const updated = { ...prev };
-            const entries: Array<{ processId: string; seenAt: string }> = [];
-            let changed = false;
-            for (const task of tasks) {
-                const completedAt = getTaskCompletedAtIso(task);
-                if (completedAt && updated[task.id] !== completedAt) {
-                    updated[task.id] = completedAt;
-                    entries.push({ processId: task.id, seenAt: completedAt });
-                    changed = true;
-                }
+    // Returns whether anything changed.
+    const markTasksSeen = useCallback((tasks: any[]): boolean => {
+        const updated = { ...seenMapRef.current };
+        const entries: Array<{ processId: string; seenAt: string }> = [];
+        for (const task of tasks) {
+            const completedAt = getTaskCompletedAtIso(task);
+            if (completedAt && updated[task.id] !== completedAt) {
+                updated[task.id] = completedAt;
+                entries.push({ processId: task.id, seenAt: completedAt });
             }
-            if (entries.length > 0) schedulePatch(entries);
-            return changed ? updated : prev;
-        });
+        }
+        if (entries.length === 0) return false;
+        seenMapRef.current = updated;
+        schedulePatch(entries);
+        setSeenMap(updated);
+        return true;
     }, [schedulePatch]);
 
-    // Mark a specific task as unseen/unread.
-    const markUnseen = useCallback((processId: string) => {
-        setSeenMap(prev => {
-            if (!(processId in prev)) return prev;
-            const updated = { ...prev };
-            delete updated[processId];
-            deleteSeenEntry(workspaceId, processId).catch(() => {});
-            return updated;
-        });
+    // Mark a specific task as unseen/unread. Returns whether an entry was removed.
+    const markUnseen = useCallback((processId: string): boolean => {
+        if (!(processId in seenMapRef.current)) return false;
+        const updated = { ...seenMapRef.current };
+        delete updated[processId];
+        seenMapRef.current = updated;
+        deleteSeenEntry(workspaceId, processId).catch(() => {});
+        setSeenMap(updated);
+        return true;
     }, [workspaceId]);
 
     return { unseenProcessIds, unseenCount: unseenProcessIds.size, markSeen, markAllSeen, markTasksSeen, markUnseen };

--- a/packages/coc/src/server/spa/client/react/features/chat/sessionContextDrop.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/sessionContextDrop.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
+import type { LlmToolsConfig } from '@plusplusoneplusplus/coc-client';
 import { useCocClient } from '../../repos/cloneRouting';
+import { getOrFetchConfig, peekConfig, configCacheKey } from '../../api/staticConfigCache';
 import type { AttachedContextItem } from './hooks/useAttachedContext';
 import {
     GIT_COMMIT_CONTEXT_DRAG_KIND,
@@ -542,10 +544,26 @@ export function validateSessionContextAttachmentsForSend(options: {
     return null;
 }
 
+/** Derives conversation-retrieval availability from a workspace's LLM-tools config. */
+function deriveRetrievalAvailable(config: LlmToolsConfig): boolean {
+    const hasGetConversation = (config.tools ?? []).some(tool => tool.name === 'get_conversation');
+    const disabled = config.disabledLlmTools ?? [];
+    return config.conversationRetrievalAvailable === true
+        && hasGetConversation
+        && !disabled.includes('get_conversation');
+}
+
 export function useConversationRetrievalCapability(workspaceId: string | undefined, enabled: boolean): boolean | null {
-    const [available, setAvailable] = useState<boolean | null>(enabled && workspaceId ? null : false);
     // AC-07: read the LLM-tools config from the selected clone's server.
     const cloneClient = useCocClient(workspaceId);
+    // Seed from a warm workspace-config cache hit so a reopen resolves without a
+    // transient null (AC-01: llm-tools-config is cached per workspace, so
+    // switching conversations in the same workspace issues no refetch).
+    const [available, setAvailable] = useState<boolean | null>(() => {
+        if (!enabled || !workspaceId) return false;
+        const cached = peekConfig<LlmToolsConfig>(configCacheKey.llmToolsConfig(workspaceId));
+        return cached !== undefined ? deriveRetrievalAvailable(cached) : null;
+    });
 
     useEffect(() => {
         if (!enabled || !workspaceId) {
@@ -553,16 +571,20 @@ export function useConversationRetrievalCapability(workspaceId: string | undefin
             return;
         }
 
+        const key = configCacheKey.llmToolsConfig(workspaceId);
+        // Warm cache hit — resolve synchronously, no network round-trip (AC-01).
+        const cached = peekConfig<LlmToolsConfig>(key);
+        if (cached !== undefined) {
+            setAvailable(deriveRetrievalAvailable(cached));
+            return;
+        }
+
         let cancelled = false;
         setAvailable(null);
-        cloneClient.preferences.getLlmToolsConfig(workspaceId)
+        getOrFetchConfig(key, () => cloneClient.preferences.getLlmToolsConfig(workspaceId))
             .then((config) => {
                 if (cancelled) return;
-                const hasGetConversation = (config.tools ?? []).some(tool => tool.name === 'get_conversation');
-                const disabled = config.disabledLlmTools ?? [];
-                setAvailable(config.conversationRetrievalAvailable === true
-                    && hasGetConversation
-                    && !disabled.includes('get_conversation'));
+                setAvailable(deriveRetrievalAvailable(config));
             })
             .catch(() => {
                 if (!cancelled) setAvailable(false);

--- a/packages/coc/src/server/spa/client/react/features/repo-settings/LlmToolsPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-settings/LlmToolsPanel.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { LlmToolMeta, LlmToolParam, LlmToolsConfig } from '@plusplusoneplusplus/coc-client';
 import { getSpaCocClient } from '../../api/cocClient';
+import { getOrFetchConfig, peekConfig, invalidateConfig, configCacheKey } from '../../api/staticConfigCache';
 import { useGlobalToast } from '../../contexts/ToastContext';
 
 interface LlmToolsPanelProps {
@@ -99,14 +100,26 @@ function ToolParams({ tool }: { tool: LlmToolMeta }) {
 
 export function LlmToolsPanel({ workspaceId }: LlmToolsPanelProps) {
     const { addToast } = useGlobalToast();
-    const [tools, setTools] = useState<LlmToolMeta[]>([]);
-    const [disabledTools, setDisabledTools] = useState<string[]>([]);
-    const [loading, setLoading] = useState(true);
+    // Seed from a warm per-workspace cache hit so a reopen paints without a
+    // loading flash and without refetching (AC-01).
+    const seed = peekConfig<LlmToolsConfig>(configCacheKey.llmToolsConfig(workspaceId));
+    const [tools, setTools] = useState<LlmToolMeta[]>(seed?.tools ?? []);
+    const [disabledTools, setDisabledTools] = useState<string[]>(seed?.disabledLlmTools ?? []);
+    const [loading, setLoading] = useState(seed === undefined);
     const [saving, setSaving] = useState(false);
 
     const loadConfig = useCallback(() => {
+        const key = configCacheKey.llmToolsConfig(workspaceId);
+        // Warm cache hit — apply synchronously without a loading flash (AC-01).
+        const cached = peekConfig<LlmToolsConfig>(key);
+        if (cached !== undefined) {
+            setTools(cached.tools ?? []);
+            setDisabledTools(cached.disabledLlmTools ?? []);
+            setLoading(false);
+            return;
+        }
         setLoading(true);
-        getSpaCocClient().preferences.getLlmToolsConfig(workspaceId)
+        getOrFetchConfig(key, () => getSpaCocClient().preferences.getLlmToolsConfig(workspaceId))
             .then((data: LlmToolsConfig) => {
                 setTools(data.tools ?? []);
                 setDisabledTools(data.disabledLlmTools ?? []);
@@ -129,6 +142,9 @@ export function LlmToolsPanel({ workspaceId }: LlmToolsPanelProps) {
                 workspaceId,
                 { disabledLlmTools: nextDisabled },
             );
+            // AC-05: drop the cached workspace config so other readers (e.g. the
+            // chat conversation-retrieval check) refetch the changed config.
+            invalidateConfig(configCacheKey.llmToolsConfig(workspaceId));
         } catch (e: any) {
             setDisabledTools(prevDisabled);
             addToast(e?.message ?? 'Failed to save LLM tools config', 'error');

--- a/packages/coc/src/server/spa/client/react/hooks/useModels.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useModels.ts
@@ -10,6 +10,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getSpaCocClient, getSpaCocClientErrorMessage } from '../api/cocClient';
 import { getActiveProvider } from '../utils/config';
+import { getOrFetchConfig, peekConfig, invalidateConfig, configCacheKey } from '../api/staticConfigCache';
 
 /** Billing metadata preserved from the model catalog (e.g. tokenPrices.longContext.contextMax). */
 export interface ModelBillingInfo {
@@ -115,32 +116,55 @@ function mapModel(m: RawModel): ModelInfo {
     };
 }
 
+/** Maps a raw provider models response (`{ models }`) into ModelInfo[]. */
+function mapModelsResponse(data: unknown): ModelInfo[] {
+    const models = (data as { models?: unknown } | null | undefined)?.models;
+    return Array.isArray(models) ? models.map(mapModel) : [];
+}
+
 /**
  * Fetches models from the active provider's catalog.
  * All model consumers (chat picker, queue dialogs, etc.) use this hook
  * so they automatically reflect the active provider's model list.
  */
 export function useModels(providerOverride?: string): { models: ModelInfo[]; loading: boolean; error: string | null; reload: () => void } {
-    const [models, setModels] = useState<ModelInfo[]>([]);
-    const [loading, setLoading] = useState(true);
+    const provider = providerOverride ?? getActiveProvider();
+    const modelsKey = configCacheKey.models(provider);
+    // Seed from the session cache so a warm reopen (provider already seen this
+    // session) paints the catalog immediately with no loading flash.
+    const [models, setModels] = useState<ModelInfo[]>(() => {
+        const cached = peekConfig(modelsKey);
+        return cached !== undefined ? mapModelsResponse(cached) : [];
+    });
+    const [loading, setLoading] = useState(() => peekConfig(modelsKey) === undefined);
     const [error, setError] = useState<string | null>(null);
     const [reloadToken, setReloadToken] = useState(0);
-    const provider = providerOverride ?? getActiveProvider();
 
     const load = useCallback(() => {
+        // Force a fresh fetch: drop the cached response so the effect refetches.
+        invalidateConfig(configCacheKey.models(provider));
         setReloadToken(token => token + 1);
-    }, []);
+    }, [provider]);
 
     useEffect(() => {
+        const key = configCacheKey.models(provider);
+        // Warm cache hit — serve synchronously without clearing models or
+        // flipping to a loading state, so a conversation switch does not flash.
+        const cached = peekConfig(key);
+        if (cached !== undefined) {
+            setModels(mapModelsResponse(cached));
+            setError(null);
+            setLoading(false);
+            return;
+        }
         setLoading(true);
         setError(null);
         setModels([]);
         let cancelled = false;
-        getSpaCocClient().agentProviders.listModels(provider)
-            .then((data: any) => {
+        getOrFetchConfig(key, () => getSpaCocClient().agentProviders.listModels(provider))
+            .then((data: unknown) => {
                 if (cancelled) return;
-                const arr = Array.isArray(data?.models) ? data.models.map(mapModel) : [];
-                setModels(arr);
+                setModels(mapModelsResponse(data));
             })
             .catch((e: unknown) => {
                 if (!cancelled) setError(getSpaCocClientErrorMessage(e, 'Failed to load models'));
@@ -183,15 +207,21 @@ export function useModelConfig(): {
         setLocalModels(models);
     }, [models]);
 
-    // Load persisted reasoning efforts on mount
+    // Load persisted reasoning efforts on mount (through the session cache).
     useEffect(() => {
-        getSpaCocClient().agentProviders.getReasoningEfforts(provider)
-            .then((data: { reasoningEfforts: Record<string, string> }) => {
+        let cancelled = false;
+        getOrFetchConfig(
+            configCacheKey.reasoningEfforts(provider),
+            () => getSpaCocClient().agentProviders.getReasoningEfforts(provider),
+        )
+            .then((data: { reasoningEfforts?: Record<string, string> }) => {
+                if (cancelled) return;
                 if (data?.reasoningEfforts && typeof data.reasoningEfforts === 'object') {
                     setReasoningEfforts(data.reasoningEfforts);
                 }
             })
             .catch(() => { /* reasoning efforts are optional */ });
+        return () => { cancelled = true; };
     }, [provider]);
 
     const toggleModel = useCallback(async (modelId: string, enabled: boolean) => {
@@ -202,6 +232,9 @@ export function useModelConfig(): {
             const updated = localModels.map(m => m.id === modelId ? { ...m, enabled } : m);
             const enabledModels = updated.filter(m => m.id === modelId ? enabled : m.enabled).map(m => m.id);
             await getSpaCocClient().agentProviders.setEnabledModels(provider, enabledModels);
+            // Enabled-model set changed — drop the cached catalog so the next
+            // read (e.g. the chat model picker) refetches (AC-05).
+            invalidateConfig(configCacheKey.models(provider));
         } catch {
             // Revert optimistic update on error
             setLocalModels(models);
@@ -222,6 +255,9 @@ export function useModelConfig(): {
         }
         try {
             await getSpaCocClient().agentProviders.setReasoningEffort(provider, modelId, effort);
+            // Reasoning-effort map changed — drop the cached map so the next
+            // read refetches (AC-05).
+            invalidateConfig(configCacheKey.reasoningEfforts(provider));
         } catch {
             setReasoningEfforts(prev);
         }

--- a/packages/coc/src/server/spa/client/react/hooks/useProviderEffortTiers.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useProviderEffortTiers.ts
@@ -18,6 +18,7 @@
  */
 import { useState, useEffect, useCallback } from 'react';
 import { getSpaCocClient, getSpaCocClientErrorMessage } from '../api/cocClient';
+import { getOrFetchConfig, peekConfig, invalidateConfig, configCacheKey } from '../api/staticConfigCache';
 import type { AgentProvider } from './useProviderModels';
 
 export type EffortTierKey = 'very-low' | 'low' | 'medium' | 'high';
@@ -97,10 +98,23 @@ export function useProviderEffortTiers(provider: AgentProvider): UseProviderEffo
     const [saving, setSaving] = useState(false);
 
     const load = useCallback(() => {
+        const key = configCacheKey.effortTiers(provider);
+        // Warm cache hit — apply synchronously without a loading flash.
+        const cached = peekConfig<{ effortTiers?: ServerTierMap; defaults?: DefaultsMap }>(key);
+        if (cached !== undefined) {
+            const normalized = normalizeFromServer(cached.effortTiers as ServerTierMap);
+            setRemote(normalized);
+            setLocal(normalized);
+            setDefaults((cached.defaults ?? {}) as DefaultsMap);
+            setLoading(false);
+            setError(null);
+            setSaveError(null);
+            return;
+        }
         setLoading(true);
         setError(null);
         setSaveError(null);
-        getSpaCocClient().agentProviders.getEffortTiers(provider)
+        getOrFetchConfig(key, () => getSpaCocClient().agentProviders.getEffortTiers(provider))
             .then((data) => {
                 const normalized = normalizeFromServer(data.effortTiers as ServerTierMap);
                 setRemote(normalized);
@@ -114,6 +128,12 @@ export function useProviderEffortTiers(provider: AgentProvider): UseProviderEffo
     }, [provider]);
 
     useEffect(() => { load(); }, [load]);
+
+    /** Explicit reload: drop the cached tiers first so the fetch is fresh. */
+    const reload = useCallback(() => {
+        invalidateConfig(configCacheKey.effortTiers(provider));
+        load();
+    }, [provider, load]);
 
     const setTier = useCallback((tier: EffortTierKey, model: string, reasoningEffort: string) => {
         setLocal(prev => ({ ...prev, [tier]: { model, reasoningEffort, source: 'config' } }));
@@ -150,6 +170,8 @@ export function useProviderEffortTiers(provider: AgentProvider): UseProviderEffo
                 }
             }
             const response = await getSpaCocClient().agentProviders.replaceEffortTiers(provider, map);
+            // Settings mutation — drop the cached tiers so other mounts refetch (AC-05).
+            invalidateConfig(configCacheKey.effortTiers(provider));
             const normalized = normalizeFromServer(response.effortTiers as ServerTierMap);
             setRemote(normalized);
             setLocal(normalized);
@@ -168,5 +190,5 @@ export function useProviderEffortTiers(provider: AgentProvider): UseProviderEffo
 
     const dirty = !configEntriesEqual(remote, local);
 
-    return { tiers: local, loading, error, saveError, saving, dirty, setTier, clearTier, save, cancel, reload: load };
+    return { tiers: local, loading, error, saveError, saving, dirty, setTier, clearTier, save, cancel, reload };
 }

--- a/packages/coc/src/server/spa/client/react/hooks/useProviderModels.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useProviderModels.ts
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect, useCallback } from 'react';
 import { getSpaCocClient, getSpaCocClientErrorMessage } from '../api/cocClient';
+import { getOrFetchConfig, peekConfig, invalidateConfig, configCacheKey } from '../api/staticConfigCache';
 
 /** Billing metadata preserved from the model catalog (e.g. tokenPrices.longContext.contextMax). */
 export interface ProviderModelBillingInfo {
@@ -97,6 +98,12 @@ function mapModel(m: RawModel): ProviderModelInfo {
     };
 }
 
+/** Maps a raw provider models response (`{ models }`) into ProviderModelInfo[]. */
+function mapModelsResponse(data: unknown): ProviderModelInfo[] {
+    const models = (data as { models?: unknown } | null | undefined)?.models;
+    return Array.isArray(models) ? models.map(mapModel) : [];
+}
+
 export type AgentProvider = 'copilot' | 'codex' | 'claude';
 
 export function useProviderModels(provider: AgentProvider): {
@@ -105,17 +112,29 @@ export function useProviderModels(provider: AgentProvider): {
     error: string | null;
     reload: () => void;
 } {
-    const [models, setModels] = useState<ProviderModelInfo[]>([]);
-    const [loading, setLoading] = useState(true);
+    const modelsKey = configCacheKey.models(provider);
+    // Seed from the session cache so a warm reopen paints with no loading flash.
+    const [models, setModels] = useState<ProviderModelInfo[]>(() => {
+        const cached = peekConfig(modelsKey);
+        return cached !== undefined ? mapModelsResponse(cached) : [];
+    });
+    const [loading, setLoading] = useState(() => peekConfig(modelsKey) === undefined);
     const [error, setError] = useState<string | null>(null);
 
     const load = useCallback(() => {
+        const key = configCacheKey.models(provider);
+        const cached = peekConfig(key);
+        if (cached !== undefined) {
+            setModels(mapModelsResponse(cached));
+            setError(null);
+            setLoading(false);
+            return;
+        }
         setLoading(true);
         setError(null);
-        getSpaCocClient().agentProviders.listModels(provider)
-            .then((data) => {
-                const arr = Array.isArray(data?.models) ? data.models.map(mapModel) : [];
-                setModels(arr);
+        getOrFetchConfig(key, () => getSpaCocClient().agentProviders.listModels(provider))
+            .then((data: unknown) => {
+                setModels(mapModelsResponse(data));
             })
             .catch((e: unknown) => { setError(getSpaCocClientErrorMessage(e, `Failed to load ${provider} models`)); })
             .finally(() => setLoading(false));
@@ -123,7 +142,13 @@ export function useProviderModels(provider: AgentProvider): {
 
     useEffect(() => { load(); }, [load]);
 
-    return { models, loading, error, reload: load };
+    /** Explicit reload: drop the cached catalog first so the fetch is fresh. */
+    const reload = useCallback(() => {
+        invalidateConfig(configCacheKey.models(provider));
+        load();
+    }, [provider, load]);
+
+    return { models, loading, error, reload };
 }
 
 export function useProviderModelConfig(provider: AgentProvider): {
@@ -146,13 +171,19 @@ export function useProviderModelConfig(provider: AgentProvider): {
     }, [models]);
 
     useEffect(() => {
-        getSpaCocClient().agentProviders.getReasoningEfforts(provider)
+        let cancelled = false;
+        getOrFetchConfig(
+            configCacheKey.reasoningEfforts(provider),
+            () => getSpaCocClient().agentProviders.getReasoningEfforts(provider),
+        )
             .then((data) => {
+                if (cancelled) return;
                 if (data?.reasoningEfforts && typeof data.reasoningEfforts === 'object') {
                     setReasoningEfforts(data.reasoningEfforts);
                 }
             })
             .catch(() => { /* reasoning efforts are optional */ });
+        return () => { cancelled = true; };
     }, [provider]);
 
     const toggleModel = useCallback(async (modelId: string, enabled: boolean) => {
@@ -162,6 +193,9 @@ export function useProviderModelConfig(provider: AgentProvider): {
             const updated = localModels.map(m => m.id === modelId ? { ...m, enabled } : m);
             const enabledModels = updated.filter(m => m.id === modelId ? enabled : m.enabled).map(m => m.id);
             await getSpaCocClient().agentProviders.setEnabledModels(provider, enabledModels);
+            // Enabled-model set changed — drop the cached catalog so other
+            // consumers (e.g. the chat model picker) refetch (AC-05).
+            invalidateConfig(configCacheKey.models(provider));
         } catch {
             setLocalModels(models);
         } finally {
@@ -180,6 +214,9 @@ export function useProviderModelConfig(provider: AgentProvider): {
         }
         try {
             await getSpaCocClient().agentProviders.setReasoningEffort(provider, modelId, effort);
+            // Reasoning-effort map changed — drop the cached map so the next
+            // read refetches (AC-05).
+            invalidateConfig(configCacheKey.reasoningEfforts(provider));
         } catch {
             setReasoningEfforts(prev);
         }

--- a/packages/coc/src/server/spa/client/react/hooks/useProviderReasoningEfforts.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useProviderReasoningEfforts.ts
@@ -12,15 +12,31 @@
  */
 import { useState, useEffect } from 'react';
 import { getSpaCocClient } from '../api/cocClient';
+import { getOrFetchConfig, peekConfig, configCacheKey } from '../api/staticConfigCache';
 import type { AgentProvider } from './useProviderModels';
 
+type ReasoningEffortsResponse = { reasoningEfforts?: Record<string, string> };
+
+function extractMap(data: ReasoningEffortsResponse | undefined): Record<string, string> {
+    return data?.reasoningEfforts && typeof data.reasoningEfforts === 'object' ? data.reasoningEfforts : {};
+}
+
 export function useProviderReasoningEfforts(provider: AgentProvider): Record<string, string> {
-    const [reasoningEfforts, setReasoningEfforts] = useState<Record<string, string>>({});
+    // Seed from the session cache so a warm reopen has the map immediately.
+    const [reasoningEfforts, setReasoningEfforts] = useState<Record<string, string>>(
+        () => extractMap(peekConfig<ReasoningEffortsResponse>(configCacheKey.reasoningEfforts(provider))),
+    );
 
     useEffect(() => {
+        const key = configCacheKey.reasoningEfforts(provider);
+        const cached = peekConfig<ReasoningEffortsResponse>(key);
+        if (cached !== undefined) {
+            setReasoningEfforts(extractMap(cached));
+            return;
+        }
         let cancelled = false;
-        getSpaCocClient().agentProviders.getReasoningEfforts(provider)
-            .then((data: { reasoningEfforts?: Record<string, string> }) => {
+        getOrFetchConfig(key, () => getSpaCocClient().agentProviders.getReasoningEfforts(provider))
+            .then((data: ReasoningEffortsResponse) => {
                 if (cancelled) return;
                 if (data?.reasoningEfforts && typeof data.reasoningEfforts === 'object') {
                     setReasoningEfforts(data.reasoningEfforts);

--- a/packages/coc/src/server/spa/client/react/utils/runWhenIdle.ts
+++ b/packages/coc/src/server/spa/client/react/utils/runWhenIdle.ts
@@ -1,0 +1,22 @@
+/**
+ * Run `callback` once the browser is idle — i.e. after the current critical
+ * render/paint work has settled — so a non-critical fetch does not compete with
+ * the message-render path (chat-load-perf AC-03). Uses `requestIdleCallback`
+ * where available and falls back to a macrotask `setTimeout` (Safari, jsdom).
+ * The `timeout` bound guarantees the work still runs promptly on a busy page,
+ * so deferred data still loads automatically rather than waiting for true idle.
+ *
+ * Returns a disposer that cancels the pending callback if it has not run yet —
+ * call it from an effect cleanup so a deferred fetch never fires after an
+ * unmount or a dependency change.
+ */
+export function runWhenIdle(callback: () => void, timeoutMs = 200): () => void {
+    if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+        const handle = window.requestIdleCallback(() => callback(), { timeout: timeoutMs });
+        return () => {
+            if (typeof window.cancelIdleCallback === 'function') window.cancelIdleCallback(handle);
+        };
+    }
+    const handle = setTimeout(callback, 0);
+    return () => clearTimeout(handle);
+}

--- a/packages/coc/test/server/agent-provider-effort-tiers-routes.test.ts
+++ b/packages/coc/test/server/agent-provider-effort-tiers-routes.test.ts
@@ -117,10 +117,11 @@ async function stopServer(): Promise<void> {
     return new Promise(resolve => server.close(() => resolve()));
 }
 
-async function apiGet(path: string): Promise<{ status: number; body: unknown }> {
+async function apiGet(path: string): Promise<{ status: number; body: unknown; cacheControl: string | null }> {
     const res = await fetch(`${baseUrl}${path}`);
+    const cacheControl = res.headers.get('cache-control');
     const body = await res.json();
-    return { status: res.status, body };
+    return { status: res.status, body, cacheControl };
 }
 
 async function apiPut(path: string, payload: unknown): Promise<{ status: number; body: unknown }> {
@@ -261,6 +262,27 @@ describe('GET /api/agent-providers/:provider/effort-tiers', () => {
         const { status, body } = await apiGet('/api/agent-providers/invalid/effort-tiers');
         expect(status).toBe(400);
         expect((body as { error: string }).error).toContain('Invalid provider');
+    });
+
+    // AC-04: short-lived HTTP cache so a cold reload within the TTL skips the round-trip.
+    it('sets a short-lived private Cache-Control header on the 200', async () => {
+        const ctx = makeCtx({ ...makeConfigFunctions({}) });
+        server = makeServer(ctx);
+        await startServer();
+
+        const { status, cacheControl } = await apiGet('/api/agent-providers/copilot/effort-tiers');
+        expect(status).toBe(200);
+        expect(cacheControl).toBe('private, max-age=60');
+    });
+
+    it('does not set Cache-Control on the 400 invalid-provider response', async () => {
+        const ctx = makeCtx();
+        server = makeServer(ctx);
+        await startServer();
+
+        const { status, cacheControl } = await apiGet('/api/agent-providers/invalid/effort-tiers');
+        expect(status).toBe(400);
+        expect(cacheControl).toBeNull();
     });
 
     it('isolates providers — codex tiers not visible on copilot', async () => {

--- a/packages/coc/test/server/agent-provider-model-routes.test.ts
+++ b/packages/coc/test/server/agent-provider-model-routes.test.ts
@@ -113,10 +113,11 @@ async function stopServer(): Promise<void> {
     return new Promise(resolve => server.close(() => resolve()));
 }
 
-async function apiGet(path: string): Promise<{ status: number; body: unknown }> {
+async function apiGet(path: string): Promise<{ status: number; body: unknown; cacheControl: string | null }> {
     const res = await fetch(`${baseUrl}${path}`);
+    const cacheControl = res.headers.get('cache-control');
     const body = await res.json();
-    return { status: res.status, body };
+    return { status: res.status, body, cacheControl };
 }
 
 async function apiPut(path: string, payload: unknown): Promise<{ status: number; body: unknown }> {
@@ -406,6 +407,27 @@ describe('GET /api/agent-providers/:provider/models/reasoning-efforts', () => {
         expect(status).toBe(200);
         const data = body as { provider: string; reasoningEfforts: Record<string, string> };
         expect(data.reasoningEfforts).toEqual({ 'model-y': 'low' });
+    });
+
+    // AC-04: short-lived HTTP cache so a cold reload within the TTL skips the round-trip.
+    it('sets a short-lived private Cache-Control header on the 200', async () => {
+        const ctx = makeCtx({ ...makeConfigFunctions({}) });
+        server = makeServer(ctx);
+        await startServer();
+
+        const { status, cacheControl } = await apiGet('/api/agent-providers/copilot/models/reasoning-efforts');
+        expect(status).toBe(200);
+        expect(cacheControl).toBe('private, max-age=60');
+    });
+
+    it('does not set Cache-Control on the 400 invalid-provider response', async () => {
+        const ctx = makeCtx();
+        server = makeServer(ctx);
+        await startServer();
+
+        const { status, cacheControl } = await apiGet('/api/agent-providers/bogus/models/reasoning-efforts');
+        expect(status).toBe(400);
+        expect(cacheControl).toBeNull();
     });
 });
 

--- a/packages/coc/test/server/llm-tools-config-api.test.ts
+++ b/packages/coc/test/server/llm-tools-config-api.test.ts
@@ -34,7 +34,7 @@ vi.mock('@plusplusoneplusplus/forge', async (importOriginal) => {
 function request(
     url: string,
     options: { method?: string; body?: string; headers?: Record<string, string> } = {},
-): Promise<{ status: number; body: string; json: () => any }> {
+): Promise<{ status: number; body: string; json: () => any; headers: http.IncomingHttpHeaders }> {
     return new Promise((resolve, reject) => {
         const parsed = new URL(url);
         const req = http.request(
@@ -54,6 +54,7 @@ function request(
                         status: res.statusCode || 0,
                         body: bodyStr,
                         json: () => JSON.parse(bodyStr),
+                        headers: res.headers,
                     });
                 });
             },
@@ -123,6 +124,19 @@ describe('LLM Tools Config API endpoints', () => {
         it('returns 404 when workspace not found', async () => {
             const res = await request(`${base()}/api/workspaces/unknown-ws/llm-tools-config`);
             expect(res.status).toBe(404);
+        });
+
+        // AC-04: short-lived HTTP cache so a cold reload within the TTL skips the round-trip.
+        it('sets a short-lived private Cache-Control header on the 200', async () => {
+            const res = await request(`${base()}/api/workspaces/${WORKSPACE_ID}/llm-tools-config`);
+            expect(res.status).toBe(200);
+            expect(res.headers['cache-control']).toBe('private, max-age=60');
+        });
+
+        it('does not set Cache-Control on the 404 unknown-workspace response', async () => {
+            const res = await request(`${base()}/api/workspaces/unknown-ws/llm-tools-config`);
+            expect(res.status).toBe(404);
+            expect(res.headers['cache-control']).toBeUndefined();
         });
 
         it('returns all tools from the registry', async () => {

--- a/packages/coc/test/server/queue-handler.test.ts
+++ b/packages/coc/test/server/queue-handler.test.ts
@@ -582,6 +582,15 @@ describe('Queue Handler', () => {
             expect(body.models).toContain('claude-haiku-4.5');
         });
 
+        // AC-04: short-lived HTTP cache so a cold reload within the TTL skips the round-trip.
+        it('sets a short-lived private Cache-Control header on the 200', async () => {
+            const srv = await startServer();
+
+            const res = await request(`${srv.url}/api/queue/models`);
+            expect(res.status).toBe(200);
+            expect(res.headers['cache-control']).toBe('private, max-age=60');
+        });
+
         it('should resolve provider from the queue route context', async () => {
             const routes: any[] = [];
             let providerLookups = 0;

--- a/packages/coc/test/setup.ts
+++ b/packages/coc/test/setup.ts
@@ -6,10 +6,19 @@
  * should inject a mock `aiService` via `createExecutionServer({ aiService })`.
  */
 
-import { vi, expect } from 'vitest';
+import { vi, expect, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
+import { _clearConfigCache } from '../src/server/spa/client/react/api/staticConfigCache';
 
 expect.extend(matchers);
+
+// The static-config client cache is a module-level singleton that persists for
+// the lifetime of a test file. Clear it before every test so a provider/
+// workspace config cached by one test never leaks into the next and silently
+// suppresses an expected refetch.
+beforeEach(() => {
+    _clearConfigCache();
+});
 
 // Mock @excalidraw/excalidraw — the package imports open-color.json without
 // `type: "json"` import assertions, which fails on Node.js ≥ 24. Since tests

--- a/packages/coc/test/spa/react/ChatPrStatusCard.test.tsx
+++ b/packages/coc/test/spa/react/ChatPrStatusCard.test.tsx
@@ -363,6 +363,27 @@ describe('ChatPrStatusCard / usePrChatStatusItems', () => {
         expect(mocks.pullRequests.getForOrigin).not.toHaveBeenCalled();
     });
 
+    it('AC-03: defers the bindings round-trip past the synchronous mount', async () => {
+        vi.useFakeTimers();
+        try {
+            mocks.pullRequests.listChatBindingsForOrigin.mockResolvedValue({ bindings: {} });
+            // Empty turns → no detected PRs → no detail fetch; isolates the
+            // bindings probe itself for the deferral assertion.
+            render(
+                <ChatPrStatusCard turns={[]} workspaceId="ws1" remoteUrl={GH_REMOTE} taskId="t1" />,
+            );
+            // The bindings probe is non-critical chrome: it must NOT fire during
+            // the synchronous mount/effect commit — it is deferred to browser
+            // idle so the conversation paints first.
+            expect(mocks.pullRequests.listChatBindingsForOrigin).not.toHaveBeenCalled();
+            // Once the browser idles (macrotask fallback in jsdom), it loads.
+            await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+            expect(mocks.pullRequests.listChatBindingsForOrigin).toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('regression: a remote workspace routes through getCocClientForWorkspace, never the local client', async () => {
         // A remote-owned chat: the workspace id only resolves on its remote server.
         // Resolving it against the local client 404s with "Repo <ws> not found".

--- a/packages/coc/test/spa/react/api/staticConfigCache.test.ts
+++ b/packages/coc/test/spa/react/api/staticConfigCache.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for staticConfigCache — the session-scoped, in-memory cache for static
+ * provider/workspace config (models, reasoning-efforts, effort-tiers per
+ * provider; llm-tools-config per workspace).
+ *
+ * Covers the foundational behaviour for:
+ *  - AC-01: a second read of an already-cached key returns from cache with no
+ *    network call; a read for a new key fetches once and populates the cache.
+ *  - AC-05: after invalidating a key, the next read fetches fresh instead of
+ *    returning the stale cached value.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    getOrFetchConfig,
+    peekConfig,
+    invalidateConfig,
+    configCacheKey,
+    DEFAULT_CONFIG_TTL_MS,
+    _clearConfigCache,
+    _getConfigCacheSize,
+} from '../../../../src/server/spa/client/react/api/staticConfigCache';
+
+/** Resolves the microtask queue so `.then` callbacks on already-settled promises run. */
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+beforeEach(() => {
+    _clearConfigCache();
+});
+
+describe('configCacheKey', () => {
+    it('keys provider-scoped config by provider and workspace config by workspace', () => {
+        expect(configCacheKey.models('copilot')).toBe('models:copilot');
+        expect(configCacheKey.reasoningEfforts('codex')).toBe('reasoning-efforts:codex');
+        expect(configCacheKey.effortTiers('claude')).toBe('effort-tiers:claude');
+        expect(configCacheKey.llmToolsConfig('ws-1')).toBe('llm-tools-config:ws-1');
+    });
+
+    it('produces distinct keys per provider so different providers never collide', () => {
+        expect(configCacheKey.models('copilot')).not.toBe(configCacheKey.models('codex'));
+    });
+});
+
+describe('getOrFetchConfig — AC-01 cache reads', () => {
+    it('fetches once for a new key and populates the cache', async () => {
+        const fetcher = vi.fn().mockResolvedValue({ models: ['a'] });
+
+        const value = await getOrFetchConfig('models:copilot', fetcher);
+
+        expect(value).toEqual({ models: ['a'] });
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        expect(_getConfigCacheSize()).toBe(1);
+    });
+
+    it('returns from cache with NO network call on the second read of the same key', async () => {
+        const fetcher = vi.fn().mockResolvedValue({ models: ['a'] });
+
+        const first = await getOrFetchConfig('models:copilot', fetcher);
+        const second = await getOrFetchConfig('models:copilot', fetcher);
+
+        expect(second).toBe(first); // identical cached reference
+        expect(fetcher).toHaveBeenCalledTimes(1); // not called again
+    });
+
+    it('fetches separately for a different (not-yet-seen) key', async () => {
+        const copilot = vi.fn().mockResolvedValue('copilot-models');
+        const codex = vi.fn().mockResolvedValue('codex-models');
+
+        await getOrFetchConfig(configCacheKey.models('copilot'), copilot);
+        await getOrFetchConfig(configCacheKey.models('codex'), codex);
+
+        expect(copilot).toHaveBeenCalledTimes(1);
+        expect(codex).toHaveBeenCalledTimes(1);
+        expect(_getConfigCacheSize()).toBe(2);
+
+        // Re-reading copilot stays a cache hit; codex's fetch did not disturb it.
+        await getOrFetchConfig(configCacheKey.models('copilot'), copilot);
+        expect(copilot).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes concurrent in-flight reads of the same key into a single fetch', async () => {
+        let resolveFetch: (value: unknown) => void = () => {};
+        const fetcher = vi.fn().mockReturnValue(new Promise(resolve => { resolveFetch = resolve; }));
+
+        const p1 = getOrFetchConfig('models:copilot', fetcher);
+        const p2 = getOrFetchConfig('models:copilot', fetcher);
+
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        resolveFetch({ models: ['x'] });
+        const [r1, r2] = await Promise.all([p1, p2]);
+
+        expect(r1).toEqual({ models: ['x'] });
+        expect(r2).toEqual({ models: ['x'] });
+        expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a rejected fetch — the next read retries', async () => {
+        const fetcher = vi.fn()
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockResolvedValueOnce('recovered');
+
+        await expect(getOrFetchConfig('models:copilot', fetcher)).rejects.toThrow('boom');
+        expect(_getConfigCacheSize()).toBe(0);
+
+        const value = await getOrFetchConfig('models:copilot', fetcher);
+        expect(value).toBe('recovered');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('getOrFetchConfig — TTL expiry', () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('serves from cache within the TTL and refetches after it lapses', async () => {
+        const fetcher = vi.fn()
+            .mockResolvedValueOnce('first')
+            .mockResolvedValueOnce('second');
+
+        const a = await getOrFetchConfig('models:copilot', fetcher, 1000);
+        expect(a).toBe('first');
+
+        // Within TTL: cache hit, no refetch.
+        vi.advanceTimersByTime(500);
+        const b = await getOrFetchConfig('models:copilot', fetcher, 1000);
+        expect(b).toBe('first');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        // Past TTL: refetch.
+        vi.advanceTimersByTime(600);
+        const c = await getOrFetchConfig('models:copilot', fetcher, 1000);
+        expect(c).toBe('second');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('defaults to a 60-minute TTL matching the conversation cache', async () => {
+        const fetcher = vi.fn()
+            .mockResolvedValueOnce('first')
+            .mockResolvedValueOnce('second');
+
+        await getOrFetchConfig('models:copilot', fetcher);
+
+        // Just before the default TTL — still cached.
+        vi.advanceTimersByTime(DEFAULT_CONFIG_TTL_MS - 1);
+        expect(await getOrFetchConfig('models:copilot', fetcher)).toBe('first');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        // Just past the default TTL — refetch.
+        vi.advanceTimersByTime(2);
+        expect(await getOrFetchConfig('models:copilot', fetcher)).toBe('second');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('invalidateConfig — AC-05 invalidate-on-mutate', () => {
+    it('drops the key so the next read fetches fresh instead of the stale value', async () => {
+        const fetcher = vi.fn()
+            .mockResolvedValueOnce('stale')
+            .mockResolvedValueOnce('fresh');
+
+        expect(await getOrFetchConfig('effort-tiers:copilot', fetcher)).toBe('stale');
+
+        invalidateConfig('effort-tiers:copilot');
+        expect(_getConfigCacheSize()).toBe(0);
+
+        expect(await getOrFetchConfig('effort-tiers:copilot', fetcher)).toBe('fresh');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidating one key leaves other keys cached', async () => {
+        const copilot = vi.fn().mockResolvedValue('copilot');
+        const codex = vi.fn().mockResolvedValue('codex');
+
+        await getOrFetchConfig(configCacheKey.effortTiers('copilot'), copilot);
+        await getOrFetchConfig(configCacheKey.effortTiers('codex'), codex);
+
+        invalidateConfig(configCacheKey.effortTiers('copilot'));
+
+        // codex still cached — no refetch.
+        await getOrFetchConfig(configCacheKey.effortTiers('codex'), codex);
+        expect(codex).toHaveBeenCalledTimes(1);
+
+        // copilot refetches.
+        await getOrFetchConfig(configCacheKey.effortTiers('copilot'), copilot);
+        expect(copilot).toHaveBeenCalledTimes(2);
+    });
+
+    it('is a no-op for an unknown key', () => {
+        invalidateConfig('never-cached');
+        expect(_getConfigCacheSize()).toBe(0);
+    });
+});
+
+describe('peekConfig', () => {
+    it('returns undefined when the key is not cached', () => {
+        expect(peekConfig('models:copilot')).toBeUndefined();
+    });
+
+    it('returns the cached value synchronously after a fetch populates it', async () => {
+        await getOrFetchConfig('models:copilot', vi.fn().mockResolvedValue('cached'));
+        expect(peekConfig('models:copilot')).toBe('cached');
+    });
+
+    it('does not trigger a fetch', () => {
+        const fetcher = vi.fn();
+        peekConfig('models:copilot');
+        expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined once the entry is past its TTL', async () => {
+        vi.useFakeTimers();
+        try {
+            await getOrFetchConfig('models:copilot', vi.fn().mockResolvedValue('cached'), 1000);
+            expect(peekConfig('models:copilot', 1000)).toBe('cached');
+            vi.advanceTimersByTime(1500);
+            expect(peekConfig('models:copilot', 1000)).toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe('_clearConfigCache', () => {
+    it('empties all cached entries', async () => {
+        await getOrFetchConfig('models:copilot', vi.fn().mockResolvedValue('a'));
+        await getOrFetchConfig('models:codex', vi.fn().mockResolvedValue('b'));
+        expect(_getConfigCacheSize()).toBe(2);
+
+        _clearConfigCache();
+        expect(_getConfigCacheSize()).toBe(0);
+    });
+
+    it('also clears in-flight promises so a fresh fetch starts after clear', async () => {
+        const fetcher = vi.fn().mockReturnValue(new Promise(() => { /* never resolves */ }));
+        getOrFetchConfig('models:copilot', fetcher);
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        _clearConfigCache();
+
+        const fetcher2 = vi.fn().mockResolvedValue('done');
+        const value = await getOrFetchConfig('models:copilot', fetcher2);
+        expect(value).toBe('done');
+        expect(fetcher2).toHaveBeenCalledTimes(1);
+        await flush();
+    });
+});

--- a/packages/coc/test/spa/react/hooks/providerConfigCache.test.ts
+++ b/packages/coc/test/spa/react/hooks/providerConfigCache.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration tests for AC-01 / AC-05: the provider-config hooks
+ * (useModels, useModelConfig, useProviderModels, useProviderReasoningEfforts,
+ * useProviderEffortTiers) read through the shared staticConfigCache.
+ *
+ * Verifies that:
+ *  - a warm second open of an already-seen provider issues NO network call and
+ *    paints without a loading flash (AC-01),
+ *  - a not-yet-seen provider fetches exactly once and populates the cache,
+ *  - useModels and useProviderModels share the per-provider models key, and
+ *  - a settings mutation (reload / save / setReasoningEffort) invalidates the
+ *    key so the next read refetches (AC-05).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+    agentProviders: {
+        listModels: vi.fn(),
+        setEnabledModels: vi.fn(),
+        getReasoningEfforts: vi.fn(),
+        setReasoningEffort: vi.fn(),
+        getEffortTiers: vi.fn(),
+        replaceEffortTiers: vi.fn(),
+    },
+}));
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../../src/server/spa/client/react/api/cocClient')>();
+    return {
+        ...actual,
+        getSpaCocClient: () => ({ agentProviders: mocks.agentProviders }),
+    };
+});
+
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    getActiveProvider: () => 'copilot',
+}));
+
+import { useModels, useModelConfig } from '../../../../src/server/spa/client/react/hooks/useModels';
+import { useProviderModels } from '../../../../src/server/spa/client/react/hooks/useProviderModels';
+import { useProviderReasoningEfforts } from '../../../../src/server/spa/client/react/hooks/useProviderReasoningEfforts';
+import { useProviderEffortTiers } from '../../../../src/server/spa/client/react/hooks/useProviderEffortTiers';
+import {
+    _clearConfigCache,
+    peekConfig,
+    configCacheKey,
+} from '../../../../src/server/spa/client/react/api/staticConfigCache';
+
+beforeEach(() => {
+    _clearConfigCache();
+    for (const fn of Object.values(mocks.agentProviders)) fn.mockReset();
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('provider-config hooks share the static-config cache (AC-01)', () => {
+    it('useModels fetches once per provider and serves a warm second open from cache', async () => {
+        mocks.agentProviders.listModels.mockResolvedValue({ provider: 'copilot', models: [{ id: 'm1', name: 'M1' }] });
+
+        const first = renderHook(() => useModels('copilot'));
+        await waitFor(() => expect(first.result.current.loading).toBe(false));
+        expect(first.result.current.models).toHaveLength(1);
+        expect(mocks.agentProviders.listModels).toHaveBeenCalledTimes(1);
+        first.unmount();
+
+        // Warm reopen: loading is already false on the first render (seeded from
+        // the cache) and no second network call is made.
+        const second = renderHook(() => useModels('copilot'));
+        expect(second.result.current.loading).toBe(false);
+        expect(second.result.current.models).toHaveLength(1);
+        expect(mocks.agentProviders.listModels).toHaveBeenCalledTimes(1);
+    });
+
+    it('useModels fetches a not-yet-seen provider exactly once', async () => {
+        mocks.agentProviders.listModels.mockResolvedValue({ provider: 'codex', models: [] });
+
+        // 'copilot' is already cached but 'codex' is new — only codex fetches.
+        const copilot = { provider: 'copilot', models: [] };
+        mocks.agentProviders.listModels.mockResolvedValueOnce(copilot);
+        const a = renderHook(() => useModels('copilot'));
+        await waitFor(() => expect(a.result.current.loading).toBe(false));
+        a.unmount();
+        const callsAfterCopilot = mocks.agentProviders.listModels.mock.calls.length;
+
+        const b = renderHook(() => useModels('codex'));
+        await waitFor(() => expect(b.result.current.loading).toBe(false));
+        expect(mocks.agentProviders.listModels).toHaveBeenCalledWith('codex');
+        expect(mocks.agentProviders.listModels.mock.calls.length).toBe(callsAfterCopilot + 1);
+    });
+
+    it('useModels and useProviderModels share the per-provider models cache key', async () => {
+        mocks.agentProviders.listModels.mockResolvedValue({ provider: 'copilot', models: [] });
+
+        const a = renderHook(() => useModels('copilot'));
+        await waitFor(() => expect(a.result.current.loading).toBe(false));
+        a.unmount();
+
+        const b = renderHook(() => useProviderModels('copilot'));
+        await waitFor(() => expect(b.result.current.loading).toBe(false));
+        // Shared cache → a single network call total across both hooks.
+        expect(mocks.agentProviders.listModels).toHaveBeenCalledTimes(1);
+    });
+
+    it('useProviderReasoningEfforts serves a warm reopen synchronously from cache', async () => {
+        mocks.agentProviders.getReasoningEfforts.mockResolvedValue({ reasoningEfforts: { 'model-a': 'high' } });
+
+        const first = renderHook(() => useProviderReasoningEfforts('copilot'));
+        await waitFor(() => expect(first.result.current).toEqual({ 'model-a': 'high' }));
+        first.unmount();
+
+        const second = renderHook(() => useProviderReasoningEfforts('copilot'));
+        // Seeded from cache on the very first render — no empty-map flash.
+        expect(second.result.current).toEqual({ 'model-a': 'high' });
+        expect(mocks.agentProviders.getReasoningEfforts).toHaveBeenCalledTimes(1);
+    });
+
+    it('useProviderEffortTiers serves a warm reopen from cache without a loading flash', async () => {
+        mocks.agentProviders.getEffortTiers.mockResolvedValue({ provider: 'copilot', effortTiers: {}, defaults: {} });
+
+        const first = renderHook(() => useProviderEffortTiers('copilot'));
+        await waitFor(() => expect(first.result.current.loading).toBe(false));
+        first.unmount();
+
+        const second = renderHook(() => useProviderEffortTiers('copilot'));
+        expect(second.result.current.loading).toBe(false);
+        expect(mocks.agentProviders.getEffortTiers).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('settings mutations invalidate the cache (AC-05)', () => {
+    it('useModels reload() invalidates the models key and refetches', async () => {
+        mocks.agentProviders.listModels.mockResolvedValue({ provider: 'copilot', models: [] });
+
+        const { result } = renderHook(() => useModels('copilot'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(mocks.agentProviders.listModels).toHaveBeenCalledTimes(1);
+
+        act(() => { result.current.reload(); });
+        await waitFor(() => expect(mocks.agentProviders.listModels).toHaveBeenCalledTimes(2));
+    });
+
+    it('useModelConfig.setReasoningEffort invalidates the reasoning-efforts key', async () => {
+        mocks.agentProviders.listModels.mockResolvedValue({ provider: 'copilot', models: [{ id: 'a', name: 'A' }] });
+        mocks.agentProviders.getReasoningEfforts.mockResolvedValue({ reasoningEfforts: {} });
+        mocks.agentProviders.setReasoningEffort.mockResolvedValue({ reasoningEfforts: { a: 'high' } });
+
+        const { result } = renderHook(() => useModelConfig());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        await waitFor(() => expect(peekConfig(configCacheKey.reasoningEfforts('copilot'))).toBeDefined());
+
+        await act(async () => { await result.current.setReasoningEffort('a', 'high'); });
+
+        expect(peekConfig(configCacheKey.reasoningEfforts('copilot'))).toBeUndefined();
+    });
+
+    it('useProviderEffortTiers.save() invalidates the cache so the next open refetches', async () => {
+        mocks.agentProviders.getEffortTiers.mockResolvedValue({ provider: 'copilot', effortTiers: {}, defaults: {} });
+        mocks.agentProviders.replaceEffortTiers.mockResolvedValue({
+            provider: 'copilot',
+            effortTiers: { high: { model: 'x', reasoningEffort: 'high', source: 'config' } },
+            defaults: {},
+        });
+
+        const first = renderHook(() => useProviderEffortTiers('copilot'));
+        await waitFor(() => expect(first.result.current.loading).toBe(false));
+
+        act(() => { first.result.current.setTier('high', 'x', 'high'); });
+        await act(async () => { await first.result.current.save(); });
+
+        expect(peekConfig(configCacheKey.effortTiers('copilot'))).toBeUndefined();
+        first.unmount();
+
+        const second = renderHook(() => useProviderEffortTiers('copilot'));
+        await waitFor(() => expect(second.result.current.loading).toBe(false));
+        // The save dropped the key, so reopening refetches (2 GETs total).
+        expect(mocks.agentProviders.getEffortTiers).toHaveBeenCalledTimes(2);
+    });
+
+    it('useProviderEffortTiers.reload() invalidates the cache and refetches', async () => {
+        mocks.agentProviders.getEffortTiers
+            .mockResolvedValueOnce({ provider: 'copilot', effortTiers: {}, defaults: {} })
+            .mockResolvedValueOnce({
+                provider: 'copilot',
+                effortTiers: { medium: { model: 'mid', reasoningEffort: 'medium', source: 'config' } },
+                defaults: {},
+            });
+
+        const { result } = renderHook(() => useProviderEffortTiers('copilot'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.tiers.medium).toBeUndefined();
+
+        act(() => { result.current.reload(); });
+        await waitFor(() => expect(result.current.tiers.medium?.model).toBe('mid'));
+        expect(mocks.agentProviders.getEffortTiers).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/coc/test/spa/react/hooks/useUnseenChat.test.ts
+++ b/packages/coc/test/spa/react/hooks/useUnseenChat.test.ts
@@ -591,6 +591,106 @@ describe('useUnseenChat', () => {
             expect(result.current.unseenProcessIds.has('b')).toBe(true);
         });
     });
+
+    // AC-02 (count half): the mark fns report whether the seen-state actually
+    // changed so RepoChatTab can gate the workspace-scoped count refetch and
+    // avoid re-firing it on a warm reopen of an already-seen conversation.
+    describe('mark fns return whether seen-state changed', () => {
+        it('markSeen returns true on a real transition and false on a no-op', async () => {
+            const history = makeTasks('a');
+            // Server reports an older seenAt → 'a' is currently unseen.
+            mockFetchSeenMap.mockResolvedValue({ a: 'old-value' });
+            const { result } = renderHook(() => useUnseenChat('ws1', history, null));
+
+            await waitFor(() => {
+                expect(result.current.unseenProcessIds.has('a')).toBe(true);
+            });
+
+            let first: boolean | undefined;
+            act(() => { first = result.current.markSeen('a'); });
+            expect(first).toBe(true);
+
+            // Reopening the now-seen task is a no-op → no count refetch upstream.
+            let second: boolean | undefined;
+            act(() => { second = result.current.markSeen('a'); });
+            expect(second).toBe(false);
+        });
+
+        it('markSeen returns false for a task without a completion timestamp', async () => {
+            mockFetchSeenMap.mockResolvedValue({ other: '2026-01-01T00:00:00Z' });
+            const history = [{ id: 'r', status: 'running' }];
+            const { result } = renderHook(() => useUnseenChat('ws1', history, null));
+
+            await waitFor(() => {
+                expect(mockFetchSeenMap).toHaveBeenCalled();
+            });
+
+            let changed: boolean | undefined;
+            act(() => { changed = result.current.markSeen('r'); });
+            expect(changed).toBe(false);
+        });
+
+        it('markAllSeen returns true when something changed, then false when already all seen', async () => {
+            const history = makeTasks('a', 'b');
+            mockFetchSeenMap.mockResolvedValue({ a: 'old' }); // 'a' unseen, 'b' unseen (absent)
+            const { result } = renderHook(() => useUnseenChat('ws1', history, null));
+
+            await waitFor(() => {
+                expect(result.current.unseenCount).toBeGreaterThan(0);
+            });
+
+            let first: boolean | undefined;
+            act(() => { first = result.current.markAllSeen(); });
+            expect(first).toBe(true);
+
+            let second: boolean | undefined;
+            act(() => { second = result.current.markAllSeen(); });
+            expect(second).toBe(false);
+        });
+
+        it('markTasksSeen returns false for an empty list and true when it changes state', async () => {
+            const history = makeTasks('a', 'b');
+            mockFetchSeenMap.mockResolvedValue({ a: 'old' });
+            const { result } = renderHook(() => useUnseenChat('ws1', history, null));
+
+            await waitFor(() => {
+                expect(result.current.unseenProcessIds.has('a')).toBe(true);
+            });
+
+            let empty: boolean | undefined;
+            act(() => { empty = result.current.markTasksSeen([]); });
+            expect(empty).toBe(false);
+
+            let changed: boolean | undefined;
+            act(() => { changed = result.current.markTasksSeen([history[0]]); });
+            expect(changed).toBe(true);
+
+            let again: boolean | undefined;
+            act(() => { again = result.current.markTasksSeen([history[0]]); });
+            expect(again).toBe(false);
+        });
+
+        it('markUnseen returns true when an entry is removed and false otherwise', async () => {
+            const history = makeTasks('a', 'b');
+            mockFetchSeenMap.mockResolvedValue({
+                a: history[0].completedAt,
+                b: history[1].completedAt,
+            });
+            const { result } = renderHook(() => useUnseenChat('ws1', history, null));
+
+            await waitFor(() => {
+                expect(result.current.unseenCount).toBe(0);
+            });
+
+            let removed: boolean | undefined;
+            act(() => { removed = result.current.markUnseen('a'); });
+            expect(removed).toBe(true);
+
+            let again: boolean | undefined;
+            act(() => { again = result.current.markUnseen('a'); });
+            expect(again).toBe(false);
+        });
+    });
 });
 
 describe('getTaskCompletedAtIso', () => {

--- a/packages/coc/test/spa/react/hooks/workspaceConfigCache.test.tsx
+++ b/packages/coc/test/spa/react/hooks/workspaceConfigCache.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Integration tests for AC-01 / AC-05 (workspace half): the `llm-tools-config`
+ * consumers — LlmToolsPanel (settings) and useConversationRetrievalCapability
+ * (per-conversation chat check) — read through the shared staticConfigCache
+ * keyed by workspace.
+ *
+ * Verifies that:
+ *  - a warm second open of an already-seen workspace issues NO network call and
+ *    paints without a loading/null flash (AC-01),
+ *  - a not-yet-seen workspace fetches exactly once and populates the cache,
+ *  - both consumers share the per-workspace key (one call total), and
+ *  - a settings mutation (the LlmToolsPanel toggle) invalidates the key so the
+ *    next read refetches (AC-05).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, renderHook, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const mocks = vi.hoisted(() => ({
+    addToast: vi.fn(),
+    preferences: {
+        getLlmToolsConfig: vi.fn(),
+        updateLlmToolsConfig: vi.fn(),
+    },
+}));
+
+// LlmToolsPanel reads via the default origin client.
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({ preferences: mocks.preferences }),
+}));
+
+// useConversationRetrievalCapability reads via the selected clone's client.
+vi.mock('../../../../src/server/spa/client/react/repos/cloneRouting', () => ({
+    useCocClient: () => ({ preferences: mocks.preferences }),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/contexts/ToastContext', () => ({
+    useGlobalToast: () => ({ addToast: mocks.addToast }),
+}));
+
+import { LlmToolsPanel } from '../../../../src/server/spa/client/react/features/repo-settings/LlmToolsPanel';
+import { useConversationRetrievalCapability } from '../../../../src/server/spa/client/react/features/chat/sessionContextDrop';
+import {
+    _clearConfigCache,
+    peekConfig,
+    configCacheKey,
+} from '../../../../src/server/spa/client/react/api/staticConfigCache';
+
+const GET_CONVO_TOOL = { name: 'get_conversation', label: 'Get Conversation', description: '', enabledByDefault: true };
+
+/** Config in which conversation retrieval is fully available. */
+function availableConfig(disabled: string[] = []) {
+    return { tools: [GET_CONVO_TOOL], disabledLlmTools: disabled, conversationRetrievalAvailable: true };
+}
+
+beforeEach(() => {
+    _clearConfigCache();
+    mocks.preferences.getLlmToolsConfig.mockReset();
+    mocks.preferences.updateLlmToolsConfig.mockReset();
+    mocks.addToast.mockReset();
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('llm-tools-config consumers share the per-workspace static-config cache (AC-01)', () => {
+    it('LlmToolsPanel fetches once per workspace and serves a warm reopen from cache', async () => {
+        mocks.preferences.getLlmToolsConfig.mockResolvedValue(availableConfig());
+
+        const first = render(<LlmToolsPanel workspaceId="ws-1" />);
+        await waitFor(() => expect(screen.getByTestId('llm-tools-panel')).toBeTruthy());
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledTimes(1);
+        first.unmount();
+
+        // Warm reopen: panel paints immediately (no loading flash) and no 2nd fetch.
+        const second = render(<LlmToolsPanel workspaceId="ws-1" />);
+        expect(screen.getByTestId('llm-tools-panel')).toBeTruthy();
+        expect(screen.queryByTestId('llm-tools-loading')).toBeNull();
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledTimes(1);
+        second.unmount();
+    });
+
+    it('useConversationRetrievalCapability serves a warm reopen synchronously from cache', async () => {
+        mocks.preferences.getLlmToolsConfig.mockResolvedValue(availableConfig());
+
+        const first = renderHook(() => useConversationRetrievalCapability('ws-2', true));
+        await waitFor(() => expect(first.result.current).toBe(true));
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledTimes(1);
+        first.unmount();
+
+        // Seeded from cache on the very first render — no transient null flash.
+        const second = renderHook(() => useConversationRetrievalCapability('ws-2', true));
+        expect(second.result.current).toBe(true);
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('LlmToolsPanel and useConversationRetrievalCapability share the per-workspace key', async () => {
+        mocks.preferences.getLlmToolsConfig.mockResolvedValue(availableConfig());
+
+        const panel = render(<LlmToolsPanel workspaceId="ws-3" />);
+        await waitFor(() => expect(screen.getByTestId('llm-tools-panel')).toBeTruthy());
+        panel.unmount();
+
+        const hook = renderHook(() => useConversationRetrievalCapability('ws-3', true));
+        await waitFor(() => expect(hook.result.current).toBe(true));
+        // Shared cache → a single network call total across both consumers.
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('useConversationRetrievalCapability fetches a not-yet-seen workspace exactly once', async () => {
+        mocks.preferences.getLlmToolsConfig.mockResolvedValue(availableConfig());
+
+        const a = renderHook(() => useConversationRetrievalCapability('ws-a', true));
+        await waitFor(() => expect(a.result.current).not.toBeNull());
+        a.unmount();
+        const callsAfterA = mocks.preferences.getLlmToolsConfig.mock.calls.length;
+
+        const b = renderHook(() => useConversationRetrievalCapability('ws-b', true));
+        await waitFor(() => expect(b.result.current).not.toBeNull());
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledWith('ws-b');
+        expect(mocks.preferences.getLlmToolsConfig.mock.calls.length).toBe(callsAfterA + 1);
+    });
+
+    it('useConversationRetrievalCapability returns false without fetching when disabled', async () => {
+        const { result } = renderHook(() => useConversationRetrievalCapability('ws-off', false));
+        expect(result.current).toBe(false);
+        expect(mocks.preferences.getLlmToolsConfig).not.toHaveBeenCalled();
+    });
+});
+
+describe('the LlmToolsPanel toggle invalidates the per-workspace cache (AC-05)', () => {
+    it('drops the workspace key on save so the next read refetches', async () => {
+        mocks.preferences.getLlmToolsConfig.mockResolvedValue(availableConfig());
+        mocks.preferences.updateLlmToolsConfig.mockResolvedValue(availableConfig(['get_conversation']));
+
+        const panel = render(<LlmToolsPanel workspaceId="ws-5" />);
+        await waitFor(() => expect(screen.getByTestId('llm-tool-toggle-get_conversation')).toBeTruthy());
+        // Cache is warm after the initial load.
+        expect(peekConfig(configCacheKey.llmToolsConfig('ws-5'))).toBeDefined();
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('llm-tool-toggle-get_conversation'));
+        });
+
+        // Mutation dropped the cached key.
+        await waitFor(() => expect(peekConfig(configCacheKey.llmToolsConfig('ws-5'))).toBeUndefined());
+        panel.unmount();
+
+        // The next reader refetches instead of serving the stale value (2 GETs total).
+        const hook = renderHook(() => useConversationRetrievalCapability('ws-5', true));
+        await waitFor(() => expect(hook.result.current).not.toBeNull());
+        expect(mocks.preferences.getLlmToolsConfig).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -1468,4 +1468,28 @@ describe('ChatDetail', () => {
             expect(USE_SEND_MESSAGE_SOURCE).toContain('promoteToRalph(processId');
         });
     });
+
+    describe('canvas discovery defers past first paint (AC-03)', () => {
+        it('imports the runWhenIdle deferral helper', () => {
+            expect(source).toContain("import { runWhenIdle } from '../../utils/runWhenIdle'");
+        });
+
+        it('wraps the canvases.list probe in runWhenIdle so messages paint first', () => {
+            // The discovery effect must schedule the round-trip through runWhenIdle
+            // rather than calling client.canvases.list synchronously on mount.
+            const idleIdx = source.indexOf('const cancelIdle = runWhenIdle(() => {');
+            const listIdx = source.indexOf('client.canvases.list(workspaceId, { processId: canvasPid })');
+            expect(idleIdx).toBeGreaterThan(-1);
+            expect(listIdx).toBeGreaterThan(idleIdx);
+            // The persisted close flag still applies synchronously, before the
+            // deferred probe — guards against regressing the no-flash behaviour.
+            const closeFlagIdx = source.indexOf('setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid))');
+            expect(closeFlagIdx).toBeGreaterThan(-1);
+            expect(closeFlagIdx).toBeLessThan(idleIdx);
+        });
+
+        it('cancels the deferred probe on cleanup', () => {
+            expect(source).toContain('return () => { cancelled = true; cancelIdle(); };');
+        });
+    });
 });

--- a/packages/coc/test/spa/react/repos/RepoChatTab.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoChatTab.test.tsx
@@ -158,10 +158,13 @@ vi.mock('../../../../src/server/spa/client/react/hooks/ui/useResizablePanel', ()
     },
 }));
 
-const mockMarkSeen = vi.fn();
-const mockMarkAllSeen = vi.fn();
-const mockMarkTasksSeen = vi.fn();
-const mockMarkUnseen = vi.fn();
+// Default to returning `true` (a real seen-state transition) so the wrapper's
+// gated `scheduleUnseenRefresh` fires; tests that exercise the no-op/warm-reopen
+// path override the return value with `.mockReturnValueOnce(false)`.
+const mockMarkSeen = vi.fn().mockReturnValue(true);
+const mockMarkAllSeen = vi.fn().mockReturnValue(true);
+const mockMarkTasksSeen = vi.fn().mockReturnValue(true);
+const mockMarkUnseen = vi.fn().mockReturnValue(true);
 let mockUnseenTaskIds = new Set<string>();
 vi.mock('../../../../src/server/spa/client/react/features/chat/hooks/useUnseenChat', () => ({
     useUnseenChat: () => ({
@@ -984,6 +987,33 @@ describe('RepoChatTab: unseen activity wiring', () => {
         await waitFor(() => {
             expect(mockRefreshUnseenCounts).toHaveBeenCalledWith(['ws-1']);
         }, { timeout: 1000 });
+    });
+
+    // AC-02 (count half): a warm reopen of an already-seen conversation no-ops
+    // the raw mark (returns false), so the wrapper must NOT re-fire the
+    // workspace-scoped count refetch.
+    it('does NOT refresh unseen counts when markSeen is a no-op (already seen)', async () => {
+        await renderTab();
+        const lastProps = mockListPane.mock.calls.at(-1)?.[0];
+
+        // Drop any render-time noise, then drive the debounce window on a fake
+        // clock so no wall-clock elapses (prevents leaked real timers from other
+        // tests from firing refreshUnseenCounts during this assertion).
+        mockRefreshUnseenCounts.mockClear();
+        vi.useFakeTimers();
+        try {
+            // Simulate reopening an already-seen conversation: raw mark reports no change.
+            mockMarkSeen.mockReturnValueOnce(false);
+            lastProps?.onMarkRead('proc-1');
+            expect(mockMarkSeen).toHaveBeenCalledWith('proc-1');
+
+            // No transition → the wrapper never schedules a refresh; advancing past
+            // the 300ms debounce window confirms nothing fires.
+            vi.advanceTimersByTime(400);
+            expect(mockRefreshUnseenCounts).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('auto-marks deep-linked task via markReadByProcessId', async () => {

--- a/packages/coc/test/spa/react/useLoops.test.tsx
+++ b/packages/coc/test/spa/react/useLoops.test.tsx
@@ -113,3 +113,53 @@ describe('useLoops WebSocket listener', () => {
         expect(mockLoopsClient.list.mock.calls.length).toBe(callsBefore);
     });
 });
+
+// AC-02: loops are workspace-scoped, so switching conversations within the same
+// workspace must re-derive the per-process view client-side WITHOUT re-issuing
+// `loops.list`. Only a workspace change re-fetches.
+describe('useLoops AC-02 — workspace-scoped fetch', () => {
+    beforeEach(() => { vi.clearAllMocks(); });
+
+    it('does not refetch when only processId changes within the same workspace', async () => {
+        mockLoopsClient.list.mockResolvedValue([
+            { id: 'l1', processId: 'process-1', status: 'active' },
+            { id: 'l2', processId: 'process-2', status: 'paused' },
+        ]);
+
+        const { result, rerender } = renderHook(
+            ({ pid }: { pid: string }) => useLoops('workspace-1', pid),
+            { initialProps: { pid: 'process-1' } },
+        );
+
+        await waitFor(() => expect(result.current.loops).toHaveLength(1));
+        expect(result.current.loops[0].id).toBe('l1');
+        expect(mockLoopsClient.list).toHaveBeenCalledTimes(1);
+
+        // Switch to a different conversation in the SAME workspace.
+        rerender({ pid: 'process-2' });
+
+        // The per-process view re-derives from the cached workspace list...
+        await waitFor(() => expect(result.current.loops[0]?.id).toBe('l2'));
+        expect(result.current.loops).toHaveLength(1);
+        // ...without issuing another loops.list round-trip.
+        expect(mockLoopsClient.list).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches when the workspace changes', async () => {
+        mockLoopsClient.list.mockResolvedValue([
+            { id: 'l1', processId: 'process-1', status: 'active' },
+        ]);
+
+        const { rerender } = renderHook(
+            ({ ws }: { ws: string }) => useLoops(ws, 'process-1'),
+            { initialProps: { ws: 'workspace-1' } },
+        );
+
+        await waitFor(() => expect(mockLoopsClient.list).toHaveBeenCalledTimes(1));
+        expect(mockLoopsClient.list).toHaveBeenLastCalledWith('workspace-1');
+
+        rerender({ ws: 'workspace-2' });
+        await waitFor(() => expect(mockLoopsClient.list).toHaveBeenCalledTimes(2));
+        expect(mockLoopsClient.list).toHaveBeenLastCalledWith('workspace-2');
+    });
+});

--- a/packages/coc/test/spa/react/utils/runWhenIdle.test.ts
+++ b/packages/coc/test/spa/react/utils/runWhenIdle.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for runWhenIdle — the post-paint / idle deferral helper used to push
+ * non-critical per-conversation fetches off the message-render critical path
+ * (chat-load-perf AC-03).
+ */
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runWhenIdle } from '../../../../src/server/spa/client/react/utils/runWhenIdle';
+
+describe('runWhenIdle', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        // Remove any requestIdleCallback stub a test installed.
+        delete (window as unknown as Record<string, unknown>).requestIdleCallback;
+        delete (window as unknown as Record<string, unknown>).cancelIdleCallback;
+    });
+
+    describe('setTimeout fallback (no requestIdleCallback — jsdom default)', () => {
+        it('runs the callback on a macrotask, not synchronously', () => {
+            vi.useFakeTimers();
+            const cb = vi.fn();
+            runWhenIdle(cb);
+            // Deferred: nothing runs in the current tick.
+            expect(cb).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(0);
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+
+        it('disposer cancels the pending callback before it runs', () => {
+            vi.useFakeTimers();
+            const cb = vi.fn();
+            const cancel = runWhenIdle(cb);
+            cancel();
+            vi.advanceTimersByTime(0);
+            expect(cb).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('requestIdleCallback path (when available)', () => {
+        it('uses requestIdleCallback with a timeout bound and runs the callback', () => {
+            const ric = vi.fn((fn: IdleRequestCallback) => {
+                fn({ didTimeout: false, timeRemaining: () => 0 } as IdleDeadline);
+                return 7;
+            });
+            (window as unknown as Record<string, unknown>).requestIdleCallback = ric;
+
+            const cb = vi.fn();
+            runWhenIdle(cb, 123);
+
+            expect(ric).toHaveBeenCalledTimes(1);
+            expect(ric.mock.calls[0][1]).toEqual({ timeout: 123 });
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+
+        it('disposer calls cancelIdleCallback with the handle', () => {
+            const ric = vi.fn(() => 42);
+            const cic = vi.fn();
+            (window as unknown as Record<string, unknown>).requestIdleCallback = ric;
+            (window as unknown as Record<string, unknown>).cancelIdleCallback = cic;
+
+            const cancel = runWhenIdle(vi.fn());
+            cancel();
+
+            expect(cic).toHaveBeenCalledWith(42);
+        });
+    });
+});


### PR DESCRIPTION
Reduces the number of requests fired when a chat loads, to speed up first paint.

- Adds a session-scoped static-config client cache and routes provider config + llm-tools-config reads through it (per-workspace), so repeated config lookups don't refetch (AC-01/AC-05).
- Re-keys `useLoops` to workspace scope and derives the per-process view, and gates the unseen-count refetch on a real seen-state change, eliminating redundant refetches (AC-02).
- Adds short-lived `Cache-Control` headers on the 4 static config endpoints (AC-04).
- Defers canvas + PR-binding fetches until past first paint via a `runWhenIdle` helper (AC-03).
- Documents the chat-load request budget (AC-06).