### PR TITLE
pr/049a39a8f docs remove vscode extension structural

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,15 +2,15 @@
 - Never `git add/commit` files under `.vscode/tasks` (creating is fine).
 - Assume no backward compatibility unless explicitly asked.
 - Use `claude-haiku-4.5` for simple exploration tasks. Use `claude-sonnet-4.6` for complex exploration tasks.
-- By default, focus on the CoC (Copilot of Copilot) project (`packages/coc/`, `packages/coc-server/`, `packages/forge/`). Ignore the VS Code extension (`src/`) unless the user explicitly asks about it.
+- By default, focus on CoC (Copilot of Copilot) packages such as `packages/coc/`, `packages/coc-client/`, `packages/coc-workflow/`, `packages/coc-agent-sdk/`, and `packages/forge/`.
 - When the plan involves UI/UX, make sure to include the visual design in the plan.
 - When fixing the tests, check commit history to see if the test was broken by a previous commit. And if the commit is a new feature or behaivor change and is intentional. You SHOULD gather more information and make a decision on whether to fix the test or the source code.
 - Never include personal or privacy data (e.g., real names, emails, usernames, API keys, tokens, passwords, internal URLs, absolute local paths like `/Users/<name>/...`) in commit messages, code comments, or checked-in code. Use placeholders, relative paths, or anonymized values instead.
 
 ## Project Principles
-- CoC (Copilot of Copilot) is independent of the VS Code extension.
+- CoC (Copilot of Copilot) is a standalone Node CLI/server and web dashboard.
 - CoC is independent of the deep-wiki CLI, but may invoke it as a child process.
-- run `npm run build` to build both vscode extension and other packages
+- run `npm run build` to build the workspace packages
 - run `npm run test` to run all the tests
 - Do not reinvent the wheel. Use the existing code and documentation to build the new features if possible.
 - New feature (e.g. in development) flag must be disabled by default. 

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -6,8 +6,12 @@ Chat detail composer gating is driven by persisted process state. A cancelled
 chat can be continued only when the process has a saved `sdkSessionId`; if no
 SDK session was saved, or if `metadata.stoppedChatResume.resumable === false`
 after a strict stopped-chat resume failure, `ChatDetail` keeps
-`FollowUpInputArea` disabled and shows a non-retryable inline error with no retry
-button or fresh-session fallback.
+`FollowUpInputArea` disabled and shows a non-retryable inline error with no
+follow-up resume or fresh-session fallback. A terminal **failed** chat in that
+state still surfaces a "Retry task" button (`onRetryTask` → `retry-task-button`)
+inside the error block, gated by `ChatDetail.canRetryFailedTask`, which re-runs
+the original payload as a new conversation via `client.queue.retry`; a
+`cancelled` chat without a session does not get this button.
 
 ## Entry Point & Shell
 

--- a/.github/skills/coc-knowledge/references/mcp-settings.md
+++ b/.github/skills/coc-knowledge/references/mcp-settings.md
@@ -7,7 +7,7 @@ Workspace MCP servers in CoC are a merge of two sources: global servers from `~/
 - **Global**: `~/.copilot/mcp-config.json` — root key `mcpServers`
 - **Workspace**: `<repo>/.vscode/mcp.json` — root key `servers`
 
-Extra fields (`description`, `toolScope`) are stored directly on server entries in config files. VS Code ignores unknown keys; CoC reads and surfaces them.
+Extra fields (`description`, `toolScope`) are stored directly on server entries in config files. Consumers that ignore unknown keys can keep using the same file; CoC reads and surfaces these fields.
 
 ## REST API
 

--- a/.github/skills/coc-knowledge/references/monorepo.md
+++ b/.github/skills/coc-knowledge/references/monorepo.md
@@ -1,15 +1,16 @@
 # Monorepo Layout, Build, and Release
 
-The published Node packages plus a frozen VS Code extension live in one npm workspaces monorepo. This file documents the cross-package contract, build/test commands, package management, and conventions enforced across the whole tree. Load it when planning multi-package changes, debugging build/release issues, or wiring new conventions.
+The repository is an npm workspaces monorepo for published Node packages. This file documents the cross-package contract, build/test commands, package management, and conventions enforced across the whole tree. Load it when planning multi-package changes, debugging build/release issues, or wiring new conventions.
 
 ## Products & Shared Packages
 
 | Product | Location | Runtime | Description |
 |---------|----------|---------|-------------|
-| **VS Code Extension** | `packages/vscode-extension/` | VS Code | Markdown review, git diff review, code review, shortcut groups, global notes, tasks viewer, YAML workflows — **FROZEN: do not modify** |
 | **CoC CLI** | `packages/coc/` | Node.js | CLI for executing YAML-based AI workflows (`coc run|validate|list|serve|wipe-data`) |
+| **CoC Container** | `packages/coccontainer/` | Node.js | Container-oriented CoC server package with messaging integrations and service entry points |
 | **CoC Client** | `packages/coc-client/` | Node.js/browser | Framework-free TypeScript client for CoC REST and realtime APIs |
 | **Deep Wiki** | `packages/deep-wiki/` | Node.js | CLI that auto-generates comprehensive wikis for codebases (`deep-wiki seeds|discover|generate|theme|init`) |
+| **Teams Bot** | `packages/teams-bot/` | Node.js | Microsoft Teams bot integration for CoC-backed workflows |
 
 | Shared Package | Location | Description |
 |----------------|----------|-------------|
@@ -19,7 +20,7 @@ The published Node packages plus a frozen VS Code extension live in one npm work
 | **coc-memory** | `packages/coc-memory/` | Memory V2 core package: SQLite-backed fact/episode stores, hybrid search, embedding provider abstraction, capture service, safety scanning |
 | **whatsapp-bot** | `packages/whatsapp-bot/` | Standalone WhatsApp bot via Baileys — no CoC/forge deps. Used by `coccontainer` when `messaging.whatsapp.enabled` is true |
 
-**Architectural boundary:** Pure Node.js logic lives in packages (no VS Code deps). VS Code-specific wrappers live in `packages/vscode-extension/src/shortcuts/`. Example: `forge/src/ai/` = pure AI SDK; `packages/vscode-extension/src/shortcuts/ai-service/` = VS Code UI wrapper. **`packages/vscode-extension/` is frozen — do not read, edit, or reason about its code.**
+**Architectural boundary:** Shared behavior belongs in Node packages with explicit package contracts. UI-facing behavior for the CoC dashboard lives under `packages/coc/`; reusable REST clients live in `packages/coc-client/`; workflow, memory, SDK, and utility logic stay in their dedicated packages.
 
 ## Package Management & Publishing
 
@@ -43,13 +44,11 @@ Published workspaces (`coc`, `coc-workflow`, `forge`, `coc-agent-sdk`, `coc-memo
 ## Build & Test
 
 - **Build packages:** `npm run build:packages`
-- **Build extension:** `npm run compile`
-- **Watch:** `npm run watch`
-- **Test all:** `npm run test` (extension Mocha tests, 6900+)
+- **Build all:** `npm run build`
+- **Compile:** `npm run compile` (alias for package build)
+- **Test all:** `npm run test`
 - **Test packages:** `npm run test:run` in any package directory (Vitest)
 - **Lint:** `npm run lint`
-- **Package:** `npm run vsce:package`
-- **Publish:** `npm run vsce:publish`
 - **Debug CoC:** `cd packages/coc && npm run build && npm link && cd ../..` then `coc run <path>` or `coc serve --no-open`
 - **Debug Deep Wiki:** `cd packages/deep-wiki && npm run build && npm link && cd ../..` then `deep-wiki generate <repo>`
 - **Run CoCContainer with rebuild loop:** `./scripts/coccontainer-serve-loop.sh --port 8080` installs dependencies, builds and links the package chain, verifies native dependencies such as `better-sqlite3`, then starts `coccontainer serve --no-open`
