### PR TITLE
feat: add OneDrive default skill directories to skill-config-resolver

### DIFF
--- a/packages/coc/src/server/executors/skill-config-resolver.ts
+++ b/packages/coc/src/server/executors/skill-config-resolver.ts
@@ -9,6 +9,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import {
@@ -99,6 +100,13 @@ export async function resolveSkillConfig(
     if (dataDir) {
         const globalSkillsDir = path.join(dataDir, 'skills');
         await tryAddSkillDirectory(globalSkillsDir, globalSkillsDir);
+    }
+
+    // Check OneDrive-based default skill directories (Windows)
+    const homedir = os.homedir();
+    for (const variant of ['OneDrive', 'OneDrive - Microsoft']) {
+        const oneDriveSkillsDir = path.join(homedir, variant, '.github', 'skills');
+        await tryAddSkillDirectory(oneDriveSkillsDir, oneDriveSkillsDir);
     }
 
     if (extraSkillFolders) {

--- a/packages/coc/test/server/executors/skill-config-resolver.test.ts
+++ b/packages/coc/test/server/executors/skill-config-resolver.test.ts
@@ -6,6 +6,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+
+// Capture real homedir before any mock takes effect.
+// Must use `var` because vi.mock factories are hoisted above `let`/`const` declarations.
+// eslint-disable-next-line no-var
+var _realHomedir: string;
+
+vi.mock('os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('os')>();
+    _realHomedir = actual.homedir();
+    return {
+        ...actual,
+        homedir: vi.fn(() => _realHomedir),
+    };
+});
+
 import { resolveSkillConfig } from '../../../src/server/executors/skill-config-resolver';
 import { getBundledSkillsPath } from '@plusplusoneplusplus/forge';
 import { createMockProcessStore } from '../helpers/mock-process-store';
@@ -17,6 +32,8 @@ describe('resolveSkillConfig', () => {
     beforeEach(() => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-cfg-'));
         store = createMockProcessStore({ initialWorkspaces: [] });
+        // Ensure each test starts with the real homedir as default
+        vi.mocked(os.homedir).mockImplementation(() => _realHomedir);
     });
 
     afterEach(() => {
@@ -72,5 +89,83 @@ describe('resolveSkillConfig', () => {
         expect(result.disabledSkills).toBeDefined();
         expect(result.disabledSkills).toContain('create-work-item');
         expect(result.disabledSkills).toContain('go-deep');
+    });
+
+    describe('OneDrive skill directories', () => {
+        it('includes OneDrive skill dir when it exists', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            fs.mkdirSync(oneDriveSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(oneDriveSkillsDir);
+        });
+
+        it('includes OneDrive - Microsoft skill dir when it exists', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveMsSkillsDir = path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills');
+            fs.mkdirSync(oneDriveMsSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(oneDriveMsSkillsDir);
+        });
+
+        it('includes both OneDrive variants when both exist', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            const oneDriveMsSkillsDir = path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills');
+            fs.mkdirSync(oneDriveSkillsDir, { recursive: true });
+            fs.mkdirSync(oneDriveMsSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(oneDriveSkillsDir);
+            expect(result.skillDirectories).toContain(oneDriveMsSkillsDir);
+        });
+
+        it('skips OneDrive skill dirs that do not exist', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            fs.mkdirSync(fakeHome, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            const dirs = result.skillDirectories ?? [];
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            const oneDriveMsSkillsDir = path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills');
+            expect(dirs).not.toContain(oneDriveSkillsDir);
+            expect(dirs).not.toContain(oneDriveMsSkillsDir);
+        });
+
+        it('OneDrive dirs appear after global and before bundled', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            fs.mkdirSync(oneDriveSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const dataDir = path.join(tmpDir, 'data');
+            const globalSkillsDir = path.join(dataDir, 'skills');
+            fs.mkdirSync(globalSkillsDir, { recursive: true });
+
+            const result = await resolveSkillConfig(store, dataDir, undefined, undefined);
+
+            const bundledDir = getBundledSkillsPath();
+            if (fs.existsSync(bundledDir)) {
+                const dirs = result.skillDirectories!;
+                const globalIdx = dirs.indexOf(globalSkillsDir);
+                const oneDriveIdx = dirs.indexOf(oneDriveSkillsDir);
+                const bundledIdx = dirs.indexOf(bundledDir);
+                expect(globalIdx).toBeLessThan(oneDriveIdx);
+                expect(oneDriveIdx).toBeLessThan(bundledIdx);
+            }
+        });
     });
 });


### PR DESCRIPTION
Check ~/OneDrive/.github/skills and ~/OneDrive - Microsoft/.github/skills as default skill directories (after global ~/.coc/skills, before bundled). Both paths are optional and silently skipped if they don't exist.