### PR TITLE
feat: add auto-merge badge to PR banner

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -21,7 +21,7 @@ import { cn } from '../../ui';
 import { useApp } from '../../contexts/AppContext';
 import { getSpaCocClientErrorMessage } from '../../api/cocClient';
 import { useCocClient } from '../../repos/cloneRouting';
-import { formatTimestamp, prStatusBadge } from './pr-utils';
+import { formatTimestamp, prStatusBadge, autoMergeBadge } from './pr-utils';
 import { ReviewerBadge } from './ReviewerBadge';
 import { ThreadList } from './ThreadList';
 import { PrReviewSummaryPanel } from './PrReviewSummaryPanel';
@@ -393,6 +393,20 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
                             Risk: {reviewSummary.risk}
                         </span>
                     )}
+                    {pr.autoMerge?.enabled && (() => {
+                        const badge = autoMergeBadge(pr.autoMerge);
+                        return badge ? (
+                            <span
+                                className={cn(
+                                    'inline-flex min-h-[20px] shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-semibold',
+                                    badge.className,
+                                )}
+                                data-testid="pr-auto-merge-badge"
+                            >
+                                {badge.emoji} {badge.label}
+                            </span>
+                        ) : null;
+                    })()}
                     {unresolvedCount > 0 && (
                         <span className="inline-flex min-h-[20px] shrink-0 items-center gap-1 rounded-full bg-yellow-100 px-1.5 py-0.5 text-[11px] font-semibold text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200">
                             {unresolvedCount} unresolved

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/pr-utils.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/pr-utils.ts
@@ -131,6 +131,14 @@ export interface QueueRiskSignals {
     hasUnresolvedBlockingThread?: boolean;
 }
 
+export interface PullRequestAutoMerge {
+    enabled: boolean;
+    state: 'not-enabled' | 'armed' | 'queued' | 'blocked';
+    enabledBy?: { name: string; email?: string } | null;
+    mergeMethod?: 'merge' | 'squash' | 'rebase';
+    blockedReason?: string;
+}
+
 /** Shape of a pull request as returned by the /api/origins/:originId/pull-requests endpoint. */
 export interface PullRequest {
     id: number | string;
@@ -154,6 +162,8 @@ export interface PullRequest {
     headSha?: string;
     /** Real diff stats enriched by the server for list/detail queue metadata. */
     diffStats?: PullRequestDiffStats;
+    /** Auto-merge configuration and state. */
+    autoMerge?: PullRequestAutoMerge;
 }
 
 function stringifyIdentityId(id: string | number | undefined): string {
@@ -258,6 +268,37 @@ export function prStatusBadge(status: PrStatus | string): StatusBadge {
 
 export function prStatusColor(status: PrStatus | string): string {
     return prStatusBadge(status).className;
+}
+
+export function autoMergeBadge(autoMerge?: PullRequestAutoMerge): StatusBadge | null {
+    if (!autoMerge?.enabled) return null;
+
+    switch (autoMerge.state) {
+        case 'blocked':
+            return {
+                emoji: '🚫',
+                label: 'Auto-merge blocked',
+                className: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+            };
+        case 'queued':
+            return {
+                emoji: '⏳',
+                label: 'Auto-merge queued',
+                className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
+            };
+        case 'armed':
+            return {
+                emoji: '🔄',
+                label: 'Auto-merge armed',
+                className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+            };
+        default:
+            return {
+                emoji: '✅',
+                label: 'Auto-merge enabled',
+                className: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+            };
+    }
 }
 
 export function normalizeReviewVote(vote?: string | null): string {


### PR DESCRIPTION
Add visual feedback for PR auto-merge status (enabled, armed, queued, or blocked)
to the PR detail banner. The auto-merge data is already being fetched from the
backend via ProviderPullRequest.autoMerge.

Changes:
- Add PullRequestAutoMerge interface to pr-utils.ts
- Add autoMerge field to PullRequest type
- Create autoMergeBadge helper function with state-specific styling
- Display auto-merge badge in PR hero row with status-appropriate colors

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