@@ -72,15 +71,8 @@ Published workspaces (`coc`, `coc-workflow`, `forge`, `coc-agent-sdk`, `coc-memo
 
 **Model resolution:** `task.config.model` > `PerRepoPreferences.defaultModels[mode]` > `defaultModel` > CLI default.
 
-## VS Code Extension (FROZEN)
-
-> ⚠️ `packages/vscode-extension/` is frozen and no longer actively developed. AI agents must NOT read, edit, or reason about code in `packages/vscode-extension/`. It is not an npm workspace.
-
-Historical reference (do not modify): entry point `packages/vscode-extension/src/extension.ts`. Feature modules under `packages/vscode-extension/src/shortcuts/` covered markdown comments, git diff comments, code review, YAML pipelines, tasks viewer, AI service, git layer, skills, and shared base classes. Configuration lived in `.vscode/shortcuts.yaml` with a versioned migration system (v1→v4). MCP/Permissions were handled via `SendMessageOptions`.
-
 ## Development Notes
 
-- TypeScript, webpack bundling, VS Code API ≥ 1.95.0, Node.js ≥ 24
+- TypeScript packages targeting Node.js ≥ 24
 - Format on save and import organization enabled
 - Cross-platform: Linux, macOS, Windows
-- (Extension only, frozen) Tree data providers extend `BaseTreeDataProvider` or `FilterableTreeDataProvider`; commands are registered centrally in `src/shortcuts/commands.ts`

--- a/.github/skills/coc-knowledge/references/task-comments.md
+++ b/.github/skills/coc-knowledge/references/task-comments.md
@@ -196,4 +196,4 @@ A: Comments persist. Anchors attempt to relocate to the new content via fuzzy ma
 
 - [CoC README](../packages/coc/README.md) — Main CoC documentation
 - [Pipeline YAML Guide](../CLAUDE.md#yaml-pipeline-framework) — Pipeline configuration
-- [VS Code Extension](../README.md) — Extension features
+- [Dashboard SPA](dashboard-spa.md) — Dashboard module layout

--- a/.github/skills/draft/SKILL.md
+++ b/.github/skills/draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draft
-description: Draft a user experience specification for a requested feature. Use when planning new features, designing user flows, or creating UX specs for this VS Code extension.
+description: Draft a user experience specification for a requested CoC feature. Use when planning new features, designing user flows, or creating UX specs for the CoC dashboard, CLI, server, or Node packages.
 ---
 
 # Draft UX Specification
@@ -10,10 +10,11 @@ Draft a user experience specification for the requested feature or ask. Include:
 1. **User Story**: Who is the user and what problem are they solving?
 
 2. **Entry Points**: How does the user discover and access this feature?
-   - Commands (Command Palette)
+   - Dashboard tabs, routes, or panels
+   - CLI commands
    - Context menus (right-click)
    - Keyboard shortcuts
-   - Tree view interactions
+   - Lists, tables, sidebars, or detail views
    - Settings
 
 3. **User Flow**: Step-by-step walkthrough of the primary workflow
@@ -29,9 +30,9 @@ Draft a user experience specification for the requested feature or ask. Include:
 
 5. **Visual Design Considerations**:
    - Icons needed
-   - Tree view representation
+   - List, table, sidebar, or detail-view representation
    - Notifications/status indicators
-   - Any webview or editor requirements
+   - Any dashboard or editor requirements
 
 6. **Settings & Configuration**:
    - What should be configurable?
@@ -39,4 +40,4 @@ Draft a user experience specification for the requested feature or ask. Include:
 
 7. **Discoverability**: How will users learn about this feature?
 
-Focus on clarity and simplicity. Prefer conventions already established in this extension. No code details.
+Focus on clarity and simplicity. Prefer conventions already established in CoC. No code details.

--- a/.github/skills/impl/scripts/archive-task-file.py
+++ b/.github/skills/impl/scripts/archive-task-file.py
@@ -121,9 +121,9 @@ def main() -> int:
         return 0
 
     # 3) Check legacy location: <workspace>/.vscode/
-    vscode_root = workspace_root / ".vscode"
-    if is_subpath(task_abs, vscode_root):
-        archive_dir = vscode_root / "tasks" / "archive"
+    legacy_config_root = workspace_root / ".vscode"
+    if is_subpath(task_abs, legacy_config_root):
+        archive_dir = legacy_config_root / "tasks" / "archive"
         archive_dir.mkdir(parents=True, exist_ok=True)
         dest = unique_dest(archive_dir / task_abs.name)
         shutil.move(str(task_abs), str(dest))

--- a/.github/skills/impl/scripts/test_archive_task_file.py
+++ b/.github/skills/impl/scripts/test_archive_task_file.py
@@ -110,13 +110,13 @@ class TestFindCocTasksRoot:
 
 # ── main() integration tests ───────────────────────────────────────
 
-class TestMainLegacyVscode:
+class TestMainLegacyConfig:
     """Legacy .vscode/ path archiving."""
 
-    def test_archives_vscode_task(self, tmp_path: Path):
-        vscode = tmp_path / ".vscode" / "tasks" / "feat"
-        vscode.mkdir(parents=True)
-        task = vscode / "plan.md"
+    def test_archives_legacy_task(self, tmp_path: Path):
+        legacy_tasks_dir = tmp_path / ".vscode" / "tasks" / "feat"
+        legacy_tasks_dir.mkdir(parents=True)
+        task = legacy_tasks_dir / "plan.md"
         task.write_text("hello")
 
         with mock.patch("sys.argv", ["prog", "--task", str(task), "--workspace", str(tmp_path)]):
@@ -128,7 +128,7 @@ class TestMainLegacyVscode:
         assert archived.exists()
         assert archived.read_text() == "hello"
 
-    def test_skip_outside_vscode(self, tmp_path: Path):
+    def test_skip_outside_legacy_config(self, tmp_path: Path):
         other = tmp_path / "somewhere" / "plan.md"
         other.parent.mkdir(parents=True)
         other.write_text("hello")
@@ -214,7 +214,7 @@ class TestMainCocTasks:
         assert (archive_dir / "plan (1).md").exists()
         assert (archive_dir / "plan (1).md").read_text() == "new"
 
-    def test_coc_takes_priority_over_vscode(self, tmp_path: Path):
+    def test_coc_takes_priority_over_legacy_config(self, tmp_path: Path):
         """If a file is under both .coc and .vscode (unusual), .coc wins."""
         # This wouldn't happen in practice, but tests priority ordering
         coc = tmp_path / ".vscode"  # pathological: coc data dir = .vscode

--- a/.github/skills/pipeline-generator/SKILL.md
+++ b/.github/skills/pipeline-generator/SKILL.md
@@ -463,7 +463,7 @@ nodes:
 1. Save this as `.vscode/workflows/[name]/pipeline.yaml`
 2. Place any referenced CSV/JSON files in the same directory
 3. Place any referenced scripts in the same directory (or adjust `cwd`)
-4. Execute from the VSCode Workflows view or via `coc run`
+4. Execute from the CoC dashboard Workflows tab or via `coc run`
 ````
 
 **For Linear Pipelines:**
@@ -498,7 +498,7 @@ reduce:
 **How to use:**
 1. Save this as `.vscode/workflows/[name]/pipeline.yaml`
 2. If using CSV input, create the CSV file at the specified path
-3. Execute from the VSCode Workflows view or via `coc run`
+3. Execute from the CoC dashboard Workflows tab or via `coc run`
 4. For testing: The `limit: 100` setting processes only the first 100 items
 
 **Key design decisions:**

--- a/.gitignore
+++ b/.gitignore
@@ -119,9 +119,6 @@ dist/
 ehthumbs.db
 Thumbs.db
 
-# Legacy integration test runner
-.vscode-test/
-
 # Webpack build output
 out/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ dist
 # TernJS port file
 .tern-port
 
-# VSCode extension specific
+# Legacy package build artifacts
 out/
 dist/
 *.vsix
@@ -119,7 +119,7 @@ dist/
 ehthumbs.db
 Thumbs.db
 
-# VSCode test runner
+# Legacy integration test runner
 .vscode-test/
 
 # Webpack build output

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,16 +1,16 @@
 <!--
   Sync Impact Report
   ==================
-  Version change: 0.0.0 → 1.0.0 (initial constitution creation)
+  Version change: 1.0.0 -> 1.0.1 (CoC project framing clarification)
 
-  Modified principles: N/A (initial version)
+  Modified principles:
+    - I. User Experience First (dashboard, CLI, and server workflow framing)
+    - II. Cross-Platform Support (Node package and dashboard path handling)
+    - III. Type Safety and Quality (package build command wording)
 
-  Added sections:
-    - Core Principles (3 principles)
-    - Quality Standards
-    - Governance
+  Added sections: N/A
 
-  Removed sections: N/A (initial version)
+  Removed sections: N/A
 
   Templates requiring updates:
     - .specify/templates/plan-template.md ✅ (already has Constitution Check section)
@@ -32,23 +32,23 @@ All features and changes MUST prioritize end-user experience above implementatio
 - UI interactions MUST be responsive (no perceptible lag for common operations)
 - Error messages MUST be actionable and user-friendly (avoid technical jargon)
 - New features MUST NOT break existing workflows without migration path
-- Keyboard navigation MUST be fully supported for all tree view operations
-- Configuration changes MUST take effect without requiring extension reload where feasible
+- Keyboard navigation MUST be fully supported for dashboard lists, dialogs, and command surfaces
+- Configuration changes MUST take effect without requiring process restart where feasible
 
-**Rationale:** A VSCode extension lives in the user's daily workflow. Friction or confusion directly impacts productivity and adoption.
+**Rationale:** CoC is used through a web dashboard, CLI commands, and Node package APIs in daily development workflows. Friction or confusion directly impacts productivity and adoption.
 
 ### II. Cross-Platform Support
 
-The extension MUST function consistently across Windows, macOS, and Linux.
+The CoC dashboard, CLI, server, and published Node packages MUST function consistently across Windows, macOS, and Linux.
 
 **Requirements:**
-- File path handling MUST use platform-agnostic APIs (VSCode URI, path.join)
-- Keyboard shortcuts MUST have appropriate platform variants (Ctrl vs Cmd)
-- Native file dialogs MUST account for platform limitations (documented in README)
+- File path handling MUST use platform-agnostic APIs (`node:path`, URL/URI helpers, workspace-aware path helpers)
+- Dashboard keyboard shortcuts MUST have appropriate platform variants (Ctrl vs Cmd)
+- File picker, shell, and browser interactions MUST account for platform limitations (documented in README)
 - All features MUST be manually tested on at least two platforms before release
 - Configuration files MUST use forward slashes for path separators in YAML
 
-**Rationale:** VSCode's cross-platform nature means users expect extensions to work regardless of OS. Platform-specific bugs erode trust.
+**Rationale:** CoC spans Node.js CLIs, an HTTP server, and a browser-based dashboard. Users expect the same behavior regardless of OS, and platform-specific bugs erode trust.
 
 ### III. Type Safety and Quality
 
@@ -59,7 +59,7 @@ TypeScript strict mode and comprehensive testing MUST be maintained.
 - All public APIs MUST have explicit type annotations
 - New features MUST include corresponding test coverage
 - ESLint MUST pass with zero errors before merge
-- Code MUST compile without warnings (`npm run compile`)
+- Code MUST compile without warnings (`npm run build`)
 
 **Rationale:** Type safety catches errors at compile time, reducing runtime bugs. Consistent quality gates prevent regression.
 
@@ -68,20 +68,20 @@ TypeScript strict mode and comprehensive testing MUST be maintained.
 ### Testing Requirements
 
 - Unit tests MUST cover utility functions and data transformations
-- Integration tests SHOULD cover major user workflows (group CRUD, sync operations)
-- Test commands: `npm run pretest && npm test`
+- Integration tests SHOULD cover major user workflows (dashboard operations, CLI commands, sync flows)
+- Test commands: `npm run test`
 - Tests MUST pass in CI before merge
 
 ### Performance Benchmarks
 
-- Tree view initial load: SHOULD complete in under 500ms for configurations with <100 items
-- File operations: MUST NOT block the extension host
-- Memory: Extension SHOULD NOT leak memory during normal operation cycles
+- Dashboard initial load: SHOULD complete in under 500ms for configurations with <100 items
+- File operations: MUST NOT block the server event loop or long-running worker flows
+- Memory: CoC processes SHOULD NOT leak memory during normal operation cycles
 
 ### Accessibility
 
 - All interactive elements MUST be keyboard-accessible
-- Tree items MUST have appropriate ARIA labels
+- Dashboard lists and controls MUST have appropriate ARIA labels
 - Theme-aware icons MUST maintain sufficient contrast in both light and dark themes
 
 ## Governance
@@ -105,6 +105,6 @@ TypeScript strict mode and comprehensive testing MUST be maintained.
 
 ### Versioning Policy
 
-This constitution follows semantic versioning. The version number reflects governance stability, not extension version.
+This constitution follows semantic versioning. The version number reflects governance stability, not package version.
 
-**Version**: 1.0.0 | **Ratified**: 2025-12-14 | **Last Amended**: 2025-12-14
+**Version**: 1.0.1 | **Ratified**: 2025-12-14 | **Last Amended**: 2026-06-28

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Guidance for AI agents working in this repository. NEVER create document files u
 
 ## Repo Layout (one-liner)
 
-npm workspaces monorepo with one frozen VS Code extension and published Node packages including `coc-workflow`, `forge`, `coc`, `coc-client`, `coc-agent-sdk`, and `deep-wiki`. `packages/vscode-extension/` is **FROZEN — do not read, edit, or reason about its code.**
+npm workspaces monorepo for published Node packages including `coc-workflow`, `forge`, `coc`, `coc-client`, `coc-agent-sdk`, `coc-memory`, `deep-wiki`, `coccontainer`, `whatsapp-bot`, and `teams-bot`.
 
 ## Load the CoC Knowledge Skill
 
@@ -22,7 +22,6 @@ For anything touching CoC, forge, deep-wiki, coc-client, the dashboard SPA, REST
 - **Multi-repo:** every feature must support multiple workspaces.
 - **Repo-scoped data:** all per-repo runtime data lives under `~/.coc/repos/<workspaceId>/`; resolve paths with `getRepoDataPath(dataDir, workspaceId, filename)`. Never add new top-level dirs under `~/.coc/` for per-repo data.
 - **Work items:** create/update via `POST http://localhost:4000/api/workspaces/<workspaceId>/work-items` — never write `work-items/*.json` files directly.
-- **VS Code extension is frozen:** do not read, edit, or reason about `packages/vscode-extension/`. It is not an npm workspace.
 - **Warm client keep-alive (client process only):** `coc-agent-sdk` and above MAY keep a provider *client process* warm between turns, keyed by `(provider, workingDirectory)`, for a short idle TTL (`COC_WARM_CLIENT_TTL_MS`, default `300000`ms; `0` disables warming entirely). A fresh session is still created/resumed per turn on the warm client — never cache *session objects* and never add `sendFollowUp`. Warm clients are torn down on abort/interrupt/error, on TTL expiry, and on SDK `cleanup()`/`dispose()`. Providers that cannot stay warm (Claude, whose `query()` spawns per turn) fall back to cold-start transparently. See `WarmClientRegistry` in `coc-agent-sdk`. The SPA prewarms the client while the user types a follow-up, debounced by `COC_WARM_PREWARM_DEBOUNCE_MS` (default `500`ms; resolved on the server and surfaced via runtime config).
 - **Model resolution order:** `task.config.model` > `PerRepoPreferences.defaultModels[mode]` > `defaultModel` > CLI default.
 - **Node.js ≥ 24** for every package (`engines.node`).

--- a/docs/designs/commit-range-review.md
+++ b/docs/designs/commit-range-review.md
@@ -1,543 +1,320 @@
-# Commit Range Review Feature
+# Branch Range Review Feature
 
 ## Overview
 
-The Commit Range Review feature provides a logical aggregation of multiple commits into a single reviewable unit in the Git tree view. This addresses the common workflow where developers push multiple commits to a feature branch and need to review all changes collectively against the base branch.
+Branch Range Review presents all commits on the active branch as one reviewable unit. The feature answers the same question a pull request file list answers: what changes are unique to this branch compared with the repository's default base?
+
+The implementation boundary is split between:
+
+- `@plusplusoneplusplus/forge/git`: pure git range detection, file lists, diff stats, and per-file diff loading.
+- `packages/coc/`: REST routes and dashboard surfaces for branch-range overview, file diffs, comments, and AI review actions.
+- `@plusplusoneplusplus/forge/diff`: shared diff provider abstractions for commit, range, working-tree, pull request, and pull-request iteration sources.
 
 ## Problem Statement
 
-Currently, the Git view supports:
-- Reviewing pending changes (staged/unstaged files)
-- Reviewing individual commits and their diffs
+Developers commonly create several commits before opening or updating a pull request. Reviewing each commit independently loses the cumulative context and makes it harder to spot what the branch contributes as a whole.
 
-**Missing capability:** Review all commits on a feature branch as a single logical unit, similar to how Pull Requests show "Files Changed" view.
+Key needs:
 
-### User Pain Points
-1. Feature branches often contain multiple commits that need collective review
-2. Reviewing commits one-by-one is tedious and loses context
-3. Local main branch might be out of sync with remote, making local comparisons inaccurate
-4. No easy way to see "what would be in my PR" before creating it
+1. Show all branch-only commits as a single review target.
+2. Compare against the remote default branch when available.
+3. Load file-level diffs on demand for large ranges.
+4. Preserve review comments and AI follow-up context across sessions.
 
-## Solution: Commit Range Item
+## User Surface
 
-Add a new tree item type in the Git view that represents a range of commits, displaying the cumulative diff across all commits in that range.
+### Branch Range Overview
 
-## UI Design
+The CoC dashboard Git tab shows a Branch Range area when the selected workspace has commits ahead of the default base.
 
-### Git Tree View Structure
+Example summary:
 
-```
-▼ SHORTCUTS
-  ▼ Changes (3)
-    ▶ Staged (1)
-    ▶ Unstaged (2)
-  
-  ▼ Branch Changes
-    ▶ 📦 feature/auth-flow: 8 commits ahead of origin/main
-       15 files changed • +450/-120
-  
-  ▼ Commits (5)
-    ▶ abc1234 Latest commit message
-    ▶ def5678 Previous commit
-    ▶ ghi9012 Another commit
-    ...
-    
-  ▼ Comments (2)
-    ...
+```text
+feature/auth-flow
+8 commits ahead of origin/main
+15 files changed, +450/-120
 ```
 
-### Expanded Commit Range Item
+The range is hidden when there are no branch-only commits unless a caller explicitly asks for an empty range through the API.
 
-When expanded, shows all files changed across the commit range:
+### File List
 
+Files in the range are displayed with status and line counts:
+
+```text
+M src/auth/login.ts           +120/-30
+M src/auth/register.ts        +80/-20
+A src/auth/oauth.ts           +200/-0
+D src/old-auth.ts             +0/-50
+R src/utils.ts -> src/utils2.ts +20/-20
 ```
-▼ 📦 feature/auth-flow: 8 commits ahead of origin/main
-   M src/auth/login.ts           (+120/-30)
-   M src/auth/register.ts        (+80/-20)
-   A src/auth/oauth.ts           (+200)
-   D src/old-auth.ts             (-50)
-   R src/utils.ts → utils2.ts    (+20/-20)
-```
 
-**File status prefixes:**
-- `M` - Modified
-- `A` - Added
-- `D` - Deleted
-- `R` - Renamed
+Status codes:
 
-### Range Item Display Format
+| Code | Meaning |
+|------|---------|
+| `M` | Modified |
+| `A` | Added |
+| `D` | Deleted |
+| `R` | Renamed |
+| `C` | Copied |
+| `U` | Conflict |
 
-**General format:** `{branch-name}: {count} commits ahead of {remote-default-branch}`
+### Actions
 
-**Examples:**
-- `feature/auth-flow: 8 commits ahead of origin/main`
-- `bugfix/login: 3 commits ahead of origin/master`
-- `main: 2 commits ahead of origin/main` (unpushed commits on main)
-- `HEAD: 5 commits ahead of origin/main` (detached HEAD state)
+Range-level actions:
 
-### When Section Appears
+- Refresh branch range.
+- Copy range ref, such as `origin/main...HEAD`.
+- Copy range summary.
+- Run an AI review against the full range.
+- Open all comments for the range.
 
-The **"Branch Changes"** section is **automatically shown** when:
-1. Current branch has commits not in the remote default branch
-2. Comparison: `origin/main..HEAD` (or `origin/master..HEAD`)
-3. Commit count > 0
+File-level actions:
 
-**Section hidden when:**
-- On default branch with no unpushed commits
-- Current branch is up-to-date with remote default branch
-- No remote tracking branch exists and no difference from local default branch
-
-**Note:** The entire section (including header) is hidden when there are no branch changes to show, keeping the tree view clean.
+- Open the combined diff for that file.
+- Copy the repository-relative path.
+- Send the file diff to AI with branch-range context.
+- Add, reply to, resolve, update, or delete diff comments.
 
 ## Comparison Logic
 
-### Key Principle: Always Compare Against Remote
+### Base Selection
 
-**Why `origin/main` instead of local `main`?**
-- Local main branch may be behind remote
-- Users want to see "what's in my PR" - which compares against remote
-- More accurate representation of divergence
+Prefer the remote default branch:
+
+1. `origin/main`
+2. `origin/master`
+3. `refs/remotes/origin/HEAD`
+4. local `main`
+5. local `master`
+
+Remote refs are preferred because they match the pull-request comparison users usually care about. Local defaults are fallbacks for repositories without a remote.
 
 ### Git Commands
 
-**Find merge base:**
+Find merge base:
+
 ```bash
 git merge-base HEAD origin/main
 ```
 
-**Count commits ahead:**
+Count commits ahead:
+
 ```bash
 git rev-list --count origin/main..HEAD
 ```
 
-**Get changed files with stats:**
+Get changed files and stats:
+
 ```bash
-git diff --name-status origin/main...HEAD
-git diff --stat origin/main...HEAD
+git diff --name-status -M -C origin/main...HEAD
+git diff --numstat origin/main...HEAD
+git diff --shortstat origin/main...HEAD
 ```
 
-**Get cumulative diff for a file:**
+Get a file diff:
+
 ```bash
 git diff origin/main...HEAD -- path/to/file
 ```
 
-### Branch Detection
+Get the full range diff:
 
-1. Detect current branch: `git rev-parse --abbrev-ref HEAD`
-2. Detect default branch: Check for `origin/main` or `origin/master`
-3. Calculate commits ahead: `git rev-list --count origin/{default}..HEAD`
-4. If count > 0, show range item
-
-## User Interactions
-
-### Context Menu on Range Item
-
-Right-click on range item:
-```
-📦 feature/auth-flow: 8 commits ahead of origin/main
-  ├─ Review Against Rules          # Send all commits to AI code review
-  ├─ Copy Commit Range             # Copy "origin/main...HEAD"
-  ├─ Refresh Range                 # Recalculate stats
-  └─ Copy Range Summary            # Copy summary text
+```bash
+git diff origin/main...HEAD
 ```
 
-### Context Menu on File Within Range
-
-Right-click on file (e.g., `M src/auth/login.ts`):
-```
-M src/auth/login.ts
-  ├─ Open with Diff Review         # Opens combined diff across all commits
-  ├─ Open File                     # Opens current version in editor
-  ├─ Copy Relative Path
-  └─ Reveal in Explorer
-```
-
-### Clicking on File
-
-Single-click on file → Opens **Diff Review Editor** showing:
-- Combined diff from all commits in the range
-- URI scheme: `git-range://{repoRoot}/{base}...{head}/{filePath}`
-- Supports inline commenting with Ctrl+Shift+M (Cmd+Shift+M)
-
-## Diff Review Editor
-
-### Editor Header
-```
-┌─────────────────────────────────────────────────┐
-│ Combined diff: origin/main...HEAD               │
-│ src/auth/login.ts                               │
-│                                                 │
-│ 8 commits (abc1234...xyz7890) • +120/-30       │
-└─────────────────────────────────────────────────┘
-```
-
-### Diff Content
-- Shows unified diff of all changes across commits
-- Uses `git diff origin/main...HEAD -- path/to/file`
-- Syntax highlighting based on file type
-- Line numbers shown for both old and new content
-
-### Comments
-- Comments anchored to line numbers in combined diff
-- Stored with scope: `range:{base}:{head}:{filePath}`
-- Comments persist across new commits (as long as range ref is valid)
-- Displayed in "Comments" section of Git tree view
-
-## Technical Implementation
-
-### New Files
-
-```
-src/shortcuts/git/
-├── git-commit-range-item.ts          # Tree item for commit range
-├── git-range-diff-provider.ts        # Custom text document provider for range diffs
-├── git-range-service.ts              # Service for range calculations
-└── branch-changes-section-item.ts    # Section header for "Branch Changes"
-```
-
-### Modified Files
-
-```
-src/shortcuts/git/
-├── tree-data-provider.ts             # Add "Branch Changes" section
-├── git-log-service.ts                # Add range detection methods
-└── types.ts                          # Add range-related types
-
-src/shortcuts/git-diff-comments/
-├── diff-comments-manager.ts          # Support range-scoped comments
-└── diff-review-editor-provider.ts    # Handle range diff URIs
-```
-
-### Core Types
+## Core Types
 
 ```typescript
-/**
- * Represents a range of commits
- */
 interface GitCommitRange {
-    // Base reference (usually origin/main or origin/master)
-    baseRef: string;
-    
-    // Head reference (usually HEAD or branch name)
-    headRef: string;
-    
-    // Number of commits in range
-    commitCount: number;
-    
-    // Files changed in range
-    files: GitCommitRangeFile[];
-    
-    // Total line changes
-    additions: number;
-    deletions: number;
-    
-    // Merge base commit hash
-    mergeBase: string;
-    
-    // Current branch name (if any)
-    branchName?: string;
+  baseRef: string;
+  headRef: string;
+  commitCount: number;
+  files: GitCommitRangeFile[];
+  additions: number;
+  deletions: number;
+  mergeBase: string;
+  branchName?: string;
+  repositoryRoot: string;
+  repositoryName: string;
 }
 
-/**
- * File within a commit range
- */
 interface GitCommitRangeFile {
-    // File path relative to repository root
-    path: string;
-    
-    // Change status
-    status: GitChangeStatus;
-    
-    // Line changes for this file
-    additions: number;
-    deletions: number;
-    
-    // Old path (for renames)
-    oldPath?: string;
+  path: string;
+  status: GitChangeStatus;
+  additions: number;
+  deletions: number;
+  oldPath?: string;
+  repositoryRoot: string;
 }
 ```
 
-### URI Scheme
-
-Custom URI scheme for range diffs: `git-range://`
-
-**Format:** `git-range://{repoRoot}/{baseRef}...{headRef}/{filePath}`
-
-**Example:** `git-range:///Users/dev/project/origin/main...HEAD/src/auth/login.ts`
-
-### Range Detection Algorithm
+## Detection Algorithm
 
 ```typescript
 async function detectCommitRange(repoRoot: string): Promise<GitCommitRange | null> {
-    // 1. Get current branch
-    const currentBranch = await getCurrentBranch(repoRoot);
-    
-    // 2. Detect default remote branch
-    const defaultBranch = await getDefaultRemoteBranch(repoRoot); // origin/main or origin/master
-    
-    // 3. Find merge base
-    const mergeBase = await getMergeBase(repoRoot, 'HEAD', defaultBranch);
-    
-    // 4. Count commits ahead
-    const commitCount = await countCommitsAhead(repoRoot, defaultBranch, 'HEAD');
-    
-    // 5. If no commits ahead, return null (don't show range)
-    if (commitCount === 0) {
-        return null;
-    }
-    
-    // 6. Get changed files
-    const files = await getChangedFiles(repoRoot, defaultBranch, 'HEAD');
-    
-    // 7. Calculate total additions/deletions
-    const { additions, deletions } = await getDiffStats(repoRoot, defaultBranch, 'HEAD');
-    
-    return {
-        baseRef: defaultBranch,
-        headRef: 'HEAD',
-        commitCount,
-        files,
-        additions,
-        deletions,
-        mergeBase,
-        branchName: currentBranch
-    };
+  const currentBranch = await getCurrentBranch(repoRoot);
+  const defaultBranch = getDefaultRemoteBranch(repoRoot);
+  if (!defaultBranch) return null;
+
+  const mergeBase = getMergeBase(repoRoot, 'HEAD', defaultBranch);
+  if (!mergeBase) return null;
+
+  const commitCount = countCommitsAhead(repoRoot, defaultBranch, 'HEAD');
+  if (commitCount === 0) return null;
+
+  const files = getChangedFiles(repoRoot, defaultBranch, 'HEAD');
+  const { additions, deletions } = getDiffStats(repoRoot, defaultBranch, 'HEAD');
+
+  return {
+    baseRef: defaultBranch,
+    headRef: 'HEAD',
+    commitCount,
+    files,
+    additions,
+    deletions,
+    mergeBase,
+    branchName: currentBranch !== 'HEAD' ? currentBranch : undefined,
+    repositoryRoot: repoRoot,
+    repositoryName: path.basename(repoRoot),
+  };
 }
 ```
+
+## Diff Loading
+
+Branch range review uses the shared diff provider contract:
+
+- `listFiles()` eagerly returns file metadata.
+- `getFileDiff(filePath)` lazily returns one file diff.
+- `prefetchAll()` loads all file diffs for AI review.
+- `getFullDiff()` returns the combined range diff.
+- `getSummary()` returns aggregate counts.
+
+This hybrid loading strategy keeps the dashboard responsive for large ranges while still supporting whole-range AI review.
 
 ## Comment Storage
 
-### Comment Scope
+Diff comments are workspace scoped. Server-side storage lives under the CoC data directory for the selected workspace:
 
-Range comments use a special scope format:
+```text
+~/.coc/repos/<workspaceId>/diff-comments/<storageKey>.json
 ```
-range:{baseRef}:{headRef}:{filePath}
+
+Range comments use a context that includes repository identity, base ref, head ref, and file path. The storage key is a stable hash of that context.
+
+Repository-local exports or shared review artifacts may use the existing configuration directory:
+
+```text
+.vscode/comments/
 ```
 
-**Example:** `range:origin/main:HEAD:src/auth/login.ts`
+That path is a CoC configuration/artifact directory, not an application package.
 
-### Storage Location
-
-Comments stored in: `.vscode/comments/range/{hash}.json`
-
-**Hash calculation:** SHA256 of scope string
-
-### Comment Structure
+## Comment Shape
 
 ```typescript
-interface RangeComment {
-    // Comment ID
-    id: string;
-    
-    // Comment scope
-    scope: string; // "range:origin/main:HEAD:src/auth/login.ts"
-    
-    // Comment text
-    text: string;
-    
-    // Line number in combined diff
-    lineNumber: number;
-    
-    // Selected text
+interface DiffComment {
+  id: string;
+  text: string;
+  category: 'bug' | 'question' | 'suggestion' | 'praise' | 'nitpick' | 'general';
+  status: 'open' | 'resolved';
+  context: {
+    repoId: string;
+    oldRef: string;
+    newRef: string;
+    filePath: string;
+    side: 'old' | 'new';
+  };
+  anchor: {
+    startLine: number;
+    endLine: number;
     selectedText: string;
-    
-    // Comment category
-    category: CommentCategory;
-    
-    // Timestamps
-    createdAt: string;
-    updatedAt?: string;
-    
-    // Resolution status
-    resolved: boolean;
+    contextBefore?: string;
+    contextAfter?: string;
+    fingerprint: string;
+  };
+  createdAt: string;
+  updatedAt?: string;
 }
 ```
 
-## Settings
+## REST Surface
 
-```typescript
-{
-    // Enable/disable commit range feature
-    "workspaceShortcuts.git.commitRange.enabled": true,
-    
-    // Auto-detect and show range item
-    "workspaceShortcuts.git.commitRange.autoDetect": true,
-    
-    // Default base branch name (fallback if remote not found)
-    "workspaceShortcuts.git.commitRange.defaultBaseBranch": "main",
-    
-    // Maximum number of files to show in range
-    "workspaceShortcuts.git.commitRange.maxFiles": 100,
-    
-    // Show range item even when on default branch
-    "workspaceShortcuts.git.commitRange.showOnDefaultBranch": true
-}
-```
+The dashboard reads branch range data through workspace-scoped routes:
 
-## Commands
+| Route | Purpose |
+|-------|---------|
+| `GET /api/workspaces/:id/git/branch-range` | Branch overview |
+| `GET /api/workspaces/:id/git/branch-range/files` | File list |
+| `GET /api/workspaces/:id/git/branch-range/diff` | Full range diff |
+| `GET /api/workspaces/:id/git/branch-range/files/*/diff` | File diff |
+| `GET /api/diff-comments/:wsId` | List workspace diff comments |
+| `POST /api/diff-comments/:wsId` | Add a diff comment |
+| `POST /api/diff-comments/:wsId/resolve-with-ai` | Resolve selected comments with AI |
 
-### New Commands
-
-```typescript
-// Refresh range calculation
-shortcuts.git.refreshCommitRange
-
-// Copy range reference (e.g., "origin/main...HEAD")
-shortcuts.git.copyRangeRef
-
-// Copy range summary text
-shortcuts.git.copyRangeSummary
-
-// Review range against rules
-shortcuts.git.reviewRangeAgainstRules
-```
-
-## Integration with Existing Features
-
-### AI Code Review
-
-When "Review Against Rules" is invoked on a range item:
-1. Collect all commits in range
-2. Generate combined diff for each file
-3. Build review prompt with all changes
-4. Submit to AI service with context: "Reviewing {count} commits on {branch}"
-
-### Diff Comments Tree View
-
-Range comments appear in the existing "Comments" section:
-```
-▼ Comments (5)
-  ▼ Range: feature/auth-flow → origin/main (3)
-    ▶ src/auth/login.ts (2)
-    ▶ src/auth/oauth.ts (1)
-  ▼ Commit abc1234 (2)
-    ...
-```
+Every route must remain workspace scoped so multi-repo dashboard sessions route to the selected repository.
 
 ## Edge Cases
 
-### No Remote Tracking Branch
+| Scenario | Behavior |
+|----------|----------|
+| No remote default branch | Fall back to local `main` or `master`; otherwise hide the range. |
+| Detached HEAD | Use `HEAD` as the head label and keep all range operations available. |
+| Default branch has unpushed commits | Show the range when commits are ahead of the remote default. |
+| Remote is ahead | Still show local branch-only commits; conflict detection is a separate concern. |
+| Large ranges | Limit file list to the configured max, show truncation state, and load diffs on demand. |
+| Binary files | Include the file metadata; diff view shows binary-file messaging and disables line comments. |
 
-**Scenario:** Repository has no remote or no tracking branch
+## AI Review Integration
 
-**Behavior:**
-- Fall back to comparing against local default branch (main/master)
-- Range label: `feature/auth-flow: 8 commits ahead of main` (no "origin/")
+When a user starts AI review for a branch range:
 
-### Detached HEAD
-
-**Scenario:** HEAD is not on any branch
-
-**Behavior:**
-- Show range item with label: `HEAD: 5 commits ahead of origin/main`
-- All functionality works the same
-
-### Unpushed Commits on Main
-
-**Scenario:** User is on main branch with unpushed commits
-
-**Behavior:**
-- Show range item: `main: 2 commits ahead of origin/main`
-- Useful for reviewing local changes before pushing to main
-
-### Remote is Ahead
-
-**Scenario:** Remote has new commits not in local branch
-
-**Behavior:**
-- Still show local commits ahead of remote
-- Range shows what would be unique in a PR
-- User should pull/rebase to see conflicts
-
-### Large Ranges
-
-**Scenario:** Range contains 100+ commits or 500+ files
-
-**Behavior:**
-- Show warning in range item description
-- Limit file list to configured max (default 100)
-- Add "Show all files..." action to load more
-
-### Binary Files
-
-**Scenario:** Range includes binary file changes
-
-**Behavior:**
-- Show in file list with appropriate icon
-- Diff editor shows "Binary file changed" message
-- No commenting support for binary diffs
-
-## Future Enhancements
-
-### Phase 2 Features
-
-1. **Multiple Range Items**
-   - Allow manual creation of custom ranges
-   - Pin important ranges to tree view
-   - Compare different branches side-by-side
-
-2. **Range Templates**
-   - Save frequently used range configurations
-   - Quick actions: "Last week's commits", "Unpushed work", etc.
-
-3. **Range Comparison**
-   - Compare current range against previous state
-   - "Show what changed since last review"
-
-4. **AI Summaries**
-   - Auto-generate commit range summary
-   - Suggest PR description based on changes
-
-5. **Conflict Detection**
-   - Highlight potential merge conflicts in range
-   - Preview what would happen on merge
+1. Resolve the current workspace and branch range.
+2. Prefetch diffs through the shared diff provider.
+3. Build a prompt that references file paths and range metadata.
+4. Enqueue the review through CoC so progress and results appear in chat/process history.
+5. Keep generated findings tied to the workspace and diff context.
 
 ## Testing Strategy
 
-### Unit Tests
+Unit tests:
 
-- `GitRangeService.detectCommitRange()` - Range detection logic
-- `GitRangeService.getChangedFiles()` - File list generation
-- `GitRangeService.getDiffForFile()` - Cumulative diff generation
-- Range comment storage and retrieval
+- Default branch detection.
+- Commit count and merge-base handling.
+- File list parsing for modified, added, deleted, renamed, copied, and conflict statuses.
+- Diff stat parsing.
+- Storage-key stability for diff comments.
 
-### Integration Tests
+Integration tests:
 
-- Range item appears when on feature branch
-- Range item hidden when on default branch (no ahead commits)
-- File list updates when new commits added
-- Diff editor opens with correct combined diff
-- Comments persist across range updates
+- Branch range appears for a feature branch with commits ahead.
+- Branch range is hidden when no commits are ahead.
+- File list refreshes after new commits.
+- Per-file diff loading uses the correct `base...head` comparison.
+- Comments persist and relocate across range refreshes.
 
-### Manual Testing Scenarios
+Dashboard tests:
 
-1. **Feature branch workflow**
-   - Create feature branch
-   - Make multiple commits
-   - Verify range item appears with correct count
-   - Review files and add comments
-
-2. **Main branch workflow**
-   - Switch to main
-   - Make local commits without pushing
-   - Verify range shows unpushed commits
-
-3. **Complex history**
-   - Merge commits in range
-   - Renamed files across commits
-   - Deleted and re-added files
+- Overview renders summary counts.
+- Large diffs show truncation affordances.
+- All-comments view lists open and resolved comments.
+- AI review actions route through the selected workspace.
 
 ## Success Metrics
 
-- Range item correctly appears/disappears based on branch state
-- Cumulative diff matches `git diff origin/main...HEAD`
-- Comments persist and display correctly
-- Performance acceptable for ranges up to 100 commits
-- No false positives/negatives in range detection
+- Range summary matches `git diff <base>...HEAD`.
+- File counts and line stats match git output.
+- Comments stay scoped to the correct workspace and file context.
+- Large ranges remain usable without loading every diff eagerly.
+- AI review receives the complete range context without breaking multi-repo routing.
 
 ## References
 
 - Git Documentation: [git-diff](https://git-scm.com/docs/git-diff)
 - Git Documentation: [git-rev-list](https://git-scm.com/docs/git-rev-list)
-- Existing implementation: `src/shortcuts/git-diff-comments/`
-- Related feature: AI Code Review (`docs/designs/ai-code-review-map-reduce.md`)
+- Diff provider architecture: `packages/forge/src/diff/README.md`
+- Git range service: `packages/forge/src/git/git-range-service.ts`
+- Dashboard Git tab spec: `packages/coc/specs/repo-git-tab.spec.md`

--- a/docs/designs/pipeline-core-extraction.md
+++ b/docs/designs/pipeline-core-extraction.md
@@ -1,478 +1,214 @@
-# Pipeline Core Package Extraction
+# Workflow Core Package Boundary
 
 ## Overview
 
-Extract the AI pipeline execution engine, map-reduce framework, and Copilot SDK integration into a standalone Node.js package. This enables:
+The workflow core boundary keeps AI workflow execution, map-reduce helpers, git utilities, diff providers, editor-independent rendering helpers, and SDK integration in reusable Node packages. CoC then consumes those packages from the CLI, HTTP server, queue executors, and dashboard.
 
-1. **CLI usage** - Run pipelines from command line without VS Code
-2. **Testability** - Pure Node.js tests without VS Code test runner
-3. **Reusability** - Use in other tools, scripts, or applications
+This boundary serves three goals:
 
-## Current State
+1. **CLI usage** - `coc run` and package APIs run workflows without a UI runtime.
+2. **Testability** - Pure logic has Vitest coverage in package tests.
+3. **Reusability** - Other tools can consume workflow, AI, git, diff, and rendering helpers through package exports.
 
-After decoupling work, the following files are now **VS Code-free**:
+## Package Responsibilities
 
-| File | Status |
-|------|--------|
-| `ai-service/copilot-sdk-service.ts` | ✅ Pure (config via `configureSessionPool()`) |
-| `ai-service/session-pool.ts` | ✅ Pure |
-| `ai-service/types.ts` | ✅ Pure |
-| `ai-service/cli-utils.ts` | ✅ Pure |
-| `ai-service/prompt-builder.ts` | ✅ Pure |
-| `map-reduce/**/*.ts` | ✅ All pure |
-| `yaml-pipeline/*.ts` (except `ui/`) | ✅ All pure |
-| `shared/file-utils.ts` | ✅ Pure |
-| `shared/glob-utils.ts` | ✅ Pure |
-| `shared/exec-utils.ts` | ✅ Pure |
-| `shared/http-utils.ts` | ✅ Pure |
-| `shared/text-matching.ts` | ✅ Pure |
-| `shared/ai-response-parser.ts` | ✅ Pure |
+| Package | Responsibility |
+|---------|----------------|
+| `@plusplusoneplusplus/coc-workflow` | Pure DAG workflow compiler/executor, legacy pipeline YAML compatibility, workflow logger contracts, workflow errors, and Ralph portable helpers. |
+| `@plusplusoneplusplus/forge` | AI utilities, map-reduce, git CLI services, diff providers, process store, review helpers, editor-independent rendering/anchor helpers, and compatibility exports. |
+| `@plusplusoneplusplus/coc-agent-sdk` | Provider-agnostic Copilot/Codex SDK wrapper, model registry, session lifecycle, warm client registry, and streaming state machine. |
+| `@plusplusoneplusplus/coc` | CLI, HTTP server, queue executors, dashboard SPA, workspace routing, and runtime persistence. |
+| `@plusplusoneplusplus/coc-client` | Framework-free REST and realtime client for dashboard and external consumers. |
 
-**Remaining dependency:** `ai-service-logger.ts` → `shared/extension-logger.ts` uses `vscode.OutputChannel`
+Shared behavior belongs in these packages. Runtime surfaces that depend on CoC workspace state, HTTP routes, queue semantics, or dashboard components stay in `packages/coc/`.
 
-## Package Structure
+## Core Module Layout
 
-```
-packages/
-└── pipeline-core/
-    ├── package.json
-    ├── tsconfig.json
-    ├── vitest.config.ts
-    ├── src/
-    │   ├── index.ts                    # Public API exports
-    │   │
-    │   ├── ai/
-    │   │   ├── index.ts
-    │   │   ├── copilot-sdk-service.ts
-    │   │   ├── session-pool.ts
-    │   │   ├── cli-utils.ts
-    │   │   ├── prompt-builder.ts
-    │   │   ├── logger.ts               # New: simple logger interface
-    │   │   └── types.ts
-    │   │
-    │   ├── map-reduce/
-    │   │   ├── index.ts
-    │   │   ├── executor.ts
-    │   │   ├── concurrency-limiter.ts
-    │   │   ├── prompt-template.ts
-    │   │   ├── temp-file-utils.ts
-    │   │   ├── types.ts
-    │   │   ├── jobs/
-    │   │   ├── reducers/
-    │   │   └── splitters/
-    │   │
-    │   ├── pipeline/
-    │   │   ├── index.ts
-    │   │   ├── executor.ts
-    │   │   ├── csv-reader.ts
-    │   │   ├── template.ts
-    │   │   ├── filter-executor.ts
-    │   │   ├── prompt-resolver.ts
-    │   │   ├── skill-resolver.ts
-    │   │   ├── input-generator.ts
-    │   │   └── types.ts
-    │   │
-    │   └── utils/
-    │       ├── index.ts
-    │       ├── file-utils.ts
-    │       ├── glob-utils.ts
-    │       ├── exec-utils.ts
-    │       ├── http-utils.ts
-    │       ├── text-matching.ts
-    │       └── ai-response-parser.ts
-    │
-    └── test/
+```text
+packages/coc-workflow/src/
+  index.ts
+  logger.ts
+  errors/
+  workflow/
+    compiler.ts
+    executor.ts
+    scheduler.ts
+    validator.ts
+    pipeline-compat.ts
+    nodes/
+    types.ts
+  ralph/
+
+packages/forge/src/
+  ai/
+  map-reduce/
+  git/
+  diff/
+  editor/
+  review/
+  workflow/
+  utils/
+
+packages/coc-agent-sdk/src/
+  providers/
+  services/
+  model-registry/
+  warm-client-registry.ts
 ```
 
 ## Logger Abstraction
 
-The only remaining VS Code dependency is the logger. Create a simple interface:
+Package code uses a small logger interface instead of depending on any host UI.
 
 ```typescript
-// packages/pipeline-core/src/logger.ts
-
 export interface Logger {
-    debug(category: string, message: string): void;
-    info(category: string, message: string): void;
-    warn(category: string, message: string): void;
-    error(category: string, message: string, error?: Error): void;
+  debug(category: string, message: string): void;
+  info(category: string, message: string): void;
+  warn(category: string, message: string): void;
+  error(category: string, message: string, error?: Error): void;
 }
 
 export const consoleLogger: Logger = {
-    debug: (cat, msg) => console.debug(`[${cat}] ${msg}`),
-    info: (cat, msg) => console.log(`[${cat}] ${msg}`),
-    warn: (cat, msg) => console.warn(`[${cat}] ${msg}`),
-    error: (cat, msg, err) => console.error(`[${cat}] ${msg}`, err || ''),
+  debug: (category, message) => console.debug(`[${category}] ${message}`),
+  info: (category, message) => console.log(`[${category}] ${message}`),
+  warn: (category, message) => console.warn(`[${category}] ${message}`),
+  error: (category, message, error) => console.error(`[${category}] ${message}`, error ?? ''),
 };
 
-export const nullLogger: Logger = {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-};
-
-// Global logger instance (can be replaced)
 let globalLogger: Logger = consoleLogger;
 
 export function setLogger(logger: Logger): void {
-    globalLogger = logger;
+  globalLogger = logger;
 }
 
 export function getLogger(): Logger {
-    return globalLogger;
+  return globalLogger;
 }
 ```
 
-**In extension**, bridge to VS Code logger:
+CoC wraps this contract with Pino-backed server logging. Tests can use a null or in-memory logger.
 
-```typescript
-// vscode-extension/src/adapters/logger-adapter.ts
-import { Logger, setLogger } from 'pipeline-core';
-import { getExtensionLogger, LogCategory } from './shared/extension-logger';
-
-export function initializeCoreLogger(): void {
-    const vscodeLogger = getExtensionLogger();
-
-    setLogger({
-        debug: (cat, msg) => vscodeLogger.debug(cat as LogCategory, msg),
-        info: (cat, msg) => vscodeLogger.info(cat as LogCategory, msg),
-        warn: (cat, msg) => vscodeLogger.warn(cat as LogCategory, msg),
-        error: (cat, msg, err) => vscodeLogger.error(cat as LogCategory, msg, err),
-    });
-}
-```
-
-## File Migration Map
-
-### AI Service
-
-| Source | Destination | Changes |
-|--------|-------------|---------|
-| `copilot-sdk-service.ts` | `src/ai/` | Replace `getExtensionLogger()` with `getLogger()` |
-| `session-pool.ts` | `src/ai/` | None |
-| `types.ts` | `src/ai/` | None |
-| `cli-utils.ts` | `src/ai/` | None |
-| `prompt-builder.ts` | `src/ai/` | None |
-
-### Map-Reduce (all files move as-is)
-
-| Source | Destination |
-|--------|-------------|
-| `executor.ts` | `src/map-reduce/` |
-| `concurrency-limiter.ts` | `src/map-reduce/` |
-| `prompt-template.ts` | `src/map-reduce/` |
-| `temp-file-utils.ts` | `src/map-reduce/` |
-| `types.ts` | `src/map-reduce/` |
-| `jobs/*.ts` | `src/map-reduce/jobs/` |
-| `reducers/*.ts` | `src/map-reduce/reducers/` |
-| `splitters/*.ts` | `src/map-reduce/splitters/` |
-
-### YAML Pipeline (core files only)
-
-| Source | Destination |
-|--------|-------------|
-| `executor.ts` | `src/pipeline/` |
-| `csv-reader.ts` | `src/pipeline/` |
-| `template.ts` | `src/pipeline/` |
-| `filter-executor.ts` | `src/pipeline/` |
-| `prompt-resolver.ts` | `src/pipeline/` |
-| `skill-resolver.ts` | `src/pipeline/` |
-| `input-generator.ts` | `src/pipeline/` |
-| `types.ts` | `src/pipeline/` |
-
-**Stay in extension:**
-- `yaml-pipeline/ui/*` - VS Code tree views and commands
-- `yaml-pipeline/bundled/*` - VS Code-specific bundled pipelines
-
-### Shared Utils
-
-| Source | Destination |
-|--------|-------------|
-| `file-utils.ts` | `src/utils/` |
-| `glob-utils.ts` | `src/utils/` |
-| `exec-utils.ts` | `src/utils/` |
-| `http-utils.ts` | `src/utils/` |
-| `text-matching.ts` | `src/utils/` |
-| `ai-response-parser.ts` | `src/utils/` |
-
-## Package Configuration
-
-### package.json
-
-```json
-{
-  "name": "pipeline-core",
-  "version": "1.0.0",
-  "description": "AI pipeline execution engine with map-reduce framework",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": "./dist/index.js",
-    "./ai": "./dist/ai/index.js",
-    "./map-reduce": "./dist/map-reduce/index.js",
-    "./pipeline": "./dist/pipeline/index.js",
-    "./utils": "./dist/utils/index.js"
-  },
-  "files": ["dist"],
-  "scripts": {
-    "build": "tsc",
-    "test": "vitest",
-    "lint": "eslint src"
-  },
-  "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.0",
-    "js-yaml": "^4.1.0",
-    "csv-parse": "^5.5.0",
-    "glob": "^10.3.0"
-  },
-  "devDependencies": {
-    "typescript": "^5.3.0",
-    "vitest": "^1.0.0",
-    "@types/node": "^20.0.0",
-    "@types/js-yaml": "^4.0.0"
-  },
-  "engines": {
-    "node": ">=18"
-  }
-}
-```
-
-## Public API
-
-### Main Exports
-
-```typescript
-// packages/pipeline-core/src/index.ts
-
-// Logger
-export { Logger, consoleLogger, nullLogger, setLogger, getLogger } from './logger';
-
-// AI Service
-export {
-    CopilotSDKService,
-    getCopilotSDKService,
-    resetCopilotSDKService,
-    SessionPoolConfig,
-    DEFAULT_SESSION_POOL_CONFIG,
-    SendMessageOptions,
-    SDKInvocationResult,
-    PermissionHandler,
-    approveAllPermissions,
-    denyAllPermissions,
-} from './ai';
-
-export { SessionPool } from './ai/session-pool';
-
-// Map-Reduce
-export { MapReduceExecutor, createExecutor } from './map-reduce';
-export type { MapReduceOptions, MapReduceResult, MapJob } from './map-reduce/types';
-
-// Pipeline
-export { executePipeline, parsePipelineYaml } from './pipeline';
-export type { PipelineConfig, PipelineResult } from './pipeline/types';
-
-// Utils
-export * from './utils';
-```
-
-## Usage Examples
-
-### Standalone CLI Usage
+## Public Workflow API
 
 ```typescript
 import {
-    CopilotSDKService,
-    executePipeline,
-    consoleLogger,
-    setLogger
-} from 'pipeline-core';
-import { readFileSync } from 'fs';
+  compileToWorkflow,
+  executeWorkflow,
+  flattenWorkflowResult,
+} from '@plusplusoneplusplus/coc-workflow';
 
-// Use console logger (default)
-setLogger(consoleLogger);
-
-// Get the service and configure
-const aiService = CopilotSDKService.getInstance();
-aiService.configureSessionPool({
-    maxSessions: 5,
-    idleTimeoutMs: 300000
+const config = compileToWorkflow(yamlContent);
+const result = await executeWorkflow(config, {
+  aiInvoker,
+  workingDirectory,
+  onProgress,
+  signal,
 });
 
-// Execute pipeline
-const pipelineYaml = readFileSync('./pipeline.yaml', 'utf-8');
-const result = await executePipeline({
-    pipelineYaml,
-    basePath: './my-pipeline',
-    aiService,
-    onProgress: (current, total) => {
-        console.log(`Processing ${current}/${total}`);
-    }
-});
-
-console.log('Results:', result.outputs);
+const flat = flattenWorkflowResult(result);
 ```
 
-### VS Code Extension Usage
+## Public Diff API
 
 ```typescript
-// In extension activation
 import {
-    CopilotSDKService,
-    setLogger
-} from 'pipeline-core';
-import * as vscode from 'vscode';
-import { getExtensionLogger, LogCategory } from './shared/extension-logger';
+  createCommitDiffProvider,
+  createRangeDiffProvider,
+  createWorkingTreeDiffProvider,
+} from '@plusplusoneplusplus/forge';
 
-export function activate(context: vscode.ExtensionContext) {
-    // Bridge logger to VS Code output channel
-    const vscodeLogger = getExtensionLogger();
-    setLogger({
-        debug: (cat, msg) => vscodeLogger.debug(cat as LogCategory, msg),
-        info: (cat, msg) => vscodeLogger.info(cat as LogCategory, msg),
-        warn: (cat, msg) => vscodeLogger.warn(cat as LogCategory, msg),
-        error: (cat, msg, err) => vscodeLogger.error(cat as LogCategory, msg, err),
-    });
-
-    // Configure SDK service from VS Code settings
-    const config = vscode.workspace.getConfiguration('workspaceShortcuts.aiService.sdk');
-    const aiService = CopilotSDKService.getInstance();
-    aiService.configureSessionPool({
-        maxSessions: config.get('maxSessions', 5),
-        idleTimeoutMs: config.get('sessionTimeout', 300000)
-    });
-}
+const provider = createRangeDiffProvider('/repo', 'origin/main', 'HEAD');
+const files = await provider.listFiles();
+const diff = await provider.getFileDiff(files[0].path, { maxLines: 500 });
 ```
 
-## Monorepo Setup
+The diff provider contract supports single commits, commit ranges, working tree changes, pull requests, and pull-request iterations behind one interface.
 
-### Directory Structure
+## Public AI Service Boundary
 
-```
-shortcuts/
-├── package.json                  # Workspace root
-├── packages/
-│   └── pipeline-core/            # pipeline-core
-│       ├── package.json
-│       └── src/
-└── vscode-extension/             # VS Code extension
-    ├── package.json              # depends on pipeline-core
-    └── src/
-        ├── extension.ts
-        └── shortcuts/
-            ├── ai-service/       # Only VS Code-specific files remain
-            │   ├── ai-process-manager.ts
-            │   ├── ai-process-tree-provider.ts
-            │   └── ...
-            └── yaml-pipeline/
-                └── ui/           # Only UI components remain
+The SDK package owns provider process lifecycle and per-turn session creation. Higher packages may warm provider client processes for a short TTL, but they must not cache session objects or add follow-up shortcuts that bypass the per-turn session lifecycle.
+
+```typescript
+import { SDKServiceRegistry } from '@plusplusoneplusplus/coc-agent-sdk';
+
+const service = SDKServiceRegistry.get(provider);
+const result = await service.sendMessage(prompt, {
+  workingDirectory,
+  model,
+  reasoningEffort,
+  signal,
+});
 ```
 
-### Root package.json
+## CoC Integration
 
-```json
-{
-  "name": "shortcuts-monorepo",
-  "private": true,
-  "workspaces": [
-    "packages/*",
-    "vscode-extension"
-  ]
-}
+CLI execution:
+
+```bash
+coc run path/to/workflow.yaml
+coc validate path/to/workflow.yaml
 ```
 
-## Implementation Tasks
+Queue execution:
 
-### Phase 1: Setup ✅ COMPLETED
-- [x] Create monorepo structure with npm workspaces
-- [x] Set up `packages/pipeline-core/` with package.json and tsconfig
-- [x] Create logger abstraction module
+```typescript
+import { compileToWorkflow, executeWorkflow } from '@plusplusoneplusplus/coc-workflow';
 
-### Phase 2: Copy Files ✅ COMPLETED
-- [x] Copy map-reduce module to core package
-- [x] Copy pipeline module to core package
-- [x] Copy utils module to core package
-- [x] Copy ai module to core package
+const config = compileToWorkflow(yamlContent);
+const result = await executeWorkflow(config, {
+  aiInvoker: createQueueAIInvoker(task, workspace),
+  workingDirectory: workspace.root,
+  onProgress: event => publishProgress(task.id, event),
+  signal: task.abortSignal,
+});
+```
 
-### Phase 3: Update Extension ✅ COMPLETED
-- [x] Update extension to import from `pipeline-core` instead of local files
-- [x] Initialize logger bridge in extension activation
-- [x] Verify all functionality works with core package imports (6900 tests passing)
-- [x] Remove duplicated files from `src/shortcuts/`
+Dashboard integration:
 
-**Current state:** Extension index files re-export from `pipeline-core`. Duplicated source files
-have been removed from the extension. All imports now use either the index files (which re-export
-from pipeline-core) or import directly from `@anthropic-ai/pipeline-core`.
+- Workflow list and run controls call CoC routes.
+- Process detail subscribes to progress events.
+- Task and diff comments use workspace-scoped persistence.
+- Git, PR, branch range, and work item features consume Forge services through server routes.
 
-### Phase 4: Test Migration ✅ COMPLETED
-- [x] Set up vitest for core package (`vitest.config.ts`)
-- [x] Migrated all pure logic tests (see Test Migration Map below)
-- [x] All 569 tests passing in pipeline-core package
-- [x] All 6900 extension tests passing
-- [x] Remove duplicated tests from extension after Phase 3 completion
+## Workspace and Persistence Rules
 
-### Phase 5: Cleanup ✅ COMPLETED
-- [x] Remove duplicated source files from extension after Phase 3
-- [x] Remove duplicated test files from extension after Phase 4
-- [x] Update all AGENTS.md files
-- [x] Final documentation updates
+- All per-repo runtime data lives under `~/.coc/repos/<workspaceId>/`.
+- Use `getRepoDataPath(dataDir, workspaceId, filename)` when adding repo-scoped server data.
+- Work items are created and updated through the CoC REST API.
+- Runtime paths must support multiple registered workspaces in one server.
+- YAML workflow examples may live in `.vscode/workflows/` or `.vscode/pipelines/` as repository configuration directories.
 
-## Test Migration Map
+## Test Strategy
 
-### Map-Reduce Tests
+Package tests:
 
-| Test File | Status | Tests | Destination |
-|-----------|--------|-------|-------------|
-| `concurrency-limiter.test.ts` | ✅ Migrated | 21 | `test/map-reduce/` |
-| `temp-file-utils.test.ts` | ✅ Migrated | 38 | `test/map-reduce/` |
-| `executor.test.ts` | ✅ Migrated | 19 | `test/map-reduce/` |
-| `prompt-template.test.ts` | ✅ Migrated | 35 | `test/map-reduce/` |
-| `reducers.test.ts` | ✅ Migrated | 20 | `test/map-reduce/` |
-| `splitters.test.ts` | ✅ Migrated | 23 | `test/map-reduce/` |
-| `reduce-process-tracking.test.ts` | ✅ Migrated | 6 | `test/map-reduce/` |
+- Workflow compiler, validator, scheduler, node executors, parameters, and progress events.
+- Map-reduce executor, splitters, reducers, concurrency limits, and temp-file utilities.
+- Git range, git log, branch services, and diff provider parsing.
+- Logger adapters and error helpers.
 
-### Pipeline Tests
+CoC tests:
 
-| Test File | Status | Tests | Destination |
-|-----------|--------|-------|-------------|
-| `csv-reader.test.ts` | ✅ Migrated | 40 | `test/pipeline/` |
-| `executor.test.ts` | ✅ Migrated | 56 | `test/pipeline/` |
-| `template.test.ts` | ✅ Migrated | 65 | `test/pipeline/` |
-| `skill-resolver.test.ts` | ✅ Migrated | 42 | `test/pipeline/` |
-| `input-generator.test.ts` | ✅ Migrated | 48 | `test/pipeline/` |
-| `edge-cases.test.ts` | ✅ Migrated | 22 | `test/pipeline/` |
-| `ai-reduce.test.ts` | ✅ Migrated | 19 | `test/pipeline/` |
-| `batch-mapping.test.ts` | ✅ Migrated | 26 | `test/pipeline/` |
-| `text-mode.test.ts` | ✅ Migrated | 38 | `test/pipeline/` |
-| `results-file.test.ts` | ✅ Migrated | 12 | `test/pipeline/` |
-| `multi-model-fanout.test.ts` | ✅ Migrated | 32 | `test/pipeline/` |
-| `index.test.ts` | ✅ Migrated | 25 | `test/pipeline/` |
+- CLI command behavior.
+- Server queue execution.
+- Workspace-scoped route handling.
+- Dashboard rendering and browser flows.
 
-**Total: 569 tests migrated to pipeline-core package**
+## Build Contract
 
-### Tests That Stay in Extension (VS Code UI)
+Root package build order:
 
-| Test File | Reason |
-|-----------|--------|
-| `commands.test.ts` | Tests VS Code commands |
-| `pipeline-executor-service.test.ts` | Uses MockAIProcessManager, VS Code integration |
-| `preview-content.test.ts` | Tests UI, imports from `ui/types` |
-| `preview-mermaid.test.ts` | Tests UI, imports from `ui/types` |
-| `result-viewer.test.ts` | Tests UI content generation |
+```text
+coc-agent-sdk -> coc-workflow -> forge -> coc-client -> coc-memory -> teams-bot -> coc -> deep-wiki
+```
 
-## What Stays in Extension
+Direct package builds keep the same dependency order through package prebuild scripts.
 
-These files remain in the VS Code extension (not extracted):
+## Design Constraints
 
-| Module | Files | Reason |
-|--------|-------|--------|
-| AI Service | `ai-process-manager.ts` | Uses vscode.Memento |
-| AI Service | `ai-process-tree-provider.ts` | VS Code TreeDataProvider |
-| AI Service | `ai-process-document-provider.ts` | VS Code TextDocumentContentProvider |
-| AI Service | `copilot-cli-invoker.ts` | Uses vscode config/clipboard |
-| AI Service | `interactive-session-*.ts` | VS Code UI |
-| Pipeline | `yaml-pipeline/ui/*` | VS Code tree views |
-| Pipeline | `yaml-pipeline/bundled/*` | VS Code-specific |
-| Shared | `extension-logger.ts` | Uses vscode.OutputChannel |
-| Shared | `*-tree-data-provider.ts` | VS Code TreeDataProvider |
-| Shared | `*-document-provider.ts` | VS Code providers |
+1. Keep pure workflow execution in `coc-workflow`.
+2. Keep compatibility utilities and git/diff/review helpers in `forge`.
+3. Keep HTTP, queue, workspace, and dashboard concerns in `coc`.
+4. Keep SDK provider lifecycle in `coc-agent-sdk`.
+5. Do not introduce repo-scoped runtime data outside `~/.coc/repos/<workspaceId>/`.
+6. Do not break multi-repo routing.

--- a/docs/designs/pipeline-scheduler.md
+++ b/docs/designs/pipeline-scheduler.md
@@ -2,67 +2,69 @@
 
 ## Overview
 
-This document describes the design for adding cron-based scheduling support to the `pipeline-core` package. The scheduler uses a file-based persistence model that stores schedule state alongside pipeline definitions, enabling schedules to survive process restarts without external database dependencies.
+This document describes cron-based scheduling for YAML workflows. The scheduler uses file-based configuration alongside workflow definitions and stores runtime state in a workspace-scoped data location, so schedules survive process restarts without Redis, MongoDB, or another external service.
 
 ## Goals
 
-1. **Recurring Execution** - Run pipelines on cron schedules (daily, weekly, etc.)
-2. **Persistence** - Schedules survive process restarts
-3. **Timezone Support** - Schedule in local or specific timezones
-4. **Missed Execution Handling** - Gracefully handle executions missed during downtime
-5. **Zero External Dependencies** - No Redis, MongoDB, or other infrastructure required
-6. **Multi-Environment** - Work in VS Code extension, CLI daemon, and Node.js backends
+1. **Recurring execution** - Run workflows on cron schedules.
+2. **Persistence** - Preserve schedule state across process restarts.
+3. **Timezone support** - Schedule in local or specific IANA timezones.
+4. **Missed execution handling** - Decide whether to run or skip executions missed during downtime.
+5. **Zero external infrastructure** - Work without a database or distributed lock service.
+6. **Multi-environment support** - Run from the CoC server, CLI daemon, and other Node.js hosts.
+7. **Multi-repo safety** - Scope schedules, state, and execution to the selected workspace.
 
-## Non-Goals (v1)
+## Non-Goals
 
-- Distributed scheduling across multiple machines
-- Sub-second precision scheduling
-- Complex workflow orchestration (pipeline chaining)
-- Web UI for schedule management
-
----
+- Distributed scheduling across multiple machines.
+- Sub-second precision.
+- Complex workflow orchestration beyond a single scheduled workflow.
+- Dashboard authoring UI in the first version.
 
 ## File Structure
 
-### Pipeline Package Layout
+Workflow definitions can live in a repository configuration directory:
 
-```
+```text
 .vscode/pipelines/
-├── daily-report/
-│   ├── pipeline.yaml           # Pipeline definition with schedule block
-│   ├── .schedule-state.json    # Runtime state (managed by scheduler)
-│   └── input.csv
-├── weekly-sync/
-│   ├── pipeline.yaml
-│   └── .schedule-state.json
-└── .scheduler.lock             # Lock file preventing concurrent instances
+  daily-report/
+    pipeline.yaml
+    input.csv
+  weekly-sync/
+    pipeline.yaml
 ```
 
-### Schedule Block in pipeline.yaml
+Scheduler runtime state must live under the CoC data directory for the workspace:
+
+```text
+~/.coc/repos/<workspaceId>/pipeline-schedules/
+  daily-report-a1b2c3.state.json
+  weekly-sync-d4e5f6.state.json
+  scheduler.lock
+```
+
+The `.vscode/pipelines/` path is repository configuration. The `~/.coc/repos/<workspaceId>/` path is runtime state.
+
+## Schedule Block
 
 ```yaml
 name: "Daily Bug Report"
 description: "Generate daily bug triage report"
 
-# New: Schedule configuration
 schedule:
-  cron: "0 9 * * 1-5"           # 9 AM on weekdays
-  timezone: "America/New_York"   # IANA timezone (optional, defaults to system)
-  enabled: true                  # Can disable without removing config
+  cron: "0 9 * * 1-5"
+  timezone: "America/New_York"
+  enabled: true
 
-  # Error handling
   retryPolicy:
-    maxRetries: 3                # Retry failed executions (default: 3)
-    retryDelayMs: 60000          # Delay between retries (default: 1 min)
+    maxRetries: 3
+    retryDelayMs: 60000
 
-  # Missed execution handling
-  missedExecution: "run"         # "run" | "skip" (default: "run")
+  missedExecution: "run"
 
-  # Execution window (optional)
   window:
-    maxDelayMinutes: 30          # Skip if more than 30 min late
+    maxDelayMinutes: 30
 
-# Existing pipeline config
 input:
   from:
     type: csv
@@ -76,756 +78,407 @@ reduce:
   type: json
 ```
 
-### State File Format (.schedule-state.json)
+## State File Format
 
 ```json
 {
   "version": 1,
+  "workspaceId": "ws-abc123",
   "scheduleId": "daily-report-a1b2c3",
   "pipelineId": "daily-report",
-
+  "pipelinePath": ".vscode/pipelines/daily-report/pipeline.yaml",
   "status": "idle",
   "enabled": true,
-
   "lastRun": {
     "startedAt": "2026-01-26T14:00:00.000Z",
     "completedAt": "2026-01-26T14:02:35.000Z",
     "success": true,
-    "resultFile": ".results/2026-01-26T14-00-00.json",
+    "resultFile": "results/2026-01-26T14-00-00.json",
     "itemsProcessed": 42,
     "error": null
   },
-
   "nextRun": "2026-01-27T14:00:00.000Z",
-
   "stats": {
     "totalRuns": 156,
     "successfulRuns": 152,
     "failedRuns": 4,
     "lastFailure": "2026-01-20T14:00:00.000Z"
   },
-
-  "history": [
-    {
-      "startedAt": "2026-01-26T14:00:00.000Z",
-      "completedAt": "2026-01-26T14:02:35.000Z",
-      "success": true,
-      "duration": 155000
-    }
-  ]
+  "history": []
 }
 ```
 
-### Lock File Format (.scheduler.lock)
+## Lock File Format
 
 ```json
 {
   "pid": 12345,
   "hostname": "dev-machine",
+  "workspaceId": "ws-abc123",
   "startedAt": "2026-01-26T08:00:00.000Z",
   "heartbeat": "2026-01-26T14:30:00.000Z"
 }
 ```
 
----
+Each workspace has its own lock. A single CoC server may manage schedules for multiple workspaces without sharing lock files between them.
 
 ## Component Architecture
 
+```text
+PipelineScheduler
+  CronParser
+  StateManager
+  ExecutionCoordinator
+  LockManager
+  TimerManager
+  PipelineDiscovery
+  EventEmitter
+    -> executeWorkflow()
+    -> CoC queue/process tracker
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      PipelineScheduler                          │
-│  (Main orchestrator - manages lifecycle and coordinates)        │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐ │
-│  │ CronParser   │  │ StateManager │  │ ExecutionCoordinator  │ │
-│  │              │  │              │  │                       │ │
-│  │ - parse()    │  │ - load()     │  │ - execute()           │ │
-│  │ - nextRun()  │  │ - save()     │  │ - retry()             │ │
-│  │ - validate() │  │ - history()  │  │ - cancel()            │ │
-│  └──────────────┘  └──────────────┘  └───────────────────────┘ │
-│                                                                 │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐ │
-│  │ LockManager  │  │ TimerManager │  │ PipelineDiscovery     │ │
-│  │              │  │              │  │                       │ │
-│  │ - acquire()  │  │ - schedule() │  │ - scan()              │ │
-│  │ - release()  │  │ - cancel()   │  │ - watch()             │ │
-│  │ - heartbeat()│  │ - list()     │  │ - getScheduled()      │ │
-│  └──────────────┘  └──────────────┘  └───────────────────────┘ │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              │ uses
-                              ▼
-                 ┌─────────────────────────┐
-                 │   Existing Executor     │
-                 │   (executePipeline)     │
-                 └─────────────────────────┘
-```
-
-### Component Responsibilities
 
 | Component | Responsibility |
 |-----------|----------------|
-| `PipelineScheduler` | Main entry point. Lifecycle management, event emission, public API |
-| `CronParser` | Parse cron expressions, calculate next execution times with timezone |
-| `StateManager` | Read/write `.schedule-state.json`, manage execution history |
-| `ExecutionCoordinator` | Run pipelines, handle retries, track in-flight executions |
-| `LockManager` | Prevent concurrent scheduler instances, heartbeat monitoring |
-| `TimerManager` | Manage Node.js timers for scheduled executions |
-| `PipelineDiscovery` | Scan for pipelines with schedules, watch for changes |
-
----
+| `PipelineScheduler` | Lifecycle management, public API, and event emission. |
+| `CronParser` | Parse cron expressions and calculate next run times. |
+| `StateManager` | Read/write workspace-scoped schedule state and history. |
+| `ExecutionCoordinator` | Execute workflows, apply retry policy, and track in-flight runs. |
+| `LockManager` | Prevent concurrent scheduler instances for one workspace. |
+| `TimerManager` | Own pending timers and cancellation. |
+| `PipelineDiscovery` | Scan configured directories for workflows with `schedule:` blocks. |
 
 ## Core Types
 
 ```typescript
-// packages/pipeline-core/src/scheduler/types.ts
-
-/**
- * Schedule configuration in pipeline.yaml
- */
 export interface ScheduleConfig {
-    /** Cron expression (5 or 6 fields) */
-    cron: string;
-
-    /** IANA timezone (e.g., "America/New_York"). Defaults to system timezone */
-    timezone?: string;
-
-    /** Whether schedule is active. Defaults to true */
-    enabled?: boolean;
-
-    /** Retry policy for failed executions */
-    retryPolicy?: {
-        maxRetries?: number;      // Default: 3
-        retryDelayMs?: number;    // Default: 60000
-    };
-
-    /** How to handle missed executions: "run" or "skip". Default: "run" */
-    missedExecution?: 'run' | 'skip';
-
-    /** Execution window constraints */
-    window?: {
-        maxDelayMinutes?: number; // Skip if execution is delayed beyond this
-    };
+  cron: string;
+  timezone?: string;
+  enabled?: boolean;
+  retryPolicy?: {
+    maxRetries?: number;
+    retryDelayMs?: number;
+  };
+  missedExecution?: 'run' | 'skip';
+  window?: {
+    maxDelayMinutes?: number;
+  };
 }
 
-/**
- * Runtime state for a scheduled pipeline
- */
 export interface ScheduleState {
-    version: number;
-    scheduleId: string;
-    pipelineId: string;
-
-    status: ScheduleStatus;
-    enabled: boolean;
-
-    lastRun: RunRecord | null;
-    nextRun: string | null;  // ISO timestamp
-
-    stats: ScheduleStats;
-    history: RunRecord[];    // Last N runs (configurable)
+  version: number;
+  workspaceId: string;
+  scheduleId: string;
+  pipelineId: string;
+  pipelinePath: string;
+  status: ScheduleStatus;
+  enabled: boolean;
+  lastRun: RunRecord | null;
+  nextRun: string | null;
+  stats: ScheduleStats;
+  history: RunRecord[];
 }
 
 export type ScheduleStatus =
-    | 'idle'        // Waiting for next execution
-    | 'running'     // Currently executing
-    | 'paused'      // Manually paused
-    | 'error'       // Last run failed, waiting for retry/next
-    | 'disabled';   // Schedule disabled in config
+  | 'idle'
+  | 'running'
+  | 'paused'
+  | 'error'
+  | 'disabled';
 
-/**
- * Record of a single execution
- */
 export interface RunRecord {
-    startedAt: string;
-    completedAt: string | null;
-    success: boolean;
-    duration?: number;        // ms
-    itemsProcessed?: number;
-    resultFile?: string;
-    error?: string;
-    retryAttempt?: number;
-}
-
-/**
- * Aggregate statistics
- */
-export interface ScheduleStats {
-    totalRuns: number;
-    successfulRuns: number;
-    failedRuns: number;
-    lastFailure: string | null;
-    averageDuration?: number;  // ms
-}
-
-/**
- * Information about a scheduled pipeline
- */
-export interface ScheduleInfo {
-    scheduleId: string;
-    pipelineId: string;
-    pipelineName: string;
-    pipelineDirectory: string;
-
-    config: ScheduleConfig;
-    state: ScheduleState;
-
-    nextRunIn?: number;  // ms until next run
+  startedAt: string;
+  completedAt: string | null;
+  success: boolean;
+  duration?: number;
+  itemsProcessed?: number;
+  resultFile?: string;
+  error?: string;
+  retryAttempt?: number;
 }
 ```
-
----
 
 ## Public API
 
 ```typescript
-// packages/pipeline-core/src/scheduler/scheduler.ts
-
 export interface SchedulerOptions {
-    /** Root directory containing pipeline packages */
-    pipelinesDirectory: string;
-
-    /** Workspace root for resolving skills */
-    workspaceRoot?: string;
-
-    /** AI invoker for pipeline execution */
-    aiInvoker: AIInvoker;
-
-    /** Optional process tracker for UI integration */
-    processTracker?: ProcessTracker;
-
-    /** Maximum history entries to keep per pipeline. Default: 50 */
-    maxHistoryEntries?: number;
-
-    /** Lock file stale threshold in ms. Default: 60000 (1 min) */
-    lockStaleThresholdMs?: number;
-
-    /** Heartbeat interval in ms. Default: 10000 (10 sec) */
-    heartbeatIntervalMs?: number;
-}
-
-export interface SchedulerEvents {
-    /** Emitted when a scheduled execution starts */
-    'execution:start': (info: { scheduleId: string; pipelineId: string }) => void;
-
-    /** Emitted when execution completes successfully */
-    'execution:complete': (info: {
-        scheduleId: string;
-        pipelineId: string;
-        result: PipelineExecutionResult;
-        duration: number;
-    }) => void;
-
-    /** Emitted when execution fails */
-    'execution:error': (info: {
-        scheduleId: string;
-        pipelineId: string;
-        error: Error;
-        willRetry: boolean;
-        retryAttempt?: number;
-    }) => void;
-
-    /** Emitted when a schedule is added/updated/removed */
-    'schedule:changed': (info: {
-        scheduleId: string;
-        pipelineId: string;
-        change: 'added' | 'updated' | 'removed';
-    }) => void;
-
-    /** Emitted when scheduler starts/stops */
-    'scheduler:status': (status: 'starting' | 'running' | 'stopping' | 'stopped') => void;
+  workspaceId: string;
+  workspaceRoot: string;
+  dataDir: string;
+  pipelinesDirectory: string;
+  aiInvoker: AIInvoker;
+  processTracker?: ProcessTracker;
+  maxHistoryEntries?: number;
+  lockStaleThresholdMs?: number;
+  heartbeatIntervalMs?: number;
 }
 
 export class PipelineScheduler extends EventEmitter {
-    constructor(options: SchedulerOptions);
+  constructor(options: SchedulerOptions);
 
-    // Lifecycle
+  start(): Promise<void>;
+  stop(timeoutMs?: number): Promise<void>;
+  isRunning(): boolean;
 
-    /**
-     * Start the scheduler. Acquires lock, loads state, sets up timers.
-     * @throws {SchedulerLockError} if another instance is running
-     */
-    start(): Promise<void>;
+  listSchedules(): Promise<ScheduleInfo[]>;
+  getSchedule(scheduleId: string): Promise<ScheduleInfo | undefined>;
+  triggerNow(scheduleId: string): Promise<PipelineExecutionResult>;
+  pause(scheduleId: string): Promise<void>;
+  resume(scheduleId: string): Promise<void>;
+  cancel(scheduleId: string): Promise<void>;
 
-    /**
-     * Stop the scheduler gracefully. Waits for in-flight executions.
-     * @param timeoutMs - Max time to wait for executions. Default: 30000
-     */
-    stop(timeoutMs?: number): Promise<void>;
+  getUpcoming(limit?: number): Promise<Array<{
+    scheduleId: string;
+    pipelineId: string;
+    nextRun: Date;
+  }>>;
 
-    /**
-     * Check if scheduler is running
-     */
-    isRunning(): boolean;
-
-    // Schedule Management
-
-    /**
-     * Get all scheduled pipelines
-     */
-    listSchedules(): Promise<ScheduleInfo[]>;
-
-    /**
-     * Get info for a specific schedule
-     */
-    getSchedule(scheduleId: string): Promise<ScheduleInfo | undefined>;
-
-    /**
-     * Manually trigger a scheduled pipeline (outside normal schedule)
-     */
-    triggerNow(scheduleId: string): Promise<PipelineExecutionResult>;
-
-    /**
-     * Pause a schedule (skip upcoming executions until resumed)
-     */
-    pause(scheduleId: string): Promise<void>;
-
-    /**
-     * Resume a paused schedule
-     */
-    resume(scheduleId: string): Promise<void>;
-
-    /**
-     * Cancel a currently running execution
-     */
-    cancel(scheduleId: string): Promise<void>;
-
-    // Queries
-
-    /**
-     * Get upcoming executions across all schedules
-     */
-    getUpcoming(limit?: number): Promise<Array<{
-        scheduleId: string;
-        pipelineId: string;
-        nextRun: Date;
-    }>>;
-
-    /**
-     * Get execution history for a schedule
-     */
-    getHistory(scheduleId: string, limit?: number): Promise<RunRecord[]>;
-
-    // Resource cleanup
-    dispose(): void;
+  getHistory(scheduleId: string, limit?: number): Promise<RunRecord[]>;
+  dispose(): void;
 }
 ```
 
----
+## Startup Sequence
 
-## Scheduler Lifecycle
-
-### Startup Sequence
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                         start()                                   │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 1. Acquire Lock                                                   │
-│    - Check .scheduler.lock exists                                 │
-│    - If exists, check if stale (heartbeat too old)               │
-│    - If stale or not exists, write new lock                      │
-│    - If active, throw SchedulerLockError                         │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 2. Start Heartbeat                                                │
-│    - Update .scheduler.lock every heartbeatIntervalMs            │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 3. Discover Pipelines                                             │
-│    - Scan pipelinesDirectory for pipeline.yaml files             │
-│    - Filter to those with schedule: block                        │
-│    - Watch for file changes                                       │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 4. Load State                                                     │
-│    - For each scheduled pipeline:                                 │
-│      - Load .schedule-state.json (or create default)             │
-│      - Parse schedule config                                      │
-│      - Calculate next run time                                    │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 5. Handle Missed Executions                                       │
-│    - For each schedule where nextRun < now:                       │
-│      - If missedExecution == "run": queue for immediate execution│
-│      - If missedExecution == "skip": calculate next future run   │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 6. Set Timers                                                     │
-│    - For each enabled schedule:                                   │
-│      - Set timer for nextRun                                      │
-│    - Emit 'scheduler:status' = 'running'                         │
-└──────────────────────────────────────────────────────────────────┘
+```text
+start()
+  1. Resolve workspace-scoped state directory.
+  2. Acquire the workspace scheduler lock.
+  3. Start lock heartbeat.
+  4. Discover workflow files with schedule blocks.
+  5. Load or initialize state for each schedule.
+  6. Handle missed executions.
+  7. Set timers for enabled schedules.
+  8. Emit running status.
 ```
 
-### Execution Flow
+## Execution Flow
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                      Timer Fires                                  │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 1. Pre-Execution Check                                            │
-│    - Verify schedule still enabled                                │
-│    - Check window.maxDelayMinutes (skip if too late)             │
-│    - Update state: status = 'running'                            │
-│    - Emit 'execution:start'                                       │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 2. Execute Pipeline                                               │
-│    - Load pipeline.yaml                                           │
-│    - Call executePipeline() with aiInvoker                       │
-│    - Track progress via processTracker                           │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-              ┌─────────────┴─────────────┐
-              │                           │
-              ▼                           ▼
-┌─────────────────────────┐   ┌─────────────────────────┐
-│ 3a. Success             │   │ 3b. Failure             │
-│                         │   │                         │
-│ - Save result to file   │   │ - Check retry policy    │
-│ - Update state:         │   │ - If retries remain:    │
-│   - lastRun = success   │   │   - Schedule retry      │
-│   - Calculate nextRun   │   │   - Emit with willRetry │
-│   - Increment stats     │   │ - Else:                 │
-│ - Emit 'complete'       │   │   - Update state: error │
-│ - Set timer for nextRun │   │   - Calculate nextRun   │
-│                         │   │   - Emit 'error'        │
-└─────────────────────────┘   └─────────────────────────┘
+```text
+Timer fires
+  1. Verify schedule is still enabled.
+  2. Check execution window.
+  3. Mark state as running.
+  4. Compile workflow YAML.
+  5. Execute through executeWorkflow().
+  6. Publish progress through processTracker when provided.
+  7. Persist result metadata and next run.
+  8. Emit completion or retry/failure event.
 ```
 
-### Shutdown Sequence
+## Shutdown Sequence
 
+```text
+stop()
+  1. Emit stopping status.
+  2. Cancel pending timers.
+  3. Wait for in-flight executions up to timeout.
+  4. Stop heartbeat.
+  5. Release workspace lock.
+  6. Stop file watchers.
+  7. Emit stopped status.
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                         stop()                                    │
-└───────────────────────────┬──────────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ 1. Emit 'scheduler:status' = 'stopping'                          │
-│ 2. Cancel all pending timers                                      │
-│ 3. Wait for in-flight executions (up to timeoutMs)               │
-│ 4. Stop heartbeat                                                 │
-│ 5. Release lock (delete .scheduler.lock)                         │
-│ 6. Stop file watchers                                             │
-│ 7. Emit 'scheduler:status' = 'stopped'                           │
-└──────────────────────────────────────────────────────────────────┘
-```
-
----
 
 ## Cron Parsing
 
-### Supported Format
+Use `croner` for cron parsing:
 
-Standard 5-field cron with optional 6th field for seconds:
-
-```
-┌────────────── second (0-59) [optional]
-│ ┌──────────── minute (0-59)
-│ │ ┌────────── hour (0-23)
-│ │ │ ┌──────── day of month (1-31)
-│ │ │ │ ┌────── month (1-12)
-│ │ │ │ │ ┌──── day of week (0-7, 0 and 7 = Sunday)
-│ │ │ │ │ │
-* * * * * *
-```
-
-### Special Characters
-
-| Character | Meaning | Example |
-|-----------|---------|---------|
-| `*` | Any value | `* * * * *` = every minute |
-| `,` | List | `1,15 * * * *` = minute 1 and 15 |
-| `-` | Range | `1-5 * * * *` = minutes 1 through 5 |
-| `/` | Step | `*/15 * * * *` = every 15 minutes |
-
-### Predefined Schedules
-
-| Alias | Equivalent |
-|-------|------------|
-| `@yearly` | `0 0 1 1 *` |
-| `@monthly` | `0 0 1 * *` |
-| `@weekly` | `0 0 * * 0` |
-| `@daily` | `0 0 * * *` |
-| `@hourly` | `0 * * * *` |
-
-### Library Choice: croner
-
-Use [croner](https://github.com/hexagon/croner) for cron parsing:
-
-- Lightweight (~5KB)
-- Native timezone support via `Intl.DateTimeFormat`
-- No external dependencies
-- TypeScript-first
-- Actively maintained
+- Small dependency footprint.
+- Native timezone support through `Intl.DateTimeFormat`.
+- TypeScript-friendly API.
 
 ```typescript
 import { Cron } from 'croner';
 
-const job = new Cron("0 9 * * 1-5", {
-    timezone: "America/New_York"
+const job = new Cron('0 9 * * 1-5', {
+  timezone: 'America/New_York',
 }, () => {
-    // Execute pipeline
+  void scheduler.triggerNow(scheduleId);
 });
 
-// Get next run time
 const nextRun = job.nextRun();
 ```
 
----
+Supported syntax:
+
+| Syntax | Meaning | Example |
+|--------|---------|---------|
+| `*` | Any value | `* * * * *` |
+| `,` | List | `1,15 * * * *` |
+| `-` | Range | `1-5 * * * *` |
+| `/` | Step | `*/15 * * * *` |
+| `@daily` | Daily alias | `@daily` |
 
 ## Error Handling
 
-### Error Categories
-
 | Category | Handling | Example |
 |----------|----------|---------|
-| **Config Error** | Skip schedule, log warning | Invalid cron syntax |
-| **Lock Error** | Fail startup, inform user | Another scheduler running |
-| **Execution Error** | Retry per policy | AI timeout, network error |
-| **State Error** | Recreate state file | Corrupted JSON |
-| **System Error** | Log, continue others | Disk full on one save |
+| Config error | Disable schedule and report validation details. | Invalid cron syntax. |
+| Lock error | Fail startup for that workspace scheduler. | Active scheduler heartbeat. |
+| Execution error | Retry according to policy. | AI timeout or network error. |
+| State error | Recreate state if safe, otherwise disable schedule. | Corrupted JSON. |
+| System error | Log, keep other schedules running. | Disk full for one state write. |
 
-### Retry Logic
+Retry behavior:
 
 ```typescript
-async function executeWithRetry(
-    scheduleId: string,
-    config: ScheduleConfig,
-    attempt: number = 1
-): Promise<PipelineExecutionResult> {
-    const maxRetries = config.retryPolicy?.maxRetries ?? 3;
-    const retryDelayMs = config.retryPolicy?.retryDelayMs ?? 60000;
+async function executeWithRetry(scheduleId: string, config: ScheduleConfig, attempt = 1) {
+  const maxRetries = config.retryPolicy?.maxRetries ?? 3;
+  const retryDelayMs = config.retryPolicy?.retryDelayMs ?? 60000;
 
-    try {
-        return await executePipeline(/* ... */);
-    } catch (error) {
-        if (attempt < maxRetries) {
-            this.emit('execution:error', {
-                scheduleId,
-                error,
-                willRetry: true,
-                retryAttempt: attempt
-            });
-
-            await delay(retryDelayMs * attempt); // Exponential backoff
-            return executeWithRetry(scheduleId, config, attempt + 1);
-        }
-
-        throw error; // Max retries exceeded
+  try {
+    return await executeWorkflowForSchedule(scheduleId);
+  } catch (error) {
+    if (attempt < maxRetries) {
+      emitExecutionError({ scheduleId, error, willRetry: true, retryAttempt: attempt });
+      await delay(retryDelayMs * attempt);
+      return executeWithRetry(scheduleId, config, attempt + 1);
     }
+
+    throw error;
+  }
 }
 ```
 
----
-
-## Integration Points
-
-### VS Code Extension
+## CoC Server Integration
 
 ```typescript
-// src/extension.ts
-import { PipelineScheduler } from 'pipeline-core';
+import { PipelineScheduler } from '@plusplusoneplusplus/coc-workflow/scheduler';
+import { getRepoDataPath } from '../paths';
 
-let scheduler: PipelineScheduler | undefined;
+export async function startWorkspaceScheduler(workspace: WorkspaceInfo, dataDir: string) {
+  const stateDir = getRepoDataPath(dataDir, workspace.id, 'pipeline-schedules');
 
-export async function activate(context: ExtensionContext) {
-    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    if (!workspaceRoot) return;
+  const scheduler = new PipelineScheduler({
+    workspaceId: workspace.id,
+    workspaceRoot: workspace.root,
+    dataDir: stateDir,
+    pipelinesDirectory: path.join(workspace.root, '.vscode', 'pipelines'),
+    aiInvoker: createServerAIInvoker(workspace),
+    processTracker: createProcessTracker(workspace.id),
+  });
 
-    const pipelinesDir = path.join(workspaceRoot, '.vscode', 'pipelines');
+  scheduler.on('execution:start', info => {
+    publishWorkspaceEvent(workspace.id, { type: 'pipeline-schedule-start', info });
+  });
 
-    scheduler = new PipelineScheduler({
-        pipelinesDirectory: pipelinesDir,
-        workspaceRoot,
-        aiInvoker: createAIInvoker(),
-        processTracker: aiProcessManager
-    });
+  scheduler.on('execution:complete', info => {
+    publishWorkspaceEvent(workspace.id, { type: 'pipeline-schedule-complete', info });
+  });
 
-    // UI updates
-    scheduler.on('execution:start', (info) => {
-        vscode.window.setStatusBarMessage(`Running: ${info.pipelineId}...`);
-    });
+  scheduler.on('execution:error', info => {
+    publishWorkspaceEvent(workspace.id, { type: 'pipeline-schedule-error', info });
+  });
 
-    scheduler.on('execution:complete', (info) => {
-        vscode.window.showInformationMessage(
-            `Pipeline "${info.pipelineId}" completed in ${info.duration}ms`
-        );
-    });
-
-    scheduler.on('execution:error', (info) => {
-        if (!info.willRetry) {
-            vscode.window.showErrorMessage(
-                `Pipeline "${info.pipelineId}" failed: ${info.error.message}`
-            );
-        }
-    });
-
-    await scheduler.start();
-
-    context.subscriptions.push({
-        dispose: () => scheduler?.stop()
-    });
+  await scheduler.start();
+  return scheduler;
 }
 ```
 
-### CLI Daemon
+## CLI Daemon Integration
 
 ```typescript
-// cli/daemon.ts
-import { PipelineScheduler } from 'pipeline-core';
+import { PipelineScheduler } from '@plusplusoneplusplus/coc-workflow/scheduler';
 
 async function main() {
-    const scheduler = new PipelineScheduler({
-        pipelinesDirectory: process.argv[2] || '.vscode/pipelines',
-        aiInvoker: createCLIAIInvoker()
-    });
+  const scheduler = new PipelineScheduler({
+    workspaceId: resolveWorkspaceId(process.cwd()),
+    workspaceRoot: process.cwd(),
+    dataDir: resolveWorkspaceScheduleDataDir(process.cwd()),
+    pipelinesDirectory: process.argv[2] || '.vscode/pipelines',
+    aiInvoker: createCLIAIInvoker(),
+  });
 
-    // Graceful shutdown
-    process.on('SIGTERM', async () => {
-        console.log('Shutting down...');
-        await scheduler.stop();
-        process.exit(0);
-    });
+  process.on('SIGTERM', () => void scheduler.stop().then(() => process.exit(0)));
+  process.on('SIGINT', () => void scheduler.stop().then(() => process.exit(0)));
 
-    process.on('SIGINT', async () => {
-        console.log('Interrupted, shutting down...');
-        await scheduler.stop();
-        process.exit(0);
-    });
-
-    await scheduler.start();
-    console.log('Scheduler running. Press Ctrl+C to stop.');
-
-    // Keep process alive
-    setInterval(() => {}, 1000);
+  await scheduler.start();
+  console.log('Scheduler running. Press Ctrl+C to stop.');
 }
 ```
 
-### CLI Commands
+## CLI Commands
 
 ```bash
-# Start daemon
-pipeline-core scheduler start
-
-# List schedules
-pipeline-core scheduler list
-
-# Get schedule status
-pipeline-core scheduler status <schedule-id>
-
-# Trigger immediate execution
-pipeline-core scheduler trigger <schedule-id>
-
-# Pause/resume
-pipeline-core scheduler pause <schedule-id>
-pipeline-core scheduler resume <schedule-id>
-
-# View history
-pipeline-core scheduler history <schedule-id> --limit 10
+coc scheduler start --workspace <path>
+coc scheduler list --workspace <path>
+coc scheduler status <schedule-id> --workspace <path>
+coc scheduler trigger <schedule-id> --workspace <path>
+coc scheduler pause <schedule-id> --workspace <path>
+coc scheduler resume <schedule-id> --workspace <path>
+coc scheduler history <schedule-id> --workspace <path> --limit 10
 ```
-
----
 
 ## File Watching
 
-The scheduler watches for changes to pipeline.yaml files:
+The scheduler watches configured pipeline directories for `pipeline.yaml` changes.
 
 | Change | Action |
 |--------|--------|
-| Schedule added | Load state, set timer |
-| Schedule modified | Recalculate next run, reset timer |
-| Schedule removed | Cancel timer, archive state |
-| Pipeline deleted | Cancel timer, cleanup state |
+| Schedule added | Load state and set timer. |
+| Schedule modified | Recalculate next run and reset timer. |
+| Schedule removed | Cancel timer and mark state disabled. |
+| Pipeline deleted | Cancel timer and preserve history for audit. |
 
 ```typescript
-// Debounce file changes (500ms)
-private setupFileWatcher(): void {
-    const watcher = fs.watch(this.pipelinesDirectory, { recursive: true });
+function setupFileWatcher(directory: string): void {
+  const watcher = fs.watch(directory, { recursive: true });
 
-    watcher.on('change', debounce((eventType, filename) => {
-        if (filename?.endsWith('pipeline.yaml')) {
-            this.handlePipelineChange(filename);
-        }
-    }, 500));
+  watcher.on('change', debounce((_eventType, filename) => {
+    if (filename?.endsWith('pipeline.yaml')) {
+      void reloadPipelineSchedule(filename);
+    }
+  }, 500));
 }
 ```
-
----
 
 ## Testing Strategy
 
-### Unit Tests
+Unit tests:
 
-- Cron parsing with various expressions
-- Timezone calculations
-- State serialization/deserialization
-- Retry logic
-- Lock acquisition/release
+- Cron parsing and timezone calculations.
+- State serialization and history trimming.
+- Lock acquisition, stale-lock recovery, and release.
+- Retry and missed-execution behavior.
+- Workspace-scoped path resolution.
 
-### Integration Tests
+Integration tests:
 
-- Full scheduler lifecycle (start → execute → stop)
-- Missed execution handling
-- File watching and dynamic updates
-- Concurrent scheduler prevention
-- Graceful shutdown with in-flight execution
+- Scheduler lifecycle: start, execute, stop.
+- Concurrent scheduler prevention for one workspace.
+- Independent schedulers for separate workspaces.
+- Dynamic file updates.
+- Graceful shutdown with in-flight execution.
 
-### Mock Utilities
+Mock timer helper:
 
 ```typescript
-// Test helper: advance time without waiting
 class MockTimerManager implements TimerManager {
-    private timers: Map<string, { callback: () => void; triggerAt: number }>;
+  private timers = new Map<string, { callback: () => void; triggerAt: number }>();
 
-    advanceTime(ms: number): void {
-        const now = Date.now() + ms;
-        for (const [id, timer] of this.timers) {
-            if (timer.triggerAt <= now) {
-                timer.callback();
-                this.timers.delete(id);
-            }
-        }
+  advanceTime(ms: number): void {
+    const now = Date.now() + ms;
+    for (const [id, timer] of this.timers) {
+      if (timer.triggerAt <= now) {
+        timer.callback();
+        this.timers.delete(id);
+      }
     }
+  }
 }
 ```
 
----
-
 ## Future Considerations
 
-### Phase 2 Enhancements
+1. Pipeline chaining:
 
-1. **Pipeline Chaining** - Run pipeline B after pipeline A completes
    ```yaml
    schedule:
      cron: "0 9 * * *"
-     after: "data-fetch"  # Wait for data-fetch to complete first
+     after: "data-fetch"
    ```
 
-2. **Execution Conditions** - Skip based on runtime conditions
+2. Execution conditions:
+
    ```yaml
    schedule:
      cron: "0 9 * * *"
@@ -833,7 +486,8 @@ class MockTimerManager implements TimerManager {
        file_exists: "input/data.csv"
    ```
 
-3. **Notifications** - Webhook/email on completion/failure
+3. Notifications:
+
    ```yaml
    schedule:
      cron: "0 9 * * *"
@@ -841,17 +495,13 @@ class MockTimerManager implements TimerManager {
        on_failure: "https://hooks.slack.com/..."
    ```
 
-### Phase 3 Enhancements
+4. Dashboard schedule management.
+5. Metrics export through OpenTelemetry.
+6. Distributed scheduling with an external lock backend.
 
-1. **Distributed Scheduling** - Redis backend for multi-machine coordination
-2. **Web Dashboard** - View/manage schedules via browser
-3. **Metrics Export** - Prometheus/OpenTelemetry integration
+## Example Configurations
 
----
-
-## Appendix: Example Configurations
-
-### Daily Report at 9 AM EST
+### Daily Report
 
 ```yaml
 name: "Daily Bug Report"
@@ -868,7 +518,7 @@ reduce:
   type: json
 ```
 
-### Weekly Sync on Sunday Midnight
+### Weekly Sync
 
 ```yaml
 name: "Weekly Data Sync"
@@ -876,7 +526,7 @@ schedule:
   cron: "0 0 * * 0"
   retryPolicy:
     maxRetries: 5
-    retryDelayMs: 300000  # 5 minutes
+    retryDelayMs: 300000
 
 input:
   from: { type: csv, path: "sync-targets.csv" }
@@ -887,14 +537,14 @@ reduce:
   type: table
 ```
 
-### Every 15 Minutes During Business Hours
+### Business-Hours Monitor
 
 ```yaml
 name: "Queue Monitor"
 schedule:
-  cron: "*/15 9-17 * * 1-5"  # Every 15 min, 9-5, Mon-Fri
+  cron: "*/15 9-17 * * 1-5"
   timezone: "America/Los_Angeles"
-  missedExecution: "skip"  # Don't catch up on missed checks
+  missedExecution: "skip"
 
 input:
   items:

--- a/docs/designs/yaml-pipeline-framework.md
+++ b/docs/designs/yaml-pipeline-framework.md
@@ -1,136 +1,27 @@
-# YAML Pipeline Framework Design (MVP)
+# YAML Pipeline Framework Design
 
 ## Summary
 
-A simple YAML-based configuration for running AI MapReduce workflows. Start with CSV input, a prompt template for map, and list output.
+The YAML pipeline framework lets users define AI workflows in a single YAML file and run them through CoC. The MVP centers on CSV input, a prompt template for each row, and deterministic list output. The same configuration compiles into the shared workflow engine used by the CoC CLI, server queue, dashboard, and package consumers.
 
 ## Goals
 
-- Define a workflow in a single YAML file
-- CSV file as input (each row becomes an item)
-- Simple prompt template with `{{column}}` variable substitution
-- Schema-light output definition (just field names)
-- Deterministic list/table output
+- Define a workflow in one YAML file.
+- Read CSV input where each row becomes an item.
+- Substitute `{{column}}` values into a prompt template.
+- Ask AI to return a small JSON object with declared fields.
+- Produce deterministic list or table output.
+- Run from `coc run`, the CoC dashboard Workflows tab, or direct package APIs.
 
-## Non-Goals (for now)
+## Non-Goals
 
-- Git integration, file globs, shell commands
-- AI-powered reduce phase
-- Complex reduce operations (group-by, stats, etc.)
-- Caching, retries, streaming
-- Multiple output destinations
-
----
+- Git input, file globs, shell commands, or HTTP sources.
+- AI-powered reduce.
+- Complex reduce operations such as grouping and statistics.
+- Caching, retries, or streaming.
+- Multiple output destinations.
 
 ## YAML Schema
-
-```yaml
-name: "Pipeline Name"
-
-input:
-  type: csv
-  path: "./data.csv"
-
-map:
-  prompt: |
-    Analyze this item:
-    Title: {{title}}
-    Description: {{description}}
-  
-  output: [severity, category, summary]
-
-reduce:
-  type: list
-```
-
----
-
-## Input: CSV
-
-Read a CSV file. First row is headers. Each row becomes an item.
-
-```yaml
-input:
-  type: csv
-  path: "./bugs.csv"          # Required: path to CSV file
-  delimiter: ","               # Optional: default ","
-```
-
-**Example CSV:**
-```csv
-id,title,description,priority
-1,Login broken,Users can't login,high
-2,Slow search,Search takes 10s,medium
-```
-
-**Produces items:**
-```json
-{ "id": "1", "title": "Login broken", "description": "Users can't login", "priority": "high" }
-{ "id": "2", "title": "Slow search", "description": "Search takes 10s", "priority": "medium" }
-```
-
----
-
-## Map: Prompt Template
-
-Run a prompt for each item. Use `{{column_name}}` to insert values.
-
-```yaml
-map:
-  prompt: |
-    Analyze this bug report:
-    
-    ID: {{id}}
-    Title: {{title}}
-    Description: {{description}}
-    Priority: {{priority}}
-    
-    Classify this bug and provide your assessment.
-  
-  output: [severity, category, effort_hours, needs_more_info]
-  
-  parallel: 3                  # Optional: max concurrent calls (default: 5)
-```
-
-**How it works:**
-
-1. The `prompt` is sent to AI with each row's values substituted
-2. The `output` field names are appended to the prompt automatically:
-   > "Return JSON with these fields: severity, category, effort_hours, needs_more_info"
-3. The AI response is parsed as JSON and stored as `output` for each item
-4. If AI returns extra fields, they are ignored. If fields are missing, they become `null`.
-
----
-
-## Reduce: List Output
-
-Show all results as a formatted list (no AI call, deterministic).
-
-```yaml
-reduce:
-  type: list
-```
-
-**Output:**
-```
-## Results (3 items)
-
-### Item 1
-**Input:** id=1, title=Login broken, priority=high
-**Output:** severity=critical, category=backend, effort_hours=4, needs_more_info=false
-
-### Item 2
-**Input:** id=2, title=Slow search, priority=medium
-**Output:** severity=medium, category=database, effort_hours=8, needs_more_info=false
-
-...
-```
-
-The list shows both input (CSV row) and output (AI response) for each item.
-
----
-
-## Complete Example
 
 ```yaml
 name: "Bug Triage"
@@ -142,57 +33,128 @@ input:
 map:
   prompt: |
     Analyze this bug:
-    
+
     Title: {{title}}
     Description: {{description}}
     Reporter Priority: {{priority}}
-    
-    Classify the severity (critical/high/medium/low), 
-    category (ui/backend/database/infra),
-    estimate effort in hours,
-    and note if more info is needed.
-  
+
+    Classify the severity, category, effort, and whether more info is needed.
   output: [severity, category, effort_hours, needs_more_info]
-  
   parallel: 3
 
 reduce:
   type: list
 ```
 
----
+Pipeline files can live anywhere a user can pass to `coc run`. Repository-scoped workflow examples often use `.vscode/workflows/` or `.vscode/pipelines/` as configuration directories.
+
+## Input: CSV
+
+The CSV reader treats the first row as headers and turns each following row into a string-valued item.
+
+```yaml
+input:
+  type: csv
+  path: "./bugs.csv"
+  delimiter: ","
+```
+
+Example CSV:
+
+```csv
+id,title,description,priority
+1,Login broken,Users can't login,high
+2,Slow search,Search takes 10s,medium
+```
+
+Produced items:
+
+```json
+{ "id": "1", "title": "Login broken", "description": "Users can't login", "priority": "high" }
+{ "id": "2", "title": "Slow search", "description": "Search takes 10s", "priority": "medium" }
+```
+
+## Map Phase
+
+For each item, the engine substitutes item fields into the prompt and invokes AI with a concurrency limit.
+
+```yaml
+map:
+  prompt: |
+    Analyze this bug report:
+    ID: {{id}}
+    Title: {{title}}
+    Description: {{description}}
+    Priority: {{priority}}
+  output: [severity, category, effort_hours, needs_more_info]
+  parallel: 3
+```
+
+Execution rules:
+
+1. `{{field}}` placeholders are replaced with matching item values.
+2. The declared output fields are added to the AI instruction.
+3. The AI response is parsed as JSON.
+4. Missing declared fields become `null`.
+5. Extra response fields are ignored.
+
+## Reduce Phase
+
+The MVP reduce phase is deterministic and formats mapped outputs without another AI call.
+
+```yaml
+reduce:
+  type: list
+```
+
+Example output:
+
+```text
+## Results (2 items)
+
+### Item 1
+Input: id=1, title=Login broken, priority=high
+Output: severity=critical, category=backend, effort_hours=4, needs_more_info=false
+
+### Item 2
+Input: id=2, title=Slow search, priority=medium
+Output: severity=medium, category=database, effort_hours=8, needs_more_info=false
+```
 
 ## Execution Flow
 
-```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  Read CSV   │ ──▶ │  Map: AI    │ ──▶ │   Reduce    │ ──▶ │   Output    │
-│  (N rows)   │     │  (N calls)  │     │  (1 call or │     │  (panel)    │
-│             │     │             │     │   format)   │     │             │
-└─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘
+```text
+Read CSV -> Map with AI -> Reduce deterministically -> Store and display result
 ```
 
-1. **Read CSV** - Parse file, create N items
-2. **Map** - For each item, run prompt with substituted values (parallel with limit)
-3. **Reduce** - Either AI summarize, or format as list/table
-4. **Output** - Show in AI Processes panel
+1. Parse the YAML file.
+2. Resolve relative paths against the workflow directory.
+3. Load CSV rows.
+4. Run the map prompt over each item with a concurrency limit.
+5. Parse AI JSON responses into declared output fields.
+6. Format the final result.
+7. Return output to the CLI, dashboard task/process view, or package caller.
 
----
+## Package Boundaries
 
-## Implementation
+```text
+packages/coc-workflow/src/workflow/
+  compiler.ts          # YAML to WorkflowConfig
+  executor.ts          # DAG execution lifecycle
+  nodes/               # load/map/ai/reduce/filter/script/merge/transform executors
+  pipeline-compat.ts   # Legacy pipeline YAML compatibility
+  types.ts             # Public workflow contracts
 
-### Files
-
+packages/coc/src/
+  commands/run.ts      # coc run
+  commands/validate.ts # YAML validation
+  server/executors/    # Queue-backed workflow execution
+  server/spa/client/   # Dashboard workflow surfaces
 ```
-src/shortcuts/yaml-pipeline/
-├── types.ts              # PipelineConfig interface
-├── csv-reader.ts         # Parse CSV to items
-├── template.ts           # Simple {{var}} substitution
-├── executor.ts           # Run the pipeline
-└── commands.ts           # VSCode command registration
-```
 
-### Key Types
+`@plusplusoneplusplus/coc-workflow` owns the pure compile and execute path. `@plusplusoneplusplus/forge` keeps compatibility exports and utility surfaces. CoC owns CLI/server/dashboard integration.
+
+## Key Types
 
 ```typescript
 interface PipelineConfig {
@@ -204,7 +166,7 @@ interface PipelineConfig {
   };
   map: {
     prompt: string;
-    output: string[];      // Field names expected from AI
+    output: string[];
     parallel?: number;
   };
   reduce: {
@@ -213,18 +175,16 @@ interface PipelineConfig {
 }
 
 interface PipelineItem {
-  [key: string]: string;  // CSV columns
+  [key: string]: string;
 }
 
 interface MapResult {
   item: PipelineItem;
-  output: Record<string, unknown>;  // AI response with declared fields
+  output: Record<string, unknown>;
 }
 ```
 
-### Template Engine
-
-Simple implementation - just replace `{{var}}` with values:
+## Template Substitution
 
 ```typescript
 function substituteTemplate(template: string, item: Record<string, string>): string {
@@ -232,72 +192,65 @@ function substituteTemplate(template: string, item: Record<string, string>): str
 }
 ```
 
-### Prompt Generation
-
-Append output schema to the user's prompt:
+## Prompt Generation
 
 ```typescript
 function buildFullPrompt(userPrompt: string, outputFields: string[]): string {
-  const fieldsStr = outputFields.join(', ');
   return `${userPrompt}
 
-Return JSON with these fields: ${fieldsStr}`;
+Return JSON with these fields: ${outputFields.join(', ')}`;
 }
 ```
 
----
+## Execution Surfaces
 
-## VSCode Integration
+CLI:
 
-### Command
+```bash
+coc run path/to/pipeline.yaml
+```
+
+Validation:
+
+```bash
+coc validate path/to/pipeline.yaml
+```
+
+Package API:
 
 ```typescript
-vscode.commands.registerCommand('shortcuts.runPipeline', async (uri: vscode.Uri) => {
-  const yamlContent = await vscode.workspace.fs.readFile(uri);
-  const config = yaml.parse(yamlContent.toString());
-  
-  await executePipeline(config);
-});
+import { compileToWorkflow, executeWorkflow } from '@plusplusoneplusplus/coc-workflow';
+
+const config = compileToWorkflow(yamlContent);
+const result = await executeWorkflow(config, { aiInvoker });
 ```
 
-### Context Menu
+Dashboard:
 
-Add to `package.json`:
-```json
-{
-  "menus": {
-    "explorer/context": [
-      {
-        "command": "shortcuts.runPipeline",
-        "when": "resourceExtname == .yaml || resourceExtname == .yml",
-        "group": "shortcuts"
-      }
-    ]
-  }
-}
-```
+- Workflows tab for saved workspace workflows.
+- Process/task detail for progress, output, comments, and follow-up AI work.
 
-### Output
+## Error Handling
 
-Results appear in the existing AI Processes panel as a grouped process.
-
----
+| Error | Behavior |
+|-------|----------|
+| YAML parse failure | Return validation error with line context when available. |
+| Missing CSV file | Fail before starting map execution. |
+| Missing CSV column | Substitute an empty string. |
+| AI JSON parse failure | Mark the item failed and apply the configured workflow error policy. |
+| Map item failure | Abort or warn according to workflow settings. |
 
 ## Future Extensions
 
-Once MVP works, consider adding:
-
-1. **More input types**: git commits, file glob, shell command output
-2. **AI reduce**: Summarize results with another AI call
-3. **Table reduce**: Format output as markdown table
-4. **More reduce operations**: group-by, filter, sort
-5. **Output options**: file, clipboard, notification
-6. **Settings**: model selection, temperature, retries
-
----
+1. More input types: file glob, git commits, shell command output, HTTP.
+2. AI reduce: summarize or synthesize mapped outputs.
+3. Table reduce and JSON reduce.
+4. Filtering, grouping, and sorting.
+5. Output destinations: file, notes, clipboard, work item, or webhook.
+6. Runtime settings: model selection, timeouts, retries, and cancellation.
 
 ## Open Questions
 
-1. **Error handling**: Skip failed items or abort entire pipeline?
-2. **Large CSVs**: Stream or load all at once? Limit rows?
-3. **JSON parse failures**: Retry with correction prompt, or skip item?
+1. Should large CSVs stream by default or load all rows first?
+2. Should invalid AI JSON retry with a correction prompt?
+3. Should item-level failures be resumable from a persisted checkpoint?

--- a/docs/wiki/git-diff-review.md
+++ b/docs/wiki/git-diff-review.md
@@ -1,156 +1,171 @@
-# Git Diff Review Editor — UX Specification
+# Git Diff Review UX Specification
 
 ## 1. User Story
 
-**As a developer**, I want to annotate git changes (staged, unstaged, or committed) with inline comments while reading a diff, so I can record observations, questions, and action items that persist across sessions and can be fed into AI-powered code review workflows.
+As a developer, I want to annotate git changes with inline comments while reading a diff, so I can record observations, questions, and action items that persist across sessions and can be sent into AI-assisted review workflows.
 
 Secondary personas:
-- **Code reviewers** who want structured, categorized feedback organized per-file and per-commit.
-- **AI-assisted reviewers** who want to generate prompts from their annotations for deeper Copilot analysis.
 
----
+- Code reviewers who want structured, categorized feedback organized by file and review source.
+- AI-assisted reviewers who want to generate prompts from their annotations.
+- Team leads who want review notes to remain attached to a workspace and diff context.
 
-## 2. Entry Points
+## 2. Supported Review Sources
 
-### Context Menus
-| Location | Action |
-|---|---|
-| Git panel → changed file (right-click) | **Open with Diff Review** |
-| Source Control file list (right-click) | **Open with Diff Review** |
-| Commit node in Git History / Log (right-click) | **Open with Diff Review** |
+The review surface uses the shared diff provider abstraction, which supports:
 
-### Command Palette
-- `Open with Git Diff Review Editor` — opens the current `.git-diff-review` virtual file
+| Source | Description |
+|--------|-------------|
+| Working tree | Staged, unstaged, or combined local changes. |
+| Commit | A single commit compared with its parent. |
+| Branch range | A feature branch compared with a base ref such as `origin/main`. |
+| Pull request | Latest remote provider diff. |
+| Pull-request iteration | A specific remote provider revision or iteration. |
 
-### Tree View (Shortcuts Panel → Git Diff Comments)
-- Clicking a **DiffCommentFileItem** re-opens the corresponding diff in the review editor
-- Clicking a **DiffCommentItem** scrolls to the annotated region
+## 3. Entry Points
 
-### File Association
-- Files with the `.git-diff-review` extension automatically open in this editor (default handler)
+Dashboard entry points:
 
----
+- Repository Git tab changed-file list.
+- Commit detail file list.
+- Branch range overview and file list.
+- Pull request detail diff/file list.
+- Diff comment list grouped by workspace, source, and file.
 
-## 3. User Flow
+Programmatic entry points:
 
-### 3.1 Opening a Diff for Review
+- CoC REST routes for git branch-range data and diff comments.
+- Forge diff provider factories for package consumers.
+- AI tools that pre-bind commit, range, or file context.
 
-1. User right-clicks a changed file in the Git panel or Source Control view.
-2. Selects **Open with Diff Review**.
-3. A side-by-side diff editor opens:
-   - **Left pane**: old version (red deletions)
-   - **Right pane**: new version (green additions)
-   - Syntax highlighting applied based on file language.
-4. Existing comments appear as highlighted inline annotations:
-   - **Yellow highlight** = open comment
-   - **Green highlight** = resolved comment
-5. The **Git Diff Comments** tree view populates, organizing entries under a category for the diff's origin (e.g., *Pending Changes* for unstaged, *Commit abc1234* for committed).
+## 4. User Flow
 
-### 3.2 Adding a Comment
+### 4.1 Opening a Diff
 
-1. User selects a text range in either the old or new pane.
-2. A floating action panel appears offering **Add Comment**.
-3. User types their comment and confirms.
-4. The selected range is highlighted (yellow). The comment appears:
-   - As an inline annotation in the editor.
-   - As a new **DiffCommentItem** in the tree view.
+1. User selects a changed file, commit file, branch-range file, or pull-request file in the dashboard.
+2. The right pane or pop-out review window opens a unified diff view.
+3. Existing comments load for the workspace and diff context.
+4. Open comments render with an attention highlight; resolved comments render with a muted resolved style.
+5. The comments list groups notes by source and file.
 
-### 3.3 Editing / Deleting a Comment
+### 4.2 Adding a Comment
 
-- **Edit**: Right-click comment in tree → **Edit Comment** → inline input box pre-filled with existing text → confirm.
-- **Delete**: Right-click comment → **Delete** → confirmation dialog → removed from editor and tree.
-- **Bulk delete**: Right-click a file or category node → **Delete All** → confirmation.
+1. User selects a range of diff text.
+2. The comment action appears near the selection.
+3. User chooses a category and enters a comment.
+4. The dashboard posts the comment to the workspace-scoped diff-comments API.
+5. The selected range is highlighted and the comments list updates.
 
-### 3.4 Resolving a Comment
+### 4.3 Editing, Replying, and Deleting
 
-1. Right-click a comment in the tree or use the inline action in the editor.
-2. Comment highlight changes to green; it is marked *resolved*.
-3. An **Undo** toast appears for ~30 seconds to reverse the action.
-4. Resolved comments can be shown/hidden via the `showResolved` setting.
+- Edit updates comment text and `updatedAt`.
+- Reply adds threaded context under the original comment.
+- Delete removes the selected comment after confirmation.
+- Bulk delete applies only to the selected source/file scope.
 
-### 3.5 Generating an AI Prompt
+### 4.4 Resolving Comments
 
-1. Right-click a comment, file, or category node in the tree.
-2. Choose **Copy Prompt** (copies to clipboard) or **Show Prompt** (opens in a new editor tab).
-3. The prompt includes: selected text, file path, diff side, surrounding context, and comment text.
-4. Optionally choose **Ask AI** in the webview to send directly to Copilot CLI (terminal mode) or clipboard.
+1. User resolves one comment, all comments for a file, or all comments in a selected source.
+2. Resolved comments move to the resolved visual style.
+3. The action remains reversible while the local UI still has undo context.
+4. Resolved comments can be shown or hidden through review settings.
 
-### 3.6 Resolving / Clearing All
+### 4.5 Sending Comments to AI
 
-- **Resolve All** at category or file level: marks all open comments resolved.
-- **Delete All Resolved**: bulk-removes resolved comments at any scope level.
-- **Global Undo Resolve**: restores the last resolved batch within the undo window.
+1. User selects a comment, file, or source group.
+2. User chooses an AI action such as ask, resolve, or summarize.
+3. CoC builds a prompt containing file paths, diff refs, selected text, surrounding context, and comments.
+4. The prompt is submitted through the selected workspace's AI route or queue.
+5. AI output is linked back to the process/chat history and review context.
 
----
-
-## 4. Edge Cases & Error Handling
+## 5. Edge Cases and Error Handling
 
 | Scenario | Behavior |
-|---|---|
-| File no longer exists (deleted since diff was captured) | Tree item shows a warning badge; opening the editor shows a "File not found" message. |
-| Comment anchor becomes stale after file edits | Anchor is re-located by content fingerprint; if unrecoverable, comment is shown at the nearest valid line with a "position approximate" indicator. |
-| Empty comment text on save | Validation prevents saving; an inline error message prompts for non-empty content. |
-| AI not available (Copilot CLI missing) | Falls back to **Copy to Clipboard** mode; user is notified via info notification. |
-| Diff has no changes | Editor shows "No changes to display" placeholder. |
-| Unsaved changes in editable diff | Standard VS Code dirty-file indicator; "Save" action available in the webview toolbar. |
+|----------|----------|
+| File no longer exists | Show a warning and keep comments visible in the comments list. |
+| Anchor becomes stale | Relocate by fingerprint and surrounding context; otherwise show nearest valid line with an approximate-position indicator. |
+| Empty comment text | Block save and show inline validation. |
+| AI provider unavailable | Keep comments saved and offer prompt copy or retry once AI is configured. |
+| Diff has no changes | Show a no-changes placeholder. |
+| Binary file | Show file metadata and disable line-anchored commenting. |
+| Workspace changes | Reload comments through the selected workspace client. |
 
----
+## 6. Visual Design
 
-## 5. Visual Design Considerations
+### Comment Categories
 
-### Icons
-| Element | Icon |
-|---|---|
-| Diff Comments tree view container | `$(git-pull-request)` or `$(diff)` |
-| Category node (Pending Changes) | `$(source-control)` |
-| Category node (Commit) | `$(git-commit)` |
-| File node | File-type icon from VS Code theme |
-| Open comment | `$(comment)` with yellow accent |
-| Resolved comment | `$(check)` with green accent |
+| Category | Use |
+|----------|-----|
+| Bug | Potential defect or regression. |
+| Question | Needs clarification. |
+| Suggestion | Improvement idea. |
+| Praise | Positive note. |
+| Nitpick | Minor style or cleanup. |
+| General | Default note. |
 
-### Tree View Layout
+### Comments List
+
+```text
+Diff Comments
+  Branch range: feature/auth-flow -> origin/main
+    src/auth/login.ts
+      [bug] This logic might miss the refresh case
+      [question] Why not use the existing helper?
+  Commit abc1234
+    src/api/users.ts
+      [resolved] Naming looks good
 ```
-▼ Git Diff Comments
-  ▼ Pending Changes  (3 open, 1 resolved)
-    ▼ src/auth/login.ts  (lines 12–18)
-        "This logic might miss the refresh…"
-        "Why not use the existing helper?"
-  ▼ Commit abc1234
-    ▼ src/api/users.ts  (lines 44–50)
-        "✓ Resolved: naming looks good"
-```
 
-### Editor Webview
-- Two-column layout with synchronized scrolling.
-- Gutter line numbers on both sides.
-- Highlighted annotation bands span the full column width.
-- Floating comment panel docks to the bottom of the selection range.
-- Toolbar at the top: breadcrumb path, copy/open actions, AI button (if enabled).
+### Diff View
+
+- Unified diff with line numbers and hunk headers.
+- File header with path, status, additions, deletions, and source metadata.
+- Inline highlighted ranges for comments.
+- Comment cards attached to the relevant hunk or shown in a side panel on narrow layouts.
+- Toolbar actions for copy path, ask AI, resolve comments, and open pop-out.
 
 ### Notifications
-- Toast for undo after resolve (timed, dismissible).
-- Info bar for AI fallback to clipboard.
-- Error notification for unrecoverable anchor loss.
 
----
+- Inline validation for save failures.
+- Toast for undoable resolve actions.
+- Error banner for unrecoverable anchor loss or API failures.
 
-## 6. Settings & Configuration
+## 7. Settings and Configuration
 
 | Setting | Default | Description |
-|---|---|---|
-| `workspaceShortcuts.diffReview.showResolved` | `true` | Show resolved comments in tree and editor |
-| `workspaceShortcuts.diffReview.highlightColor` | Yellow (rgba) | Highlight color for open comments |
-| `workspaceShortcuts.diffReview.resolvedHighlightColor` | Green (rgba) | Highlight color for resolved comments |
-| `workspaceShortcuts.diffReview.askAIEnabled` | `true` | Show AI actions in context menus and webview |
-| `workspaceShortcuts.diffReview.aiMenuConfig` | (built-in) | AI command menu entries (comment & interactive modes) |
-| `workspaceShortcuts.diffReview.predefinedComments` | `[]` | Quick-pick comment templates for faster annotation |
+|---------|---------|-------------|
+| `diffReview.showResolved` | `true` | Show resolved comments in list and diff view. |
+| `diffReview.askAIEnabled` | `true` | Show AI actions for comments and files. |
+| `diffReview.predefinedComments` | `[]` | Quick comment templates. |
+| `diffReview.maxDiffLines` | `500` | Initial diff line cap before expansion. |
 
----
+Repository-level shared review configuration or exports can use:
 
-## 7. Discoverability
+```text
+.vscode/comments/
+```
 
-- **Welcome walkthrough**: A VS Code walkthrough step titled *"Review git changes inline"* demonstrates opening the diff editor and adding a first comment.
-- **Context menu prominence**: The **Open with Diff Review** action appears at the top of the right-click menu for changed files in the Source Control panel.
-- **Tree view empty state**: When no comments exist, the *Git Diff Comments* panel shows a placeholder with a button: *"Open a changed file with Diff Review to start annotating."*
-- **README / extension marketplace page**: Feature section with a GIF showing comment annotation and AI prompt generation.
-- **Keyboard shortcut hint**: The floating annotation panel shows the shortcut key (e.g., `Ctrl+Shift+M`) on first use.
+Runtime comment persistence remains workspace scoped under the CoC data directory.
+
+## 8. API Contracts
+
+| Route | Purpose |
+|-------|---------|
+| `GET /api/diff-comments/:wsId` | List all workspace diff comments. |
+| `POST /api/diff-comments/:wsId` | Create a comment. |
+| `GET /api/diff-comments/:wsId/:key` | List comments for one diff context. |
+| `PATCH /api/diff-comments/:wsId/:key/:id` | Update a comment. |
+| `DELETE /api/diff-comments/:wsId/:key/:id` | Delete a comment. |
+| `POST /api/diff-comments/:wsId/:key/:id/replies` | Add a reply. |
+| `POST /api/diff-comments/:wsId/:key/:id/ask-ai` | Ask AI about one comment. |
+| `POST /api/diff-comments/:wsId/resolve-with-ai` | Resolve selected comments with AI. |
+
+All routes include a workspace ID so multi-repo sessions stay correctly scoped.
+
+## 9. Discoverability
+
+- Repository Git tab empty states explain how to open a diff and start commenting.
+- Branch range and pull request views show comment counts next to files.
+- Comment lists show category and status filters.
+- AI actions are grouped with other review actions, not hidden behind developer-only controls.
+- Keyboard shortcuts are optional accelerators; all actions are reachable from visible controls.

--- a/docs/wiki/seeds.yaml
+++ b/docs/wiki/seeds.yaml
@@ -366,8 +366,7 @@ themes:
   - theme: copilot-cli-invocation
     description: >-
       Invokes the GitHub Copilot CLI as a child process or copies prompts to the
-      clipboard as a fallback, bridging the VS Code extension with the Copilot
-      CLI tool.
+      clipboard as a fallback, bridging CoC workflows with the Copilot CLI tool.
     hints:
       - CopilotCLIInvoker
       - copilot-cli-invoker

--- a/docs/wiki/seeds.yaml
+++ b/docs/wiki/seeds.yaml
@@ -263,7 +263,7 @@ themes:
     hints:
       - sync-manager
       - SyncProvider
-      - vscode-sync-provider
+      - WorkItemSyncProvider
       - workspaceShortcuts.sync
       - cloud-sync
   - theme: drag-and-drop-reordering

--- a/docs/wiki/seeds.yaml
+++ b/docs/wiki/seeds.yaml
@@ -3,7 +3,7 @@ themes:
     description: >-
       Allows users to organize files and folders into named logical groups for
       quick access. Supports nested subgroups, icons, and drag-and-drop
-      reordering within the VS Code sidebar.
+      reordering in the dashboard file navigation.
     hints:
       - LogicalGroup
       - logicalGroups
@@ -67,8 +67,7 @@ themes:
   - theme: ai-process-queue
     description: >-
       Manages a queue of AI tasks with per-repo isolation, status tracking, and
-      real-time progress in the VS Code status bar and tree view. Supports
-      cancellation and retry.
+      real-time progress in the CoC dashboard. Supports cancellation and retry.
     hints:
       - AIQueueService
       - TaskQueueManager
@@ -79,7 +78,7 @@ themes:
     description: >-
       Wraps the GitHub Copilot SDK to provide session management, session
       pooling, MCP server control, and permission handling for all AI features
-      in the extension.
+      in CoC.
     hints:
       - CopilotSDKService
       - session-pool
@@ -89,7 +88,7 @@ themes:
   - theme: interactive-ai-sessions
     description: >-
       Enables long-running, multi-turn conversations with AI that can be
-      monitored and resumed. Sessions are tracked in a tree view and support
+      monitored and resumed. Sessions are tracked in the dashboard and support
       streaming output.
     hints:
       - interactive-session-manager
@@ -98,9 +97,9 @@ themes:
       - ai-session-resume
   - theme: ai-process-persistence
     description: >-
-      Persists AI process history across VS Code restarts using the Memento API.
-      Processes are isolated per workspace and can be viewed, removed, or
-      cleared via a dedicated tree view.
+      Persists AI process history across CoC server restarts. Processes are
+      isolated per workspace and can be viewed, removed, or cleared from the
+      dashboard.
     hints:
       - AIProcessManager
       - mock-ai-process-manager
@@ -152,8 +151,8 @@ themes:
       - article-cache
   - theme: coc-cli-pipeline-runner
     description: >-
-      A standalone CLI (coc) that executes YAML-based AI pipelines outside of VS
-      Code, with commands for run, validate, list, and serve.
+      A standalone CLI (coc) that executes YAML-based AI pipelines, with
+      commands for run, validate, list, and serve.
     hints:
       - coc run
       - coc validate
@@ -163,8 +162,8 @@ themes:
   - theme: ai-execution-dashboard
     description: >-
       A web server and SPA dashboard for tracking AI process execution across
-      multiple VS Code workspaces in real time. Provides REST API, WebSocket,
-      and SSE streaming.
+      multiple registered workspaces in real time. Provides REST API,
+      WebSocket, and SSE streaming.
     hints:
       - coc serve
       - ProcessStore
@@ -173,9 +172,9 @@ themes:
       - SPA
   - theme: multi-workspace-process-tracking
     description: >-
-      Allows multiple VS Code workspaces to submit AI processes to a shared
-      server with workspace-scoped filtering and deterministic workspace
-      identity via SHA-256 hash.
+      Allows multiple workspaces to submit AI processes to a shared server with
+      workspace-scoped filtering and deterministic workspace identity via
+      SHA-256 hash.
     hints:
       - WorkspaceInfo
       - workspace-identity
@@ -195,9 +194,9 @@ themes:
       - availableTools
   - theme: git-repository-exploration
     description: >-
-      Provides a tree view of git commits, branches, staged/unstaged changes,
-      and commit ranges within VS Code. Supports looking up commits and browsing
-      file changes per commit.
+      Provides dashboard views of git commits, branches, staged/unstaged
+      changes, and commit ranges. Supports looking up commits and browsing file
+      changes per commit.
     hints:
       - git-service
       - GitCommitItem
@@ -207,7 +206,8 @@ themes:
   - theme: commit-range-review
     description: >-
       Lets users select a range of commits and submit the combined diff for AI
-      review or annotation. Surfaces range items in the git tree view.
+      review or annotation. Surfaces range details through git/diff review
+      views.
     hints:
       - git-commit-range-item
       - git-range-service
@@ -216,8 +216,8 @@ themes:
   - theme: global-notes
     description: >-
       Stores short notes accessible from any workspace, independent of shortcut
-      groups. Notes use a virtual document provider and are persisted in global
-      VS Code storage.
+      groups. Notes use CoC note storage and are available across registered
+      workspaces.
     hints:
       - GlobalNotesTreeDataProvider
       - NoteDocumentProvider
@@ -258,9 +258,8 @@ themes:
       - resolveBasePath
   - theme: cloud-sync
     description: >-
-      Synchronizes shortcuts configuration across devices using VS Code Settings
-      Sync. Supports configurable sync providers, intervals, and manual trigger
-      commands.
+      Synchronizes notes and workspace data across devices using configurable
+      sync providers, intervals, and manual trigger commands.
     hints:
       - sync-manager
       - SyncProvider
@@ -299,9 +298,9 @@ themes:
       - onKey
   - theme: theme-and-icon-management
     description: >-
-      Manages VS Code theme-aware icon selection and centralized icon constants,
-      ensuring correct icons appear in light/dark/high-contrast modes across all
-      tree views.
+      Manages dashboard theme-aware icon selection and centralized icon
+      constants, ensuring correct icons appear in light, dark, and
+      high-contrast modes.
     hints:
       - ThemeManager
       - tree-icon-utils
@@ -386,8 +385,8 @@ themes:
       - job-template-commands
   - theme: lm-tools-integration
     description: >-
-      Registers language model tools (via VS Code LM API) that can be called by
-      AI agents, such as resolving review comments programmatically.
+      Registers language model tools that can be called by AI agents, such as
+      resolving review comments programmatically.
     hints:
       - lm-tools
       - register-tools
@@ -397,7 +396,7 @@ themes:
   - theme: notification-and-error-handling
     description: >-
       Provides centralized user-facing error notifications and status messages
-      with consistent formatting across all extension features.
+      with consistent formatting across CoC features.
     hints:
       - notification-manager
       - error-handler
@@ -417,7 +416,7 @@ themes:
   - theme: webview-search-integration
     description: >-
       Integrates a webview-based search provider that filters the shortcuts tree
-      in response to user search queries entered in a VS Code search input.
+      in response to user search queries entered in the dashboard.
     hints:
       - inline-search-provider
       - WebviewSearchProvider
@@ -425,9 +424,8 @@ themes:
       - searchFilter
   - theme: debug-panel
     description: >-
-      Provides a VS Code panel for inspecting extension internals, configuration
-      state, and diagnostic information to aid in development and
-      troubleshooting.
+      Provides a dashboard panel for inspecting configuration state and
+      diagnostic information to aid in development and troubleshooting.
     hints:
       - debug-panel
       - DebugPanel
@@ -446,19 +444,17 @@ themes:
   - theme: pipeline-core-extraction
     description: >-
       A standalone Node.js package (pipeline-core) encapsulating the AI pipeline
-      engine, logger, map-reduce framework, and utilities with no VS Code
-      dependencies, enabling reuse in CLI tools.
+      engine, logger, map-reduce framework, and utilities, enabling reuse in CLI
+      tools.
     hints:
       - pipeline-core
       - packages/forge
       - pure Node.js
-      - no VS Code
       - TaskQueueManager
   - theme: process-store-persistence
     description: >-
       Provides a file-based process store (~/.coc/) with atomic writes and
-      bounded retention for persisting AI process state outside VS Code across
-      server restarts.
+      bounded retention for persisting AI process state across server restarts.
     hints:
       - FileProcessStore
       - ProcessStore

--- a/media/styles/components.css
+++ b/media/styles/components.css
@@ -125,7 +125,7 @@
 }
 
 /* ==============================
- * Highlight.js Theme (VSCode-like)
+ * Highlight.js Theme (editor-like)
  * ============================== */
 .hljs {
     background: transparent !important;
@@ -260,7 +260,7 @@
     }
 }
 
-/* VSCode theme detection */
+/* Editor theme detection */
 body.vscode-light .hljs-keyword {
     color: #0000ff;
 }

--- a/media/styles/diff-webview.css
+++ b/media/styles/diff-webview.css
@@ -498,7 +498,7 @@ body.vscode-light {
     color: var(--vscode-gitDecoration-deletedResourceForeground, #cf222e);
 }
 
-/* High contrast theme - use VS Code variables */
+/* High contrast theme - use editor variables */
 body.vscode-high-contrast .diff-line-addition,
 body.vscode-high-contrast .line-added {
     background-color: var(--vscode-diffEditor-insertedLineBackground, rgba(155, 185, 85, 0.2));
@@ -779,7 +779,7 @@ body.vscode-high-contrast .inline-diff-line-deletion {
 }
 
 /* ================================== */
-/* Highlight.js Theme (VSCode-like)   */
+/* Highlight.js Theme (editor-like)   */
 /* ================================== */
 
 /* Base styles for highlighted code */
@@ -1209,4 +1209,3 @@ body.vscode-high-contrast .inline-diff-line-deletion {
     outline: 1px solid var(--vscode-focusBorder, #007fd4);
     outline-offset: 1px;
 }
-

--- a/packages/coc-agent-sdk/src/mcp-config-loader.ts
+++ b/packages/coc-agent-sdk/src/mcp-config-loader.ts
@@ -2,7 +2,7 @@
  * MCP Config Loader
  *
  * Utility for loading MCP server configuration from the user's home directory
- * and from VS Code workspace configuration.
+ * and from workspace MCP configuration.
  * 
  * Features:
  * - Cross-platform home directory resolution
@@ -26,7 +26,7 @@ export interface MCPConfigFile {
 }
 
 /**
- * Structure of VS Code workspace MCP config (.vscode/mcp.json)
+ * Structure of workspace MCP config (.vscode/mcp.json)
  */
 export interface VSCodeMCPConfigFile {
     /** Map of server names to their configurations */
@@ -52,8 +52,8 @@ export interface MCPConfigLoadResult {
 /** Default config file path relative to home directory */
 const CONFIG_DIR = '.copilot';
 const CONFIG_FILE = 'mcp-config.json';
-const VSCODE_CONFIG_DIR = '.vscode';
-const VSCODE_MCP_CONFIG_FILE = 'mcp.json';
+const WORKSPACE_CONFIG_DIR = '.vscode';
+const WORKSPACE_MCP_CONFIG_FILE = 'mcp.json';
 
 /** Cached config keyed by absolute config path to avoid cross-workspace contamination */
 const cachedConfigs = new Map<string, MCPConfigLoadResult>();
@@ -100,13 +100,13 @@ export function getMcpConfigPath(): string {
 }
 
 /**
- * Get the path to a workspace VS Code MCP config file.
+ * Get the path to a workspace MCP config file.
  *
  * @param workingDirectory - Workspace directory for the request
  * @returns The full path to <workingDirectory>/.vscode/mcp.json
  */
 export function getWorkspaceMcpConfigPath(workingDirectory: string): string {
-    return path.join(workingDirectory, VSCODE_CONFIG_DIR, VSCODE_MCP_CONFIG_FILE);
+    return path.join(workingDirectory, WORKSPACE_CONFIG_DIR, WORKSPACE_MCP_CONFIG_FILE);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -140,7 +140,7 @@ function optionalBoolean(value: unknown): boolean | undefined {
     return typeof value === 'boolean' ? value : undefined;
 }
 
-function normalizeVSCodeServer(server: Record<string, unknown>): MCPServerConfig | undefined {
+function normalizeWorkspaceMcpServer(server: Record<string, unknown>): MCPServerConfig | undefined {
     if (typeof server.command === 'string') {
         const config: MCPLocalServerConfig = { command: server.command };
         if (server.type === 'local' || server.type === 'stdio') config.type = server.type;
@@ -150,7 +150,7 @@ function normalizeVSCodeServer(server: Record<string, unknown>): MCPServerConfig
         if (env) config.env = env;
         if (typeof server.cwd === 'string') config.cwd = server.cwd;
         // The SDK requires `tools: string[]`; missing/empty means "no tools".
-        // Default to ["*"] (all tools) when not specified, matching VS Code behavior.
+        // Default to ["*"] (all tools) when not specified, matching the workspace config behavior.
         config.tools = stringArray(server.tools) ?? ['*'];
         const timeout = optionalNumber(server.timeout);
         if (timeout !== undefined) config.timeout = timeout;
@@ -174,7 +174,7 @@ function normalizeVSCodeServer(server: Record<string, unknown>): MCPServerConfig
     return undefined;
 }
 
-function normalizeVSCodeServers(config: VSCodeMCPConfigFile): Record<string, MCPServerConfig> {
+function normalizeWorkspaceMcpServers(config: VSCodeMCPConfigFile): Record<string, MCPServerConfig> {
     if (!isRecord(config.servers)) {
         return {};
     }
@@ -187,7 +187,7 @@ function normalizeVSCodeServers(config: VSCodeMCPConfigFile): Record<string, MCP
             continue;
         }
 
-        const normalizedServer = normalizeVSCodeServer(server);
+        const normalizedServer = normalizeWorkspaceMcpServer(server);
         if (normalizedServer) {
             const serverType = normalizedServer.type ?? ('command' in normalizedServer ? 'stdio' : 'unknown');
             aiLog.debug({ serverName: name, type: serverType, enabled: normalizedServer.enabled }, '[MCP] Workspace server normalized');
@@ -307,7 +307,7 @@ export function loadDefaultMcpConfig(forceReload = false): MCPConfigLoadResult {
 
 /**
  * Load MCP server configuration from <workingDirectory>/.vscode/mcp.json.
- * VS Code's top-level `servers` map is normalized to Forge's mcpServers shape.
+ * The workspace top-level `servers` map is normalized to Forge's mcpServers shape.
  *
  * @param workingDirectory - Workspace directory for the request
  * @param forceReload - If true, bypass the cache and reload from disk
@@ -317,7 +317,7 @@ export function loadWorkspaceMcpConfig(workingDirectory: string, forceReload = f
     const configPath = getWorkspaceMcpConfigPath(workingDirectory);
     return loadMcpConfigFromPath(
         configPath,
-        (config) => normalizeVSCodeServers(config as VSCodeMCPConfigFile),
+        (config) => normalizeWorkspaceMcpServers(config as VSCodeMCPConfigFile),
         'workspace',
         forceReload,
     );

--- a/packages/coc-agent-sdk/src/model-registry.ts
+++ b/packages/coc-agent-sdk/src/model-registry.ts
@@ -3,7 +3,6 @@
  *
  * Single source of truth for all AI model definitions used across the codebase.
  * When adding, updating, or removing a model, only this file needs to change
- * (plus `package.json` enum for VS Code settings UI).
  *
  * Design:
  * - `MODEL_REGISTRY` is the authoritative list of supported models.
@@ -47,8 +46,7 @@ export interface ModelDefinition {
  *
  * To add a new model:
  * 1. Add an entry here
- * 2. Update the `package.json` enum (for VS Code settings UI)
- * 3. All types, helpers, and tests will automatically pick it up
+ * 2. All types, helpers, and tests will automatically pick it up
  */
 const MODEL_DEFINITIONS: readonly ModelDefinition[] = [
     {
@@ -227,7 +225,7 @@ export interface IModelListClient {
 export async function fetchModelsFromClient(client: IModelListClient): Promise<ModelInfo[]> {
     // Pre-emptively suppress EPIPE re-throws from the SDK's connectViaStdio() stdin
     // error handler. When the CLI exits unexpectedly (e.g., in test environments
-    // where VS Code's process.execPath is used to spawn the CLI, causing argument
+    // where the host process.execPath is used to spawn the CLI, causing argument
     // parsing failures), writing to its stdin raises EPIPE. The SDK re-throws that
     // error inside the stdin 'error' listener unless forceStopping is true, which
     // makes it an uncaughtException that bypasses normal promise-rejection handling.

--- a/packages/coc-memory/src/index.ts
+++ b/packages/coc-memory/src/index.ts
@@ -4,7 +4,7 @@
  * Core memory system for CoC: types, store interfaces, embedding provider
  * abstraction, safety scanning, and extraction contracts.
  *
- * This package is pure Node.js/TypeScript — no UI code, no VS Code deps.
+ * This package is pure Node.js/TypeScript with no UI-specific dependencies.
  * UI lives in packages/coc. SQLite store implementations also live in
  * packages/coc-memory/src/store-impl/ (added in AC-02/AC-03).
  */

--- a/packages/coc-workflow/src/logger.ts
+++ b/packages/coc-workflow/src/logger.ts
@@ -2,7 +2,7 @@
  * Logger abstraction for the workflow package.
  * 
  * This module provides a simple logger interface that can be implemented
- * by different environments (VS Code, CLI, tests, etc.).
+ * by different environments (CLI, server, tests, etc.).
  * 
  * Usage:
  *   import { getLogger, setLogger, consoleLogger } from '@plusplusoneplusplus/coc-workflow';
@@ -11,7 +11,7 @@
  *   const logger = getLogger();
  *   logger.info('AI', 'Processing started');
  *   
- *   // Or set a custom logger (e.g., VS Code output channel)
+ *   // Or set a custom logger sink
  *   setLogger(myCustomLogger);
  */
 

--- a/packages/coc-workflow/src/logger.ts
+++ b/packages/coc-workflow/src/logger.ts
@@ -109,15 +109,15 @@ let globalLogger: Logger = consoleLogger;
  * @param logger The logger implementation to use
  * 
  * @example
- * // In VS Code extension
+ * // During server startup
  * import { setLogger } from '@plusplusoneplusplus/coc-workflow';
- * import { getExtensionLogger } from './shared/extension-logger';
+ * import { serverLogger } from './server-logger';
  * 
  * setLogger({
- *     debug: (cat, msg) => getExtensionLogger().debug(cat, msg),
- *     info: (cat, msg) => getExtensionLogger().info(cat, msg),
- *     warn: (cat, msg) => getExtensionLogger().warn(cat, msg),
- *     error: (cat, msg, err) => getExtensionLogger().error(cat, msg, err),
+ *     debug: (cat, msg) => serverLogger.debug(cat, msg),
+ *     info: (cat, msg) => serverLogger.info(cat, msg),
+ *     warn: (cat, msg) => serverLogger.warn(cat, msg),
+ *     error: (cat, msg, err) => serverLogger.error(cat, msg, err),
  * });
  */
 export function setLogger(logger: Logger): void {

--- a/packages/coc-workflow/src/workflow/pipeline-compat.ts
+++ b/packages/coc-workflow/src/workflow/pipeline-compat.ts
@@ -36,7 +36,7 @@ export interface PipelineConfig {
      *
      * - Absolute paths are used as-is
      * - Relative paths are resolved relative to the pipeline package directory
-     * - If omitted, callers use their own default (VS Code uses workspaceRoot, CLI uses --workspace-root or pipeline dir)
+     * - If omitted, callers use their own default (selected workspace root, CLI --workspace-root, or pipeline dir)
      */
     workingDirectory?: string;
     /** Input configuration (required for map-reduce mode, optional for job mode) */

--- a/packages/coc-workflow/src/workflow/result-adapter.ts
+++ b/packages/coc-workflow/src/workflow/result-adapter.ts
@@ -2,7 +2,7 @@
  * WorkflowResult → Flat Display Adapter
  *
  * Converts the Map-based WorkflowResult into a flat structure suitable for
- * CLI output formatting, SPA display, and VS Code result viewers.
+ * CLI output formatting and SPA display.
  *
  * Cross-platform compatible (Linux/Mac/Windows).
  */

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -118,7 +118,12 @@ all have their own `references/*.md`.
   session. If strict resume fails, persist
   `metadata.stoppedChatResume = { resumable: false, reason:
   'strict-resume-failed', ... }`; the REST API and SPA must treat that process
-  as non-resumable and must not offer retry or fresh-session fallback.
+  as non-resumable and must not offer follow-up resume or a fresh-session
+  fallback that continues the stopped chat. A terminal **failed** chat may still
+  expose a "Retry task" button (`FollowUpInputArea` `onRetryTask` →
+  `retry-task-button`, gated by `ChatDetail.canRetryFailedTask`) that re-runs the
+  original task payload as a brand-new conversation via `client.queue.retry` —
+  distinct from resuming the dead session.
 - **Process metadata field updates** from dashboard/server callers should use
   `client.processes.patchMetadata(...)` or API `metadataPatch` unless a full
   metadata replacement is intentional; full `metadata` on

--- a/packages/coc/README.md
+++ b/packages/coc/README.md
@@ -1,6 +1,6 @@
 # CoC (Copilot of Copilot)
 
-A standalone Node.js CLI for executing YAML-based AI pipelines outside VS Code.
+A standalone Node.js CLI and dashboard for executing YAML-based AI pipelines.
 
 ## Prerequisites
 

--- a/packages/coc/specs/admin-tab.spec.md
+++ b/packages/coc/specs/admin-tab.spec.md
@@ -156,7 +156,7 @@ Tool routes (separate `DashboardTab`s) sharing the admin shell: `memory`, `skill
 ### 3.6 Settings Sub-Tab — Integrations
 
 **US-08 — Configure desktop link handlers**
-> As an administrator, I want CoC to register URL handlers (e.g. `vscode://`).
+> As an administrator, I want to choose which external URL schemes CoC opens through desktop link handlers.
 
 - **Given** Settings → Integrations is active
 - **When** the user toggles a handler

--- a/packages/coc/src/server/admin/admin-handler.ts
+++ b/packages/coc/src/server/admin/admin-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for administrative operations (data wipe).
  * Uses time-limited tokens for confirmation of destructive operations.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/admin/stats-handler.ts
+++ b/packages/coc/src/server/admin/stats-handler.ts
@@ -4,7 +4,7 @@
  * Provides GET /api/stats/token-usage, which aggregates per-day per-model
  * token consumption across all persisted processes.
  *
- * No VS Code dependencies — uses only Node.js built-ins.
+ * Pure Node.js; uses only built-ins.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/canvas/canvas-capability-runner.ts
+++ b/packages/coc/src/server/canvas/canvas-capability-runner.ts
@@ -15,7 +15,7 @@
  * `capabilities` object whose values are synchronous functions taking
  * `(state, params)` and returning the complete next state object.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/canvas/canvas-store.ts
+++ b/packages/coc/src/server/canvas/canvas-store.ts
@@ -17,7 +17,7 @@
  * also writes a version snapshot so the dashboard can step through history
  * and restore an older state as a new revision.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/canvas/excalidraw-scene.ts
+++ b/packages/coc/src/server/canvas/excalidraw-scene.ts
@@ -21,7 +21,7 @@
  *   fidelity is lost — server normalization is the persisted floor, client
  *   normalization is the render ceiling.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/core/image-utils.ts
+++ b/packages/coc/src/server/core/image-utils.ts
@@ -2,7 +2,7 @@
  * Image Utilities
  *
  * Shared image helpers for decoding base64 data URL images into temp files
- * and producing SDK Attachment objects. Pure Node.js (no VS Code deps).
+ * and producing SDK Attachment objects. Pure Node.js.
  *
  * Replicates the pattern from src/shortcuts/tasks-viewer/ai-task-commands.ts
  * adapted for server context.

--- a/packages/coc/src/server/errors.ts
+++ b/packages/coc/src/server/errors.ts
@@ -4,7 +4,7 @@
  * Provides a structured APIError class, factory functions for common HTTP errors,
  * and a handleAPIError function for consistent error responses across all API routes.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/autopilot-executor.ts
+++ b/packages/coc/src/server/executors/autopilot-executor.ts
@@ -8,7 +8,7 @@
  * - systemMessage: undefined (no read-only restriction — full read/write access)
  * - tools: follow-up suggestion tool (when configured)
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -11,7 +11,7 @@
  * - tools (follow-up suggestions or other injected tools)
  * - effectivePrompt (prompt with any mode-specific suffix appended)
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/chat-executor.ts
+++ b/packages/coc/src/server/executors/chat-executor.ts
@@ -8,7 +8,7 @@
  * - systemMessage: READ_ONLY_SYSTEM_MESSAGE + optional auto-folder location block
  * - tools: follow-up suggestion tool (when configured)
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/chat-turn-context-builder.ts
+++ b/packages/coc/src/server/executors/chat-turn-context-builder.ts
@@ -11,7 +11,7 @@
  * independently coordinate Memory V2 tools, Memory V2 prompt context,
  * SDK built-in exclusions, ask-user handles, and resource disposal.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/classification-executor.ts
+++ b/packages/coc/src/server/executors/classification-executor.ts
@@ -10,7 +10,7 @@
  * headSha) tuple. The AI calls the tool with the final per-hunk classifications
  * and the handler writes them to the file-based classification store.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/commit-chat-executor.ts
+++ b/packages/coc/src/server/executors/commit-chat-executor.ts
@@ -9,7 +9,7 @@
  * construction time so the AI only provides per-call values (filePath,
  * lineStart, side, comment).
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/image-store.ts
+++ b/packages/coc/src/server/executors/image-store.ts
@@ -6,7 +6,7 @@
  * - Temp-file helpers for decoding images into SDK Attachment objects
  * - Rehydration helper for restoring images lazily from external blob files
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/mcp-tool-enforcement.ts
+++ b/packages/coc/src/server/executors/mcp-tool-enforcement.ts
@@ -24,7 +24,7 @@
  * is identical to the SDK's default global+workspace load, so behavior is
  * preserved; it only narrows the set when a server or tool is actually disabled.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/memory-v2-addon.ts
+++ b/packages/coc/src/server/executors/memory-v2-addon.ts
@@ -12,7 +12,7 @@
  * Workspace memory (gated by repoPrefs.memoryV2.enabled). Returns the empty
  * addon when neither scope is enabled or any error occurs.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/note-chat-executor.ts
+++ b/packages/coc/src/server/executors/note-chat-executor.ts
@@ -5,7 +5,7 @@
  * The note path is prepended to the user's first message by the client;
  * the AI reads the note file via its file-reading tools as needed.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/note-create-executor.ts
+++ b/packages/coc/src/server/executors/note-create-executor.ts
@@ -7,7 +7,7 @@
  * Returns `{ path, title, notebook }` in the process metadata for the
  * SPA client to navigate to the newly created note.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/process-lifecycle-runner.ts
+++ b/packages/coc/src/server/executors/process-lifecycle-runner.ts
@@ -16,7 +16,7 @@
  * Extends BaseExecutor for shared streaming/session plumbing (sessions map,
  * cleanupSession, flushConversationTurn, persistOutput).
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -4,7 +4,7 @@
  * Pure-function helpers for assembling prompts and system messages used by
  * CLITaskExecutor.  No class state, no side-effects, no streaming references.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/prompt-tags.ts
+++ b/packages/coc/src/server/executors/prompt-tags.ts
@@ -10,7 +10,7 @@
  * use it without risking a circular dependency (notably `prompt-builder.ts`
  * re-exports from `memory-v2-addon.ts`, and both consume these helpers).
  *
- * No VS Code dependencies — pure string helpers. Cross-platform compatible.
+ * Pure string helpers. Cross-platform compatible.
  */
 
 /** Wrap `body` in a `<tag>…</tag>` block on its own lines. */

--- a/packages/coc/src/server/executors/ralph-executor.ts
+++ b/packages/coc/src/server/executors/ralph-executor.ts
@@ -19,7 +19,7 @@
  * AGENTS.md: "Prefer use file path in the prompt instead of expanding the
  * prompt with file's content."
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/resolve-comments-executor.ts
+++ b/packages/coc/src/server/executors/resolve-comments-executor.ts
@@ -10,7 +10,7 @@
  * The `buildModeOptions()` creates the resolve-comment tool and stores
  * `getResolvedIds` in a per-process Map for retrieval after the AI call.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/system-message-builder.ts
+++ b/packages/coc/src/server/executors/system-message-builder.ts
@@ -12,7 +12,7 @@
  *
  * `build()` is always async and resolves deferred steps in insertion order.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/executors/task-generation-executor.ts
+++ b/packages/coc/src/server/executors/task-generation-executor.ts
@@ -11,7 +11,7 @@
  * `super.execute(task, aiPrompt)`, and `buildModeOptions()` injects the
  * plan-generation system message stored in a per-task Map.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/cleanup-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/cleanup-infrastructure.ts
@@ -4,7 +4,7 @@
  * Creates and wires up the OutputPruner and StaleTaskDetector used by the
  * execution server.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/loop-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/loop-infrastructure.ts
@@ -6,7 +6,7 @@
  *
  * Follows the same pattern as `schedule-infrastructure.ts`.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/queue-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/queue-infrastructure.ts
@@ -8,7 +8,7 @@
  * Queue state is persisted via SqliteQueuePersistence — incremental,
  * synchronous writes to the shared processes.db.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/schedule-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/schedule-infrastructure.ts
@@ -5,7 +5,7 @@
  * SqliteScheduleRunPersistence, RepoScheduleOverrideStore, ScheduleManager)
  * used by the execution server and returns them as a plain object.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/terminal-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/terminal-infrastructure.ts
@@ -7,7 +7,7 @@
  *
  * Follows the same factory pattern as queue-infrastructure, schedule-infrastructure, etc.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/trigger-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/trigger-infrastructure.ts
@@ -14,7 +14,7 @@
  * reuses the server-side checks path — see `createCiChecksFetcher`) so this
  * builder stays free of provider/HTTP details and is unit-testable.
  *
- * No VS Code dependencies — Node.js built-ins only. Cross-platform.
+ * Pure Node.js with built-ins only. Cross-platform.
  */
 
 import DatabaseConstructor from 'better-sqlite3';

--- a/packages/coc/src/server/infrastructure/watcher-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/watcher-infrastructure.ts
@@ -8,7 +8,7 @@
  *
  * Extracted from createExecutionServer to keep index.ts focused on composition.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/infrastructure/websocket-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/websocket-infrastructure.ts
@@ -6,7 +6,7 @@
  * to it. Extracted from createExecutionServer to keep index.ts focused
  * on composition.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/llm-tools/add-diff-comment-tool.ts
+++ b/packages/coc/src/server/llm-tools/add-diff-comment-tool.ts
@@ -9,7 +9,7 @@
  * avoiding cross-request contamination. Pre-bound context (workspace,
  * commit, parent) is closed over so the AI only provides per-call values.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/llm-tools/canvas-tools.ts
+++ b/packages/coc/src/server/llm-tools/canvas-tools.ts
@@ -14,7 +14,7 @@
  * Every successful create/update emits a `canvas-updated` SSE event on the
  * process channel so the dashboard panel re-renders live.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/llm-tools/diff-line-mapper.ts
+++ b/packages/coc/src/server/llm-tools/diff-line-mapper.ts
@@ -8,7 +8,7 @@
  * to every visual line: hunk headers, context lines, added lines, and
  * removed lines each consume one index.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/llm-tools/memory-v2-tools.ts
+++ b/packages/coc/src/server/llm-tools/memory-v2-tools.ts
@@ -8,7 +8,7 @@
  * Both tools require a fully wired MemoryV2ToolDeps bundle injected at
  * executor construction time.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  */
 
 import {

--- a/packages/coc/src/server/llm-tools/save-classification-tool.ts
+++ b/packages/coc/src/server/llm-tools/save-classification-tool.ts
@@ -10,7 +10,7 @@
  * `classifications` array. Validation is strict — the tool returns an error
  * response when entries are malformed so the AI can retry with corrections.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/loops/loop-handler.ts
+++ b/packages/coc/src/server/loops/loop-handler.ts
@@ -5,7 +5,7 @@
  * Workspace-scoped primary routes at `/api/workspaces/:id/loops`,
  * secondary server-wide route at `/api/loops`.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  */
 
 import type * as http from 'http';

--- a/packages/coc/src/server/memory/memory-config-handler.ts
+++ b/packages/coc/src/server/memory/memory-config-handler.ts
@@ -4,7 +4,7 @@
  * REST API handlers for reading/writing the memory storage configuration.
  * Config is persisted to <dataDir>/memory-config.json using atomic write-then-rename.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/memory/memory-v2-routes.ts
+++ b/packages/coc/src/server/memory/memory-v2-routes.ts
@@ -21,7 +21,7 @@
  * All workspace-scoped routes are gated by prefs.memoryV2.enabled. Returns 404 when
  * disabled. The "global" wsId is gated by global preferences.memoryV2.enabled.
  *
- * No VS Code dependencies — pure Node.js.
+ * Pure Node.js.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/git/notes-git-handler.ts
+++ b/packages/coc/src/server/notes/git/notes-git-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for notes git operations (init, status, log, diff, commit)
  * for a given workspace's notes directory.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/git/notes-git-service.ts
+++ b/packages/coc/src/server/notes/git/notes-git-service.ts
@@ -5,7 +5,7 @@
  * (`~/.coc/repos/<wsId>/notes/`). Completely separate from the source code repo —
  * tracks markdown files only.
  *
- * No VS Code dependencies — uses only Node.js built-in modules + forge git helpers.
+ * Pure Node.js; uses built-in modules and forge git helpers.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/notes-ai-handler.ts
+++ b/packages/coc/src/server/notes/notes-ai-handler.ts
@@ -5,7 +5,7 @@
  * Enqueues a task that reads the notes tree, asks AI for a title and
  * placement, then creates the note file.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/notes-comments-handler.ts
+++ b/packages/coc/src/server/notes/notes-comments-handler.ts
@@ -11,7 +11,7 @@
  *   `~/.coc/repos/<workspaceId>/notes-comments/<encoded-root-path>/`
  *   to keep the workspace repo clean.
  *
- * No VS Code dependencies - uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/notes-image-handler.ts
+++ b/packages/coc/src/server/notes/notes-image-handler.ts
@@ -5,7 +5,7 @@
  * Repo-folder roots: images stored co-located at `<repoRoot>/.images/<uuid>.<ext>`.
  * Markdown references use relative paths: `.attachments/<uuid>.<ext>` or `.images/<uuid>.<ext>`.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/notes-read-handler.ts
+++ b/packages/coc/src/server/notes/notes-read-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for reading notes hierarchy, content, and search
  * for a given workspace.
  *
- * No VS Code dependencies - uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/notes/notes-write-handler.ts
+++ b/packages/coc/src/server/notes/notes-write-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for notes write operations (create, autosave, rename, delete)
  * for a given workspace.
  *
- * No VS Code dependencies - uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/preferences-handler.ts
+++ b/packages/coc/src/server/preferences-handler.ts
@@ -5,7 +5,7 @@
  * Stores preferences in a JSON file under the CoC data directory (~/.coc/preferences.json).
  * File format: { global?: GlobalPreferences, repos?: Record<string, PerRepoPreferences> }
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 
@@ -413,7 +413,7 @@ export const GlobalPreferencesSchema = z.object({
     linkHandlers: LinkHandlersSchema.optional().catch(undefined),
     /** Sandboxed inline previews for local .html/.htm links whose title is "embed". */
     htmlEmbed: HtmlEmbedSchema.optional().catch(undefined),
-    /** VS Code-style inline ghost-text autocomplete for the Queue Task and follow-up inputs. */
+    /** Inline ghost-text autocomplete for the Queue Task and follow-up inputs. */
     promptAutocomplete: PromptAutocompleteSchema.optional().catch(undefined),
     /** Global Memory V2 settings — independent of any workspace scope. */
     memoryV2: GlobalMemoryV2Schema.optional().catch(undefined),

--- a/packages/coc/src/server/processes/finalize-orphaned-turn.ts
+++ b/packages/coc/src/server/processes/finalize-orphaned-turn.ts
@@ -16,7 +16,7 @@
  * expose `getConversationTurns` — falls back to a simple status-only
  * `updateProcess()` call.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/processes/output-file-manager.ts
+++ b/packages/coc/src/server/processes/output-file-manager.ts
@@ -5,7 +5,7 @@
  * Files are stored per-repo at `<dataDir>/repos/<workspaceId>/outputs/<processId>.md`.
  * When no workspaceId is available, falls back to the `_shared` workspace.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/processes/output-pruner.ts
+++ b/packages/coc/src/server/processes/output-pruner.ts
@@ -4,7 +4,7 @@
  * Cleans up orphaned output files under per-repo outputs/ directories when
  * processes are removed, cleared, or pruned. Also purges stale queue.json entries.
  *
- * No VS Code dependencies -- uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/processes/resume-pending-ask-user-answers.ts
+++ b/packages/coc/src/server/processes/resume-pending-ask-user-answers.ts
@@ -15,7 +15,7 @@
  * re-enqueued by an earlier invocation) is skipped, so repeated restarts never
  * stack duplicate concurrent resumes.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/processes/stale-task-detector.ts
+++ b/packages/coc/src/server/processes/stale-task-detector.ts
@@ -9,7 +9,7 @@
  * killed via signal, process crash) without going through the normal
  * cancellation flow, leaving them stuck in 'running' state.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/prompts/prompt-handler.ts
+++ b/packages/coc/src/server/prompts/prompt-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API route for discovering skills available in a workspace.
  * Consumed by the SPA dashboard to populate the skill selection dialogs.
  *
- * No VS Code dependencies — uses only Node.js built-in modules
+ * Pure Node.js — uses only Node.js built-in modules
  * and pipeline-core exports.
  * Cross-platform compatible (Linux/Mac/Windows).
  */

--- a/packages/coc/src/server/prompts/prompt-utils.ts
+++ b/packages/coc/src/server/prompts/prompt-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Prompt File Utilities
  *
- * Discover and read `.prompt.md` files without VS Code dependencies.
+ * Discover and read `.prompt.md` files without editor-host dependencies.
  * Mirrors src/shortcuts/shared/prompt-files-utils.ts using
  * pipeline-core's findPromptFiles() for the actual scanning.
  *

--- a/packages/coc/src/server/queue/image-blob-store.ts
+++ b/packages/coc/src/server/queue/image-blob-store.ts
@@ -6,7 +6,7 @@
  *
  * Uses atomic writes (temp file + rename) for safe concurrent access.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/queue/multi-repo-queue-router.ts
+++ b/packages/coc/src/server/queue/multi-repo-queue-router.ts
@@ -6,7 +6,7 @@
  * + QueueExecutor pair. It does not itself execute tasks; execution is
  * delegated to each repo's QueueExecutor.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/queue/sqlite-queue-persistence.ts
+++ b/packages/coc/src/server/queue/sqlite-queue-persistence.ts
@@ -12,7 +12,7 @@
  * - History IS persisted — completed/failed/cancelled tasks are kept in SQLite
  *   and cleaned up on restart (served from the process store instead).
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/repos/classification-store.ts
+++ b/packages/coc/src/server/repos/classification-store.ts
@@ -11,7 +11,7 @@
  *   ~/.coc/repos/<originId>/classifications/<prId>_<headSha>.json
  *   ~/.coc/repos/<originId>/classifications/<prId>_<headSha>.json.pending
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/repos/origin-scope.ts
+++ b/packages/coc/src/server/repos/origin-scope.ts
@@ -15,7 +15,7 @@
  * Centralizing these primitives keeps two clones of the same upstream repo from
  * resolving to different storage directories.
  *
- * No VS Code dependencies — uses only Node.js + forge git helpers.
+ * Pure Node.js; uses forge git helpers.
  */
 
 import {

--- a/packages/coc/src/server/repos/review-progress-store.ts
+++ b/packages/coc/src/server/repos/review-progress-store.ts
@@ -13,7 +13,7 @@
  * Layout:
  *   ~/.coc/repos/<originId>/review-progress/<prId>.json
  *
- * No VS Code dependencies. Cross-platform compatible (Linux/Mac/Windows).
+ * Pure Node.js. Cross-platform compatible (Linux/Mac/Windows).
  */
 
 import * as fs from 'fs';

--- a/packages/coc/src/server/schedule/schedule-handler.ts
+++ b/packages/coc/src/server/schedule/schedule-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for cron schedule management: CRUD, trigger, history.
  * Mirrors the queue-handler.ts pattern.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/schedule/sqlite-schedule-run-persistence.ts
+++ b/packages/coc/src/server/schedule/sqlite-schedule-run-persistence.ts
@@ -8,7 +8,7 @@
  * Follows the same pattern as SqliteQueuePersistence: receives a
  * shared Database handle, uses prepared statements for hot paths.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/shared/queue-utils.ts
+++ b/packages/coc/src/server/shared/queue-utils.ts
@@ -1,6 +1,6 @@
 /**
  * Shared queue utilities used across bridge classes.
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  */
 
 import type { TaskQueueManager, Attachment } from '@plusplusoneplusplus/forge';

--- a/packages/coc/src/server/skills/global-skill-handler.ts
+++ b/packages/coc/src/server/skills/global-skill-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for managing skills in the global ~/.coc/skills/ directory.
  * Provides listing, scanning, installing, and deleting global skills.
  *
- * No VS Code dependencies — uses pipeline-core skill utilities.
+ * Pure Node.js; uses pipeline-core skill utilities.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/skills/instruction-handler.ts
+++ b/packages/coc/src/server/skills/instruction-handler.ts
@@ -10,7 +10,7 @@
  *   PUT    /api/workspaces/:id/instructions/:mode   — create/update file
  *   DELETE /api/workspaces/:id/instructions/:mode   — delete file
  *
- * No VS Code dependencies. Cross-platform (Linux/Mac/Windows).
+ * Pure Node.js. Cross-platform (Linux/Mac/Windows).
  */
 
 import * as fs from 'fs';

--- a/packages/coc/src/server/skills/skill-handler.ts
+++ b/packages/coc/src/server/skills/skill-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for managing skills in a workspace's .github/skills/ directory.
  * Provides listing, scanning, installing, and deleting skills.
  *
- * No VS Code dependencies — uses pipeline-core skill utilities.
+ * Pure Node.js; uses pipeline-core skill utilities.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/spa/client/comments/diff-comment-types.ts
+++ b/packages/coc/src/server/spa/client/comments/diff-comment-types.ts
@@ -2,7 +2,7 @@
  * Diff Comment Types
  *
  * Core TypeScript types for diff comments in the web UI.
- * Browser-compatible — no Node.js or VS Code dependencies.
+ * Browser-compatible with no platform dependencies.
  *
  * Selection and context types are re-exported from pipeline-core.
  * CoC-specific types (DiffComment, DiffCommentsData) are defined here.

--- a/packages/coc/src/server/spa/client/comments/diff-comment-utils.ts
+++ b/packages/coc/src/server/spa/client/comments/diff-comment-utils.ts
@@ -2,7 +2,7 @@
  * Diff Comment Utilities
  *
  * Browser-compatible helpers for diff comments.
- * No Node.js or VS Code dependencies.
+ * Browser-compatible with no platform dependencies.
  */
 
 /**

--- a/packages/coc/src/server/spa/client/comments/task-comments-types.ts
+++ b/packages/coc/src/server/spa/client/comments/task-comments-types.ts
@@ -2,7 +2,7 @@
  * Task Comments Types
  *
  * Core TypeScript types for task comments in the web UI.
- * Browser-compatible — no Node.js or VS Code dependencies.
+ * Browser-compatible with no platform dependencies.
  *
  * Selection, anchor, and relocation types are re-exported from pipeline-core.
  * CoC-specific types (TaskComment, TaskCommentsData) are defined here.

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -486,6 +486,16 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         () => (selectedAgentNode && selectedAgentId ? pathToAgent(agentRoot, selectedAgentId) : []),
         [agentRoot, selectedAgentNode, selectedAgentId],
     );
+    // A terminal *failed* chat can always be re-run from its original payload via
+    // the queue retry endpoint, regardless of whether a resumable session was
+    // saved. This single flag drives every "Retry task" affordance: the
+    // no-session notice (state 1) and the otherwise dead-end inline error shown
+    // when the chat can't be continued (state 3, `nonRetryableFollowUpError`).
+    const canRetryFailedTask = effectiveStatus === 'failed'
+        && processDetails !== null
+        && !readOnly
+        && !showSubAgentDetail
+        && !isPending;
     // Open a sub-agent (forcing the agents context so closing returns to the
     // canvas) or return to the orchestrator (null), which lands back on the
     // main thread rather than the agents canvas.
@@ -2211,6 +2221,8 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                             isCancelling={isCancelling}
                             error={error}
                             nonRetryableError={nonRetryableFollowUpError}
+                            onRetryTask={canRetryFailedTask ? handleRetryTask : undefined}
+                            retryingTask={retryingTask}
                             disabledPlaceholder={nonRetryableFollowUpError ? 'Cannot continue this stopped chat.' : undefined}
                             resumeFeedback={resumeFeedback}
                             onDismissResumeFeedback={() => setResumeFeedback(null)}
@@ -2352,6 +2364,8 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     isCancelling={isCancelling}
                     error={error}
                     nonRetryableError={nonRetryableFollowUpError}
+                    onRetryTask={canRetryFailedTask ? handleRetryTask : undefined}
+                    retryingTask={retryingTask}
                     disabledPlaceholder={nonRetryableFollowUpError ? 'Cannot continue this stopped chat.' : undefined}
                     resumeFeedback={resumeFeedback}
                     onDismissResumeFeedback={() => setResumeFeedback(null)}

--- a/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
@@ -58,6 +58,14 @@ export interface FollowUpInputAreaProps {
     error: string | null;
     /** Inline error that should not expose the retry affordance. */
     nonRetryableError?: string | null;
+    /**
+     * Re-run the whole task from its original payload. When provided alongside a
+     * `nonRetryableError`, a "Retry task" button is shown inside the error block
+     * so an un-continuable failed chat still has a one-click recovery path.
+     */
+    onRetryTask?: () => void;
+    /** Disables the "Retry task" button while a retry is in flight. */
+    retryingTask?: boolean;
     /** Placeholder to show while disabled for a known non-expiry reason. */
     disabledPlaceholder?: string;
     resumeFeedback: { type: 'success' | 'error'; message: string; command?: string } | null;
@@ -211,6 +219,8 @@ export function FollowUpInputArea({
     isCancelling,
     error,
     nonRetryableError = null,
+    onRetryTask,
+    retryingTask = false,
     disabledPlaceholder,
     resumeFeedback,
     onDismissResumeFeedback,
@@ -679,7 +689,18 @@ export function FollowUpInputArea({
                     className="chat-error-bubble bubble-error text-xs text-[#f14c4c]"
                     data-testid="follow-up-inline-error"
                 >
-                    {nonRetryableError}
+                    <div>{nonRetryableError}</div>
+                    {onRetryTask && (
+                        <button
+                            type="button"
+                            data-testid="retry-task-button"
+                            onClick={onRetryTask}
+                            disabled={retryingTask}
+                            className="mt-2 px-3 py-1.5 text-sm rounded bg-[#0e639c] hover:bg-[#1177bb] text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {retryingTask ? 'Retrying…' : 'Retry task'}
+                        </button>
+                    )}
                 </div>
             )}
             {!nonRetryableError && error && <div className="chat-error-bubble bubble-error text-xs text-[#f14c4c]">{error}</div>}

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/file-tree.ts
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/file-tree.ts
@@ -2,7 +2,7 @@
  * File-tree helper for the PR "Files changed" panel.
  *
  * Builds a folder tree from a flat list of `FileChange`s, then
- * collapses single-child folder chains the way VS Code / GitHub do
+ * collapses single-child folder chains the way common source browsers do
  * (e.g. `packages/coc/src/server` shown as one row) so reviewers can
  * see meaningful structure without scrolling past redundant prefixes.
  *
@@ -121,7 +121,7 @@ function aggregate(folder: MutableFolder): void {
     folder.fileCount = 0;
     folder.additions = 0;
     folder.deletions = 0;
-    // Folders first, then files, each alphabetical (mirrors VS Code).
+    // Folders first, then files, each alphabetical.
     const folders: MutableFolder[] = [];
     const files: FileTreeFile[] = [];
     for (const child of folder.childMap.values()) {

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/explorer/ExactOpen.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/explorer/ExactOpen.tsx
@@ -204,7 +204,7 @@ export function ExactOpen({ workspaceId, open, onClose, onFileSelect }: ExactOpe
             onClick={onClose}
             data-testid="exact-open-overlay"
         >
-            {/* Dialog at top-center, like VS Code */}
+            {/* Dialog at top-center, matching the command palette placement. */}
             <div
                 className={cn(
                     'mt-[10vh] w-[90vw] max-w-[600px] h-fit max-h-[60vh] flex flex-col',

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/explorer/QuickOpen.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/explorer/QuickOpen.tsx
@@ -1,5 +1,5 @@
 /**
- * QuickOpen — VS Code-style Ctrl+P file finder dialog.
+ * QuickOpen — command-palette-style file finder dialog.
  * Debounces keystrokes and delegates search to the server-side /search endpoint.
  * Portal-rendered to document.body.
  */
@@ -192,7 +192,7 @@ export function QuickOpen({ workspaceId, open, onClose, onFileSelect }: QuickOpe
             onClick={onClose}
             data-testid="quick-open-overlay"
         >
-            {/* Dialog at top-center, like VS Code */}
+            {/* Dialog at top-center, matching the command palette placement. */}
             <div
                 className={cn(
                     'mt-[10vh] w-[90vw] max-w-[600px] h-fit max-h-[60vh] flex flex-col',

--- a/packages/coc/src/server/spa/client/react/hooks/usePromptAutocomplete.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/usePromptAutocomplete.ts
@@ -1,5 +1,5 @@
 /**
- * usePromptAutocomplete — VS Code-style inline ghost-text completion hook.
+ * usePromptAutocomplete — inline ghost-text completion hook.
  *
  * Given the current text and cursor position of a prompt input, fetches a
  * single best completion suffix from the server and exposes it for overlay

--- a/packages/coc/src/server/spa/client/react/shared/RichTextInput.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/RichTextInput.tsx
@@ -19,8 +19,8 @@ export interface RichTextInputProps {
     id?: string;
     'data-testid'?: string;
     /**
-     * VS Code-style inline ghost-text suffix rendered after the cursor in
-     * gray italic. Pure visual; does not affect the input's value or events.
+     * Inline ghost-text suffix rendered after the cursor in gray italic.
+     * Pure visual; does not affect the input's value or events.
      * Hidden when `disabled` or empty.
      */
     ghostText?: string;

--- a/packages/coc/src/server/spa/client/react/utils/link-handler.ts
+++ b/packages/coc/src/server/spa/client/react/utils/link-handler.ts
@@ -98,8 +98,8 @@ export const LINK_HANDLER_META: LinkHandlerMeta[] = [
     },
     {
         name: 'vscode',
-        label: 'VS Code',
-        description: 'Open vscode:// and vscode-insiders:// links in the VS Code desktop app.',
+        label: 'Code Editor',
+        description: 'Open vscode:// and vscode-insiders:// links with the registered desktop handler.',
     },
     {
         name: 'file',

--- a/packages/coc/src/server/storage/data-exporter.ts
+++ b/packages/coc/src/server/storage/data-exporter.ts
@@ -4,7 +4,7 @@
  * Collects all CoC data (processes, workspaces, wikis, queue history,
  * preferences, server config) and produces a CoCExportPayload JSON object.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/storage/data-importer.ts
+++ b/packages/coc/src/server/storage/data-importer.ts
@@ -5,7 +5,7 @@
  * store, queue files, and preferences.  Supports Replace (wipe-then-restore)
  * and Merge (add-only-missing) modes.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/storage/data-wiper.ts
+++ b/packages/coc/src/server/storage/data-wiper.ts
@@ -4,7 +4,7 @@
  * Wipes all runtime/persistent data (processes, workspaces, wikis, queues,
  * preferences) while preserving system configuration files.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/streaming/sse-handler.ts
+++ b/packages/coc/src/server/streaming/sse-handler.ts
@@ -5,7 +5,7 @@
  * Clients connect to `GET /api/processes/:id/stream` to receive output chunks
  * as they arrive, followed by a status + done event on completion.
  *
- * No VS Code dependencies - uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/tasks/comments/base-comments-manager.ts
+++ b/packages/coc/src/server/tasks/comments/base-comments-manager.ts
@@ -11,7 +11,7 @@
  *   - getWorkspaceDir(wsId)  — workspace-specific storage directory
  *   - buildStorage(comments) — wraps comments in the concrete storage envelope
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/tasks/comments/diff-comments-handler.ts
+++ b/packages/coc/src/server/tasks/comments/diff-comments-handler.ts
@@ -10,7 +10,7 @@
  * For working-tree diffs (newRef === 'working-tree'), the storage key is
  *   sha256(repoId+filePath+'working-tree') and every comment is ephemeral.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/tasks/comments/task-comments-ai.ts
+++ b/packages/coc/src/server/tasks/comments/task-comments-ai.ts
@@ -37,7 +37,7 @@ export function buildEnrichedPrompt(
 
 /**
  * Build a document revision prompt for one or more open comments.
- * Ported from VS Code's PromptGenerator.generateMarkdownPrompt().
+ * Adapted from the shared markdown prompt-generation flow.
  *
  * @param comments       - Array of TaskComment objects; only status==='open' are included.
  * @param absoluteFilePath - Absolute path to the task file.

--- a/packages/coc/src/server/tasks/comments/task-comments-handler.ts
+++ b/packages/coc/src/server/tasks/comments/task-comments-handler.ts
@@ -8,7 +8,7 @@
  * Storage layout:
  *   {dataDir}/repos/{workspaceId}/tasks-comments/{sha256(filePath)}.json
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/tasks/task-generation-handler.ts
+++ b/packages/coc/src/server/tasks/task-generation-handler.ts
@@ -8,7 +8,7 @@
  *   POST /api/workspaces/:id/tasks/generate  — Generate a task with AI (SSE stream)
  *   POST /api/workspaces/:id/tasks/discover  — Discover related items for a feature
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/tasks/tasks-read-handler.ts
+++ b/packages/coc/src/server/tasks/tasks-read-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for exposing the Tasks Viewer folder hierarchy,
  * file content, and settings for a given workspace.
  *
- * No VS Code dependencies - uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/tasks/tasks-write-handler.ts
+++ b/packages/coc/src/server/tasks/tasks-write-handler.ts
@@ -4,7 +4,7 @@
  * HTTP API routes for task write operations (create, rename, delete,
  * move, archive) for a given workspace.
  *
- * No VS Code dependencies - uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/templates/replicate-apply-handler.ts
+++ b/packages/coc/src/server/templates/replicate-apply-handler.ts
@@ -7,7 +7,7 @@
  * file changes to disk. Idempotent — re-applying the same result
  * overwrites files with the same content.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/templates/templates-handler.ts
+++ b/packages/coc/src/server/templates/templates-handler.ts
@@ -6,7 +6,7 @@
  *
  * Templates are stored as `.vscode/templates/*.yaml` per workspace.
  * Mirrors workflows-handler.ts pattern (separate read + write registration).
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/coc/src/server/triggers/ci-log-fetcher.ts
+++ b/packages/coc/src/server/triggers/ci-log-fetcher.ts
@@ -17,7 +17,7 @@
  * `undefined` so the evaluator falls back to an excerpt-less prompt and the fix
  * still fires.
  *
- * No VS Code dependencies — Node.js built-ins only. Cross-platform.
+ * Pure Node.js with built-ins only. Cross-platform.
  */
 
 import { execFile } from 'child_process';

--- a/packages/coc/src/server/triggers/trigger-handler.ts
+++ b/packages/coc/src/server/triggers/trigger-handler.ts
@@ -9,7 +9,7 @@
  * best-effort emit). Only the `condition-monitor` / `ci-failure` event and the
  * `send-message` action are implemented this iteration.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  */
 
 import * as crypto from 'crypto';

--- a/packages/coc/src/server/workspaces/my-life-handler.ts
+++ b/packages/coc/src/server/workspaces/my-life-handler.ts
@@ -4,7 +4,7 @@
  * Provides endpoints for syncing personal items
  * and generating weekly summaries from notes.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  */
 
 import * as path from 'path';

--- a/packages/coc/src/server/workspaces/my-work-handler.ts
+++ b/packages/coc/src/server/workspaces/my-work-handler.ts
@@ -4,7 +4,7 @@
  * Provides endpoints for syncing action items from Work IQ (via MCP)
  * and generating weekly summaries from notes + cross-repo data.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  */
 
 import * as path from 'path';

--- a/packages/coc/test/server/queue-executor-bridge.test.ts
+++ b/packages/coc/test/server/queue-executor-bridge.test.ts
@@ -1412,7 +1412,7 @@ describe('CLITaskExecutor', () => {
                 }));
             });
 
-            it('should use VS Code extension style prompt with planFilePath and no additionalContext', async () => {
+            it('should use follow-prompt text with planFilePath and no additionalContext', async () => {
                 const existsSyncMock = vi.mocked(fs.existsSync);
 
                 existsSyncMock.mockImplementation((p: fs.PathLike) => {
@@ -1546,7 +1546,7 @@ describe('CLITaskExecutor', () => {
                 }));
             });
 
-            it('should use VS Code extension style even with additionalContext and planFilePath', async () => {
+            it('should use follow-prompt text with additionalContext and planFilePath', async () => {
                 const executor = new CLITaskExecutor(store);
 
                 const task: QueuedTask = {

--- a/packages/coc/test/spa/react/WikiComponentAnchor.test.tsx
+++ b/packages/coc/test/spa/react/WikiComponentAnchor.test.tsx
@@ -73,7 +73,7 @@ const GRAPH = {
         },
     ],
     categories: [{ id: 'ai-processing', name: 'AI Processing' }],
-    project: { name: 'shortcuts', description: 'VS Code extension' },
+    project: { name: 'shortcuts', description: 'CoC dashboard' },
 };
 
 function fakeMarkedParse(md: string): string {

--- a/packages/coc/test/spa/react/queue/PendingTaskComponents.test.tsx
+++ b/packages/coc/test/spa/react/queue/PendingTaskComponents.test.tsx
@@ -236,7 +236,7 @@ describe('PendingTaskPayload resolve comments', () => {
                 prompt: 'Fix it',
                 context: {
                     resolveComments: {
-                        documentUri: 'vscode://notes/my-note.md',
+                        documentUri: 'coc://notes/my-note.md',
                         commentIds: ['c-5'],
                     },
                 },
@@ -246,7 +246,7 @@ describe('PendingTaskPayload resolve comments', () => {
         render(<PendingTaskPayload task={task} />);
 
         expect(screen.getByText('Document')).toBeTruthy();
-        expect(screen.getByText('vscode://notes/my-note.md')).toBeTruthy();
+        expect(screen.getByText('coc://notes/my-note.md')).toBeTruthy();
     });
 
     it('renders Document Snapshot section (collapsed) when documentContent is present', () => {

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -440,23 +440,28 @@ describe('ChatDetail', () => {
         });
 
         it('renders Retry button when error is set (not gated on lastFailedMessageRef)', () => {
-            // The retry button is shown whenever error is truthy
-            const errorBubbleIdx = FOLLOW_UP_INPUT_AREA_SOURCE.indexOf('chat-error-bubble');
+            // The retry button is shown whenever error is truthy. Anchor on the
+            // retry button itself rather than the first chat-error-bubble, since
+            // the non-retryable error block above it can grow (e.g. the
+            // "Retry task" affordance) and shift a fixed-width window off target.
+            const retryBtnIdx = FOLLOW_UP_INPUT_AREA_SOURCE.indexOf('data-testid="retry-btn"');
             const retrySection = FOLLOW_UP_INPUT_AREA_SOURCE.substring(
-                errorBubbleIdx,
-                errorBubbleIdx + 600,
+                retryBtnIdx - 400,
+                retryBtnIdx + 200,
             );
             // Should NOT require lastFailedMessageRef.current in the render condition
-            expect(retrySection).not.toContain('error && lastFailedMessageRef.current');
+            expect(retrySection).not.toContain('lastFailedMessageRef.current');
             expect(retrySection).toContain('Retry');
             expect(retrySection).toContain('onRetry');
         });
 
         it('uses the shared Button component for the retry button', () => {
-            const errorBubbleIdx = FOLLOW_UP_INPUT_AREA_SOURCE.indexOf('chat-error-bubble');
+            // Anchor on the retry button marker so an enlarged non-retryable
+            // error block above cannot push the <Button> out of the window.
+            const retryBtnIdx = FOLLOW_UP_INPUT_AREA_SOURCE.indexOf('data-testid="retry-btn"');
             const retrySection = FOLLOW_UP_INPUT_AREA_SOURCE.substring(
-                errorBubbleIdx,
-                errorBubbleIdx + 600,
+                retryBtnIdx - 200,
+                retryBtnIdx + 200,
             );
             expect(retrySection).toContain('<Button');
             expect(retrySection).toContain('variant="danger"');

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
@@ -1204,6 +1204,74 @@ describe('ChatDetail', () => {
             });
             expect(screen.queryByTestId('retry-task-button')).toBeNull();
         });
+
+        it('shows a Retry task button for a failed chat with a non-retryable resume error and calls retry', async () => {
+            const task = makeTask({ status: 'failed', processId: 'proc-1' });
+            const proc = makeProcess({
+                status: 'failed',
+                sdkSessionId: 'stopped-session',
+                error: 'Provider did not resume the stopped SDK session.',
+                metadata: {
+                    mode: 'autopilot',
+                    stoppedChatResume: {
+                        resumable: false,
+                        reason: STOPPED_CHAT_STRICT_RESUME_FAILED_REASON,
+                        message: STOPPED_CHAT_STRICT_RESUME_FAILED_MESSAGE,
+                        failedAt: '2026-06-23T18:53:00.000Z',
+                        sdkSessionId: 'stopped-session',
+                    },
+                },
+            });
+            setupFetch({
+                '/skills/all': { body: { merged: [] } },
+                '/queue/': (url: string) => {
+                    if (url.includes('/retry')) {
+                        return new Response(
+                            JSON.stringify({ task: { id: 'task-2', status: 'queued' } }),
+                            { status: 201, headers: { 'content-type': 'application/json' } },
+                        );
+                    }
+                    return new Response(
+                        JSON.stringify({ task }),
+                        { status: 200, headers: { 'content-type': 'application/json' } },
+                    );
+                },
+                '/processes/': { body: { process: proc } },
+                '/models': { body: [] },
+            });
+            render(<Wrap><ChatDetail taskId="task-1" workspaceId="ws-1" /></Wrap>);
+
+            // The dead-end inline error is still shown, but now with a retry path.
+            await waitFor(() => {
+                expect(screen.getByTestId('follow-up-inline-error').textContent)
+                    .toContain('saved SDK session could not be resumed');
+            });
+            const btn = await screen.findByTestId('retry-task-button');
+            fireEvent.click(btn);
+
+            await waitFor(() => {
+                const retryCalls = fetchMock.mock.calls.filter(
+                    (c: any) => typeof c[0] === 'string' && c[0].includes('/queue/task-1/retry'),
+                );
+                expect(retryCalls.length).toBeGreaterThan(0);
+            });
+        });
+
+        it('does not show a Retry task button for a cancelled chat without a saved session', async () => {
+            const task = makeTask({ status: 'cancelled', processId: 'proc-1' });
+            const proc = makeProcess({
+                status: 'cancelled',
+                sessionId: 'legacy-session-id',
+                metadata: { mode: 'autopilot', sessionId: 'legacy-metadata-session-id' },
+            });
+            setupStandardFetch(task, proc);
+            render(<Wrap><ChatDetail taskId="task-1" /></Wrap>);
+            await waitFor(() => {
+                expect(screen.getByTestId('follow-up-inline-error').textContent)
+                    .toContain('no SDK session was saved');
+            });
+            expect(screen.queryByTestId('retry-task-button')).toBeNull();
+        });
     });
 
     // ── Task actions ───────────────────────────────────────────────────────

--- a/packages/coc/test/spa/react/repos/FollowUpInputArea.test.tsx
+++ b/packages/coc/test/spa/react/repos/FollowUpInputArea.test.tsx
@@ -578,3 +578,50 @@ describe('FollowUpInputArea — resume feedback dismiss', () => {
         expect(screen.getByRole('button', { name: 'Dismiss' })).toBeTruthy();
     });
 });
+
+describe('FollowUpInputArea — retry-task affordance', () => {
+    const nonRetryableError = 'This stopped chat cannot be continued because no SDK session was saved. Start a new chat manually.';
+
+    it('renders a "Retry task" button inside the non-retryable error when onRetryTask is provided', () => {
+        const onRetryTask = vi.fn();
+        render(<FollowUpInputArea {...makeProps({
+            inputDisabled: true,
+            nonRetryableError,
+            onRetryTask,
+            disabledPlaceholder: 'Cannot continue this stopped chat.',
+        })} />);
+        const btn = screen.getByTestId('retry-task-button');
+        expect(btn.textContent).toBe('Retry task');
+        fireEvent.click(btn);
+        expect(onRetryTask).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the "Retry task" button when onRetryTask is absent (back-compat)', () => {
+        render(<FollowUpInputArea {...makeProps({
+            inputDisabled: true,
+            nonRetryableError,
+            disabledPlaceholder: 'Cannot continue this stopped chat.',
+        })} />);
+        expect(screen.getByTestId('follow-up-inline-error').textContent).toContain('no SDK session was saved');
+        expect(screen.queryByTestId('retry-task-button')).toBeNull();
+    });
+
+    it('disables the "Retry task" button and shows a busy label while retrying', () => {
+        const onRetryTask = vi.fn();
+        render(<FollowUpInputArea {...makeProps({
+            inputDisabled: true,
+            nonRetryableError,
+            onRetryTask,
+            retryingTask: true,
+        })} />);
+        const btn = screen.getByTestId('retry-task-button') as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+        expect(btn.textContent).toBe('Retrying…');
+    });
+
+    it('shows no "Retry task" button when there is no non-retryable error', () => {
+        const onRetryTask = vi.fn();
+        render(<FollowUpInputArea {...makeProps({ onRetryTask })} />);
+        expect(screen.queryByTestId('retry-task-button')).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/repos/explorer/QuickOpen.test.ts
+++ b/packages/coc/test/spa/react/repos/explorer/QuickOpen.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for QuickOpen component — VS Code-style Ctrl+P file finder.
+ * Tests for QuickOpen component — command-palette-style file finder.
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';

--- a/packages/forge/resources/bundled-skills/pipeline-generator/SKILL.md
+++ b/packages/forge/resources/bundled-skills/pipeline-generator/SKILL.md
@@ -465,7 +465,7 @@ nodes:
 1. Save this as `.vscode/workflows/[name]/pipeline.yaml`
 2. Place any referenced CSV/JSON files in the same directory
 3. Place any referenced scripts in the same directory (or adjust `cwd`)
-4. Execute from the VSCode Workflows view or via `coc run`
+4. Execute from the CoC dashboard Workflows tab or via `coc run`
 ````
 
 **For Linear Pipelines:**
@@ -500,7 +500,7 @@ reduce:
 **How to use:**
 1. Save this as `.vscode/workflows/[name]/pipeline.yaml`
 2. If using CSV input, create the CSV file at the specified path
-3. Execute from the VSCode Workflows view or via `coc run`
+3. Execute from the CoC dashboard Workflows tab or via `coc run`
 4. For testing: The `limit: 100` setting processes only the first 100 items
 
 **Key design decisions:**

--- a/packages/forge/src/ado/ado-identity-resolver.ts
+++ b/packages/forge/src/ado/ado-identity-resolver.ts
@@ -6,7 +6,7 @@
  * session cache so future calls do not need to re-resolve.
  *
  * Best-effort: on any failure the function logs a warning and returns null.
- * No VS Code dependencies — pure Node.js.
+ * Pure Node.js.
  */
 import type { WebApi } from 'azure-devops-node-api';
 import { getLogger, LogCategory } from '../logger';

--- a/packages/forge/src/ado/ado-session-cache.ts
+++ b/packages/forge/src/ado/ado-session-cache.ts
@@ -4,7 +4,7 @@
  * calls (which take ~300–800 ms each).
  *
  * Cache is considered valid when the token expires more than 5 minutes from now.
- * No VS Code dependencies — pure Node.js.
+ * Pure Node.js.
  */
 import * as fs from 'fs/promises';
 import * as path from 'path';

--- a/packages/forge/src/ai/command-types.ts
+++ b/packages/forge/src/ai/command-types.ts
@@ -2,7 +2,7 @@
  * AI Command Types
  *
  * Type definitions for configurable AI commands.
- * These are pure types with no VS Code dependencies.
+ * These are pure types with no editor-host dependencies.
  */
 
 import { DEFAULT_PROMPTS } from './types';

--- a/packages/forge/src/ai/program-utils.ts
+++ b/packages/forge/src/ai/program-utils.ts
@@ -2,7 +2,7 @@
  * Program Utilities
  *
  * Pure Node.js utilities for checking program availability and parsing CLI output.
- * No VS Code dependencies.
+ * Pure Node.js.
  */
 
 import { execSync } from 'child_process';

--- a/packages/forge/src/ai/prompt-builder.ts
+++ b/packages/forge/src/ai/prompt-builder.ts
@@ -2,7 +2,7 @@
  * Prompt Builder (Pure Implementation)
  *
  * Pure template variable substitution for AI prompts.
- * No VS Code dependencies - can be used in CLI tools and other environments.
+ * Pure Node.js; can be used in CLI tools and other environments.
  */
 
 import { substituteVariables } from '../utils/template-engine';

--- a/packages/forge/src/ai/types.ts
+++ b/packages/forge/src/ai/types.ts
@@ -1,7 +1,7 @@
 /**
  * AI Service Types (Pure Node.js)
  *
- * Core types for AI service operations. These types are VS Code-free
+ * Core types for AI service operations. These types are editor-independent
  * and can be used in CLI tools, tests, and other Node.js environments.
  */
 

--- a/packages/forge/src/diff/README.md
+++ b/packages/forge/src/diff/README.md
@@ -91,4 +91,4 @@ diff/
 └── index.ts              # Barrel re-exports
 ```
 
-The diff module depends only on `../git/exec` (for `execGitAsync`) and `../providers/interfaces` (for `IPullRequestsService`). It has no VS Code dependencies.
+The diff module depends only on `../git/exec` (for `execGitAsync`) and `../providers/interfaces` (for `IPullRequestsService`). It has no editor-specific runtime dependencies.

--- a/packages/forge/src/discovery/prompt-files.ts
+++ b/packages/forge/src/discovery/prompt-files.ts
@@ -11,7 +11,7 @@ const DEFAULT_PROMPT_LOCATION = '.github/prompts';
  *
  * Adapted from extension's getPromptFiles() + findPromptFilesInFolder()
  * (src/shortcuts/shared/prompt-files-utils.ts:58-121) — same recursive
- * walk logic but with explicit location parameters instead of VS Code
+ * walk logic but with explicit location parameters instead of editor-host
  * settings.
  *
  * @param rootDir   Workspace/project root (absolute path)

--- a/packages/forge/src/editor/anchor-types.ts
+++ b/packages/forge/src/editor/anchor-types.ts
@@ -2,7 +2,7 @@
  * Anchor Types
  *
  * Platform-agnostic interfaces for anchor-based comment location tracking.
- * Used by both the VS Code extension and the CoC standalone server.
+ * Used by the CoC dashboard and standalone server.
  */
 
 /**

--- a/packages/forge/src/editor/host.ts
+++ b/packages/forge/src/editor/host.ts
@@ -1,11 +1,11 @@
 /**
  * Platform host abstraction for the Markdown Review Editor.
  *
- * Abstracts platform-specific operations that differ between
- * VS Code and a standalone HTTP server.
+ * Abstracts platform-specific operations for editor hosts and the standalone
+ * HTTP server.
  */
 
-/** Abstracts platform-specific operations that differ between VS Code and HTTP server */
+/** Abstracts platform-specific operations that differ between UI hosts. */
 export interface EditorHost {
     /** Show an informational notification */
     showInformation(message: string): void;

--- a/packages/forge/src/editor/index.ts
+++ b/packages/forge/src/editor/index.ts
@@ -2,8 +2,7 @@
  * Editor Abstractions
  *
  * Platform-agnostic interfaces and types for the Markdown Review Editor.
- * Both the VS Code extension and the CoC standalone HTTP server implement
- * these contracts.
+ * CoC dashboard and server-side hosts implement these contracts.
  */
 
 // Domain types

--- a/packages/forge/src/editor/messages.ts
+++ b/packages/forge/src/editor/messages.ts
@@ -5,7 +5,7 @@
  *   • WebviewToBackendMessage — messages sent from the UI to the backend
  *   • BackendToWebviewMessage — messages sent from the backend to the UI
  *
- * "Backend" can be the VS Code extension host OR a standalone HTTP server.
+ * "Backend" is the server-side host that serves the review editor UI.
  */
 
 import type { SerializedAICommand, SerializedAIMenuConfig, AICommandMode } from '../ai';

--- a/packages/forge/src/editor/parsing/block-renderers.ts
+++ b/packages/forge/src/editor/parsing/block-renderers.ts
@@ -92,9 +92,8 @@ function computeColumnWidths(table: ParsedTable): number[] {
 /**
  * Render a `ParsedTable` as an HTML `<table>` string.
  *
- * The output intentionally mirrors the CSS class names used by the
- * review-editor webview so that the same stylesheet works for both
- * the VS Code extension and the CoC SPA.
+ * The output intentionally mirrors the CSS class names used by the review
+ * editor so the CoC SPA can share one stylesheet.
  *
  * A `<colgroup>` with content-proportional widths is always emitted so that
  * the `table-layout: fixed` CSS rule distributes space meaningfully instead

--- a/packages/forge/src/editor/parsing/block-renderers.ts
+++ b/packages/forge/src/editor/parsing/block-renderers.ts
@@ -2,8 +2,8 @@
  * Block renderers — pure HTML string generation
  *
  * These functions take parsed markdown structures and produce HTML strings.
- * They have no DOM, state, or VS Code dependencies, making them suitable
- * for server-side rendering in both the VS Code webview and the CoC SPA.
+ * They have no DOM, state, or editor-host dependencies, making them suitable
+ * for server-side rendering and the CoC SPA.
  */
 
 import { escapeHtml } from '../rendering/markdown-renderer';

--- a/packages/forge/src/editor/parsing/index.ts
+++ b/packages/forge/src/editor/parsing/index.ts
@@ -2,7 +2,7 @@
  * Parsing module exports
  *
  * Pure TypeScript markdown parsing and block rendering utilities.
- * These functions have no DOM or VS Code dependencies — they are
+ * These functions have no DOM or editor-host dependencies, so they are
  * string-in, structured-data-out transformations suitable for any environment.
  */
 

--- a/packages/forge/src/editor/parsing/markdown-parser.ts
+++ b/packages/forge/src/editor/parsing/markdown-parser.ts
@@ -3,7 +3,7 @@
  *
  * Pure TypeScript structural parsing functions for markdown content.
  * Every function takes strings/arrays and returns parsed structures —
- * no side effects, no state, no DOM or VS Code dependencies.
+ * no side effects, no state, no DOM or editor-host dependencies.
  */
 
 /**

--- a/packages/forge/src/editor/rendering/index.ts
+++ b/packages/forge/src/editor/rendering/index.ts
@@ -2,7 +2,7 @@
  * Rendering module exports
  *
  * Pure TypeScript rendering primitives for markdown content.
- * These functions have no DOM or VS Code dependencies — they are
+ * These functions have no DOM or editor-host dependencies, so they are
  * string-in, string-out transformations suitable for any environment.
  */
 

--- a/packages/forge/src/editor/state-store.ts
+++ b/packages/forge/src/editor/state-store.ts
@@ -1,7 +1,7 @@
 /**
  * State persistence abstraction for the Markdown Review Editor.
  *
- * Replaces direct usage of vscode.Memento (context.workspaceState)
+ * Replaces direct usage of editor workspace-state storage.
  * with a platform-agnostic key-value interface.
  */
 

--- a/packages/forge/src/editor/transport.ts
+++ b/packages/forge/src/editor/transport.ts
@@ -1,8 +1,8 @@
 /**
  * Transport abstraction for the Markdown Review Editor.
  *
- * Abstracts the bidirectional message channel between the UI (webview)
- * and the backend (VS Code extension host or standalone HTTP server).
+ * Abstracts the bidirectional message channel between the review UI and the
+ * backend host.
  */
 
 import type { Disposable } from '../utils/process-monitor';

--- a/packages/forge/src/file-process-store.ts
+++ b/packages/forge/src/file-process-store.ts
@@ -6,7 +6,7 @@
  * Cross-workspace ID lookups via index scan across per-workspace index.json files.
  * Empty workspaceId maps to repos/_default/processes/.
  *
- * No VS Code dependencies - designed for the standalone pipeline server.
+ * Pure Node.js; designed for the standalone pipeline server.
  */
 
 import * as fs from 'fs/promises';

--- a/packages/forge/src/git/branch-service.ts
+++ b/packages/forge/src/git/branch-service.ts
@@ -1,5 +1,5 @@
 /**
- * Pure Node.js BranchService — no VS Code dependencies.
+ * Pure Node.js BranchService.
  *
  * Provides branch listing, switching, creating, deleting, merging,
  * push/pull/fetch, stash, and status queries using git CLI.

--- a/packages/forge/src/git/git-log-service.ts
+++ b/packages/forge/src/git/git-log-service.ts
@@ -1,5 +1,5 @@
 /**
- * Pure Node.js GitLogService — no VS Code dependencies.
+ * Pure Node.js GitLogService.
  *
  * Provides git commit history, branch management, diff retrieval,
  * and file content queries using the async `execAsync` helper so that

--- a/packages/forge/src/git/git-ops-store.ts
+++ b/packages/forge/src/git/git-ops-store.ts
@@ -9,7 +9,7 @@
  *
  * Follows the same atomic-write and write-queue patterns as FileProcessStore.
  *
- * No VS Code dependencies — pure Node.js.
+ * Pure Node.js.
  */
 
 import * as fs from 'fs/promises';

--- a/packages/forge/src/git/git-range-service.ts
+++ b/packages/forge/src/git/git-range-service.ts
@@ -1,5 +1,5 @@
 /**
- * Pure Node.js GitRangeService — no VS Code dependencies.
+ * Pure Node.js GitRangeService.
  *
  * Provides commit range calculations:
  * - Detecting the default remote branch (origin/main or origin/master)

--- a/packages/forge/src/git/remote.ts
+++ b/packages/forge/src/git/remote.ts
@@ -5,7 +5,7 @@
  * hashes, and resolving canonical origin IDs shared by local clones that point
  * at the same upstream repository.
  *
- * No VS Code dependencies — pure Node.js.
+ * Pure Node.js.
  */
 
 import { createHash } from 'crypto';

--- a/packages/forge/src/git/types.ts
+++ b/packages/forge/src/git/types.ts
@@ -1,8 +1,7 @@
 /**
- * Pure Node.js git types — no VS Code dependencies.
+ * Pure Node.js git types.
  *
- * Extracted from `src/shortcuts/git/types.ts`.
- * `vscode.Uri` replaced with `filePath: string`.
+ * Editor URI objects are represented as `filePath: string`.
  * UI-only types (`GitSectionType`, `GitViewCounts`) are omitted.
  */
 
@@ -180,7 +179,7 @@ export interface GitCommitRangeFile {
 }
 
 /**
- * Configuration for GitRangeService (replaces vscode.workspace.getConfiguration).
+ * Configuration for GitRangeService.
  */
 export interface GitRangeConfig {
     /** Maximum number of changed files to return from detectCommitRange (default: 100) */

--- a/packages/forge/src/git/working-tree-service.ts
+++ b/packages/forge/src/git/working-tree-service.ts
@@ -4,7 +4,7 @@
  * Provides stage, unstage, discard, delete-untracked, and getAllChanges
  * using the git CLI (via execGit) and Node's `fs` module.
  *
- * No VS Code dependencies.
+ * Pure Node.js.
  */
 
 import * as fs from 'fs';

--- a/packages/forge/src/logger.ts
+++ b/packages/forge/src/logger.ts
@@ -111,15 +111,15 @@ let globalLogger: Logger = consoleLogger;
  * @param logger The logger implementation to use
  * 
  * @example
- * // In VS Code extension
- * import { setLogger } from 'pipeline-core';
- * import { getExtensionLogger } from './shared/extension-logger';
+ * // During server startup
+ * import { setLogger } from '@plusplusoneplusplus/forge';
+ * import { serverLogger } from './server-logger';
  * 
  * setLogger({
- *     debug: (cat, msg) => getExtensionLogger().debug(cat, msg),
- *     info: (cat, msg) => getExtensionLogger().info(cat, msg),
- *     warn: (cat, msg) => getExtensionLogger().warn(cat, msg),
- *     error: (cat, msg, err) => getExtensionLogger().error(cat, msg, err),
+ *     debug: (cat, msg) => serverLogger.debug(cat, msg),
+ *     info: (cat, msg) => serverLogger.info(cat, msg),
+ *     warn: (cat, msg) => serverLogger.warn(cat, msg),
+ *     error: (cat, msg, err) => serverLogger.error(cat, msg, err),
  * });
  */
 export function setLogger(logger: Logger): void {

--- a/packages/forge/src/logger.ts
+++ b/packages/forge/src/logger.ts
@@ -4,7 +4,7 @@ import { resetLogger as resetWorkflowLogger, setLogger as setWorkflowLogger } fr
  * Logger abstraction for pipeline-core package.
  * 
  * This module provides a simple logger interface that can be implemented
- * by different environments (VS Code, CLI, tests, etc.).
+ * by different environments (CLI, server, tests, etc.).
  * 
  * Usage:
  *   import { getLogger, setLogger, consoleLogger } from 'pipeline-core';
@@ -13,7 +13,7 @@ import { resetLogger as resetWorkflowLogger, setLogger as setWorkflowLogger } fr
  *   const logger = getLogger();
  *   logger.info('AI', 'Processing started');
  *   
- *   // Or set a custom logger (e.g., VS Code output channel)
+ *   // Or set a custom logger sink
  *   setLogger(myCustomLogger);
  */
 

--- a/packages/forge/src/memory/base-file-store.ts
+++ b/packages/forge/src/memory/base-file-store.ts
@@ -7,7 +7,7 @@
  * - Safe JSON reads with default value (readJSON)
  * - Safe subdirectory listing (listDirectory)
  *
- * No VS Code dependencies — pure Node.js.
+ * Pure Node.js.
  */
 import * as fs from 'fs/promises';
 import * as path from 'path';

--- a/packages/forge/src/memory/types.ts
+++ b/packages/forge/src/memory/types.ts
@@ -4,7 +4,7 @@
  * Core type definitions shared by the bounded memory store and tool-call
  * cache subsystems.
  *
- * No VS Code dependencies — pure Node.js types for pipeline-core.
+ * Pure Node.js types for pipeline-core.
  */
 
 // ---------------------------------------------------------------------------

--- a/packages/forge/src/process-store.ts
+++ b/packages/forge/src/process-store.ts
@@ -4,7 +4,7 @@
  * Abstract storage interface for AI processes with workspace-scoped querying.
  * Enables multi-workspace process tracking for the standalone AI execution server.
  *
- * No VS Code dependencies - can be used in CLI tools and other environments.
+ * Pure Node.js; can be used in CLI tools and other environments.
  */
 
 import { AIProcess, AIProcessStatus, AIProcessType, ProcessEvent, ConversationTurn, TimelineItem } from './ai/process-types';
@@ -324,8 +324,8 @@ export type ProcessChangeCallback = (event: ProcessEvent) => void;
 /**
  * Abstract storage interface for AI processes.
  *
- * Implementations may be backed by VS Code Memento (extension),
- * in-memory Map (tests / server), or SQLite (persistent server).
+ * Implementations may be backed by in-memory Map (tests / server) or SQLite
+ * (persistent server).
  */
 export interface ProcessStore {
     addProcess(process: AIProcess): Promise<void>;

--- a/packages/forge/src/queue/follow-prompt.ts
+++ b/packages/forge/src/queue/follow-prompt.ts
@@ -2,8 +2,8 @@
  * Follow-Prompt Types and Utilities
  *
  * Shared payload interface and prompt-building logic for follow-prompt tasks.
- * Used by both the VS Code extension and the CoC server to ensure consistent
- * prompt construction when executing skill/prompt-file based AI tasks.
+ * Used by the CoC server and Node queue consumers to ensure consistent prompt
+ * construction when executing skill/prompt-file based AI tasks.
  *
  * Cross-platform compatible (Linux/Mac/Windows).
  */

--- a/packages/forge/src/sqlite-process-store.ts
+++ b/packages/forge/src/sqlite-process-store.ts
@@ -5,7 +5,7 @@
  * All methods are synchronous at the SQLite level, wrapped in async
  * to satisfy the ProcessStore interface's Promise return types.
  *
- * No VS Code dependencies — designed for the standalone CoC server.
+ * Pure Node.js; designed for the standalone CoC server.
  */
 
 import * as fs from 'fs';

--- a/packages/forge/src/tasks/discovery-prompt-builder.ts
+++ b/packages/forge/src/tasks/discovery-prompt-builder.ts
@@ -3,7 +3,7 @@
  *
  * Pure-Node prompt builder for feature-folder discovery.
  * Builds a discovery request prompt from a feature description,
- * keywords, and scope parameters — no VS Code dependencies.
+ * keywords, and scope parameters.
  *
  * Cross-platform compatible (Linux/Mac/Windows).
  */

--- a/packages/forge/src/tasks/index.ts
+++ b/packages/forge/src/tasks/index.ts
@@ -100,7 +100,7 @@ export {
 } from './task-operations';
 
 export {
-    // Task prompt builders (pure Node.js, no VS Code deps)
+    // Task prompt builders (pure Node.js)
     AUTO_FOLDER_SENTINEL,
     AutoFolderContext,
     buildAutoFolderLocationBlock,

--- a/packages/forge/src/tasks/index.ts
+++ b/packages/forge/src/tasks/index.ts
@@ -1,6 +1,6 @@
 /**
- * Tasks module - Types and parsing utilities for task management.
- * Extracted from the VS Code extension's tasks-viewer for use in CLI tools.
+ * Tasks module - types and parsing utilities for task management in CLI tools
+ * and CoC server flows.
  */
 
 export {

--- a/packages/forge/src/tasks/related-items-loader.ts
+++ b/packages/forge/src/tasks/related-items-loader.ts
@@ -1,8 +1,8 @@
 /**
  * Related Items Loader
  * 
- * Handles reading and writing of related.yaml files in feature folders.
- * Extracted from the VS Code extension for use in CLI tools and other Node.js consumers.
+ * Handles reading and writing of related.yaml files in feature folders for CLI
+ * tools and other Node.js consumers.
  */
 
 import * as fs from 'fs';

--- a/packages/forge/src/tasks/task-manager.ts
+++ b/packages/forge/src/tasks/task-manager.ts
@@ -2,11 +2,10 @@
  * TaskManager Facade
  *
  * Composes task-scanner, task-operations, task-parser, and related-items-loader
- * into a single entry point with the same public API as the VS Code TaskManager,
- * but free of all VS Code dependencies.
+ * into a single entry point with a stable task-management API.
  *
  * Consumers pass settings at construction time instead of reading from
- * vscode.workspace.getConfiguration(). File watching is left to the consumer;
+ * editor workspace configuration APIs. File watching is left to the consumer;
  * an optional onRefresh callback is stored for internal use (e.g., after batch
  * operations).
  */

--- a/packages/forge/src/tasks/task-operations.ts
+++ b/packages/forge/src/tasks/task-operations.ts
@@ -1,6 +1,6 @@
 /**
  * Task CRUD operations and composite helpers — Pure Node.js functions for task file management.
- * No VS Code dependencies. Every function takes explicit path arguments.
+ * Pure Node.js. Every function takes explicit path arguments.
  */
 
 import * as fs from 'fs';

--- a/packages/forge/src/tasks/task-parser.ts
+++ b/packages/forge/src/tasks/task-parser.ts
@@ -1,6 +1,6 @@
 /**
- * Task parsing utilities extracted from the VS Code extension's tasks-viewer module.
- * Pure Node.js functions with no VS Code dependencies.
+ * Task parsing utilities for task management.
+ * Pure Node.js functions with no editor dependencies.
  */
 
 import * as fs from 'fs';

--- a/packages/forge/src/tasks/task-prompt-builder.ts
+++ b/packages/forge/src/tasks/task-prompt-builder.ts
@@ -291,7 +291,7 @@ export function buildDeepModePrompt(
 
 /**
  * Gather context from a feature folder (related.yaml, plan.md, spec.md).
- * Pure Node.js — no VS Code dependencies.
+ * Pure Node.js.
  */
 export async function gatherFeatureContext(
     folderPath: string,

--- a/packages/forge/src/tasks/task-prompt-builder.ts
+++ b/packages/forge/src/tasks/task-prompt-builder.ts
@@ -1,9 +1,8 @@
 /**
  * Task Prompt Builder
  *
- * Pure-Node prompt-building functions for AI task generation.
- * Extracted from the VS Code extension's ai-task-commands.ts for reuse
- * in CLI tools and the CoC server without any VS Code dependencies.
+ * Pure-Node prompt-building functions for AI task generation in CLI tools and
+ * the CoC server.
  *
  * Cross-platform compatible (Linux/Mac/Windows).
  */
@@ -19,7 +18,6 @@ import { loadRelatedItems } from './related-items-loader';
 
 /**
  * Feature context gathered from a feature folder.
- * Mirror of the extension's FeatureContext but without VS Code types.
  */
 export interface FeatureContextInput {
     hasContent: boolean;

--- a/packages/forge/src/tasks/task-scanner.ts
+++ b/packages/forge/src/tasks/task-scanner.ts
@@ -1,6 +1,6 @@
 /**
- * Task scanning and grouping utilities extracted from the VS Code extension's TaskManager.
- * Pure Node.js functions with no VS Code dependencies.
+ * Task scanning and grouping utilities for task management.
+ * Pure Node.js functions with no editor dependencies.
  * All scanning functions use async I/O via fs.promises.
  */
 
@@ -365,4 +365,3 @@ export async function buildTaskFolderHierarchy(
 
     return { root: rootFolder, folderMap };
 }
-

--- a/packages/forge/src/tasks/types.ts
+++ b/packages/forge/src/tasks/types.ts
@@ -1,6 +1,6 @@
 /**
- * Task types extracted from the VS Code extension's tasks-viewer module.
- * Pure TypeScript types with no VS Code dependencies.
+ * Task management types.
+ * Pure TypeScript types with no editor dependencies.
  */
 
 /**

--- a/packages/forge/src/utils/paste-context-manager.ts
+++ b/packages/forge/src/utils/paste-context-manager.ts
@@ -5,7 +5,7 @@
  * file-path references for AI prompts. This avoids blowing up the context
  * window when users paste large logs, JSON, or stack traces.
  *
- * No VS Code dependencies — uses only Node.js built-in modules.
+ * Pure Node.js; uses only built-in modules.
  * Cross-platform compatible (Linux/Mac/Windows).
  */
 

--- a/packages/forge/src/utils/process-monitor.ts
+++ b/packages/forge/src/utils/process-monitor.ts
@@ -14,7 +14,7 @@ import { getLogger, LogCategory } from '../logger';
 
 /**
  * Disposable interface for cleanup
- * Compatible with VS Code's Disposable interface
+ * Compatible with Disposable-like interfaces
  */
 export interface Disposable {
     dispose(): void;

--- a/packages/forge/src/utils/terminal-types.ts
+++ b/packages/forge/src/utils/terminal-types.ts
@@ -2,7 +2,7 @@
  * Terminal Types (Pure Node.js)
  * 
  * Types for terminal detection and external terminal launching.
- * These types are VS Code-free and can be used in CLI tools.
+ * These types are editor-independent and can be used in CLI tools.
  */
 
 import { InteractiveToolType } from '../ai/types';
@@ -33,7 +33,7 @@ export type InteractiveSessionStatus = 'starting' | 'active' | 'ended' | 'error'
 
 /**
  * An interactive CLI session running in an external terminal.
- * This is a pure data type without VS Code dependencies.
+ * This is a pure data type without editor-host dependencies.
  */
 export interface InteractiveSession {
     /** Unique session identifier */

--- a/packages/forge/src/workflow/pipeline-compat.ts
+++ b/packages/forge/src/workflow/pipeline-compat.ts
@@ -36,7 +36,7 @@ export interface PipelineConfig {
      *
      * - Absolute paths are used as-is
      * - Relative paths are resolved relative to the pipeline package directory
-     * - If omitted, callers use their own default (VS Code uses workspaceRoot, CLI uses --workspace-root or pipeline dir)
+     * - If omitted, callers use their own default (selected workspace root, CLI --workspace-root, or pipeline dir)
      */
     workingDirectory?: string;
     /** Input configuration (required for map-reduce mode, optional for job mode) */

--- a/packages/forge/src/workflow/result-adapter.ts
+++ b/packages/forge/src/workflow/result-adapter.ts
@@ -2,7 +2,7 @@
  * WorkflowResult → Flat Display Adapter
  *
  * Converts the Map-based WorkflowResult into a flat structure suitable for
- * CLI output formatting, SPA display, and VS Code result viewers.
+ * CLI output formatting and SPA display.
  *
  * Cross-platform compatible (Linux/Mac/Windows).
  */

--- a/packages/forge/test/ai/mcp-config-loader.test.ts
+++ b/packages/forge/test/ai/mcp-config-loader.test.ts
@@ -84,7 +84,7 @@ describe('MCP Config Loader', () => {
     });
 
     describe('getWorkspaceMcpConfigPath', () => {
-        it('returns the VS Code workspace MCP config path', () => {
+        it('returns the workspace MCP config path', () => {
             expect(getWorkspaceMcpConfigPath(workspaceDir)).toBe(workspaceConfigPath);
         });
     });
@@ -349,7 +349,7 @@ describe('MCP Config Loader', () => {
             expect(result.configPath).toBe(workspaceConfigPath);
         });
 
-        it('loads VS Code servers from .vscode/mcp.json', () => {
+        it('loads workspace servers from .vscode/mcp.json', () => {
             const config: VSCodeMCPConfigFile = {
                 servers: {
                     'workspace-server': {
@@ -372,7 +372,7 @@ describe('MCP Config Loader', () => {
             expect(result.mcpServers).toEqual(config.servers);
         });
 
-        it('normalizes VS Code servers and strips unsupported top-level fields', () => {
+        it('normalizes workspace servers and strips unsupported top-level fields', () => {
             const config = {
                 servers: {
                     vscode: {

--- a/packages/forge/test/queue/follow-prompt.test.ts
+++ b/packages/forge/test/queue/follow-prompt.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for follow-prompt shared utilities.
  *
- * Validates buildFollowPromptText and isFollowPromptPayload used by both
- * the VS Code extension and the CoC server.
+ * Validates buildFollowPromptText and isFollowPromptPayload for CoC server
+ * and Node queue consumers.
  */
 import { describe, it, expect } from 'vitest';
 import {

--- a/packages/forge/test/tasks/task-prompt-builder.test.ts
+++ b/packages/forge/test/tasks/task-prompt-builder.test.ts
@@ -1,8 +1,8 @@
 /**
  * Task Prompt Builder Tests
  *
- * Tests for the pure-Node prompt-building functions extracted from
- * the VS Code extension's ai-task-commands.ts.
+ * Tests for the pure-Node prompt-building functions used by CoC task
+ * generation.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/packages/teams-bot/src/bot.ts
+++ b/packages/teams-bot/src/bot.ts
@@ -6,7 +6,7 @@
  *   Works with any Entra ID app that has Teams Graph permissions.
  * - 'mcp': Uses the Teams MCP server (agent365). Requires McpServers.Teams.All
  *   scope, which is only preauthorized for first-party Microsoft apps
- *   (Copilot Studio, M365 Copilot, VS Code Copilot Chat).
+ *   (Copilot Studio, M365 Copilot, editor chat clients).
  */
 
 import type { TeamsBotOptions, BotStatus, InboundTeamsMessage, TeamsChannel, TeamsTransportMode, TeamsTransport } from './types';
@@ -386,4 +386,3 @@ export class TeamsBot {
         return hasAgent && hasRepo && hasMessage;
     }
 }
-

--- a/scripts/convert_svg_to_png.py
+++ b/scripts/convert_svg_to_png.py
@@ -124,7 +124,7 @@ def main():
     # Default paths
     svg_path = Path("resources/icons/shortcuts.svg")
     png_path = Path("resources/icons/shortcuts.png")
-    size = 128  # VS Code marketplace recommended size
+    size = 128  # legacy marketplace icon size
 
     # Parse command line arguments
     if len(sys.argv) > 1:

--- a/scripts/convert_svg_to_png.py
+++ b/scripts/convert_svg_to_png.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Smart SVG to PNG converter for VS Code extensions
+Smart SVG to PNG converter for package icons
 Converts SVG icons to PNG format with proper sizing for marketplace requirements
 """
 


### PR DESCRIPTION
- **docs: remove vscode extension structural references**
- **docs: reframe constitution around coc packages**
- **docs: remove stale vscode UI references**
- **docs: remove stale vscode design references**
- **docs: remove stale vscode extension phrase matches**
- **docs: clean broad vscode prose references**
- **docs: finish vscode cleanup validation**
- **feat(spa): offer "Retry task" for un-continuable failed chats**
