### PR TITLE
fix(spa): reconstruct Write-created files in whisper diff

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperFileDiff.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperFileDiff.ts
@@ -141,7 +141,12 @@ function collectHunks(toolCalls: WhisperDiffToolCall[], targetPath: string): Fil
             });
         } else if (toolName === 'create' && isRecord(call.args)) {
             if (normalizePath(editPath(call.args)) !== target) continue;
-            const fileText = typeof call.args.file_text === 'string' ? call.args.file_text : '';
+            // Different file-create tools name the body differently: Codex uses
+            // `file_text`, Claude Code's `Write` uses `content`. Accept either so
+            // a `Write`-created file reconstructs its lines instead of showing an
+            // empty new-file diff.
+            const rawText = call.args.file_text ?? call.args.content ?? call.args.contents;
+            const fileText = typeof rawText === 'string' ? rawText : '';
             const body = fileText === '' ? [] : fileText.split('\n').map(l => '+' + l);
             hunks.push({
                 header: `@@ -0,0 +1,${lineCount(fileText)} @@`,

--- a/packages/coc/test/spa/react/buildWhisperFileDiff.test.ts
+++ b/packages/coc/test/spa/react/buildWhisperFileDiff.test.ts
@@ -105,12 +105,46 @@ describe('buildWhisperFileDiff', () => {
         expect(diff).toContain('-x');
         expect(diff).toContain('+y');
 
+        // Claude Code's `Write` tool stores the body under `content` (not Codex's
+        // `file_text`); both must reconstruct.
         const createCalls: WhisperDiffToolCall[] = [
-            { toolName: 'Write', args: { file_path: 'src/z.ts', file_text: 'hi' } },
+            { toolName: 'Write', args: { file_path: 'src/z.ts', content: 'hi' } },
         ];
         const createDiff = buildWhisperFileDiff(createCalls, 'src/z.ts')!;
         expect(createDiff).toContain('--- /dev/null');
         expect(createDiff).toContain('+hi');
+    });
+
+    // Regression: a `Write`-created file carries its body under `content`, not
+    // `file_text`. Reading only `file_text` reconstructed an empty new-file diff
+    // (`@@ -0,0 +1,0 @@` with no body lines). Accept `content` so the real lines
+    // show.
+    it('reconstructs a Write create from its `content` arg, not an empty diff', () => {
+        const calls: WhisperDiffToolCall[] = [
+            { toolName: 'Write', args: { file_path: 'src/new.tsx', content: 'line1\nline2\nline3' } },
+        ];
+        const lines = buildWhisperFileDiff(calls, 'src/new.tsx')!.split('\n');
+        expect(lines[0]).toBe('diff --git a/src/new.tsx b/src/new.tsx');
+        expect(lines).toContain('new file mode 100644');
+        expect(lines).toContain('--- /dev/null');
+        expect(lines).toContain('@@ -0,0 +1,3 @@');
+        expect(lines).toContain('+line1');
+        expect(lines).toContain('+line2');
+        expect(lines).toContain('+line3');
+        // The bug produced this empty-file header with no added lines.
+        expect(lines).not.toContain('@@ -0,0 +1,0 @@');
+    });
+
+    it('prefers `file_text` over `content` when both are present on a create', () => {
+        const calls: WhisperDiffToolCall[] = [
+            {
+                toolName: 'create',
+                args: { path: 'src/dup.ts', file_text: 'from-file_text', content: 'from-content' },
+            },
+        ];
+        const diff = buildWhisperFileDiff(calls, 'src/dup.ts')!;
+        expect(diff).toContain('+from-file_text');
+        expect(diff).not.toContain('+from-content');
     });
 
     it('matches paths irrespective of slash direction', () => {


### PR DESCRIPTION
The whisper diff panel replays a turn's file-edit tool calls into a
synthetic per-file diff. Its `create` branch read the new file body only
from `file_text` (the Codex arg name), but Claude Code's `Write` tool
stores the body under `content`. A `Write`-created file therefore
reconstructed as an empty new-file diff (`@@ -0,0 +1,0 @@` with no added
lines) even though the committed file had content.

Accept `content`/`contents` in addition to `file_text` so a Write-created
file shows its actual lines.

Fix the existing alias test that masked this (it passed `file_text` under
the `Write` name, i.e. Codex semantics) and add regression tests for the
`content` arg and the file_text-over-content precedence.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
