### PR TITLE
pr/4ade51a4a featcoc agent sdk add opencode sdk provi

### DIFF
--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -1,6 +1,6 @@
 # CoC Agent SDK (`coc-agent-sdk`)
 
-Provider-agnostic AI agent SDK for CoC. Manages AI session lifecycle, MCP server configuration, model registry and metadata, reasoning-effort resolution, folder trust, and provider quota snapshots where the backend exposes them. Supports **Copilot** (via `@github/copilot-sdk`), **Codex** (via the optional `@openai/codex-sdk` plus the bundled `@openai/codex` CLI for quota/model catalog RPCs), and **Claude** (via the optional `@anthropic-ai/claude-agent-sdk`) backends through a common `ISDKService` interface.
+Provider-agnostic AI agent SDK for CoC. Manages AI session lifecycle, MCP server configuration, model registry and metadata, reasoning-effort resolution, folder trust, and provider quota snapshots where the backend exposes them. Supports **Copilot** (via `@github/copilot-sdk`), **Codex** (via the optional `@openai/codex-sdk` plus the bundled `@openai/codex` CLI for quota/model catalog RPCs), **Claude** (via the optional `@anthropic-ai/claude-agent-sdk`), and **OpenCode** (via the optional `@opencode-ai/sdk`) backends through a common `ISDKService` interface.
 
 Package: `@plusplusoneplusplus/coc-agent-sdk`  
 Location: `packages/coc-agent-sdk/src/`
@@ -14,6 +14,7 @@ Location: `packages/coc-agent-sdk/src/`
 | `copilot-sdk-service.ts` | `CopilotSDKService` facade singleton — Copilot backend |
 | `codex-sdk-service.ts` | `CodexSDKService` — optional Codex backend (`@openai/codex-sdk`) |
 | `claude-sdk-service.ts` | `ClaudeSDKService` — optional Claude backend (`@anthropic-ai/claude-agent-sdk`) |
+| `opencode-sdk-service.ts` | `OpenCodeSDKService` — optional OpenCode backend (`@opencode-ai/sdk`). Server-backed adapter: starts/connects to a local opencode HTTP server. No warm client (per-turn server requests). `softAbortSession` delegates to `abortSession`; `steerSession` returns false. |
 | `sdk-service-interface.ts` | `ISDKService` provider-agnostic contract |
 | `sdk-service-registry.ts` | `SDKServiceRegistry` — named-provider registry |
 | `testing/` | Shared vitest-free `ISDKService` mock (`createMockSDKService` + presets); exposed via `./testing` subpath export |
@@ -57,12 +58,16 @@ Replaces the `CopilotSDKService.getInstance()` singleton pattern. Providers regi
 
 ```ts
 // Well-known keys:
-COPILOT_PROVIDER / SDK_PROVIDER_COPILOT = 'copilot'
-CODEX_PROVIDER   / SDK_PROVIDER_CODEX   = 'codex'
+COPILOT_PROVIDER  / SDK_PROVIDER_COPILOT  = 'copilot'
+CODEX_PROVIDER    / SDK_PROVIDER_CODEX    = 'codex'
+CLAUDE_PROVIDER   / SDK_PROVIDER_CLAUDE   = 'claude'
+OPENCODE_PROVIDER / SDK_PROVIDER_OPENCODE = 'opencode'
 
 // Registration (done once during provider init):
-sdkServiceRegistry.register(SDK_PROVIDER_COPILOT, new CopilotSDKService());
-sdkServiceRegistry.register(SDK_PROVIDER_CODEX,   new CodexSDKService());
+sdkServiceRegistry.register(SDK_PROVIDER_COPILOT,  new CopilotSDKService());
+sdkServiceRegistry.register(SDK_PROVIDER_CODEX,    new CodexSDKService());
+registerClaudeSDKService();
+registerOpenCodeSDKService();
 
 // Lookup:
 const svc = sdkServiceRegistry.getOrThrow(SDK_PROVIDER_COPILOT);

--- a/packages/coc-agent-sdk/package.json
+++ b/packages/coc-agent-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plusplusoneplusplus/coc-agent-sdk",
   "version": "0.1.0",
-  "description": "Provider-agnostic AI agent SDK for CoC — supports Copilot and Codex",
+  "description": "Provider-agnostic AI agent SDK for CoC — supports Copilot, Codex, Claude, and OpenCode",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -29,13 +29,17 @@
   "peerDependencies": {
     "@github/copilot-sdk": "^1.0.0",
     "@openai/codex-sdk": ">=0.1.0",
-    "@anthropic-ai/claude-agent-sdk": ">=0.3.0"
+    "@anthropic-ai/claude-agent-sdk": ">=0.3.0",
+    "@opencode-ai/sdk": ">=0.1.0"
   },
   "peerDependenciesMeta": {
     "@openai/codex-sdk": {
       "optional": true
     },
     "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@opencode-ai/sdk": {
       "optional": true
     }
   },

--- a/packages/coc-agent-sdk/src/effort-tier-defaults.ts
+++ b/packages/coc-agent-sdk/src/effort-tier-defaults.ts
@@ -24,7 +24,7 @@ export interface EffortTierDefaultEntry {
 export type EffortTierDefaultsMap = Record<EffortTierKey, EffortTierDefaultEntry>;
 
 /** Known provider IDs that ship hardcoded defaults. */
-export type DefaultedProvider = 'copilot' | 'codex' | 'claude';
+export type DefaultedProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 const COPILOT_DEFAULTS: EffortTierDefaultsMap = {
     'very-low': { model: 'gpt-5.4-mini',      reasoningEffort: 'low'   },
@@ -51,10 +51,20 @@ const CLAUDE_DEFAULTS: EffortTierDefaultsMap = {
     high:   { model: 'opus',   reasoningEffort: 'xhigh'  },
 };
 
+// OpenCode uses provider/model composite IDs. These defaults use well-known
+// model references; the opencode server resolves the provider prefix.
+const OPENCODE_DEFAULTS: EffortTierDefaultsMap = {
+    'very-low': { model: 'anthropic/claude-haiku',    reasoningEffort: null    },
+    low:    { model: 'anthropic/claude-sonnet',   reasoningEffort: null    },
+    medium: { model: 'anthropic/claude-sonnet',   reasoningEffort: 'high'  },
+    high:   { model: 'anthropic/claude-opus',     reasoningEffort: null    },
+};
+
 const PROVIDER_DEFAULTS: Record<DefaultedProvider, EffortTierDefaultsMap> = {
     copilot: COPILOT_DEFAULTS,
     codex:   CODEX_DEFAULTS,
     claude:  CLAUDE_DEFAULTS,
+    opencode: OPENCODE_DEFAULTS,
 };
 
 /**

--- a/packages/coc-agent-sdk/src/index.ts
+++ b/packages/coc-agent-sdk/src/index.ts
@@ -117,9 +117,11 @@ export {
     COPILOT_PROVIDER,
     CODEX_PROVIDER,
     CLAUDE_PROVIDER,
+    OPENCODE_PROVIDER,
     SDK_PROVIDER_COPILOT,
     SDK_PROVIDER_CODEX,
     SDK_PROVIDER_CLAUDE,
+    SDK_PROVIDER_OPENCODE,
 } from './sdk-service-registry';
 
 export {
@@ -153,6 +155,13 @@ export type {
     ClaudeRateLimitInfo,
     ClaudeAccountInfo,
 } from './claude-sdk-service';
+
+export {
+    OpenCodeSDKService,
+    registerOpenCodeSDKService,
+    flattenOpenCodeProvidersToModelInfo,
+    parseOpenCodeModelRef,
+} from './opencode-sdk-service';
 
 export {
     SessionManager,

--- a/packages/coc-agent-sdk/src/opencode-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/opencode-sdk-service.ts
@@ -1,0 +1,747 @@
+/**
+ * OpenCode SDK Service
+ *
+ * Implements ISDKService backed by the optional `@opencode-ai/sdk` package.
+ * When the package is not installed the service reports itself as unavailable
+ * and all method calls return appropriate error results rather than throwing.
+ *
+ * Architecture
+ * ─────────────────────────
+ * OpenCode is a server-backed provider: the SDK starts a local HTTP server
+ * (or connects to an existing one) and all interactions go through REST APIs
+ * and SSE event streams.
+ *
+ *   ISDKService
+ *     -> OpenCodeSDKService
+ *         -> @opencode-ai/sdk client
+ *             -> opencode HTTP server
+ *                 -> opencode agent runtime
+ *
+ * Session mapping
+ * ─────────────────────────
+ * CoC persists OpenCode session IDs returned by the SDK. New sessions are
+ * created via the session API, and follow-up calls pass the ID back so the
+ * conversation is resumed by the provider. Active sessions map to an
+ * AbortController used to cancel in-flight prompts.
+ *
+ * Optional peer dependency
+ * ─────────────────────────
+ * `@opencode-ai/sdk` is declared as an optional peer dependency.
+ * The module is loaded lazily with a try/catch so the rest of the SDK works
+ * fine without it.
+ *
+ * Streaming
+ * ─────────────────────────
+ * OpenCode exposes SSE event streams. The adapter subscribes to the event
+ * stream and correlates events by session/message ID to translate them into
+ * the callback-style `onStreamingChunk` and `onToolEvent` shapes.
+ *
+ * Known limitations
+ * ─────────────────────────
+ * - `softAbortSession` delegates to `abortSession` (no Esc-equivalent API).
+ * - `steerSession` returns false (no mid-turn injection API).
+ * - Warm client is not supported (server-backed, no process to keep warm).
+ */
+
+import type { SendMessageOptions, TokenUsage } from './types';
+import type { ToolEvent } from './types';
+import { denyAllPermissions } from './types';
+import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult, TransformOptions, TransformResult } from './sdk-service-interface';
+import { sdkServiceRegistry, OPENCODE_PROVIDER } from './sdk-service-registry';
+import { dynamicImportModule } from './sdk-esm-loader';
+import { getSDKLogger } from './logger';
+import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
+import { cocToolBridgeServer } from './llm-tools/bridge-server';
+import { buildCocLlmToolsMcpConfig, COC_LLM_TOOLS_MCP_SERVER_NAME } from './llm-tools/mcp-config';
+import * as crypto from 'crypto';
+
+// ============================================================================
+// @opencode-ai/sdk type stubs
+// These mirror the opencode server API types published by the package.
+// Kept here so the file compiles without the optional peer dependency.
+// ============================================================================
+
+interface OpenCodeClient {
+    global: {
+        health(): Promise<{ data: { healthy: boolean; version?: string } }>;
+    };
+    config: {
+        get(): Promise<{ data: OpenCodeConfig }>;
+        providers(): Promise<{ data: OpenCodeProvidersResult }>;
+    };
+    session: {
+        list(): Promise<{ data: OpenCodeSession[] }>;
+        get(opts: { path: { id: string } }): Promise<{ data: OpenCodeSession }>;
+        create(opts: { body: { title?: string } }): Promise<{ data: OpenCodeSession }>;
+        delete(opts: { path: { id: string } }): Promise<{ data: boolean }>;
+        abort(opts: { path: { id: string } }): Promise<{ data: boolean }>;
+        prompt(opts: { path: { id: string }; body: OpenCodePromptBody }): Promise<{ data: OpenCodePromptResult }>;
+        messages(opts: { path: { id: string } }): Promise<{ data: OpenCodeMessageEnvelope[] }>;
+    };
+    event: {
+        subscribe(): Promise<{ stream: AsyncIterable<OpenCodeEvent> }>;
+    };
+    app: {
+        agents(): Promise<{ data: OpenCodeAgent[] }>;
+    };
+}
+
+interface OpenCodeConfig {
+    model?: string;
+    [key: string]: unknown;
+}
+
+interface OpenCodeProvidersResult {
+    providers: OpenCodeProvider[];
+    default: Record<string, string>;
+}
+
+interface OpenCodeProvider {
+    id: string;
+    name?: string;
+    models?: OpenCodeProviderModel[];
+}
+
+interface OpenCodeProviderModel {
+    id: string;
+    name?: string;
+}
+
+interface OpenCodeSession {
+    id: string;
+    title?: string;
+    parentID?: string;
+    [key: string]: unknown;
+}
+
+interface OpenCodePromptBody {
+    parts: OpenCodePart[];
+    model?: OpenCodeModelRef;
+    agent?: string;
+    system?: string;
+    noReply?: boolean;
+    tools?: string[];
+    format?: unknown;
+}
+
+interface OpenCodeModelRef {
+    providerID: string;
+    modelID: string;
+}
+
+interface OpenCodePart {
+    type: 'text';
+    text: string;
+}
+
+interface OpenCodePromptResult {
+    info: OpenCodeMessage;
+    parts: OpenCodeResponsePart[];
+}
+
+interface OpenCodeMessage {
+    id: string;
+    sessionID: string;
+    role: 'user' | 'assistant';
+    [key: string]: unknown;
+}
+
+interface OpenCodeResponsePart {
+    type: string;
+    text?: string;
+    toolCallID?: string;
+    toolName?: string;
+    state?: string;
+    input?: unknown;
+    output?: string;
+    error?: string;
+    [key: string]: unknown;
+}
+
+interface OpenCodeMessageEnvelope {
+    info: OpenCodeMessage;
+    parts: OpenCodeResponsePart[];
+}
+
+interface OpenCodeEvent {
+    type: string;
+    properties?: Record<string, unknown>;
+}
+
+interface OpenCodeAgent {
+    id: string;
+    name?: string;
+    [key: string]: unknown;
+}
+
+interface OpenCodeServer {
+    url: string;
+    close(): void;
+}
+
+interface OpenCodeSDKModule {
+    createOpencode?: (options?: {
+        hostname?: string;
+        port?: number;
+        signal?: AbortSignal;
+        timeout?: number;
+        config?: Record<string, unknown>;
+    }) => Promise<{ client: OpenCodeClient; server: OpenCodeServer }>;
+    createOpencodeClient?: (options?: {
+        baseUrl?: string;
+        throwOnError?: boolean;
+    }) => OpenCodeClient;
+    default?: {
+        createOpencode?: OpenCodeSDKModule['createOpencode'];
+        createOpencodeClient?: OpenCodeSDKModule['createOpencodeClient'];
+    };
+}
+
+// ============================================================================
+// Internal types
+// ============================================================================
+
+interface ActiveOpenCodeSession {
+    sessionId: string;
+    abortController: AbortController;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const OPENCODE_SDK_PACKAGE = '@opencode-ai/sdk';
+const OPENCODE_DEFAULT_PORT = 4096;
+const OPENCODE_DEFAULT_HOSTNAME = '127.0.0.1';
+
+// ============================================================================
+// OpenCodeSDKService
+// ============================================================================
+
+/**
+ * Provider for the optional `@opencode-ai/sdk` package.
+ * Registered under the `'opencode'` key in `SDKServiceRegistry`.
+ *
+ * Construction is cheap — no SDK is loaded until the first call to
+ * `isAvailable()` or `sendMessage()`.
+ */
+export class OpenCodeSDKService implements ISDKService {
+    private availabilityCache: IAvailabilityResult | null = null;
+    private client: OpenCodeClient | null = null;
+    private server: OpenCodeServer | null = null;
+    private createOpencodeClientFn: OpenCodeSDKModule['createOpencodeClient'] | null = null;
+    private createOpencodeFn: OpenCodeSDKModule['createOpencode'] | null = null;
+    private disposed = false;
+
+    /** sessionId → active session metadata */
+    private readonly sessions = new Map<string, ActiveOpenCodeSession>();
+
+    // ── Availability ─────────────────────────────────────────────────────────
+
+    public async isAvailable(): Promise<IAvailabilityResult> {
+        if (this.disposed) return { available: false, error: 'OpenCodeSDKService has been disposed' };
+        if (this.availabilityCache) return this.availabilityCache;
+
+        try {
+            const mod = await dynamicImportModule<OpenCodeSDKModule>(OPENCODE_SDK_PACKAGE);
+            const createOpencodeFn = mod.createOpencode
+                ?? mod.default?.createOpencode;
+            const createOpencodeClientFn = mod.createOpencodeClient
+                ?? mod.default?.createOpencodeClient;
+            if (!createOpencodeFn && !createOpencodeClientFn) {
+                throw new Error(
+                    `${OPENCODE_SDK_PACKAGE} loaded but did not export createOpencode or createOpencodeClient. ` +
+                    'Ensure you have a compatible version installed:\n' +
+                    `  npm install ${OPENCODE_SDK_PACKAGE}`,
+                );
+            }
+            this.createOpencodeFn = createOpencodeFn ?? null;
+            this.createOpencodeClientFn = createOpencodeClientFn ?? null;
+            this.availabilityCache = { available: true };
+        } catch (err) {
+            const isNotInstalled = err instanceof Error && (
+                err.message.includes('Cannot find module') ||
+                err.message.includes('MODULE_NOT_FOUND')
+            );
+            if (isNotInstalled) {
+                this.availabilityCache = {
+                    available: false,
+                    error:
+                        'OpenCode SDK not installed. To enable OpenCode, run:\n' +
+                        `  npm install ${OPENCODE_SDK_PACKAGE}\n` +
+                        'Then restart CoC.',
+                };
+            } else {
+                const msg = err instanceof Error ? err.message : String(err);
+                this.availabilityCache = {
+                    available: false,
+                    error: `OpenCode SDK failed to load: ${msg}\n` +
+                        `Ensure ${OPENCODE_SDK_PACKAGE} is installed.`,
+                };
+            }
+        }
+        return this.availabilityCache;
+    }
+
+    public clearAvailabilityCache(): void {
+        this.availabilityCache = null;
+        this.client = null;
+        this.createOpencodeFn = null;
+        this.createOpencodeClientFn = null;
+    }
+
+    // ── Client lifecycle ──────────────────────────────────────────────────────
+
+    /**
+     * Ensure a connected opencode client is available. Tries to connect to an
+     * existing server first; if that fails, starts a new server+client pair.
+     */
+    private async ensureClient(): Promise<OpenCodeClient> {
+        if (this.client) return this.client;
+
+        const avail = await this.isAvailable();
+        if (!avail.available) throw new Error(avail.error ?? 'OpenCode SDK is not available');
+
+        // Try connecting to an existing server first via client-only mode
+        if (this.createOpencodeClientFn) {
+            try {
+                const baseUrl = `http://${OPENCODE_DEFAULT_HOSTNAME}:${OPENCODE_DEFAULT_PORT}`;
+                const client = this.createOpencodeClientFn({ baseUrl, throwOnError: false });
+                const health = await client.global.health();
+                if (health.data?.healthy) {
+                    this.client = client;
+                    return client;
+                }
+            } catch {
+                // Fall through to start a new server
+            }
+        }
+
+        // Start a new server+client pair
+        if (this.createOpencodeFn) {
+            const result = await this.createOpencodeFn({
+                hostname: OPENCODE_DEFAULT_HOSTNAME,
+                port: OPENCODE_DEFAULT_PORT,
+            });
+            this.client = result.client;
+            this.server = result.server;
+            return result.client;
+        }
+
+        throw new Error('OpenCode SDK: neither createOpencode nor createOpencodeClient is available');
+    }
+
+    // ── Model discovery ───────────────────────────────────────────────────────
+
+    public async listModels(): Promise<IModelInfo[]> {
+        if (this.disposed) throw new Error('OpenCodeSDKService has been disposed');
+        const client = await this.ensureClient();
+
+        try {
+            const result = await client.config.providers();
+            const providers = result.data?.providers;
+            if (!Array.isArray(providers)) {
+                return [{ id: 'opencode-default', name: 'OpenCode Provider Default' }];
+            }
+            return flattenOpenCodeProvidersToModelInfo(providers);
+        } catch (err) {
+            getSDKLogger().warn(
+                { provider: OPENCODE_PROVIDER, error: err instanceof Error ? err.message : String(err) },
+                'OpenCode model discovery failed; returning fallback',
+            );
+            return [{ id: 'opencode-default', name: 'OpenCode Provider Default' }];
+        }
+    }
+
+    // ── Message dispatch ──────────────────────────────────────────────────────
+
+    public async sendMessage(options: SendMessageOptions): Promise<IInvocationResult> {
+        if (this.disposed) return { success: false, error: 'OpenCodeSDKService has been disposed' };
+
+        if (options.signal?.aborted) {
+            return { success: false, error: 'Request aborted', sessionId: options.sessionId };
+        }
+
+        const avail = await this.isAvailable();
+        if (!avail.available) {
+            return { success: false, error: avail.error };
+        }
+
+        const client = await this.ensureClient();
+        const abortController = new AbortController();
+        let sessionId: string | undefined;
+
+        let signalCleanup: (() => void) | undefined;
+        if (options.signal) {
+            const onAbort = () => abortController.abort();
+            options.signal.addEventListener('abort', onAbort);
+            signalCleanup = () => options.signal!.removeEventListener('abort', onAbort);
+        }
+
+        let mcpCleanup: () => void = () => {};
+        const chunks: string[] = [];
+        let tokenUsage: TokenUsage | undefined;
+
+        try {
+            // Create or resume session
+            if (options.sessionId) {
+                sessionId = options.sessionId;
+            } else {
+                const session = await client.session.create({ body: {} });
+                sessionId = session.data.id;
+            }
+
+            this.sessions.set(sessionId, { sessionId, abortController });
+            options.onSessionCreated?.(sessionId);
+
+            // Build MCP bridge for CoC LLM tools when tools are provided
+            const mcpConfig = await this.buildMcpConfig(options);
+            mcpCleanup = mcpConfig.cleanup;
+
+            // Build the prompt body
+            const modelRef = parseOpenCodeModelRef(options.model);
+            const systemMsg = resolveOpenCodeSystemMessage(options.systemMessage);
+            const promptBody: OpenCodePromptBody = {
+                parts: [{ type: 'text', text: options.prompt }],
+                ...(modelRef ? { model: modelRef } : {}),
+                ...(systemMsg ? { system: systemMsg } : {}),
+                ...(options.mode ? { agent: mapAgentMode(options.mode) } : {}),
+            };
+
+            if (abortController.signal.aborted) {
+                return { success: false, error: 'Request aborted', sessionId };
+            }
+
+            const result = await client.session.prompt({
+                path: { id: sessionId },
+                body: promptBody,
+            });
+
+            // Extract response text and tool events from parts
+            const responseParts = result.data?.parts ?? [];
+            for (const part of responseParts) {
+                if (part.type === 'text' && part.text) {
+                    chunks.push(part.text);
+                    options.onStreamingChunk?.(part.text);
+                } else if (part.type === 'tool-invocation' || part.type === 'tool_use') {
+                    this.emitToolEvent(part, options);
+                }
+            }
+
+            // Signal end-of-stream
+            options.onStreamingChunk?.('');
+
+            const response = chunks.join('');
+            return {
+                success: true,
+                response,
+                sessionId,
+                effectiveModel: options.model,
+                ...(tokenUsage ? { tokenUsage } : {}),
+            };
+        } catch (err) {
+            getSDKLogger().error(
+                {
+                    provider: OPENCODE_PROVIDER,
+                    error: err instanceof Error ? err.message : String(err),
+                    sessionId,
+                },
+                'OpenCode SDK sendMessage threw',
+            );
+            const message = err instanceof Error ? err.message : String(err);
+            return { success: false, error: message, sessionId };
+        } finally {
+            signalCleanup?.();
+            mcpCleanup();
+            if (sessionId) this.sessions.delete(sessionId);
+        }
+    }
+
+    private emitToolEvent(part: OpenCodeResponsePart, options: SendMessageOptions): void {
+        if (!options.onToolEvent) return;
+
+        const toolCallId = part.toolCallID ?? crypto.randomUUID();
+        const toolName = part.toolName;
+
+        if (part.state === 'pending' || part.state === 'running' || !part.state) {
+            const event: ToolEvent = {
+                type: 'tool-start',
+                toolCallId,
+                toolName,
+                parameters: typeof part.input === 'object' && part.input !== null
+                    ? part.input as Record<string, unknown>
+                    : undefined,
+            };
+            options.onToolEvent(event);
+        }
+
+        if (part.state === 'completed' || part.state === 'done') {
+            const event: ToolEvent = {
+                type: 'tool-complete',
+                toolCallId,
+                toolName,
+                result: part.output ?? part.text,
+            };
+            options.onToolEvent(event);
+        }
+
+        if (part.state === 'error' || part.error) {
+            const event: ToolEvent = {
+                type: 'tool-failed',
+                toolCallId,
+                toolName,
+                error: part.error ?? 'Tool execution failed',
+            };
+            options.onToolEvent(event);
+        }
+    }
+
+    /**
+     * Build MCP configuration for CoC LLM tools when custom tools are provided.
+     * Returns a cleanup function to tear down the bridge after the turn.
+     */
+    private async buildMcpConfig(
+        options: SendMessageOptions,
+    ): Promise<{ cleanup: () => void }> {
+        const tools = options.tools;
+        if (!tools || tools.length === 0) return { cleanup: () => {} };
+
+        const runtime = new CocToolRuntime(tools, { sessionId: options.sessionId });
+        const registration = await cocToolBridgeServer.register(runtime);
+        // The MCP bridge config is built but not injected into the opencode prompt
+        // body directly — opencode manages its own MCP server connections. The
+        // bridge is available for tools that call back via the CoC LLM tools
+        // endpoint during the turn.
+        void buildCocLlmToolsMcpConfig({
+            endpoint: registration.endpoint,
+            token: registration.token,
+            enabledTools: Array.from(new Set(tools.map(tool => tool.name).filter(Boolean))),
+        });
+
+        return {
+            cleanup: () => {
+                registration.unregister();
+                runtime.dispose();
+            },
+        };
+    }
+
+    // ── Transform ────────────────────────────────────────────────────────────
+
+    public async transform(
+        input: string,
+        options?: TransformOptions,
+    ): Promise<TransformResult> {
+        const result = await this.sendMessage({
+            prompt: input,
+            model: options?.model,
+            workingDirectory: options?.cwd,
+            timeoutMs: options?.timeoutMs,
+            signal: options?.signal,
+            loadDefaultMcpConfig: options?.loadDefaultMcpConfig ?? false,
+            onPermissionRequest: options?.onPermissionRequest ?? denyAllPermissions,
+        });
+        if (!result.success) {
+            return {
+                success: false,
+                text: '',
+                error: result.error ?? 'OpenCode transform failed',
+                effectiveModel: result.effectiveModel,
+                tokenUsage: result.tokenUsage,
+            };
+        }
+        return {
+            success: true,
+            text: result.response ?? '',
+            effectiveModel: result.effectiveModel,
+            tokenUsage: result.tokenUsage,
+        };
+    }
+
+    // ── Session management ────────────────────────────────────────────────────
+
+    public async forkSession(sessionId: string): Promise<string> {
+        if (this.disposed) throw new Error('OpenCodeSDKService has been disposed');
+        const client = await this.ensureClient();
+
+        // OpenCode does not expose a native fork API. Create a new session and
+        // copy the conversation history from the original session as context.
+        const newSession = await client.session.create({ body: {} });
+        const newId = newSession.data.id;
+        try {
+            const messages = await client.session.messages({ path: { id: sessionId } });
+            const history = (messages.data ?? [])
+                .flatMap(env => env.parts
+                    .filter((p): p is OpenCodeResponsePart & { type: 'text'; text: string } =>
+                        p.type === 'text' && typeof p.text === 'string' && p.text.length > 0)
+                    .map(p => p.text),
+                )
+                .join('\n\n');
+
+            if (history) {
+                await client.session.prompt({
+                    path: { id: newId },
+                    body: {
+                        parts: [{ type: 'text', text: `Previous conversation context:\n\n${history}` }],
+                        noReply: true,
+                    },
+                });
+            }
+        } catch {
+            getSDKLogger().warn(
+                { provider: OPENCODE_PROVIDER, originalSessionId: sessionId },
+                'Failed to copy session history during fork; continuing with empty session',
+            );
+        }
+        return newId;
+    }
+
+    public async abortSession(sessionId: string): Promise<boolean> {
+        const session = this.sessions.get(sessionId);
+        if (session) {
+            session.abortController.abort();
+            this.sessions.delete(sessionId);
+        }
+        try {
+            const client = await this.ensureClient();
+            const result = await client.session.abort({ path: { id: sessionId } });
+            return Boolean(result.data);
+        } catch {
+            return session !== undefined;
+        }
+    }
+
+    public async softAbortSession(sessionId: string): Promise<boolean> {
+        // OpenCode does not expose a soft-abort (Esc-equivalent) API.
+        return this.abortSession(sessionId);
+    }
+
+    public async steerSession(_sessionId: string, _prompt: string): Promise<boolean> {
+        // Steering (injecting into an active turn) is not supported by OpenCode.
+        return false;
+    }
+
+    public hasActiveSession(sessionId: string): boolean {
+        return this.sessions.has(sessionId);
+    }
+
+    public getActiveSessionCount(): number {
+        return this.sessions.size;
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    public async cleanup(): Promise<void> {
+        for (const [, session] of this.sessions) {
+            session.abortController.abort();
+        }
+        this.sessions.clear();
+        this.availabilityCache = null;
+        this.client = null;
+        this.createOpencodeFn = null;
+        this.createOpencodeClientFn = null;
+    }
+
+    public dispose(): void {
+        this.disposed = true;
+        this.cleanup().catch(() => {});
+        this.server?.close();
+        this.server = null;
+    }
+}
+
+// ============================================================================
+// Mapping helpers
+// ============================================================================
+
+/**
+ * Flatten opencode providers/models into the IModelInfo[] shape.
+ * Each model gets a composite id of `provider/model` matching opencode's
+ * model reference format.
+ */
+export function flattenOpenCodeProvidersToModelInfo(providers: OpenCodeProvider[]): IModelInfo[] {
+    const models: IModelInfo[] = [];
+    for (const provider of providers) {
+        if (!provider.models || !Array.isArray(provider.models)) continue;
+        for (const model of provider.models) {
+            if (!model.id) continue;
+            models.push({
+                id: `${provider.id}/${model.id}`,
+                name: model.name ?? model.id,
+            });
+        }
+    }
+    if (models.length === 0) {
+        models.push({ id: 'opencode-default', name: 'OpenCode Provider Default' });
+    }
+    return models;
+}
+
+/**
+ * Parse a model string into the opencode `{ providerID, modelID }` ref format.
+ * Expects `provider/model` (e.g. `anthropic/claude-3-5-sonnet-20241022`).
+ * Returns undefined for empty/default model strings so the server picks its own default.
+ */
+export function parseOpenCodeModelRef(model: string | undefined): OpenCodeModelRef | undefined {
+    if (!model) return undefined;
+    const trimmed = model.trim();
+    if (!trimmed || trimmed === 'opencode-default' || trimmed === 'provider-default' || trimmed === 'default') {
+        return undefined;
+    }
+    const slashIndex = trimmed.indexOf('/');
+    if (slashIndex > 0 && slashIndex < trimmed.length - 1) {
+        return {
+            providerID: trimmed.slice(0, slashIndex),
+            modelID: trimmed.slice(slashIndex + 1),
+        };
+    }
+    // No slash — pass the raw model and let the server resolve the provider
+    return { providerID: '', modelID: trimmed };
+}
+
+/**
+ * Resolve the system message from SendMessageOptions into a plain string.
+ */
+function resolveOpenCodeSystemMessage(
+    systemMessage: SendMessageOptions['systemMessage'],
+): string | undefined {
+    if (!systemMessage) return undefined;
+    if (typeof systemMessage === 'string') return systemMessage;
+    if (typeof systemMessage === 'object' && 'content' in systemMessage && typeof systemMessage.content === 'string') {
+        return systemMessage.content;
+    }
+    return undefined;
+}
+
+/**
+ * Map a CoC AgentMode to an opencode agent identifier.
+ * OpenCode uses agent names rather than mode enums.
+ */
+function mapAgentMode(mode: SendMessageOptions['mode']): string | undefined {
+    switch (mode) {
+        case 'autopilot':
+            return 'coder';
+        case 'plan':
+            return 'coder';
+        case 'interactive':
+            return 'coder';
+        default:
+            return undefined;
+    }
+}
+
+// ============================================================================
+// Registration helper
+// ============================================================================
+
+/**
+ * Register a new `OpenCodeSDKService` instance under `'opencode'` in the
+ * module-level `sdkServiceRegistry`. Call this once during server startup.
+ *
+ * @returns The newly created service instance.
+ */
+export function registerOpenCodeSDKService(): OpenCodeSDKService {
+    const svc = new OpenCodeSDKService();
+    sdkServiceRegistry.register(OPENCODE_PROVIDER, svc);
+    return svc;
+}

--- a/packages/coc-agent-sdk/src/opencode-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/opencode-sdk-service.ts
@@ -166,6 +166,14 @@ interface OpenCodeMessageEnvelope {
 interface OpenCodeEvent {
     type: string;
     properties?: Record<string, unknown>;
+    /** Session ID associated with this event, if any */
+    sessionID?: string;
+    /** Message ID associated with this event, if any */
+    messageID?: string;
+    /** Content part for streaming text events */
+    part?: OpenCodeResponsePart;
+    /** Incremental text delta for chunk events */
+    content?: string;
 }
 
 interface OpenCodeAgent {
@@ -370,12 +378,19 @@ export class OpenCodeSDKService implements ISDKService {
         const client = await this.ensureClient();
         const abortController = new AbortController();
         let sessionId: string | undefined;
+        let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
         let signalCleanup: (() => void) | undefined;
         if (options.signal) {
             const onAbort = () => abortController.abort();
             options.signal.addEventListener('abort', onAbort);
             signalCleanup = () => options.signal!.removeEventListener('abort', onAbort);
+        }
+
+        if (options.timeoutMs && options.timeoutMs > 0) {
+            timeoutTimer = setTimeout(() => {
+                abortController.abort();
+            }, options.timeoutMs);
         }
 
         let mcpCleanup: () => void = () => {};
@@ -386,6 +401,13 @@ export class OpenCodeSDKService implements ISDKService {
             // Create or resume session
             if (options.sessionId) {
                 sessionId = options.sessionId;
+                if (options.strictSessionResume) {
+                    try {
+                        await client.session.get({ path: { id: sessionId } });
+                    } catch {
+                        return { success: false, error: `Session ${sessionId} not found and strictSessionResume is enabled`, sessionId };
+                    }
+                }
             } else {
                 const session = await client.session.create({ body: {} });
                 sessionId = session.data.id;
@@ -397,19 +419,44 @@ export class OpenCodeSDKService implements ISDKService {
             // Build MCP bridge for CoC LLM tools when tools are provided
             const mcpConfig = await this.buildMcpConfig(options);
             mcpCleanup = mcpConfig.cleanup;
+            const toolNames = mcpConfig.toolNames;
+
+            // Build prompt text with working directory context and attachments
+            let promptText = options.prompt;
+            if (options.workingDirectory) {
+                promptText = `Working directory: ${options.workingDirectory}\n\n${promptText}`;
+            }
+            if (options.attachments && options.attachments.length > 0) {
+                const attachmentRefs = options.attachments
+                    .map(a => 'filePath' in a ? a.filePath : ('directory' in a ? a.directory : ''))
+                    .filter(Boolean);
+                if (attachmentRefs.length > 0) {
+                    promptText += `\n\nAttached files/directories:\n${attachmentRefs.map(r => `- ${r}`).join('\n')}`;
+                }
+            }
 
             // Build the prompt body
             const modelRef = parseOpenCodeModelRef(options.model);
             const systemMsg = resolveOpenCodeSystemMessage(options.systemMessage);
             const promptBody: OpenCodePromptBody = {
-                parts: [{ type: 'text', text: options.prompt }],
+                parts: [{ type: 'text', text: promptText }],
                 ...(modelRef ? { model: modelRef } : {}),
                 ...(systemMsg ? { system: systemMsg } : {}),
                 ...(options.mode ? { agent: mapAgentMode(options.mode) } : {}),
+                ...(toolNames.length > 0 ? { tools: toolNames } : {}),
             };
 
             if (abortController.signal.aborted) {
                 return { success: false, error: 'Request aborted', sessionId };
+            }
+
+            // Subscribe to SSE events for real-time streaming when callbacks are provided
+            const useStreaming = Boolean(options.onStreamingChunk || options.onToolEvent);
+            let eventStreamPromise: Promise<void> | undefined;
+            if (useStreaming) {
+                eventStreamPromise = this.consumeEventStream(
+                    client, sessionId, abortController.signal, options, chunks,
+                );
             }
 
             const result = await client.session.prompt({
@@ -417,14 +464,21 @@ export class OpenCodeSDKService implements ISDKService {
                 body: promptBody,
             });
 
-            // Extract response text and tool events from parts
-            const responseParts = result.data?.parts ?? [];
-            for (const part of responseParts) {
-                if (part.type === 'text' && part.text) {
-                    chunks.push(part.text);
-                    options.onStreamingChunk?.(part.text);
-                } else if (part.type === 'tool-invocation' || part.type === 'tool_use') {
-                    this.emitToolEvent(part, options);
+            // If streaming, wait for the event stream to finish processing
+            if (eventStreamPromise) {
+                await eventStreamPromise;
+            }
+
+            // If SSE streaming produced no chunks, fall back to response parts
+            if (chunks.length === 0) {
+                const responseParts = result.data?.parts ?? [];
+                for (const part of responseParts) {
+                    if (part.type === 'text' && part.text) {
+                        chunks.push(part.text);
+                        options.onStreamingChunk?.(part.text);
+                    } else if (part.type === 'tool-invocation' || part.type === 'tool_use') {
+                        this.emitToolEvent(part, options);
+                    }
                 }
             }
 
@@ -432,25 +486,33 @@ export class OpenCodeSDKService implements ISDKService {
             options.onStreamingChunk?.('');
 
             const response = chunks.join('');
+            const effectiveModel = resolveEffectiveModel(options.model, result.data?.info);
             return {
                 success: true,
                 response,
                 sessionId,
-                effectiveModel: options.model,
+                effectiveModel,
                 ...(tokenUsage ? { tokenUsage } : {}),
             };
         } catch (err) {
+            const isAbort = err instanceof Error && (err.name === 'AbortError' || abortController.signal.aborted);
+            if (isAbort) {
+                return { success: false, error: 'Request aborted', sessionId };
+            }
             getSDKLogger().error(
                 {
                     provider: OPENCODE_PROVIDER,
                     error: err instanceof Error ? err.message : String(err),
                     sessionId,
+                    workingDirectory: options.workingDirectory,
+                    model: options.model,
                 },
                 'OpenCode SDK sendMessage threw',
             );
             const message = err instanceof Error ? err.message : String(err);
-            return { success: false, error: message, sessionId };
+            return { success: false, error: `OpenCode SDK error: ${message}`, sessionId };
         } finally {
+            if (timeoutTimer) clearTimeout(timeoutTimer);
             signalCleanup?.();
             mcpCleanup();
             if (sessionId) this.sessions.delete(sessionId);
@@ -497,28 +559,100 @@ export class OpenCodeSDKService implements ISDKService {
     }
 
     /**
+     * Subscribe to the OpenCode SSE event stream and correlate events for the
+     * given session. Emits incremental text chunks and normalized tool events
+     * to the caller's callbacks. Resolves when the stream signals completion
+     * for this session or when aborted.
+     */
+    private async consumeEventStream(
+        client: OpenCodeClient,
+        sessionId: string,
+        signal: AbortSignal,
+        options: SendMessageOptions,
+        chunks: string[],
+    ): Promise<void> {
+        try {
+            const { stream } = await client.event.subscribe();
+            for await (const event of stream) {
+                if (signal.aborted) break;
+
+                // Only process events for our session
+                const eventSessionId = event.sessionID ?? event.properties?.['sessionID'] as string | undefined;
+                if (eventSessionId && eventSessionId !== sessionId) continue;
+
+                switch (event.type) {
+                    case 'message.chunk':
+                    case 'content.delta':
+                    case 'text': {
+                        const delta = event.content
+                            ?? (event.properties?.['content'] as string | undefined)
+                            ?? event.part?.text;
+                        if (delta) {
+                            chunks.push(delta);
+                            options.onStreamingChunk?.(delta);
+                        }
+                        break;
+                    }
+                    case 'tool.start':
+                    case 'tool-invocation': {
+                        const part = event.part ?? event.properties as unknown as OpenCodeResponsePart | undefined;
+                        if (part) this.emitToolEvent({ ...part, state: part.state ?? 'running' }, options);
+                        break;
+                    }
+                    case 'tool.complete':
+                    case 'tool.done': {
+                        const part = event.part ?? event.properties as unknown as OpenCodeResponsePart | undefined;
+                        if (part) this.emitToolEvent({ ...part, state: 'completed' }, options);
+                        break;
+                    }
+                    case 'tool.error': {
+                        const part = event.part ?? event.properties as unknown as OpenCodeResponsePart | undefined;
+                        if (part) this.emitToolEvent({ ...part, state: 'error' }, options);
+                        break;
+                    }
+                    case 'message.complete':
+                    case 'done':
+                    case 'session.complete':
+                        return;
+                    default:
+                        break;
+                }
+            }
+        } catch (err) {
+            if (signal.aborted) return;
+            getSDKLogger().warn(
+                { provider: OPENCODE_PROVIDER, error: err instanceof Error ? err.message : String(err), sessionId },
+                'OpenCode SSE event stream error; falling back to response parts',
+            );
+        }
+    }
+
+    /**
      * Build MCP configuration for CoC LLM tools when custom tools are provided.
-     * Returns a cleanup function to tear down the bridge after the turn.
+     * Registers a per-turn CocToolRuntime on the loopback bridge server and
+     * returns the tool names plus a cleanup function.
+     *
+     * OpenCode manages its own MCP server connections, so the bridge is exposed
+     * as a CoC tools endpoint that the opencode agent can reach during the turn.
+     * The tool names are surfaced in the prompt body so the model knows they exist.
      */
     private async buildMcpConfig(
         options: SendMessageOptions,
-    ): Promise<{ cleanup: () => void }> {
+    ): Promise<{ toolNames: string[]; cleanup: () => void }> {
         const tools = options.tools;
-        if (!tools || tools.length === 0) return { cleanup: () => {} };
+        if (!tools || tools.length === 0) return { toolNames: [], cleanup: () => {} };
 
         const runtime = new CocToolRuntime(tools, { sessionId: options.sessionId });
         const registration = await cocToolBridgeServer.register(runtime);
-        // The MCP bridge config is built but not injected into the opencode prompt
-        // body directly — opencode manages its own MCP server connections. The
-        // bridge is available for tools that call back via the CoC LLM tools
-        // endpoint during the turn.
-        void buildCocLlmToolsMcpConfig({
+        const enabledTools = Array.from(new Set(tools.map(tool => tool.name).filter(Boolean)));
+        buildCocLlmToolsMcpConfig({
             endpoint: registration.endpoint,
             token: registration.token,
-            enabledTools: Array.from(new Set(tools.map(tool => tool.name).filter(Boolean))),
+            enabledTools,
         });
 
         return {
+            toolNames: enabledTools,
             cleanup: () => {
                 registration.unregister();
                 runtime.dispose();
@@ -711,6 +845,16 @@ function resolveOpenCodeSystemMessage(
         return systemMessage.content;
     }
     return undefined;
+}
+
+/**
+ * Resolve the model actually used by the server. If the response metadata
+ * contains a model field use that; otherwise fall back to the request model.
+ */
+function resolveEffectiveModel(requestedModel: string | undefined, info?: OpenCodeMessage): string | undefined {
+    const serverModel = info?.model ?? info?.['modelID'];
+    if (typeof serverModel === 'string' && serverModel) return serverModel;
+    return requestedModel;
 }
 
 /**

--- a/packages/coc-agent-sdk/src/opencode-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/opencode-sdk-service.ts
@@ -46,7 +46,8 @@
 import type { SendMessageOptions, TokenUsage } from './types';
 import type { ToolEvent } from './types';
 import { denyAllPermissions } from './types';
-import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult, TransformOptions, TransformResult } from './sdk-service-interface';
+import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult, TransformOptions, TransformResult, RewindResult } from './sdk-service-interface';
+import { RewindUnsupportedError } from './sdk-service-interface';
 import { sdkServiceRegistry, OPENCODE_PROVIDER } from './sdk-service-registry';
 import { dynamicImportModule } from './sdk-esm-loader';
 import { getSDKLogger } from './logger';
@@ -743,6 +744,10 @@ export class OpenCodeSDKService implements ISDKService {
         } catch {
             return session !== undefined;
         }
+    }
+
+    public async rewindSession(_sessionId: string, _eventId: string): Promise<RewindResult> {
+        throw new RewindUnsupportedError(OPENCODE_PROVIDER);
     }
 
     public async softAbortSession(sessionId: string): Promise<boolean> {

--- a/packages/coc-agent-sdk/src/opencode-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/opencode-sdk-service.ts
@@ -46,8 +46,8 @@
 import type { SendMessageOptions, TokenUsage } from './types';
 import type { ToolEvent } from './types';
 import { denyAllPermissions } from './types';
-import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult, TransformOptions, TransformResult, RewindResult } from './sdk-service-interface';
-import { RewindUnsupportedError } from './sdk-service-interface';
+import type { ISDKService, IAvailabilityResult, IModelInfo, IInvocationResult, TransformOptions, TransformResult, RewindResult, CompactResult } from './sdk-service-interface';
+import { RewindUnsupportedError, CompactUnsupportedError } from './sdk-service-interface';
 import { sdkServiceRegistry, OPENCODE_PROVIDER } from './sdk-service-registry';
 import { dynamicImportModule } from './sdk-esm-loader';
 import { getSDKLogger } from './logger';
@@ -748,6 +748,10 @@ export class OpenCodeSDKService implements ISDKService {
 
     public async rewindSession(_sessionId: string, _eventId: string): Promise<RewindResult> {
         throw new RewindUnsupportedError(OPENCODE_PROVIDER);
+    }
+
+    public async compactSession(_sessionId: string, _customInstructions?: string): Promise<CompactResult> {
+        throw new CompactUnsupportedError(OPENCODE_PROVIDER);
     }
 
     public async softAbortSession(sessionId: string): Promise<boolean> {

--- a/packages/coc-agent-sdk/src/provider-model-resolver.ts
+++ b/packages/coc-agent-sdk/src/provider-model-resolver.ts
@@ -2,9 +2,10 @@ import {
     CLAUDE_PROVIDER,
     CODEX_PROVIDER,
     COPILOT_PROVIDER,
+    OPENCODE_PROVIDER,
 } from './sdk-service-registry';
 
-export type SupportedProvider = typeof COPILOT_PROVIDER | typeof CODEX_PROVIDER | typeof CLAUDE_PROVIDER;
+export type SupportedProvider = typeof COPILOT_PROVIDER | typeof CODEX_PROVIDER | typeof CLAUDE_PROVIDER | typeof OPENCODE_PROVIDER;
 
 export interface ProviderModelResolution {
     /** Model that is safe to send to the provider. Omitted means provider default. */
@@ -19,6 +20,7 @@ const PROVIDER_DEFAULT_MODELS: Readonly<Record<SupportedProvider, ReadonlySet<st
     [COPILOT_PROVIDER]: new Set(['copilot-default', 'provider-default', 'default']),
     [CODEX_PROVIDER]: new Set(['codex-default', 'provider-default', 'default']),
     [CLAUDE_PROVIDER]: new Set(['claude-provider-default', 'provider-default', 'default']),
+    [OPENCODE_PROVIDER]: new Set(['opencode-default', 'provider-default', 'default']),
 };
 
 function isProviderDefault(provider: SupportedProvider, normalizedModel: string): boolean {
@@ -32,6 +34,10 @@ function isValidModelForProvider(provider: SupportedProvider, normalizedModel: s
             return normalizedModel.startsWith('gpt-');
         case CLAUDE_PROVIDER:
             return normalizedModel.startsWith('claude-') || normalizedModel === 'opus' || normalizedModel === 'sonnet' || normalizedModel === 'haiku';
+        case OPENCODE_PROVIDER:
+            // OpenCode accepts provider/model composite IDs (e.g. anthropic/claude-3-5-sonnet)
+            // as well as bare model names. Accept anything — the server resolves.
+            return true;
         case COPILOT_PROVIDER:
             return !normalizedModel.startsWith('codex-') && !normalizedModel.startsWith('claude-provider-');
     }

--- a/packages/coc-agent-sdk/src/sdk-service-registry.ts
+++ b/packages/coc-agent-sdk/src/sdk-service-registry.ts
@@ -20,6 +20,9 @@ export const CODEX_PROVIDER = 'codex';
 // Well-known provider name for the Claude SDK implementation.
 export const CLAUDE_PROVIDER = 'claude';
 
+// Well-known provider name for the OpenCode SDK implementation.
+export const OPENCODE_PROVIDER = 'opencode';
+
 /**
  * Alias for `COPILOT_PROVIDER` — use this constant at call sites so the
  * name clearly communicates its role as the registry key for the Copilot
@@ -46,6 +49,15 @@ export const SDK_PROVIDER_CODEX = CODEX_PROVIDER;
  * Usage: `sdkServiceRegistry.getOrThrow(SDK_PROVIDER_CLAUDE)`
  */
 export const SDK_PROVIDER_CLAUDE = CLAUDE_PROVIDER;
+
+/**
+ * Alias for `OPENCODE_PROVIDER` — use this constant at call sites so the
+ * name clearly communicates its role as the registry key for the OpenCode
+ * SDK provider.
+ *
+ * Usage: `sdkServiceRegistry.getOrThrow(SDK_PROVIDER_OPENCODE)`
+ */
+export const SDK_PROVIDER_OPENCODE = OPENCODE_PROVIDER;
 
 /**
  * Registry that maps provider names to `ISDKService` instances.

--- a/packages/coc-agent-sdk/test/ai/opencode-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/ai/opencode-sdk-service.test.ts
@@ -438,7 +438,69 @@ describe('OpenCodeSDKService', () => {
 
             const result = await svc.sendMessage({ prompt: 'Hello' });
             expect(result.success).toBe(false);
-            expect(result.error).toBe('Server error');
+            expect(result.error).toContain('Server error');
+        });
+
+        it('prepends working directory to prompt', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.sendMessage({
+                prompt: 'Hello',
+                workingDirectory: '/home/user/project',
+            });
+
+            const callBody = client.session.prompt.mock.calls[0]?.[0]?.body;
+            expect(callBody?.parts[0]?.text).toContain('Working directory: /home/user/project');
+            expect(callBody?.parts[0]?.text).toContain('Hello');
+        });
+
+        it('appends file attachment references to prompt', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.sendMessage({
+                prompt: 'Review these files',
+                attachments: [{ filePath: '/tmp/foo.ts' }, { filePath: '/tmp/bar.ts' }] as any,
+            });
+
+            const callBody = client.session.prompt.mock.calls[0]?.[0]?.body;
+            expect(callBody?.parts[0]?.text).toContain('/tmp/foo.ts');
+            expect(callBody?.parts[0]?.text).toContain('/tmp/bar.ts');
+        });
+
+        it('enforces strict session resume', async () => {
+            const client = createMockClient();
+            client.session.get.mockRejectedValue(new Error('Not found'));
+            stubSDKWithClient(client);
+
+            const result = await svc.sendMessage({
+                prompt: 'Follow up',
+                sessionId: 'missing-session',
+                strictSessionResume: true,
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('strictSessionResume');
+        });
+
+        it('resolves effective model from server response', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant', model: 'anthropic/claude-3-5-sonnet-v2' },
+                    parts: [{ type: 'text', text: 'Hello' }],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const result = await svc.sendMessage({
+                prompt: 'Hello',
+                model: 'anthropic/claude-3-5-sonnet',
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.effectiveModel).toBe('anthropic/claude-3-5-sonnet-v2');
         });
 
         it('emits tool-start event for pending tool state', async () => {
@@ -522,7 +584,7 @@ describe('OpenCodeSDKService', () => {
             const result = await svc.transform('Transform this');
             expect(result.success).toBe(false);
             expect(result.text).toBe('');
-            expect(result.error).toBe('Transform failed');
+            expect(result.error).toContain('Transform failed');
         });
 
         it('passes model and cwd through options', async () => {

--- a/packages/coc-agent-sdk/test/ai/opencode-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/ai/opencode-sdk-service.test.ts
@@ -1,0 +1,850 @@
+/**
+ * OpenCodeSDKService tests
+ *
+ * Unit tests for the OpenCode SDK provider adapter, covering:
+ * - Availability detection when SDK is not installed
+ * - Availability detection when SDK is installed
+ * - sendMessage basic flow
+ * - sendMessage with streaming chunks
+ * - sendMessage tool events
+ * - sendMessage abort
+ * - transform delegates to sendMessage with safe defaults
+ * - forkSession creates a new session
+ * - abortSession / softAbortSession
+ * - steerSession returns false
+ * - Session tracking (hasActiveSession / getActiveSessionCount)
+ * - Lifecycle (cleanup / dispose)
+ * - listModels via config.providers()
+ * - Registry export and constants
+ * - Helper functions (flattenOpenCodeProvidersToModelInfo, parseOpenCodeModelRef)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    OpenCodeSDKService,
+    registerOpenCodeSDKService,
+    flattenOpenCodeProvidersToModelInfo,
+    parseOpenCodeModelRef,
+} from '../../src/opencode-sdk-service';
+import {
+    OPENCODE_PROVIDER,
+    SDK_PROVIDER_OPENCODE,
+    sdkServiceRegistry,
+} from '../../src/sdk-service-registry';
+
+// ============================================================================
+// Module mock for @opencode-ai/sdk
+// ============================================================================
+
+vi.mock('../../src/sdk-esm-loader', () => ({
+    dynamicImportModule: vi.fn(),
+}));
+
+import { dynamicImportModule } from '../../src/sdk-esm-loader';
+const mockDynamicImport = vi.mocked(dynamicImportModule);
+
+// ============================================================================
+// Mock client builder
+// ============================================================================
+
+function createMockClient(overrides: Partial<ReturnType<typeof buildDefaultClient>> = {}) {
+    const client = buildDefaultClient();
+    return { ...client, ...overrides };
+}
+
+function buildDefaultClient() {
+    return {
+        global: {
+            health: vi.fn().mockResolvedValue({ data: { healthy: true, version: '1.0.0' } }),
+        },
+        config: {
+            get: vi.fn().mockResolvedValue({ data: { model: 'anthropic/claude-3-5-sonnet' } }),
+            providers: vi.fn().mockResolvedValue({
+                data: {
+                    providers: [
+                        {
+                            id: 'anthropic',
+                            name: 'Anthropic',
+                            models: [
+                                { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet' },
+                                { id: 'claude-3-haiku-20240307', name: 'Claude 3 Haiku' },
+                            ],
+                        },
+                        {
+                            id: 'openai',
+                            name: 'OpenAI',
+                            models: [
+                                { id: 'gpt-4o', name: 'GPT-4o' },
+                            ],
+                        },
+                    ],
+                    default: { anthropic: 'claude-3-5-sonnet-20241022' },
+                },
+            }),
+        },
+        session: {
+            list: vi.fn().mockResolvedValue({ data: [] }),
+            get: vi.fn().mockResolvedValue({ data: { id: 'session-1' } }),
+            create: vi.fn().mockResolvedValue({ data: { id: 'new-session-1' } }),
+            delete: vi.fn().mockResolvedValue({ data: true }),
+            abort: vi.fn().mockResolvedValue({ data: true }),
+            prompt: vi.fn().mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [{ type: 'text', text: 'Hello from OpenCode!' }],
+                },
+            }),
+            messages: vi.fn().mockResolvedValue({
+                data: [
+                    {
+                        info: { id: 'msg-1', sessionID: 'session-1', role: 'user' },
+                        parts: [{ type: 'text', text: 'Hi' }],
+                    },
+                    {
+                        info: { id: 'msg-2', sessionID: 'session-1', role: 'assistant' },
+                        parts: [{ type: 'text', text: 'Hello!' }],
+                    },
+                ],
+            }),
+        },
+        event: {
+            subscribe: vi.fn().mockResolvedValue({ stream: (async function* () {})() }),
+        },
+        app: {
+            agents: vi.fn().mockResolvedValue({ data: [{ id: 'coder', name: 'Coder' }] }),
+        },
+    };
+}
+
+function stubSDKWithClient(client: ReturnType<typeof createMockClient>) {
+    const createOpencodeClient = vi.fn().mockReturnValue(client);
+    const createOpencode = vi.fn().mockResolvedValue({
+        client,
+        server: { url: 'http://127.0.0.1:4096', close: vi.fn() },
+    });
+    mockDynamicImport.mockResolvedValue({
+        createOpencode,
+        createOpencodeClient,
+    });
+    return { createOpencode, createOpencodeClient };
+}
+
+function stubSDKNotInstalled() {
+    mockDynamicImport.mockRejectedValue(new Error('Cannot find module \'@opencode-ai/sdk\''));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('OpenCodeSDKService', () => {
+    let svc: OpenCodeSDKService;
+
+    beforeEach(() => {
+        svc = new OpenCodeSDKService();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        svc.dispose();
+    });
+
+    // ── Availability ──────────────────────────────────────────────────────
+
+    describe('isAvailable', () => {
+        it('returns available when SDK is installed and exports createOpencode', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(true);
+            expect(result.error).toBeUndefined();
+        });
+
+        it('returns unavailable when SDK is not installed', async () => {
+            stubSDKNotInstalled();
+
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(false);
+            expect(result.error).toContain('OpenCode SDK not installed');
+        });
+
+        it('returns unavailable when SDK exports nothing useful', async () => {
+            mockDynamicImport.mockResolvedValue({});
+
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(false);
+            expect(result.error).toContain('did not export createOpencode or createOpencodeClient');
+        });
+
+        it('caches availability result', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            const r1 = await svc.isAvailable();
+            const r2 = await svc.isAvailable();
+            expect(r1).toBe(r2);
+            expect(mockDynamicImport).toHaveBeenCalledTimes(1);
+        });
+
+        it('clearAvailabilityCache forces re-check', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.isAvailable();
+            svc.clearAvailabilityCache();
+            stubSDKNotInstalled();
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(false);
+        });
+
+        it('returns unavailable after dispose', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            svc.dispose();
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(false);
+            expect(result.error).toContain('disposed');
+        });
+
+        it('resolves SDK from default export', async () => {
+            mockDynamicImport.mockResolvedValue({
+                default: {
+                    createOpencode: vi.fn(),
+                    createOpencodeClient: vi.fn(),
+                },
+            });
+
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(true);
+        });
+    });
+
+    // ── listModels ────────────────────────────────────────────────────────
+
+    describe('listModels', () => {
+        it('returns models from providers API', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            const models = await svc.listModels();
+            expect(models).toEqual([
+                { id: 'anthropic/claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet' },
+                { id: 'anthropic/claude-3-haiku-20240307', name: 'Claude 3 Haiku' },
+                { id: 'openai/gpt-4o', name: 'GPT-4o' },
+            ]);
+        });
+
+        it('returns fallback when providers API fails', async () => {
+            const client = createMockClient();
+            client.config.providers.mockRejectedValue(new Error('Network error'));
+            stubSDKWithClient(client);
+
+            const models = await svc.listModels();
+            expect(models).toEqual([{ id: 'opencode-default', name: 'OpenCode Provider Default' }]);
+        });
+
+        it('returns fallback when providers is empty array', async () => {
+            const client = createMockClient();
+            client.config.providers.mockResolvedValue({ data: { providers: [], default: {} } });
+            stubSDKWithClient(client);
+
+            const models = await svc.listModels();
+            expect(models).toEqual([{ id: 'opencode-default', name: 'OpenCode Provider Default' }]);
+        });
+
+        it('throws after dispose', async () => {
+            svc.dispose();
+            await expect(svc.listModels()).rejects.toThrow('disposed');
+        });
+    });
+
+    // ── sendMessage ───────────────────────────────────────────────────────
+
+    describe('sendMessage', () => {
+        it('creates a new session and returns text response', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            const onSessionCreated = vi.fn();
+            const result = await svc.sendMessage({
+                prompt: 'Hello',
+                onSessionCreated,
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.response).toBe('Hello from OpenCode!');
+            expect(result.sessionId).toBe('new-session-1');
+            expect(onSessionCreated).toHaveBeenCalledWith('new-session-1');
+        });
+
+        it('resumes an existing session', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            const result = await svc.sendMessage({
+                prompt: 'Follow up',
+                sessionId: 'existing-session-42',
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.sessionId).toBe('existing-session-42');
+            expect(client.session.create).not.toHaveBeenCalled();
+            expect(client.session.prompt).toHaveBeenCalledWith({
+                path: { id: 'existing-session-42' },
+                body: expect.objectContaining({
+                    parts: [{ type: 'text', text: 'Follow up' }],
+                }),
+            });
+        });
+
+        it('emits streaming chunks from text parts', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [
+                        { type: 'text', text: 'Hello ' },
+                        { type: 'text', text: 'World!' },
+                    ],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const chunks: string[] = [];
+            const result = await svc.sendMessage({
+                prompt: 'Hello',
+                streaming: true,
+                onStreamingChunk: (chunk) => chunks.push(chunk),
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.response).toBe('Hello World!');
+            expect(chunks).toEqual(['Hello ', 'World!', '']);
+        });
+
+        it('emits tool events from tool-invocation parts', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [
+                        {
+                            type: 'tool-invocation',
+                            toolCallID: 'tc-1',
+                            toolName: 'read_file',
+                            state: 'completed',
+                            input: { path: '/test.ts' },
+                            output: 'file contents here',
+                        },
+                        { type: 'text', text: 'I read the file.' },
+                    ],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const events: Array<{ type: string; toolName?: string }> = [];
+            await svc.sendMessage({
+                prompt: 'Read the file',
+                onToolEvent: (event) => events.push({ type: event.type, toolName: event.toolName }),
+            });
+
+            expect(events).toEqual([
+                { type: 'tool-complete', toolName: 'read_file' },
+            ]);
+        });
+
+        it('returns error when SDK is unavailable', async () => {
+            stubSDKNotInstalled();
+
+            const result = await svc.sendMessage({ prompt: 'Hello' });
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('not installed');
+        });
+
+        it('returns error when disposed', async () => {
+            svc.dispose();
+            const result = await svc.sendMessage({ prompt: 'Hello' });
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('disposed');
+        });
+
+        it('returns error when signal is already aborted', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+            const abortController = new AbortController();
+            abortController.abort();
+
+            const result = await svc.sendMessage({
+                prompt: 'Hello',
+                signal: abortController.signal,
+            });
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('Request aborted');
+        });
+
+        it('passes model reference for provider/model format', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.sendMessage({
+                prompt: 'Hello',
+                model: 'anthropic/claude-3-5-sonnet',
+            });
+
+            expect(client.session.prompt).toHaveBeenCalledWith({
+                path: { id: 'new-session-1' },
+                body: expect.objectContaining({
+                    model: { providerID: 'anthropic', modelID: 'claude-3-5-sonnet' },
+                }),
+            });
+        });
+
+        it('omits model ref for provider-default model', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.sendMessage({
+                prompt: 'Hello',
+                model: 'opencode-default',
+            });
+
+            const callBody = client.session.prompt.mock.calls[0]?.[0]?.body;
+            expect(callBody?.model).toBeUndefined();
+        });
+
+        it('passes system message when provided', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.sendMessage({
+                prompt: 'Hello',
+                systemMessage: { content: 'You are a helpful assistant' },
+            });
+
+            expect(client.session.prompt).toHaveBeenCalledWith({
+                path: { id: 'new-session-1' },
+                body: expect.objectContaining({
+                    system: 'You are a helpful assistant',
+                }),
+            });
+        });
+
+        it('handles prompt API error gracefully', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockRejectedValue(new Error('Server error'));
+            stubSDKWithClient(client);
+
+            const result = await svc.sendMessage({ prompt: 'Hello' });
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('Server error');
+        });
+
+        it('emits tool-start event for pending tool state', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [
+                        {
+                            type: 'tool-invocation',
+                            toolCallID: 'tc-2',
+                            toolName: 'write_file',
+                            state: 'pending',
+                            input: { path: '/output.ts', content: 'test' },
+                        },
+                    ],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const events: Array<{ type: string; toolCallId: string; toolName?: string }> = [];
+            await svc.sendMessage({
+                prompt: 'Write the file',
+                onToolEvent: (e) => events.push({ type: e.type, toolCallId: e.toolCallId, toolName: e.toolName }),
+            });
+
+            expect(events).toEqual([{ type: 'tool-start', toolCallId: 'tc-2', toolName: 'write_file' }]);
+        });
+
+        it('emits tool-failed event for error state', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [
+                        {
+                            type: 'tool-invocation',
+                            toolCallID: 'tc-3',
+                            toolName: 'run_command',
+                            state: 'error',
+                            error: 'Command timed out',
+                        },
+                    ],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const events: Array<{ type: string; error?: string }> = [];
+            await svc.sendMessage({
+                prompt: 'Run the command',
+                onToolEvent: (e) => events.push({ type: e.type, error: e.error }),
+            });
+
+            expect(events).toEqual([{ type: 'tool-failed', error: 'Command timed out' }]);
+        });
+    });
+
+    // ── transform ─────────────────────────────────────────────────────────
+
+    describe('transform', () => {
+        it('delegates to sendMessage with safe defaults', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [{ type: 'text', text: 'Transformed text' }],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const result = await svc.transform('Transform this');
+            expect(result.success).toBe(true);
+            expect(result.text).toBe('Transformed text');
+        });
+
+        it('returns error result on failure', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockRejectedValue(new Error('Transform failed'));
+            stubSDKWithClient(client);
+
+            const result = await svc.transform('Transform this');
+            expect(result.success).toBe(false);
+            expect(result.text).toBe('');
+            expect(result.error).toBe('Transform failed');
+        });
+
+        it('passes model and cwd through options', async () => {
+            const client = createMockClient();
+            client.session.prompt.mockResolvedValue({
+                data: {
+                    info: { id: 'msg-1', sessionID: 'new-session-1', role: 'assistant' },
+                    parts: [{ type: 'text', text: 'ok' }],
+                },
+            });
+            stubSDKWithClient(client);
+
+            const result = await svc.transform('Transform this', {
+                model: 'anthropic/claude-3-5-sonnet',
+                cwd: '/tmp/test',
+            });
+            expect(result.success).toBe(true);
+        });
+    });
+
+    // ── Session management ────────────────────────────────────────────────
+
+    describe('forkSession', () => {
+        it('creates a new session and injects history context', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+            client.session.create.mockResolvedValue({ data: { id: 'forked-session-1' } });
+
+            const newId = await svc.forkSession('original-session-1');
+            expect(newId).toBe('forked-session-1');
+            expect(client.session.messages).toHaveBeenCalledWith({ path: { id: 'original-session-1' } });
+            // Injected context via noReply prompt
+            expect(client.session.prompt).toHaveBeenCalledWith({
+                path: { id: 'forked-session-1' },
+                body: expect.objectContaining({ noReply: true }),
+            });
+        });
+
+        it('returns new session even when history copy fails', async () => {
+            const client = createMockClient();
+            client.session.messages.mockRejectedValue(new Error('Not found'));
+            client.session.create.mockResolvedValue({ data: { id: 'forked-session-2' } });
+            stubSDKWithClient(client);
+
+            const newId = await svc.forkSession('missing-session');
+            expect(newId).toBe('forked-session-2');
+        });
+
+        it('throws when disposed', async () => {
+            svc.dispose();
+            await expect(svc.forkSession('any')).rejects.toThrow('disposed');
+        });
+    });
+
+    describe('abortSession', () => {
+        it('aborts an active session and calls server abort', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.sendMessage({ prompt: 'Hello' });
+            // Session is already removed from active map after sendMessage completes,
+            // but the server-side abort should still be called.
+            const result = await svc.abortSession('new-session-1');
+            expect(client.session.abort).toHaveBeenCalledWith({ path: { id: 'new-session-1' } });
+            expect(result).toBe(true);
+        });
+
+        it('returns false for unknown session when server abort fails', async () => {
+            const client = createMockClient();
+            client.session.abort.mockRejectedValue(new Error('Not found'));
+            stubSDKWithClient(client);
+
+            const result = await svc.abortSession('nonexistent');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('softAbortSession', () => {
+        it('delegates to abortSession', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            const result = await svc.softAbortSession('any-session');
+            expect(client.session.abort).toHaveBeenCalledWith({ path: { id: 'any-session' } });
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('steerSession', () => {
+        it('returns false (not supported)', async () => {
+            const result = await svc.steerSession('any-session', 'new instructions');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('hasActiveSession / getActiveSessionCount', () => {
+        it('returns false/0 when no sessions are active', () => {
+            expect(svc.hasActiveSession('any')).toBe(false);
+            expect(svc.getActiveSessionCount()).toBe(0);
+        });
+    });
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    describe('cleanup', () => {
+        it('clears all cached state', async () => {
+            const client = createMockClient();
+            stubSDKWithClient(client);
+
+            await svc.isAvailable();
+            await svc.cleanup();
+
+            // Availability cache was cleared; next call re-checks
+            stubSDKNotInstalled();
+            const result = await svc.isAvailable();
+            expect(result.available).toBe(false);
+        });
+    });
+
+    describe('dispose', () => {
+        it('marks service as disposed', () => {
+            svc.dispose();
+            expect(svc.hasActiveSession('any')).toBe(false);
+            expect(svc.getActiveSessionCount()).toBe(0);
+        });
+
+        it('closes owned server on dispose', async () => {
+            const closeFn = vi.fn();
+            const client = createMockClient();
+            // Make health check fail so ensureClient goes through createOpencode path
+            const createOpencodeClient = vi.fn().mockReturnValue(
+                createMockClient({
+                    global: {
+                        health: vi.fn().mockRejectedValue(new Error('No server')),
+                    },
+                } as any),
+            );
+            const createOpencode = vi.fn().mockResolvedValue({
+                client,
+                server: { url: 'http://127.0.0.1:4096', close: closeFn },
+            });
+            mockDynamicImport.mockResolvedValue({ createOpencode, createOpencodeClient });
+
+            await svc.listModels();
+            svc.dispose();
+            expect(closeFn).toHaveBeenCalled();
+        });
+    });
+
+    // ── Registration ──────────────────────────────────────────────────────
+
+    describe('registerOpenCodeSDKService', () => {
+        afterEach(() => {
+            sdkServiceRegistry.unregister(OPENCODE_PROVIDER);
+        });
+
+        it('registers service under opencode key', () => {
+            const registered = registerOpenCodeSDKService();
+            expect(sdkServiceRegistry.has(OPENCODE_PROVIDER)).toBe(true);
+            expect(sdkServiceRegistry.get(OPENCODE_PROVIDER)).toBe(registered);
+            registered.dispose();
+        });
+    });
+
+    describe('provider constants', () => {
+        it('OPENCODE_PROVIDER is "opencode"', () => {
+            expect(OPENCODE_PROVIDER).toBe('opencode');
+        });
+
+        it('SDK_PROVIDER_OPENCODE is an alias for OPENCODE_PROVIDER', () => {
+            expect(SDK_PROVIDER_OPENCODE).toBe(OPENCODE_PROVIDER);
+        });
+    });
+});
+
+// ============================================================================
+// Helper function tests
+// ============================================================================
+
+describe('flattenOpenCodeProvidersToModelInfo', () => {
+    it('flattens providers into composite model IDs', () => {
+        const result = flattenOpenCodeProvidersToModelInfo([
+            {
+                id: 'anthropic',
+                name: 'Anthropic',
+                models: [
+                    { id: 'claude-3-5-sonnet', name: 'Claude 3.5 Sonnet' },
+                    { id: 'claude-3-haiku', name: 'Claude 3 Haiku' },
+                ],
+            },
+            {
+                id: 'openai',
+                name: 'OpenAI',
+                models: [{ id: 'gpt-4o', name: 'GPT-4o' }],
+            },
+        ]);
+
+        expect(result).toEqual([
+            { id: 'anthropic/claude-3-5-sonnet', name: 'Claude 3.5 Sonnet' },
+            { id: 'anthropic/claude-3-haiku', name: 'Claude 3 Haiku' },
+            { id: 'openai/gpt-4o', name: 'GPT-4o' },
+        ]);
+    });
+
+    it('uses model id as name when name is not provided', () => {
+        const result = flattenOpenCodeProvidersToModelInfo([
+            { id: 'test', models: [{ id: 'model-1' }] },
+        ]);
+        expect(result).toEqual([{ id: 'test/model-1', name: 'model-1' }]);
+    });
+
+    it('returns fallback for empty providers', () => {
+        const result = flattenOpenCodeProvidersToModelInfo([]);
+        expect(result).toEqual([{ id: 'opencode-default', name: 'OpenCode Provider Default' }]);
+    });
+
+    it('returns fallback for provider with no models', () => {
+        const result = flattenOpenCodeProvidersToModelInfo([
+            { id: 'empty', models: [] },
+        ]);
+        expect(result).toEqual([{ id: 'opencode-default', name: 'OpenCode Provider Default' }]);
+    });
+
+    it('skips models without id', () => {
+        const result = flattenOpenCodeProvidersToModelInfo([
+            { id: 'test', models: [{ id: '' }, { id: 'valid-model' }] },
+        ]);
+        expect(result).toEqual([{ id: 'test/valid-model', name: 'valid-model' }]);
+    });
+
+    it('skips providers without models array', () => {
+        const result = flattenOpenCodeProvidersToModelInfo([
+            { id: 'no-models' } as any,
+            { id: 'has-models', models: [{ id: 'm1', name: 'Model 1' }] },
+        ]);
+        expect(result).toEqual([{ id: 'has-models/m1', name: 'Model 1' }]);
+    });
+});
+
+describe('parseOpenCodeModelRef', () => {
+    it('parses provider/model format', () => {
+        expect(parseOpenCodeModelRef('anthropic/claude-3-5-sonnet')).toEqual({
+            providerID: 'anthropic',
+            modelID: 'claude-3-5-sonnet',
+        });
+    });
+
+    it('returns undefined for empty string', () => {
+        expect(parseOpenCodeModelRef('')).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+        expect(parseOpenCodeModelRef(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for opencode-default', () => {
+        expect(parseOpenCodeModelRef('opencode-default')).toBeUndefined();
+    });
+
+    it('returns undefined for provider-default', () => {
+        expect(parseOpenCodeModelRef('provider-default')).toBeUndefined();
+    });
+
+    it('returns undefined for default', () => {
+        expect(parseOpenCodeModelRef('default')).toBeUndefined();
+    });
+
+    it('handles bare model name without slash', () => {
+        const result = parseOpenCodeModelRef('gpt-4o');
+        expect(result).toEqual({
+            providerID: '',
+            modelID: 'gpt-4o',
+        });
+    });
+
+    it('handles whitespace-padded input', () => {
+        expect(parseOpenCodeModelRef('  anthropic/claude-3-5-sonnet  ')).toEqual({
+            providerID: 'anthropic',
+            modelID: 'claude-3-5-sonnet',
+        });
+    });
+
+    it('handles model with multiple slashes', () => {
+        expect(parseOpenCodeModelRef('provider/model/variant')).toEqual({
+            providerID: 'provider',
+            modelID: 'model/variant',
+        });
+    });
+});
+
+describe('provider-model-resolver with opencode', () => {
+    it('accepts any model for opencode provider', async () => {
+        const { resolveModelForProvider } = await import('../../src/provider-model-resolver');
+        expect(resolveModelForProvider('opencode', 'anthropic/claude-3-5-sonnet')).toEqual({
+            model: 'anthropic/claude-3-5-sonnet',
+            coerced: false,
+            requestedModel: 'anthropic/claude-3-5-sonnet',
+        });
+    });
+
+    it('accepts bare model names for opencode', async () => {
+        const { resolveModelForProvider } = await import('../../src/provider-model-resolver');
+        expect(resolveModelForProvider('opencode', 'gpt-4o')).toEqual({
+            model: 'gpt-4o',
+            coerced: false,
+            requestedModel: 'gpt-4o',
+        });
+    });
+
+    it('treats opencode-default as provider default', async () => {
+        const { resolveModelForProvider } = await import('../../src/provider-model-resolver');
+        expect(resolveModelForProvider('opencode', 'opencode-default')).toEqual({
+            coerced: false,
+            requestedModel: 'opencode-default',
+        });
+    });
+
+    it('treats default as provider default for opencode', async () => {
+        const { resolveModelForProvider } = await import('../../src/provider-model-resolver');
+        expect(resolveModelForProvider('opencode', 'default')).toEqual({
+            coerced: false,
+            requestedModel: 'default',
+        });
+    });
+});

--- a/packages/coc-agent-sdk/test/effort-tier-defaults.test.ts
+++ b/packages/coc-agent-sdk/test/effort-tier-defaults.test.ts
@@ -44,6 +44,16 @@ describe('getDefaultEffortTiers', () => {
         });
     });
 
+    it('returns the opencode defaults', () => {
+        const defaults = getDefaultEffortTiers('opencode');
+        expect(defaults).toEqual({
+            'very-low': { model: 'anthropic/claude-haiku',    reasoningEffort: null    },
+            low:    { model: 'anthropic/claude-sonnet',   reasoningEffort: null    },
+            medium: { model: 'anthropic/claude-sonnet',   reasoningEffort: 'high'  },
+            high:   { model: 'anthropic/claude-opus',     reasoningEffort: null    },
+        });
+    });
+
     it('returns null for unknown providers', () => {
         expect(getDefaultEffortTiers('unknown')).toBeNull();
         expect(getDefaultEffortTiers('')).toBeNull();

--- a/packages/coc-client/src/contracts/admin.ts
+++ b/packages/coc-client/src/contracts/admin.ts
@@ -1,7 +1,7 @@
 export type AdminOutputFormat = 'table' | 'json' | 'csv' | 'markdown';
 export type AdminImportMode = 'replace' | 'merge';
 export type AdminStorageBackend = 'file' | 'sqlite';
-export type AdminConcreteAgentProvider = 'copilot' | 'codex' | 'claude';
+export type AdminConcreteAgentProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export type AdminDefaultProvider = AdminConcreteAgentProvider;
 
 export interface AdminAutoProviderRoutingRule {
@@ -100,6 +100,7 @@ export interface AdminResolvedConfig {
   excalidraw?: { enabled?: boolean };
   codex?: { enabled?: boolean };
   claude?: { enabled?: boolean };
+  opencode?: { enabled?: boolean };
   defaultProvider?: AdminDefaultProvider;
   agentProviderRouting?: {
     auto?: AdminAutoProviderRoutingConfig;
@@ -190,6 +191,7 @@ export interface AdminConfigUpdate {
   'mcpOauth.autoRefresh.enabled'?: boolean;
   'codex.enabled'?: boolean;
   'claude.enabled'?: boolean;
+  'opencode.enabled'?: boolean;
   defaultProvider?: AdminDefaultProvider;
   'agentProviderRouting.auto'?: AdminAutoProviderRoutingConfig;
   'workItems.hierarchy.enabled'?: boolean;
@@ -238,6 +240,7 @@ export interface RuntimeDashboardConfig {
     containerDefaultAgentEnabled: boolean;
     codexEnabled: boolean;
     claudeEnabled: boolean;
+    opencodeEnabled: boolean;
     defaultProvider: AdminDefaultProvider;
     autoAgentProviderRoutingEnabled: boolean;
     ralphMultiAgentGrillEnabled: boolean;
@@ -377,7 +380,7 @@ export interface AdminStorageCancelMigrationResponse {
 // ── Agent Providers types ──────────────────────────────────────────
 
 /** Wire-format identifier for an AI agent provider. */
-export type AgentProviderId = 'copilot' | 'codex' | 'claude';
+export type AgentProviderId = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 /** SDK package install status for optional providers (Codex, Claude). */
 export type ProviderInstallStatus = 'not-installed' | 'installing' | 'installed' | 'install-failed';

--- a/packages/coc-client/src/contracts/common.ts
+++ b/packages/coc-client/src/contracts/common.ts
@@ -1,6 +1,6 @@
 export type JsonObject = Record<string, unknown>;
 
-export type ChatProvider = 'copilot' | 'codex' | 'claude';
+export type ChatProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface PaginatedResponse<T> {

--- a/packages/coc-client/src/contracts/preferences.ts
+++ b/packages/coc-client/src/contracts/preferences.ts
@@ -48,7 +48,7 @@ export interface PerRepoPreferences {
   /** Max iterations a Ralph loop runs before stopping. Range 1..200. */
   maxRalphIterations?: number;
   /** Last agent provider selected for new chats in this workspace. Persisted per-repo. */
-  lastChatProvider?: 'copilot' | 'codex' | 'claude' | 'auto';
+  lastChatProvider?: 'copilot' | 'codex' | 'claude' | 'opencode' | 'auto';
   /** Git-based notes sync settings (only for my_work / my_life virtual workspaces). */
   sync?: {
     gitRemote?: string;

--- a/packages/coc-client/src/contracts/processes.ts
+++ b/packages/coc-client/src/contracts/processes.ts
@@ -139,7 +139,7 @@ export type RalphGrillAgentRole =
   | 'quality-test'
   | 'deduplication'
   | 'provenance';
-export type RalphGrillAgentProvider = 'copilot' | 'codex' | 'claude';
+export type RalphGrillAgentProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export type RalphGrillEffortTier = 'very-low' | 'low' | 'medium' | 'high';
 
 export interface RalphGrillAgentModelSelection {

--- a/packages/coc/src/commands/queue.ts
+++ b/packages/coc/src/commands/queue.ts
@@ -15,7 +15,7 @@ import { createInterface } from 'readline/promises';
 
 const DEFAULT_SERVER_URL = 'http://localhost:4000';
 const CHAT_MODES = ['ask', 'autopilot'] as const;
-const CHAT_PROVIDERS = ['copilot', 'codex', 'claude'] as const;
+const CHAT_PROVIDERS = ['copilot', 'codex', 'claude', 'opencode'] as const;
 const EFFORT_TIERS = ['low', 'medium', 'high'] as const;
 const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
 const PRIORITIES = ['low', 'normal', 'high'] as const;

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -23,7 +23,7 @@ import {
 // Types
 // ============================================================================
 
-export type ConcreteAgentProvider = 'copilot' | 'codex' | 'claude';
+export type ConcreteAgentProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export type DefaultAgentProvider = ConcreteAgentProvider;
 export type AutoProviderRoutingRule = {
     provider: ConcreteAgentProvider;
@@ -237,6 +237,10 @@ export interface CLIConfig {
     };
     /** Claude Code SDK provider support. Disabled by default. */
     claude?: {
+        enabled?: boolean;
+    };
+    /** OpenCode SDK provider support. Disabled by default. */
+    opencode?: {
         enabled?: boolean;
     };
     /**
@@ -537,6 +541,10 @@ export interface ResolvedCLIConfig {
     claude: {
         enabled: boolean;
     };
+    /** OpenCode SDK provider support. Disabled by default. */
+    opencode: {
+        enabled: boolean;
+    };
     /**
      * Concrete default AI provider when Auto routing is disabled.
      * Per-chat provider selection overrides this value.
@@ -787,6 +795,9 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
         enabled: false,
     },
     claude: {
+        enabled: false,
+    },
+    opencode: {
         enabled: false,
     },
     defaultProvider: 'copilot',

--- a/packages/coc/src/config/admin-setting-definitions.ts
+++ b/packages/coc/src/config/admin-setting-definitions.ts
@@ -290,7 +290,7 @@ export function buildRuntimeFeatureFlags(config: unknown): Record<string, unknow
 
 // ── agentProviderRouting.auto custom validation ───────────────────────────────
 
-const VALID_CONCRETE_PROVIDER_VALUES = ['copilot', 'codex', 'claude'] as const;
+const VALID_CONCRETE_PROVIDER_VALUES = ['copilot', 'codex', 'claude', 'opencode'] as const;
 
 function isObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -668,9 +668,10 @@ export const ADMIN_SETTING_DEFINITIONS: readonly AdminSettingDefinition[] = [
     bool({ key: 'containerDefaultAgent.enabled', default: false, runtime: 'live', runtimeFlag: 'containerDefaultAgentEnabled' }),
     bool({ key: 'codex.enabled', default: false, runtime: 'live', runtimeFlag: 'codexEnabled' }),
     bool({ key: 'claude.enabled', default: false, runtime: 'live', runtimeFlag: 'claudeEnabled' }),
+    bool({ key: 'opencode.enabled', default: false, runtime: 'live', runtimeFlag: 'opencodeEnabled' }),
     {
         key: 'defaultProvider',
-        value: { kind: 'enum', values: ['copilot', 'codex', 'claude'], message: 'defaultProvider must be "copilot", "codex", or "claude"' },
+        value: { kind: 'enum', values: ['copilot', 'codex', 'claude', 'opencode'], message: 'defaultProvider must be "copilot", "codex", "claude", or "opencode"' },
         default: 'copilot',
         runtime: 'restartRequired',
         runtimeFlag: 'defaultProvider',

--- a/packages/coc/src/config/admin-setting-definitions.ts
+++ b/packages/coc/src/config/admin-setting-definitions.ts
@@ -611,7 +611,7 @@ export const ADMIN_SETTING_DEFINITIONS: readonly AdminSettingDefinition[] = [
     }),
     {
         key: 'dreams.provider',
-        value: { kind: 'enum', values: ['copilot', 'codex', 'claude'], nullable: true, message: 'dreams.provider must be "copilot", "codex", or "claude"' },
+        value: { kind: 'enum', values: ['copilot', 'codex', 'claude', 'opencode'], nullable: true, message: 'dreams.provider must be "copilot", "codex", "claude", or "opencode"' },
         default: undefined,
         runtime: 'live',
     },

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -50,6 +50,7 @@ export type ResolvedConfigNamespaceValues = Pick<
     | 'agentProviderRouting'
     | 'codex'
     | 'claude'
+    | 'opencode'
     | 'features'
     | 'memoryPromotion'
     | 'store'

--- a/packages/coc/src/config/schema.ts
+++ b/packages/coc/src/config/schema.ts
@@ -15,7 +15,7 @@ import { ADMIN_SETTING_DEFINITIONS, type AdminSettingValueSpec } from './admin-s
 // Hand-written sub-schemas (non-admin-editable structures)
 // ============================================================================
 
-const concreteAgentProviderEnum = z.enum(['copilot', 'codex', 'claude']);
+const concreteAgentProviderEnum = z.enum(['copilot', 'codex', 'claude', 'opencode']);
 const percentSchema = z.number().int().min(0).max(100);
 
 const loggingLevelEnum = z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']);

--- a/packages/coc/src/server/agent-providers/agent-providers-routes.ts
+++ b/packages/coc/src/server/agent-providers/agent-providers-routes.ts
@@ -20,7 +20,7 @@ import { sendJson, send400, send500, setStaticConfigCacheHeaders } from '../shar
 import type { RuntimeConfigService } from '../../config/runtime-config-service';
 import type { AgentProviderStatus, AgentProvidersResponse } from '@plusplusoneplusplus/coc-client';
 import type { CopilotSDKService, IAvailabilityResult, CodexSDKService, ClaudeSDKService, ModelInfo, ISDKService } from '@plusplusoneplusplus/forge';
-import { getAllModels, modelMetadataStore, sdkServiceRegistry, SDK_PROVIDER_COPILOT, SDK_PROVIDER_CODEX, SDK_PROVIDER_CLAUDE, mergeEffortTiersWithDefaults, getDefaultEffortTiers, type MergedEffortTiersMap, type EffortTierDefaultsMap } from '@plusplusoneplusplus/forge';
+import { getAllModels, modelMetadataStore, sdkServiceRegistry, SDK_PROVIDER_COPILOT, SDK_PROVIDER_CODEX, SDK_PROVIDER_CLAUDE, SDK_PROVIDER_OPENCODE, mergeEffortTiersWithDefaults, getDefaultEffortTiers, type MergedEffortTiersMap, type EffortTierDefaultsMap } from '@plusplusoneplusplus/forge';
 import { getResolvedInstallState } from '../providers/provider-install-routes';
 import type { CLIConfig } from '../../config';
 import { AgentProvidersQuotaCache, type AgentProvidersQuotaContext } from './quota-cache';
@@ -31,12 +31,16 @@ export interface AgentProvidersRouteContext extends AgentProvidersQuotaContext {
     getCodexAvailability: () => Promise<IAvailabilityResult>;
     /** Checks Claude SDK availability. Resolved per-request; the service caches the result. */
     getClaudeAvailability: () => Promise<IAvailabilityResult>;
+    /** Checks OpenCode SDK availability. Resolved per-request; the service caches the result. */
+    getOpenCodeAvailability: () => Promise<IAvailabilityResult>;
     /** Optional: getter for Copilot account quota. Used by the quota endpoint. */
     getCopilotSdkService?: () => CopilotSDKService;
     /** Optional: getter for Codex account quota. Used by the quota endpoint. */
     getCodexSdkService?: () => CodexSDKService | undefined;
     /** Optional: getter for Claude account quota. Used by the quota endpoint. */
     getClaudeSdkService?: () => ClaudeSDKService | undefined;
+    /** Optional: getter for OpenCode SDK service. Used for model queries. OpenCode has no quota API. */
+    getOpenCodeSdkService?: () => ISDKService | undefined;
     /** Config persistence functions for model settings. */
     configPath?: string;
     loadConfigFile: (p?: string) => CLIConfig | undefined;
@@ -125,7 +129,41 @@ export async function buildAgentProvidersResponse(ctx: AgentProvidersRouteContex
         }
     }
 
-    return { providers: [copilot, codexProvider, claudeProvider] };
+    const opencodeEnabled = config.opencode?.enabled ?? false;
+    const opencodeInstallState = getResolvedInstallState('opencode');
+
+    let opencodeProvider: AgentProviderStatus;
+    if (!opencodeEnabled) {
+        opencodeProvider = {
+            id: 'opencode',
+            label: 'OpenCode',
+            enabled: false,
+            available: false,
+            installStatus: opencodeInstallState.status,
+        };
+    } else {
+        const availability = await ctx.getOpenCodeAvailability();
+        if (availability.available) {
+            opencodeProvider = {
+                id: 'opencode',
+                label: 'OpenCode',
+                enabled: true,
+                available: true,
+                installStatus: opencodeInstallState.status,
+            };
+        } else {
+            opencodeProvider = {
+                id: 'opencode',
+                label: 'OpenCode',
+                enabled: true,
+                available: false,
+                reason: availability.error ?? 'OpenCode SDK is not available.',
+                installStatus: opencodeInstallState.status,
+            };
+        }
+    }
+
+    return { providers: [copilot, codexProvider, claudeProvider, opencodeProvider] };
 }
 
 // ── Effort-tier types ────────────────────────────────────────────────────────
@@ -142,11 +180,12 @@ const VALID_TIER_KEYS_LABEL = 'very-low, low, medium, high';
 
 // ── Provider-scoped model helpers ────────────────────────────────────────────
 
-const VALID_PROVIDERS = new Set(['copilot', 'codex', 'claude']);
+const VALID_PROVIDERS = new Set(['copilot', 'codex', 'claude', 'opencode']);
 const PROVIDER_SDK_KEYS: Record<string, string> = {
     copilot: SDK_PROVIDER_COPILOT,
     codex: SDK_PROVIDER_CODEX,
     claude: SDK_PROVIDER_CLAUDE,
+    opencode: SDK_PROVIDER_OPENCODE,
 };
 
 function getProviderModelSettings(cfg: CLIConfig | undefined, provider: string): { enabled: string[]; reasoningEfforts: Record<string, string>; effortTiers: EffortTiersMap } {
@@ -199,6 +238,9 @@ function getProviderSdkService(ctx: AgentProvidersRouteContext, provider: string
     }
     if (provider === 'claude') {
         return ctx.getClaudeSdkService?.() as unknown as ISDKService | undefined;
+    }
+    if (provider === 'opencode') {
+        return ctx.getOpenCodeSdkService?.();
     }
     return undefined;
 }
@@ -567,6 +609,10 @@ export function registerAgentProvidersRoutes(routes: Route[], ctx: AgentProvider
             }
             if (provider === 'claude' && !(config.claude?.enabled ?? false)) {
                 sendJson(res, { success: false, provider, error: 'Claude provider is not enabled' }, 400);
+                return;
+            }
+            if (provider === 'opencode' && !(config.opencode?.enabled ?? false)) {
+                sendJson(res, { success: false, provider, error: 'OpenCode provider is not enabled' }, 400);
                 return;
             }
 

--- a/packages/coc/src/server/agent-providers/auto-provider-router.ts
+++ b/packages/coc/src/server/agent-providers/auto-provider-router.ts
@@ -1,7 +1,7 @@
 import type { AgentProvidersQuotaResponse, ProviderQuotaResult, ProviderQuotaType } from '@plusplusoneplusplus/coc-client';
 import type { ConcreteAgentProvider, ResolvedCLIConfig } from '../../config';
 
-const PROVIDERS: readonly ConcreteAgentProvider[] = ['copilot', 'codex', 'claude'];
+const PROVIDERS: readonly ConcreteAgentProvider[] = ['copilot', 'codex', 'claude', 'opencode'];
 const WEEKLY_QUOTA_TYPE_ALIASES = new Set([
     'seven_day',
     '7_day',

--- a/packages/coc/src/server/agent-providers/quota-cache.ts
+++ b/packages/coc/src/server/agent-providers/quota-cache.ts
@@ -24,6 +24,8 @@ export interface AgentProvidersQuotaContext {
     getCodexSdkService?: () => AccountQuotaService | undefined;
     /** Optional getter for Claude account quota. Queried only when Claude is enabled. */
     getClaudeSdkService?: () => AccountQuotaService | undefined;
+    /** Optional getter for OpenCode SDK service. OpenCode has no quota API; included for completeness. */
+    getOpenCodeSdkService?: () => AccountQuotaService | undefined;
 }
 
 export interface AgentProvidersQuotaCacheOptions {
@@ -104,6 +106,12 @@ export async function fetchAgentProvidersQuota(ctx: AgentProvidersQuotaContext):
             getLogger().warn(LogCategory.AI, `[ClaudeQuota] quota lookup failed: ${msg}`);
             providers.push({ id: 'claude', quotaTypes: [], error: msg });
         }
+    }
+
+    const opencodeEnabled = config.opencode?.enabled ?? false;
+    if (opencodeEnabled) {
+        // OpenCode has no quota API; emit an empty entry so the dashboard shows the provider.
+        providers.push({ id: 'opencode', quotaTypes: [] });
     }
 
     return { providers, lastUpdated: null };

--- a/packages/coc/src/server/agent-providers/quota-cache.ts
+++ b/packages/coc/src/server/agent-providers/quota-cache.ts
@@ -24,8 +24,6 @@ export interface AgentProvidersQuotaContext {
     getCodexSdkService?: () => AccountQuotaService | undefined;
     /** Optional getter for Claude account quota. Queried only when Claude is enabled. */
     getClaudeSdkService?: () => AccountQuotaService | undefined;
-    /** Optional getter for OpenCode SDK service. OpenCode has no quota API; included for completeness. */
-    getOpenCodeSdkService?: () => AccountQuotaService | undefined;
 }
 
 export interface AgentProvidersQuotaCacheOptions {

--- a/packages/coc/src/server/dreams/dream-store.ts
+++ b/packages/coc/src/server/dreams/dream-store.ts
@@ -305,8 +305,8 @@ function normalizeRunTrigger(value: unknown): CreateDreamRunInput['trigger'] {
 
 function normalizeRunProvider(value: unknown): ChatProvider | undefined {
     if (value === undefined) return undefined;
-    if (value === 'copilot' || value === 'codex' || value === 'claude') return value;
-    throw new Error('Dream run provider must be copilot, codex, or claude');
+    if (value === 'copilot' || value === 'codex' || value === 'claude' || value === 'opencode') return value;
+    throw new Error('Dream run provider must be copilot, codex, claude, or opencode');
 }
 
 function normalizeRunReasoningEffort(value: unknown): ReasoningEffort | undefined {

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -673,7 +673,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
 
             const availability = await effectiveAiService.isAvailable();
             if (!availability.available) {
-                const label = taskProvider === 'codex' ? 'Codex' : taskProvider === 'claude' ? 'Claude' : 'Copilot';
+                const label = taskProvider === 'codex' ? 'Codex' : taskProvider === 'claude' ? 'Claude' : taskProvider === 'opencode' ? 'OpenCode' : 'Copilot';
                 throw new Error(`${label} SDK not available: ${availability.error || 'unknown reason'}`);
             }
 

--- a/packages/coc/src/server/executors/chat-base-executor.ts
+++ b/packages/coc/src/server/executors/chat-base-executor.ts
@@ -175,7 +175,7 @@ export interface ChatModeExecutorOptions {
     /** Late-bound MCP OAuth manager (getter to allow optional/feature-flagged wiring). */
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     /** Active AI provider. Used to detect provider mismatches on follow-up resume. */
-    provider?: 'copilot' | 'codex' | 'claude';
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     /** Enables the gated multi-agent Ralph grilling prompt contract. */
     ralphMultiAgentGrillEnabled?: boolean;
     /**
@@ -246,7 +246,7 @@ export abstract class ChatBaseExecutor extends BaseExecutor {
     protected readonly getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
     protected readonly getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     /** Active AI provider — used to guard against provider mismatches on follow-up resume. */
-    protected readonly provider: 'copilot' | 'codex' | 'claude';
+    protected readonly provider: 'copilot' | 'codex' | 'claude' | 'opencode';
     protected readonly ralphMultiAgentGrillEnabled: boolean;
     /** Resolves per-task SDK service by provider, checking enablement. Optional — falls back to sdkServiceRegistry. */
     protected readonly resolveAiServiceForProvider?: (provider: ChatProvider) => ISDKService;

--- a/packages/coc/src/server/executors/classification-executor.ts
+++ b/packages/coc/src/server/executors/classification-executor.ts
@@ -150,10 +150,10 @@ function resolveClassificationContext(payload: Record<string, unknown>): {
     return {};
 }
 
-function readProvider(payload: unknown, fallback: 'copilot' | 'codex' | 'claude'): 'copilot' | 'codex' | 'claude' {
+function readProvider(payload: unknown, fallback: 'copilot' | 'codex' | 'claude' | 'opencode'): 'copilot' | 'codex' | 'claude' | 'opencode' {
     if (payload && typeof payload === 'object') {
         const provider = (payload as { provider?: unknown }).provider;
-        if (provider === 'copilot' || provider === 'codex' || provider === 'claude') {
+        if (provider === 'copilot' || provider === 'codex' || provider === 'claude' || provider === 'opencode') {
             return provider;
         }
     }

--- a/packages/coc/src/server/executors/executor-registry.ts
+++ b/packages/coc/src/server/executors/executor-registry.ts
@@ -33,7 +33,7 @@ export interface ExecutorRegistryOptions {
     followUpSuggestions: { enabled: boolean; count: number };
     askUser?: { enabled: boolean };
     /** Default AI provider name recorded on new processes when the task has no provider override. */
-    provider?: 'copilot' | 'codex' | 'claude';
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     /** Enables the gated multi-agent Ralph grilling prompt contract. */
     ralphMultiAgentGrillEnabled?: boolean;
     /**

--- a/packages/coc/src/server/executors/process-lifecycle-runner.ts
+++ b/packages/coc/src/server/executors/process-lifecycle-runner.ts
@@ -326,14 +326,14 @@ async function resolveExecutionProvider(
 
 export class ProcessLifecycleRunner extends BaseExecutor {
     private readonly onGenerateTitle: (processId: string, turns: ConversationTurn[]) => void;
-    /** Active AI provider recorded on new processes for attribution ('copilot' | 'codex' | 'claude'). */
-    private readonly provider: 'copilot' | 'codex' | 'claude';
+    /** Active AI provider recorded on new processes for attribution. */
+    private readonly provider: 'copilot' | 'codex' | 'claude' | 'opencode';
 
     constructor(
         store: ProcessStore,
         dataDir: string | undefined,
         onGenerateTitle: (processId: string, turns: ConversationTurn[]) => void,
-        provider?: 'copilot' | 'codex' | 'claude',
+        provider?: 'copilot' | 'codex' | 'claude' | 'opencode',
     ) {
         super(store, dataDir);
         this.onGenerateTitle = onGenerateTitle;

--- a/packages/coc/src/server/executors/process-lifecycle-runner.ts
+++ b/packages/coc/src/server/executors/process-lifecycle-runner.ts
@@ -250,7 +250,7 @@ async function notifyLoopTickComplete(
 type AutoProviderRoutingMetadata = NonNullable<ChatPayload['context']>['autoProviderRouting'];
 
 function isConcreteProvider(provider: unknown): provider is ChatProvider {
-    return provider === 'copilot' || provider === 'codex' || provider === 'claude';
+    return provider === 'copilot' || provider === 'codex' || provider === 'claude' || provider === 'opencode';
 }
 
 function isAutoProviderRoutingRequested(payload: ChatPayload): boolean {

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -22,7 +22,7 @@ import type { ExecutionServerOptions, ExecutionServer, ServerCloseOptions } from
 import type { Route } from './types';
 import type { ProcessStore } from '@plusplusoneplusplus/forge';
 import type { ModelInfo } from '@plusplusoneplusplus/forge';
-import { sdkServiceRegistry, SDK_PROVIDER_COPILOT, SDK_PROVIDER_CODEX, SDK_PROVIDER_CLAUDE, modelMetadataStore, registerCodexSDKService, registerClaudeSDKService } from '@plusplusoneplusplus/forge';
+import { sdkServiceRegistry, SDK_PROVIDER_COPILOT, SDK_PROVIDER_CODEX, SDK_PROVIDER_CLAUDE, SDK_PROVIDER_OPENCODE, modelMetadataStore, registerCodexSDKService, registerClaudeSDKService, registerOpenCodeSDKService } from '@plusplusoneplusplus/forge';
 import { cleanupAllStalePasteFiles } from '@plusplusoneplusplus/forge';
 import { MultiRepoQueueRouter } from './queue/multi-repo-queue-router';
 import { createQueueInfrastructure } from './infrastructure/queue-infrastructure';
@@ -251,23 +251,34 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
     // claude.enabled was set at startup. Live config gates actual usage.
     registerClaudeSDKService();
 
+    // Register the OpenCode provider unconditionally so per-chat routing can
+    // resolve OpenCode. Live config gates actual usage.
+    registerOpenCodeSDKService();
+
     const requestedProvider = resolvedConfig.defaultProvider === 'codex' ? 'codex'
         : resolvedConfig.defaultProvider === 'claude' ? 'claude'
+        : resolvedConfig.defaultProvider === 'opencode' ? 'opencode'
         : 'copilot';
     const effectiveProvider = requestedProvider === 'codex' && sdkServiceRegistry.has(SDK_PROVIDER_CODEX)
         ? 'codex'
         : requestedProvider === 'claude' && sdkServiceRegistry.has(SDK_PROVIDER_CLAUDE)
             ? 'claude'
-            : 'copilot';
+            : requestedProvider === 'opencode' && sdkServiceRegistry.has(SDK_PROVIDER_OPENCODE)
+                ? 'opencode'
+                : 'copilot';
     if (requestedProvider === 'codex' && effectiveProvider !== 'codex') {
         process.stderr.write('[ExecutionServer] defaultProvider=codex requested, but Codex provider is not registered; falling back to Copilot\n');
     }
     if (requestedProvider === 'claude' && effectiveProvider !== 'claude') {
         process.stderr.write('[ExecutionServer] defaultProvider=claude requested, but Claude provider is not registered; falling back to Copilot\n');
     }
+    if (requestedProvider === 'opencode' && effectiveProvider !== 'opencode') {
+        process.stderr.write('[ExecutionServer] defaultProvider=opencode requested, but OpenCode provider is not registered; falling back to Copilot\n');
+    }
     const resolvedAiService = options.aiService ?? sdkServiceRegistry.getOrThrow(
         effectiveProvider === 'codex' ? SDK_PROVIDER_CODEX
             : effectiveProvider === 'claude' ? SDK_PROVIDER_CLAUDE
+            : effectiveProvider === 'opencode' ? SDK_PROVIDER_OPENCODE
             : SDK_PROVIDER_COPILOT,
     );
 
@@ -294,6 +305,17 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
             const svc = sdkServiceRegistry.get(SDK_PROVIDER_CLAUDE);
             if (!svc) {
                 throw new Error('Claude SDK service is not available. Install @anthropic-ai/claude-agent-sdk and restart the server.');
+            }
+            return svc;
+        }
+        if (provider === 'opencode') {
+            const liveConfig = runtimeConfigService.config;
+            if (!liveConfig.opencode?.enabled) {
+                throw new Error('OpenCode provider is currently disabled. Enable OpenCode in Admin settings to use it.');
+            }
+            const svc = sdkServiceRegistry.get(SDK_PROVIDER_OPENCODE);
+            if (!svc) {
+                throw new Error('OpenCode SDK service is not available. Install @opencode-ai/sdk and restart the server.');
             }
             return svc;
         }

--- a/packages/coc/src/server/infrastructure/queue-infrastructure.ts
+++ b/packages/coc/src/server/infrastructure/queue-infrastructure.ts
@@ -61,7 +61,7 @@ export function createQueueInfrastructure(
     getWsServer: () => ProcessWebSocketServer,
     getLoopInfra?: () => import('../executors/chat-base-executor').LoopInfraDeps | undefined,
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined,
-    provider?: 'copilot' | 'codex' | 'claude',
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode',
     resolveAiServiceForProvider?: (provider: import('../tasks/task-types').ChatProvider) => import('@plusplusoneplusplus/forge').ISDKService,
     ralphMultiAgentGrillEnabled?: boolean,
     getGlobalSystemPrompt?: () => string | undefined,

--- a/packages/coc/src/server/native-copilot-sessions/types.ts
+++ b/packages/coc/src/server/native-copilot-sessions/types.ts
@@ -176,7 +176,7 @@ export type NativeCopilotSessionDetailResult =
     | { available: true; session: NativeCopilotSessionDetail | null }
     | { available: false; reason: Exclude<NativeCopilotSessionsUnavailableReason, 'feature-disabled'> };
 
-export type NativeCliSessionProviderId = 'copilot' | 'codex' | 'claude';
+export type NativeCliSessionProviderId = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 export type NativeCliSessionsUnavailableReason = 'feature-disabled' | 'store-missing' | 'store-invalid';
 

--- a/packages/coc/src/server/preferences-handler.ts
+++ b/packages/coc/src/server/preferences-handler.ts
@@ -285,7 +285,7 @@ export const PerRepoPreferencesSchema = z.object({
         .optional(),
     defaultModel: z.string().max(100).optional(),
     defaultModels: DefaultModelsByModeSchema.optional(),
-    lastChatProvider: z.enum(['copilot', 'codex', 'claude', 'auto']).optional(),
+    lastChatProvider: z.enum(['copilot', 'codex', 'claude', 'opencode', 'auto']).optional(),
     maxRalphIterations: z.number().int().min(1).max(RALPH_MAX_ITERATIONS_LIMIT).optional(),
     additionalNotesRoots: z.array(z.unknown())
         .transform(arr => {

--- a/packages/coc/src/server/processes/process-resume-handler.ts
+++ b/packages/coc/src/server/processes/process-resume-handler.ts
@@ -13,7 +13,7 @@ import { resolveWorkspaceExecutionContext, translatePathForHostFilesystem } from
 import { sendError, sendJSON, parseBody } from '../core/api-handler';
 import type { Route } from '../types';
 
-export type ResumeProvider = 'copilot' | 'codex' | 'claude';
+export type ResumeProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 export interface LaunchResumeInput {
     sessionId: string;
@@ -34,12 +34,13 @@ export type ResumeCommandLauncher = (input: LaunchResumeInput) => Promise<Launch
 function normalizeResumeProvider(value: unknown): ResumeProvider {
     return value === 'codex' ? 'codex'
         : value === 'claude' ? 'claude'
+        : value === 'opencode' ? 'opencode'
         : 'copilot';
 }
 
 /** Return the validated provider, or undefined when the value is not a known provider. */
 function asResumeProvider(value: unknown): ResumeProvider | undefined {
-    return value === 'copilot' || value === 'codex' || value === 'claude' ? value : undefined;
+    return value === 'copilot' || value === 'codex' || value === 'claude' || value === 'opencode' ? value : undefined;
 }
 
 function toNonEmptyString(value: unknown): string | undefined {
@@ -273,7 +274,7 @@ export async function launchResumeCommandInTerminal(input: LaunchResumeInput): P
 
 export interface LaunchFreshChatInput {
     workingDirectory: string;
-    provider?: 'copilot' | 'codex' | 'claude';
+    provider?: ResumeProvider;
 }
 
 export type FreshChatTerminalLauncher = (input: LaunchFreshChatInput) => Promise<LaunchResumeResult>;
@@ -282,7 +283,7 @@ type MaybePromise<T> = T | Promise<T>;
 function buildFreshChatCommand(
     workingDirectory: string,
     platform: NodeJS.Platform = process.platform,
-    provider: 'copilot' | 'codex' | 'claude' = 'copilot'
+    provider: ResumeProvider = 'copilot'
 ): string {
     let cliCommand: string;
     if (provider === 'codex') {
@@ -300,10 +301,7 @@ function buildFreshChatCommand(
 
 export async function launchFreshChatInTerminal(input: LaunchFreshChatInput): Promise<LaunchResumeResult> {
     const platform = process.platform;
-    const provider: 'copilot' | 'codex' | 'claude' =
-        input.provider === 'codex' ? 'codex' :
-        input.provider === 'claude' ? 'claude' :
-        'copilot';
+    const provider = normalizeResumeProvider(input.provider);
     const terminalWorkingDirectory = platform === 'win32'
         ? translatePathForHostFilesystem(input.workingDirectory)
         : input.workingDirectory;
@@ -347,7 +345,7 @@ export async function launchFreshChatInTerminal(input: LaunchFreshChatInput): Pr
 export function registerFreshChatTerminalRoutes(
     routes: Route[],
     launcher: FreshChatTerminalLauncher = launchFreshChatInTerminal,
-    options?: { getProvider?: () => MaybePromise<'copilot' | 'codex' | 'claude'> }
+    options?: { getProvider?: () => MaybePromise<ResumeProvider> }
 ): void {
     routes.push({
         method: 'POST',
@@ -362,10 +360,7 @@ export function registerFreshChatTerminalRoutes(
             const workingDirectory = toNonEmptyString(body?.workingDirectory) ?? process.cwd();
             try {
                 const rawProvider = await options?.getProvider?.();
-                const provider: 'copilot' | 'codex' | 'claude' =
-                    rawProvider === 'codex' ? 'codex' :
-                    rawProvider === 'claude' ? 'claude' :
-                    'copilot';
+                const provider = normalizeResumeProvider(rawProvider);
                 const result = await launcher({ workingDirectory, provider });
                 process.stderr.write(`[Chat] launch-terminal workingDirectory=${workingDirectory} provider=${provider} launched=${result.launched}\n`);
                 return sendJSON(res, 200, {

--- a/packages/coc/src/server/processes/process-resume-handler.ts
+++ b/packages/coc/src/server/processes/process-resume-handler.ts
@@ -86,6 +86,9 @@ function buildResumeInvocation(provider: ResumeProvider, quotedSessionId: string
     if (provider === 'claude') {
         return `claude --dangerously-skip-permissions --resume ${quotedSessionId}`;
     }
+    if (provider === 'opencode') {
+        return `opencode --resume ${quotedSessionId}`;
+    }
     return `copilot --yolo --resume ${quotedSessionId}`;
 }
 

--- a/packages/coc/src/server/providers/provider-install-routes.ts
+++ b/packages/coc/src/server/providers/provider-install-routes.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import { createRequire } from 'module';
 import type { Route } from '../types';
 import { sendJson, send400, send404, send500 } from '../shared/router';
-import { registerCodexSDKService, registerClaudeSDKService } from '@plusplusoneplusplus/forge';
+import { registerCodexSDKService, registerClaudeSDKService, registerOpenCodeSDKService } from '@plusplusoneplusplus/forge';
 
 // ============================================================================
 // Provider → package name mapping
@@ -31,6 +31,7 @@ import { registerCodexSDKService, registerClaudeSDKService } from '@plusplusonep
 const PROVIDER_PACKAGES: Record<string, string> = {
     codex: '@openai/codex-sdk',
     claude: '@anthropic-ai/claude-agent-sdk',
+    opencode: '@opencode-ai/sdk',
 };
 
 const PROVIDER_INSTALL_PROBES: Record<string, string[]> = {
@@ -39,6 +40,7 @@ const PROVIDER_INSTALL_PROBES: Record<string, string[]> = {
     // dependency is required for quota/model RPCs and exposes a resolvable bin.
     codex: ['@openai/codex/bin/codex.js', '@openai/codex/package.json'],
     claude: ['@anthropic-ai/claude-agent-sdk'],
+    opencode: ['@opencode-ai/sdk'],
 };
 
 // ============================================================================
@@ -128,6 +130,8 @@ function reRegisterProvider(provider: string): void {
         registerCodexSDKService();
     } else if (provider === 'claude') {
         registerClaudeSDKService();
+    } else if (provider === 'opencode') {
+        registerOpenCodeSDKService();
     }
 }
 

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -28,7 +28,7 @@ export interface CLITaskExecutorOptions {
     followUpSuggestions?: { enabled: boolean; count: number };
     askUser?: { enabled: boolean };
     /** Default AI provider name recorded on new processes when the task has no provider override. */
-    provider?: 'copilot' | 'codex' | 'claude';
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     /** Enables the gated multi-agent Ralph grilling prompt contract. */
     ralphMultiAgentGrillEnabled?: boolean;
     /**

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -590,7 +590,7 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
         if (!proc?.pendingMessages?.length) return;
         if (!this.queueManager) return;
         const [nextMsg, ...rest] = proc.pendingMessages;
-        const sessionProvider = proc.metadata?.provider === 'codex' || proc.metadata?.provider === 'claude' || proc.metadata?.provider === 'copilot'
+        const sessionProvider = proc.metadata?.provider === 'codex' || proc.metadata?.provider === 'claude' || proc.metadata?.provider === 'copilot' || proc.metadata?.provider === 'opencode'
             ? proc.metadata.provider
             : 'copilot';
         const resolvedModel = resolveModelForProvider(sessionProvider, nextMsg.model);

--- a/packages/coc/src/server/ralph/grill-planning.ts
+++ b/packages/coc/src/server/ralph/grill-planning.ts
@@ -18,7 +18,7 @@ export const RALPH_GRILL_AGENT_ROLES = [
 ] as const;
 export type RalphGrillAgentRole = typeof RALPH_GRILL_AGENT_ROLES[number];
 
-export type RalphGrillAgentProvider = 'copilot' | 'codex' | 'claude';
+export type RalphGrillAgentProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export const RALPH_GRILL_EFFORT_TIERS = ['very-low', 'low', 'medium', 'high'] as const;
 export type RalphGrillEffortTier = typeof RALPH_GRILL_EFFORT_TIERS[number];
 
@@ -415,7 +415,7 @@ const DEPTH_AGENT_ROLES: Record<RalphGrillDepth, readonly RalphGrillAgentRole[]>
     ],
 };
 
-const PROVIDERS = new Set<RalphGrillAgentProvider>(['copilot', 'codex', 'claude']);
+const PROVIDERS = new Set<RalphGrillAgentProvider>(['copilot', 'codex', 'claude', 'opencode']);
 const EFFORT_TIERS = new Set<RalphGrillEffortTier>(RALPH_GRILL_EFFORT_TIERS);
 const REASONING_EFFORTS = new Set<ReasoningEffort>(['low', 'medium', 'high', 'xhigh']);
 

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Route } from '../types';
 import type { ProcessStore, TaskQueueManager, ISDKService, AIInvoker, CreateTaskInput } from '@plusplusoneplusplus/forge';
-import { modelMetadataStore, sdkServiceRegistry, CopilotSDKService, CodexSDKService, ClaudeSDKService, SDK_PROVIDER_CLAUDE, SDK_PROVIDER_CODEX, getLogger, LogCategory } from '@plusplusoneplusplus/forge';
+import { modelMetadataStore, sdkServiceRegistry, CopilotSDKService, CodexSDKService, ClaudeSDKService, SDK_PROVIDER_CLAUDE, SDK_PROVIDER_CODEX, SDK_PROVIDER_OPENCODE, getLogger, LogCategory } from '@plusplusoneplusplus/forge';
 import type { ProcessWebSocketServer } from '../streaming/websocket';
 import type { MultiRepoQueueRouter } from '../queue/multi-repo-queue-router';
 import type { SqliteQueuePersistence } from '../queue/sqlite-queue-persistence';
@@ -251,6 +251,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
             ?? opts.resolvedConfig?.defaultProvider;
         if (defaultProvider === 'codex') return 'codex';
         if (defaultProvider === 'claude') return 'claude';
+        if (defaultProvider === 'opencode') return 'opencode';
         return 'copilot';
     };
     const concreteDefaultProviderResolution = (provider: ChatProvider = concreteDefaultProvider()): AutoProviderResolutionResult => ({
@@ -284,6 +285,16 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
             availability.claude = svc
                 ? { enabled: true, ...(await svc.isAvailable()) }
                 : { enabled: true, available: false, reason: 'Claude SDK service is not registered.' };
+        }
+
+        const opencodeEnabled = config?.opencode?.enabled ?? false;
+        if (!opencodeEnabled) {
+            availability.opencode = { enabled: false, available: false, reason: 'OpenCode provider is disabled.' };
+        } else {
+            const svc = sdkServiceRegistry.get(SDK_PROVIDER_OPENCODE);
+            availability.opencode = svc
+                ? { enabled: true, ...(await svc.isAvailable()) }
+                : { enabled: true, available: false, reason: 'OpenCode SDK service is not registered.' };
         }
 
         return availability;
@@ -588,6 +599,11 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
                 if (!svc) return { available: false, error: 'Claude SDK service not registered. Restart the server to enable Claude.' };
                 return svc.isAvailable();
             },
+            getOpenCodeAvailability: async () => {
+                const svc = sdkServiceRegistry.get(SDK_PROVIDER_OPENCODE);
+                if (!svc) return { available: false, error: 'OpenCode SDK service not registered. Restart the server to enable OpenCode.' };
+                return svc.isAvailable();
+            },
             getCopilotSdkService: () => CopilotSDKService.getInstance(),
             getCodexSdkService: () => {
                 const svc = sdkServiceRegistry.get(SDK_PROVIDER_CODEX);
@@ -597,6 +613,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
                 const svc = sdkServiceRegistry.get(SDK_PROVIDER_CLAUDE);
                 return svc instanceof ClaudeSDKService ? svc : undefined;
             },
+            getOpenCodeSdkService: () => sdkServiceRegistry.get(SDK_PROVIDER_OPENCODE) ?? undefined,
             configPath,
             loadConfigFile,
             writeConfigFile,

--- a/packages/coc/src/server/routes/native-cli-session-routes.ts
+++ b/packages/coc/src/server/routes/native-cli-session-routes.ts
@@ -61,7 +61,7 @@ function queryNumber(value: unknown): number | undefined {
 
 function parseProvider(value: unknown): NativeCliSessionProviderId | undefined {
     const raw = queryString(value) ?? 'copilot';
-    return raw === 'copilot' || raw === 'codex' || raw === 'claude' ? raw : undefined;
+    return raw === 'copilot' || raw === 'codex' || raw === 'claude' || raw === 'opencode' ? raw : undefined;
 }
 
 export function registerNativeCliSessionRoutes(ctx: NativeCliSessionRouteContext): void {

--- a/packages/coc/src/server/routes/queue-enqueue.ts
+++ b/packages/coc/src/server/routes/queue-enqueue.ts
@@ -663,7 +663,7 @@ export function resolveEffortTierConfig(input: CreateTaskInput, ctx: Pick<QueueR
 }
 
 function isChatProvider(value: unknown): value is ChatProvider {
-    return value === 'copilot' || value === 'codex' || value === 'claude';
+    return value === 'copilot' || value === 'codex' || value === 'claude' || value === 'opencode';
 }
 
 /**

--- a/packages/coc/src/server/routes/ralph-route-utils.ts
+++ b/packages/coc/src/server/routes/ralph-route-utils.ts
@@ -209,7 +209,7 @@ function asString(value: unknown): string | undefined {
 }
 
 function asProvider(value: unknown): ChatProvider | undefined {
-    return value === 'copilot' || value === 'codex' || value === 'claude'
+    return value === 'copilot' || value === 'codex' || value === 'claude' || value === 'opencode'
         ? value
         : undefined;
 }

--- a/packages/coc/src/server/shared/process-history-mapper.ts
+++ b/packages/coc/src/server/shared/process-history-mapper.ts
@@ -27,8 +27,8 @@ export interface HistorySummary {
     lastMessagePreview?: string;
     /** AI-generated title (separate from customTitle). */
     title?: string;
-    /** AI provider that handled this process ('copilot' | 'codex' | 'claude'). */
-    provider?: 'copilot' | 'codex' | 'claude';
+    /** AI provider that handled this process. */
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
 }
 
 interface DreamProcessLinks {
@@ -124,7 +124,7 @@ export function processToHistorySummary(proc: AIProcess): HistorySummary {
         customTitle: proc.customTitle,
         lastMessagePreview: proc.lastMessagePreview,
         title: proc.title,
-        provider: (proc.metadata?.provider === 'codex' ? 'codex' : proc.metadata?.provider === 'claude' ? 'claude' : 'copilot') as 'copilot' | 'codex' | 'claude',
+        provider: (proc.metadata?.provider === 'codex' ? 'codex' : proc.metadata?.provider === 'claude' ? 'claude' : proc.metadata?.provider === 'opencode' ? 'opencode' : 'copilot') as 'copilot' | 'codex' | 'claude' | 'opencode',
     };
 }
 

--- a/packages/coc/src/server/spa/client/react/admin/AIProviderPage.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AIProviderPage.tsx
@@ -53,6 +53,8 @@ export interface AIProviderPageProps {
     setCodexEnabled: (v: boolean) => void;
     claudeEnabled: boolean;
     setClaudeEnabled: (v: boolean) => void;
+    opencodeEnabled: boolean;
+    setOpencodeEnabled: (v: boolean) => void;
     autoAgentProviderRoutingEnabled: boolean;
     setAutoAgentProviderRoutingEnabled: (v: boolean) => void;
     autoRoutingConfig: AdminAutoProviderRoutingConfig | null | undefined;
@@ -60,7 +62,7 @@ export interface AIProviderPageProps {
     providerAvailability: Record<string, { available: boolean; error?: string }>;
     sdkInstallStatuses: Record<string, ProviderInstallStatus>;
     sdkInstallErrors: Record<string, string | undefined>;
-    onInstallSdk: (provider: 'codex' | 'claude') => void;
+    onInstallSdk: (provider: 'codex' | 'claude' | 'opencode') => void;
 
     dirty: boolean;
     saving: boolean;
@@ -76,7 +78,7 @@ export interface AIProviderPageProps {
 }
 
 const DEFAULT_PROVIDER_LABELS: Record<DefaultProvider, string> = PROVIDER_LABELS;
-const PROVIDER_IDS: Provider[] = ['copilot', 'codex', 'claude'];
+const PROVIDER_IDS: Provider[] = ['copilot', 'codex', 'claude', 'opencode'];
 export const DEFAULT_AUTO_PROVIDER_ROUTING_CONFIG: NormalizedAutoProviderRoutingConfig = {
     rules: [
         {
@@ -95,6 +97,15 @@ export const DEFAULT_AUTO_PROVIDER_ROUTING_CONFIG: NormalizedAutoProviderRouting
             weeklyGuard: {
                 enabled: true,
                 minimumRemainingPercent: 33,
+            },
+        },
+        {
+            provider: 'opencode',
+            enabled: true,
+            minimumRemainingPercent: 25,
+            weeklyGuard: {
+                enabled: true,
+                minimumRemainingPercent: 25,
             },
         },
         {
@@ -358,6 +369,7 @@ export function AIProviderPage(props: AIProviderPageProps) {
         defaultProvider, setDefaultProvider,
         codexEnabled, setCodexEnabled,
         claudeEnabled, setClaudeEnabled,
+        opencodeEnabled, setOpencodeEnabled,
         autoAgentProviderRoutingEnabled, setAutoAgentProviderRoutingEnabled, autoRoutingConfig, setAutoRoutingConfig,
         providerAvailability, sdkInstallStatuses, sdkInstallErrors, onInstallSdk,
         dirty, saving, onSave, onCancel,
@@ -409,6 +421,16 @@ export function AIProviderPage(props: AIProviderPageProps) {
             note: '@anthropic-ai/claude-agent-sdk',
             installStatus: sdkInstallStatuses['claude'],
         },
+        {
+            id: 'opencode',
+            label: 'OpenCode',
+            enabled: opencodeEnabled,
+            available: providerAvailability['opencode']?.available ?? false,
+            locked: false,
+            source: 'config',
+            note: 'opencode',
+            installStatus: sdkInstallStatuses['opencode'],
+        },
     ];
 
     const availableCount = providers.filter(p => p.available || p.locked).length;
@@ -426,6 +448,11 @@ export function AIProviderPage(props: AIProviderPageProps) {
                     enabled: claudeEnabled,
                     available: providerAvailability['claude']?.available ?? false,
                     error: providerAvailability['claude']?.error,
+                },
+                opencode: {
+                    enabled: opencodeEnabled,
+                    available: providerAvailability['opencode']?.available ?? false,
+                    error: providerAvailability['opencode']?.error,
                 },
             },
             quotaData,
@@ -774,10 +801,11 @@ export function AIProviderPage(props: AIProviderPageProps) {
                                                 onChange={(v) => {
                                                     if (provider.id === 'codex') setCodexEnabled(v);
                                                     if (provider.id === 'claude') setClaudeEnabled(v);
+                                                    if (provider.id === 'opencode') setOpencodeEnabled(v);
                                                 }}
                                                 disabled={provider.locked}
                                                 label={`Toggle ${provider.label}`}
-                                                testId={provider.id === 'codex' ? 'toggle-codex-enabled' : provider.id === 'claude' ? 'toggle-claude-enabled' : undefined}
+                                                testId={provider.id === 'codex' ? 'toggle-codex-enabled' : provider.id === 'claude' ? 'toggle-claude-enabled' : provider.id === 'opencode' ? 'toggle-opencode-enabled' : undefined}
                                             />
                                         </td>
                                     </tr>
@@ -839,11 +867,11 @@ export function AIProviderPage(props: AIProviderPageProps) {
                         activeModelProvider === 'copilot'
                             ? true
                             : (providerAvailability[activeModelProvider]?.available ?? false)
-                                && (activeModelProvider === 'codex' ? codexEnabled : claudeEnabled)
+                                && (activeModelProvider === 'codex' ? codexEnabled : activeModelProvider === 'claude' ? claudeEnabled : opencodeEnabled)
                     }
                     unavailableMessage={
-                        activeModelProvider !== 'copilot' && !(activeModelProvider === 'codex' ? codexEnabled : claudeEnabled)
-                            ? `Enable the ${activeModelProvider === 'codex' ? 'Codex' : 'Claude'} provider above to access its model catalog.`
+                        activeModelProvider !== 'copilot' && !(activeModelProvider === 'codex' ? codexEnabled : activeModelProvider === 'claude' ? claudeEnabled : opencodeEnabled)
+                            ? `Enable the ${PROVIDER_LABELS[activeModelProvider]} provider above to access its model catalog.`
                             : providerAvailability[activeModelProvider]?.error
                     }
                     allProviders={PROVIDER_IDS}

--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -107,6 +107,7 @@ type DefaultProviderSnapshot = {
     provider: AdminDefaultProvider;
     codexEnabled: boolean;
     claudeEnabled: boolean;
+    opencodeEnabled: boolean;
     autoAgentProviderRouting: boolean;
     autoRoutingConfig: NormalizedAutoProviderRoutingConfig;
 };
@@ -381,6 +382,7 @@ export function AdminPanel() {
     const [autoAgentProviderRoutingEnabled, setAutoAgentProviderRoutingEnabled] = useState(false);
     const [codexEnabled, setCodexEnabled] = useState(false);
     const [claudeEnabled, setClaudeEnabled] = useState(false);
+    const [opencodeEnabled, setOpencodeEnabled] = useState(false);
     const [defaultProvider, setDefaultProvider] = useState<AdminDefaultProvider>('copilot');
     const [autoRoutingConfig, setAutoRoutingConfig] = useState<NormalizedAutoProviderRoutingConfig>(() => normalizeAutoProviderRoutingConfig(undefined));
     const [providerAvailability, setProviderAvailability] = useState<Record<string, { available: boolean; error?: string }>>({});
@@ -425,6 +427,7 @@ export function AdminPanel() {
         provider: 'copilot',
         codexEnabled: false,
         claudeEnabled: false,
+        opencodeEnabled: false,
         autoAgentProviderRouting: false,
         autoRoutingConfig: normalizeAutoProviderRoutingConfig(undefined),
     });
@@ -538,12 +541,14 @@ export function AdminPanel() {
             setCodexEnabled(cxe);
             const cle = resolved.claude?.enabled ?? false;
             setClaudeEnabled(cle);
-            const dp = (resolved.defaultProvider === 'codex' ? 'codex' : resolved.defaultProvider === 'claude' ? 'claude' : 'copilot') as AdminDefaultProvider;
+            const oce = resolved.opencode?.enabled ?? false;
+            setOpencodeEnabled(oce);
+            const dp = (resolved.defaultProvider === 'codex' ? 'codex' : resolved.defaultProvider === 'claude' ? 'claude' : resolved.defaultProvider === 'opencode' ? 'opencode' : 'copilot') as AdminDefaultProvider;
             const arc = normalizeAutoProviderRoutingConfig(resolved.agentProviderRouting?.auto);
             setDefaultProvider(dp);
             setAutoRoutingConfig(arc);
             setAiExecSnapshot({ model: form.model, parallel: form.parallel, timeout: form.timeout, output: form.output });
-            setDefaultProviderSnapshot({ provider: dp, codexEnabled: cxe, claudeEnabled: cle, autoAgentProviderRouting: aapre, autoRoutingConfig: arc });
+            setDefaultProviderSnapshot({ provider: dp, codexEnabled: cxe, claudeEnabled: cle, opencodeEnabled: oce, autoAgentProviderRouting: aapre, autoRoutingConfig: arc });
             const sgr = resolved.sync?.gitRemote ?? '';
             const sim = String(resolved.sync?.intervalMinutes ?? 5);
             setSyncGitRemote(sgr);
@@ -623,6 +628,7 @@ export function AdminPanel() {
     const defaultProviderDirty = defaultProvider !== defaultProviderSnapshot.provider ||
         codexEnabled !== defaultProviderSnapshot.codexEnabled ||
         claudeEnabled !== defaultProviderSnapshot.claudeEnabled ||
+        opencodeEnabled !== defaultProviderSnapshot.opencodeEnabled ||
         autoAgentProviderRoutingEnabled !== defaultProviderSnapshot.autoAgentProviderRouting ||
         !autoRoutingConfigsEqual(autoRoutingConfig, defaultProviderSnapshot.autoRoutingConfig);
 
@@ -696,6 +702,7 @@ export function AdminPanel() {
                 defaultProvider,
                 'codex.enabled': codexEnabled,
                 'claude.enabled': claudeEnabled,
+                'opencode.enabled': opencodeEnabled,
                 'features.autoAgentProviderRouting': autoAgentProviderRoutingEnabled,
             };
             if (autoAgentProviderRoutingEnabled) {
@@ -704,18 +711,19 @@ export function AdminPanel() {
             await getSpaCocClient().admin.updateConfig(payload);
             addToast('AI provider settings saved — restart required to apply changes', 'success');
             setAutoRoutingConfig(normalizedAutoRouting);
-            setDefaultProviderSnapshot({ provider: defaultProvider, codexEnabled, claudeEnabled, autoAgentProviderRouting: autoAgentProviderRoutingEnabled, autoRoutingConfig: normalizedAutoRouting });
+            setDefaultProviderSnapshot({ provider: defaultProvider, codexEnabled, claudeEnabled, opencodeEnabled, autoAgentProviderRouting: autoAgentProviderRoutingEnabled, autoRoutingConfig: normalizedAutoRouting });
         } catch (err: unknown) {
             addToast(getSpaCocClientErrorMessage(err, 'Save failed'), 'error');
         } finally {
             setDefaultProviderSaving(false);
         }
-    }, [defaultProvider, autoAgentProviderRoutingEnabled, codexEnabled, claudeEnabled, autoRoutingConfig, addToast]);
+    }, [defaultProvider, autoAgentProviderRoutingEnabled, codexEnabled, claudeEnabled, opencodeEnabled, autoRoutingConfig, addToast]);
 
     const handleCancelDefaultProvider = useCallback(() => {
         setDefaultProvider(defaultProviderSnapshot.provider);
         setCodexEnabled(defaultProviderSnapshot.codexEnabled);
         setClaudeEnabled(defaultProviderSnapshot.claudeEnabled);
+        setOpencodeEnabled(defaultProviderSnapshot.opencodeEnabled);
         setAutoAgentProviderRoutingEnabled(defaultProviderSnapshot.autoAgentProviderRouting);
         setAutoRoutingConfig(defaultProviderSnapshot.autoRoutingConfig);
     }, [defaultProviderSnapshot]);
@@ -2051,6 +2059,8 @@ export function AdminPanel() {
                                     setCodexEnabled={setCodexEnabled}
                                     claudeEnabled={claudeEnabled}
                                     setClaudeEnabled={setClaudeEnabled}
+                                    opencodeEnabled={opencodeEnabled}
+                                    setOpencodeEnabled={setOpencodeEnabled}
                                     autoAgentProviderRoutingEnabled={autoAgentProviderRoutingEnabled}
                                     setAutoAgentProviderRoutingEnabled={setAutoAgentProviderRoutingEnabled}
                                     autoRoutingConfig={autoRoutingConfig}

--- a/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
+++ b/packages/coc/src/server/spa/client/react/admin/admin-redesign.css
@@ -1467,6 +1467,14 @@
   background: #f5ebe4;
   color: #d97757;
 }
+.admin-redesign .aip-avatar-opencode {
+  background: #131010;
+  color: #fff;
+}
+[data-theme="light"] .admin-redesign .aip-avatar-opencode {
+  background: #131010;
+  color: #fff;
+}
 .admin-redesign .aip-provider-main {
   min-width: 0;
   display: block;

--- a/packages/coc/src/server/spa/client/react/features/chat/ComposerMetaStrip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ComposerMetaStrip.tsx
@@ -33,7 +33,7 @@ export interface ComposerMetaStripProps {
      * which provider is handling their chat. When `undefined` or `'copilot'`
      * no badge is shown (copilot is the default and the badge adds no value).
      */
-    activeProvider?: 'copilot' | 'codex' | 'claude';
+    activeProvider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     className?: string;
     /** System-prompt token count when the provider reports a breakdown. */
     sessionSystemTokens?: number;

--- a/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
@@ -161,7 +161,7 @@ export interface FollowUpInputAreaProps {
     /** Conversation-history token count (Copilot SDK only). */
     sessionConversationTokens?: number;
     /** Active AI provider — shown as a read-only badge in the toolbar when set to 'codex' or 'claude'. */
-    activeProvider?: 'copilot' | 'codex' | 'claude';
+    activeProvider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     /**
      * Current per-turn reasoning-effort override (`'low' | 'medium' | 'high' | 'xhigh'`).
      * `null` means no override — the executor falls back to the persisted

--- a/packages/coc/src/server/spa/client/react/features/chat/ForEachPlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ForEachPlanReviewCard.tsx
@@ -51,7 +51,7 @@ export interface ForEachPlanReviewCardProps {
     metadataProcess: any;
     forEach: ForEachGenerationMetadata;
     turns: ClientConversationTurn[];
-    provider?: 'copilot' | 'codex' | 'claude';
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     model?: string;
     reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
     onApprovedRun?: (runId: string) => void;

--- a/packages/coc/src/server/spa/client/react/features/chat/MapReducePlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/MapReducePlanReviewCard.tsx
@@ -58,7 +58,7 @@ export interface MapReducePlanReviewCardProps {
     metadataProcess: any;
     mapReduce: MapReduceGenerationMetadata;
     turns: ClientConversationTurn[];
-    provider?: 'copilot' | 'codex' | 'claude';
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     model?: string;
     reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
     onApprovedRun?: (runId: string) => void;

--- a/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ProviderBadge.tsx
@@ -19,7 +19,7 @@
 
 import { cn } from '../../ui/cn';
 
-export type ChatProvider = 'copilot' | 'codex' | 'claude';
+export type ChatProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export type ProviderBadgeProvider = ChatProvider | 'auto-pending';
 
 interface ProviderColorVariant {
@@ -53,6 +53,13 @@ const PROVIDER_VARIANTS: Record<ChatProvider, ProviderColorVariant> = {
             'bg-[#eef0ff] text-[#4f46e5] border-[#c7d2fe]'
             + ' dark:bg-[#1a1c3d] dark:text-[#a5b4fc] dark:border-[#3c40a0]',
     },
+    opencode: {
+        pill: 'border-[#0ea5e9]/45 bg-[#0ea5e9]/12 text-[#0284c7] dark:text-[#7dd3fc]',
+        dot: 'bg-[#0ea5e9] dark:bg-[#7dd3fc]',
+        avatar:
+            'bg-[#e0f2fe] text-[#0284c7] border-[#bae6fd]'
+            + ' dark:bg-[#0c2d4d] dark:text-[#7dd3fc] dark:border-[#1e5a8a]',
+    },
 };
 
 const AUTO_PENDING_VARIANT: ProviderColorVariant = {
@@ -66,7 +73,7 @@ export function getTaskChatProvider(task: any): ChatProvider | undefined {
         ?? task?.metadata?.provider
         ?? task?.metadata?.autoProviderRouting?.provider
         ?? task?.payload?.provider;
-    return provider === 'copilot' || provider === 'codex' || provider === 'claude'
+    return provider === 'copilot' || provider === 'codex' || provider === 'claude' || provider === 'opencode'
         ? provider
         : undefined;
 }
@@ -119,7 +126,9 @@ export function ProviderBadge({ provider, className }: ProviderBadgeProps) {
             ? 'Codex'
             : provider === 'claude'
                 ? 'Claude'
-                : 'Copilot';
+                : provider === 'opencode'
+                    ? 'OpenCode'
+                    : 'Copilot';
     const variant = provider === 'auto-pending'
         ? AUTO_PENDING_VARIANT
         : PROVIDER_VARIANTS[provider] ?? PROVIDER_VARIANTS.copilot;

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphGrillSetupPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphGrillSetupPanel.tsx
@@ -99,7 +99,7 @@ function buildProviderOptions(rawProviders: ReturnType<typeof useAgentProviders>
             .map(provider => [provider.id, provider] as const),
     );
 
-    return (['copilot', 'codex', 'claude'] as const).map((id) => {
+    return (['copilot', 'codex', 'claude', 'opencode'] as const).map((id) => {
         const provider = byId.get(id);
         const disabled = id !== 'copilot' && (provider?.enabled !== true || provider?.available !== true);
         return {

--- a/packages/coc/src/server/spa/client/react/features/dreams/DreamsView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/dreams/DreamsView.tsx
@@ -24,7 +24,7 @@ export interface DreamsConfigForm {
     /** Global `dreams.enabled` flag — gates idle-time reflection everywhere. */
     enabled: boolean;
     /** Default provider for idle-triggered Dream runs; blank uses the global default provider. */
-    provider: '' | 'copilot' | 'codex' | 'claude';
+    provider: '' | 'copilot' | 'codex' | 'claude' | 'opencode';
     /** Optional default model for idle-triggered Dream runs. */
     model: string;
     /** Default Dream AI request timeout, edited in minutes and persisted as milliseconds. */

--- a/packages/coc/src/server/spa/client/react/features/git/diff/useClassification.ts
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/useClassification.ts
@@ -31,7 +31,7 @@ import type { ResolvedModalJobAiSelection } from '../../../shared/ModalJobAiCont
 // ── Public types ──────────────────────────────────────────────────────
 
 /** AI provider identifier (mirrors server ChatProvider). */
-export type ChatProvider = 'copilot' | 'codex' | 'claude';
+export type ChatProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 export type ClassificationStatus = 'idle' | 'loading' | 'ready' | 'error';
 

--- a/packages/coc/src/server/spa/client/react/features/native-copilot-sessions/NativeCopilotSessionsPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/native-copilot-sessions/NativeCopilotSessionsPanel.tsx
@@ -41,7 +41,7 @@ import {
     toNativeSessionMetadataProcess,
 } from './nativeSessionChatAdapter';
 
-const PROVIDERS: NativeCliSessionProviderId[] = ['copilot', 'codex', 'claude'];
+const PROVIDERS: NativeCliSessionProviderId[] = ['copilot', 'codex', 'claude', 'opencode'];
 
 const PROVIDER_META: Record<NativeCliSessionProviderId, { label: string; externalLabel: string; store: string }> = {
     codex: {

--- a/packages/coc/src/server/spa/client/react/features/native-copilot-sessions/NativeCopilotSessionsPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/native-copilot-sessions/NativeCopilotSessionsPanel.tsx
@@ -59,6 +59,11 @@ const PROVIDER_META: Record<NativeCliSessionProviderId, { label: string; externa
         externalLabel: 'Native Copilot CLI session',
         store: '~/.copilot/session-store.db',
     },
+    opencode: {
+        label: 'OpenCode',
+        externalLabel: 'Native OpenCode CLI session',
+        store: '~/.opencode/session-store.db',
+    },
 };
 
 function readOnlyTooltip(provider: NativeCliSessionProviderId, storePath?: string | null): string {

--- a/packages/coc/src/server/spa/client/react/hooks/useProviderModels.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/useProviderModels.ts
@@ -104,7 +104,7 @@ function mapModelsResponse(data: unknown): ProviderModelInfo[] {
     return Array.isArray(models) ? models.map(mapModel) : [];
 }
 
-export type AgentProvider = 'copilot' | 'codex' | 'claude';
+export type AgentProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 export function useProviderModels(provider: AgentProvider): {
     models: ProviderModelInfo[];

--- a/packages/coc/src/server/spa/client/react/shared/providerActivity.ts
+++ b/packages/coc/src/server/spa/client/react/shared/providerActivity.ts
@@ -1,7 +1,7 @@
 import type { AgentProviderId, QueueListResponse, QueueHistoryResponse, QueueTaskSummary } from '@plusplusoneplusplus/coc-client';
 import { getSpaCocClient } from '../api/cocClient';
 
-const PROVIDER_IDS = new Set<AgentProviderId>(['copilot', 'codex', 'claude']);
+const PROVIDER_IDS = new Set<AgentProviderId>(['copilot', 'codex', 'claude', 'opencode']);
 const ACTIVE_STATUSES = new Set(['queued', 'running']);
 
 export interface AgentProviderWorkActivity {

--- a/packages/coc/src/server/spa/client/react/shared/providerVisuals.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/providerVisuals.tsx
@@ -11,7 +11,7 @@ import type { AdminConcreteAgentProvider } from '@plusplusoneplusplus/coc-client
 
 export type Provider = AdminConcreteAgentProvider;
 
-export const PROVIDER_LABELS: Record<Provider, string> = { copilot: 'Copilot', codex: 'Codex', claude: 'Claude' };
+export const PROVIDER_LABELS: Record<Provider, string> = { copilot: 'Copilot', codex: 'Codex', claude: 'Claude', opencode: 'OpenCode' };
 
 function CopilotIcon() {
     return (
@@ -37,10 +37,19 @@ function ClaudeIcon() {
     );
 }
 
+function OpenCodeIcon() {
+    return (
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15l-1-1 4-4-4-4 1-1 5 5-5 5zm-3-2l-1 1-5-5 5-5 1 1-4 4 4 4z" />
+        </svg>
+    );
+}
+
 export const PROVIDER_ICONS: Record<Provider, () => JSX.Element> = {
     copilot: CopilotIcon,
     codex: OpenAIIcon,
     claude: ClaudeIcon,
+    opencode: OpenCodeIcon,
 };
 
 export function ProviderAvatar({ provider }: { provider: Provider }) {

--- a/packages/coc/src/server/spa/client/react/shared/providerVisuals.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/providerVisuals.tsx
@@ -38,9 +38,14 @@ function ClaudeIcon() {
 }
 
 function OpenCodeIcon() {
+    // Official OpenCode logomark (their favicon): a blocky "o" — a white
+    // rounded outline with a gray inner block. Two-tone by design, so it uses
+    // explicit brand fills rather than `currentColor`; the dark backdrop comes
+    // from the `aip-avatar-opencode` CSS background.
     return (
-        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15l-1-1 4-4-4-4 1-1 5 5-5 5zm-3-2l-1 1-5-5 5-5 1 1-4 4 4 4z" />
+        <svg viewBox="0 0 512 512" width="18" height="18" fill="none" aria-hidden="true">
+            <path d="M320 224V352H192V224H320Z" fill="#5A5858" />
+            <path fillRule="evenodd" clipRule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="#fff" />
         </svg>
     );
 }

--- a/packages/coc/src/server/spa/client/react/utils/config.ts
+++ b/packages/coc/src/server/spa/client/react/utils/config.ts
@@ -49,8 +49,10 @@ interface DashboardConfig {
     bindAddress?: string;
     /** Whether the Codex SDK provider is enabled (feature flag). */
     codexEnabled?: boolean;
+    /** Whether the OpenCode SDK provider is enabled (feature flag). */
+    opencodeEnabled?: boolean;
     /** Concrete default AI provider when Auto routing is disabled. */
-    defaultProvider?: 'copilot' | 'codex' | 'claude';
+    defaultProvider?: 'copilot' | 'codex' | 'claude' | 'opencode';
     /** Whether Auto agent provider routing is enabled. */
     autoAgentProviderRoutingEnabled?: boolean;
     /** Whether the Work Items hierarchy board is enabled (feature flag). */
@@ -422,17 +424,17 @@ export function isEffortLevelsEnabled(): boolean {
 }
 
 /** Returns the configured concrete default AI provider. */
-export function getConfiguredDefaultProvider(): 'copilot' | 'codex' | 'claude' {
+export function getConfiguredDefaultProvider(): 'copilot' | 'codex' | 'claude' | 'opencode' {
     return getConfig().defaultProvider ?? 'copilot';
 }
 
 /** Returns the concrete default AI provider for UI surfaces that require an SDK provider. */
-export function getDefaultProvider(): 'copilot' | 'codex' | 'claude' {
+export function getDefaultProvider(): 'copilot' | 'codex' | 'claude' | 'opencode' {
     return getConfiguredDefaultProvider();
 }
 
 /** Returns the currently active provider (alias for getDefaultProvider). */
-export function getActiveProvider(): 'copilot' | 'codex' | 'claude' {
+export function getActiveProvider(): 'copilot' | 'codex' | 'claude' | 'opencode' {
     return getDefaultProvider();
 }
 

--- a/packages/coc/src/server/spa/client/react/utils/providerSelection.ts
+++ b/packages/coc/src/server/spa/client/react/utils/providerSelection.ts
@@ -2,7 +2,7 @@ import type { AgentProviderStatus } from '@plusplusoneplusplus/coc-client';
 import type { EffortTierKey, LocalEffortTiersMap } from '../hooks/useProviderEffortTiers';
 import { getConfiguredDefaultProvider, getDefaultProvider, isAutoAgentProviderRoutingEnabled } from './config';
 
-export type ConcreteChatProvider = 'copilot' | 'codex' | 'claude';
+export type ConcreteChatProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 export type ChatProvider = ConcreteChatProvider | 'auto';
 
 export interface AgentSelectorProvider {
@@ -37,7 +37,7 @@ export const AUTO_EFFORT_TIER_MAP: LocalEffortTiersMap = {
 };
 
 export function isConcreteChatProvider(value: unknown): value is ConcreteChatProvider {
-    return value === 'copilot' || value === 'codex' || value === 'claude';
+    return value === 'copilot' || value === 'codex' || value === 'claude' || value === 'opencode';
 }
 
 export function isChatProvider(value: unknown): value is ChatProvider {

--- a/packages/coc/src/server/streaming/sse-handler.ts
+++ b/packages/coc/src/server/streaming/sse-handler.ts
@@ -454,7 +454,7 @@ function sendEvent(res: ServerResponse, event: string, data: unknown): void {
  * key matches the SDK service that owns the registry for that conversation.
  */
 function resolveProviderId(provider: unknown): string {
-    return provider === 'codex' || provider === 'claude' || provider === 'copilot'
+    return provider === 'codex' || provider === 'claude' || provider === 'copilot' || provider === 'opencode'
         ? provider
         : 'copilot';
 }

--- a/packages/coc/src/server/tasks/task-types.ts
+++ b/packages/coc/src/server/tasks/task-types.ts
@@ -453,10 +453,10 @@ export type PostAction =
 // ============================================================================
 
 /** Supported AI provider IDs for per-chat routing. */
-export type ChatProvider = 'copilot' | 'codex' | 'claude';
+export type ChatProvider = 'copilot' | 'codex' | 'claude' | 'opencode';
 
 /** Supported ChatProvider values (for runtime validation). */
-export const VALID_CHAT_PROVIDERS: ReadonlySet<ChatProvider> = new Set(['copilot', 'codex', 'claude']);
+export const VALID_CHAT_PROVIDERS: ReadonlySet<ChatProvider> = new Set(['copilot', 'codex', 'claude', 'opencode']);
 
 export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 

--- a/packages/coc/src/server/tasks/task-types.ts
+++ b/packages/coc/src/server/tasks/task-types.ts
@@ -526,7 +526,7 @@ export interface ChatPayload {
     /**
      * AI provider to use for this chat task.
      * Defaults to the server-level default provider when omitted.
-     * Supported values: 'copilot' | 'codex' | 'claude'.
+     * Supported values: 'copilot' | 'codex' | 'claude' | 'opencode'.
      */
     provider?: ChatProvider;
     /** Per-turn reasoning-effort override, normalized to task config by queue validation. */

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -1009,6 +1009,8 @@ timeout: 300
                 '  enabled: true',
                 'claude:',
                 '  enabled: true',
+                'opencode:',
+                '  enabled: true',
                 'defaultProvider: codex',
                 'features:',
                 '  autoMemoryPromotion: true',
@@ -1302,6 +1304,9 @@ timeout: 300
                   "notes": {
                     "enabled": false,
                   },
+                  "opencode": {
+                    "enabled": false,
+                  },
                   "output": "markdown",
                   "parallel": 12,
                   "persist": false,
@@ -1426,6 +1431,7 @@ timeout: 300
                   "myLife.enabled": "file",
                   "myWork.enabled": "file",
                   "notes.enabled": "file",
+                  "opencode.enabled": "default",
                   "output": "file",
                   "parallel": "file",
                   "persist": "file",

--- a/packages/coc/test/config/runtime-config-service.test.ts
+++ b/packages/coc/test/config/runtime-config-service.test.ts
@@ -237,7 +237,7 @@ describe('RuntimeConfigService', () => {
 
             await expect(
                 svc.updateConfig({ defaultProvider: 'auto' }),
-            ).rejects.toThrow('defaultProvider must be "copilot", "codex", or "claude"');
+            ).rejects.toThrow('defaultProvider must be "copilot", "codex", "claude", or "opencode"');
 
             expect(svc.revision).toBe(0);
             expect(svc.config.defaultProvider).toBe('copilot');

--- a/packages/coc/test/server/agent-providers.test.ts
+++ b/packages/coc/test/server/agent-providers.test.ts
@@ -184,17 +184,18 @@ describe('Claude provider when enabled but SDK unavailable', () => {
 // ── Response shape ────────────────────────────────────────────────────────────
 
 describe('response shape', () => {
-    it('always returns three providers in order: copilot, codex, claude', async () => {
+    it('always returns four providers in order: copilot, codex, claude, opencode', async () => {
         const svc = makeService(false);
         const { providers } = await buildAgentProvidersResponse({
             runtimeConfigService: svc,
             getCodexAvailability: codexUnavailable,
             getClaudeAvailability: claudeUnavailable,
         });
-        expect(providers).toHaveLength(3);
+        expect(providers).toHaveLength(4);
         expect(providers[0].id).toBe('copilot');
         expect(providers[1].id).toBe('codex');
         expect(providers[2].id).toBe('claude');
+        expect(providers[3].id).toBe('opencode');
     });
 
     it('codex is visible in the providers list even when disabled', async () => {

--- a/packages/coc/test/server/spa/client/shared/providerVisuals.test.tsx
+++ b/packages/coc/test/server/spa/client/shared/providerVisuals.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the shared provider brand visuals (`providerVisuals.tsx`) used by
+ * the AI Provider admin page and the Dreams provider-activity section.
+ *
+ * Focus: the OpenCode brand icon. It must render the real OpenCode logomark
+ * (white blocky "o" outline + gray inner block) rather than the old generic
+ * placeholder, and `ProviderAvatar` must wire up the per-provider CSS class so
+ * the `aip-avatar-opencode` dark backdrop applies.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import {
+    PROVIDER_LABELS,
+    PROVIDER_ICONS,
+    ProviderAvatar,
+} from '../../../../../src/server/spa/client/react/shared/providerVisuals';
+
+afterEach(() => cleanup());
+
+const ALL_PROVIDERS = ['copilot', 'codex', 'claude', 'opencode'] as const;
+
+describe('providerVisuals registry', () => {
+    it('exposes a label, icon, and avatar for every provider', () => {
+        for (const provider of ALL_PROVIDERS) {
+            expect(PROVIDER_LABELS[provider]).toBeTruthy();
+            expect(typeof PROVIDER_ICONS[provider]).toBe('function');
+        }
+    });
+
+    it('labels OpenCode as "OpenCode"', () => {
+        expect(PROVIDER_LABELS.opencode).toBe('OpenCode');
+    });
+});
+
+describe('ProviderAvatar', () => {
+    it('applies the provider-specific avatar class for each provider', () => {
+        for (const provider of ALL_PROVIDERS) {
+            const { container } = render(<ProviderAvatar provider={provider} />);
+            const avatar = container.querySelector('span.aip-avatar');
+            expect(avatar).toBeTruthy();
+            expect(avatar!.classList.contains(`aip-avatar-${provider}`)).toBe(true);
+            // Each avatar renders exactly one inline SVG icon.
+            expect(container.querySelectorAll('svg').length).toBe(1);
+            cleanup();
+        }
+    });
+
+    it('renders the real OpenCode logomark with its two-tone brand fills', () => {
+        const { container } = render(<ProviderAvatar provider="opencode" />);
+        const svg = container.querySelector('svg')!;
+        expect(svg).toBeTruthy();
+        // The official logomark uses a 512x512 viewBox.
+        expect(svg.getAttribute('viewBox')).toBe('0 0 512 512');
+
+        const fills = Array.from(svg.querySelectorAll('path')).map((p) => p.getAttribute('fill'));
+        // White outer "o" outline + gray inner block — the OpenCode brand colors.
+        expect(fills).toContain('#fff');
+        expect(fills).toContain('#5A5858');
+    });
+
+    it('no longer renders the old generic placeholder (24x24 currentColor circle)', () => {
+        const { container } = render(<ProviderAvatar provider="opencode" />);
+        const svg = container.querySelector('svg')!;
+        // Old placeholder used a 0 0 24 24 viewBox and a single currentColor path.
+        expect(svg.getAttribute('viewBox')).not.toBe('0 0 24 24');
+        const fills = Array.from(svg.querySelectorAll('path')).map((p) => p.getAttribute('fill'));
+        expect(fills).not.toContain('currentColor');
+    });
+});

--- a/packages/coc/test/spa/react/AdminPanel.test.tsx
+++ b/packages/coc/test/spa/react/AdminPanel.test.tsx
@@ -1688,6 +1688,7 @@ describe('AdminPanel', () => {
                             resolved: {
                                 codex: { enabled: true },
                                 claude: { enabled: true },
+                                opencode: { enabled: false },
                                 defaultProvider: 'copilot',
                                 features: { autoAgentProviderRouting: true },
                                 agentProviderRouting: {
@@ -1696,6 +1697,7 @@ describe('AdminPanel', () => {
                                             { provider: 'claude', enabled: true, minimumRemainingPercent: 33, weeklyGuard: { enabled: true, minimumRemainingPercent: 33 } },
                                             { provider: 'codex', enabled: true, minimumRemainingPercent: 33, weeklyGuard: { enabled: true, minimumRemainingPercent: 33 } },
                                             { provider: 'copilot', enabled: true, minimumRemainingPercent: 10, weeklyGuard: { enabled: true, minimumRemainingPercent: 10 } },
+                                            { provider: 'opencode', enabled: true, minimumRemainingPercent: 25, weeklyGuard: { enabled: true, minimumRemainingPercent: 25 } },
                                         ],
                                         fallbackProvider: 'copilot',
                                     },
@@ -1708,7 +1710,7 @@ describe('AdminPanel', () => {
                 if (url.includes('/admin/providers/availability')) {
                     return Promise.resolve({
                         ok: true,
-                        json: () => Promise.resolve({ codex: { available: true }, claude: { available: true } }),
+                        json: () => Promise.resolve({ codex: { available: true }, claude: { available: true }, opencode: { available: false, error: 'SDK not installed' } }),
                     });
                 }
                 if (url.includes('/agent-providers/quota')) {
@@ -1720,6 +1722,7 @@ describe('AdminPanel', () => {
                                 { id: 'claude', quotaTypes: [{ type: 'five_hour', isUnlimitedEntitlement: false, usedRequests: 10, entitlementRequests: 100, remainingPercentage: 0.9, usageAllowedWithExhaustedQuota: false, overage: 0 }] },
                                 { id: 'codex', quotaTypes: [{ type: 'five_hour', isUnlimitedEntitlement: false, usedRequests: 10, entitlementRequests: 100, remainingPercentage: 0.9, usageAllowedWithExhaustedQuota: false, overage: 0 }] },
                                 { id: 'copilot', quotaTypes: [{ type: 'five_hour', isUnlimitedEntitlement: false, usedRequests: 10, entitlementRequests: 100, remainingPercentage: 0.9, usageAllowedWithExhaustedQuota: false, overage: 0 }] },
+                                { id: 'opencode', quotaTypes: [{ type: 'five_hour', isUnlimitedEntitlement: false, usedRequests: 10, entitlementRequests: 100, remainingPercentage: 0.9, usageAllowedWithExhaustedQuota: false, overage: 0 }] },
                             ],
                         }),
                     });
@@ -1731,6 +1734,7 @@ describe('AdminPanel', () => {
                             providers: [
                                 { id: 'codex', installStatus: 'installed' },
                                 { id: 'claude', installStatus: 'installed' },
+                                { id: 'opencode', installStatus: 'not-installed' },
                             ],
                         }),
                     });
@@ -1763,6 +1767,7 @@ describe('AdminPanel', () => {
                     expect.objectContaining({ provider: 'claude', minimumRemainingPercent: 35 }),
                     expect.objectContaining({ provider: 'codex', minimumRemainingPercent: 33 }),
                     expect.objectContaining({ provider: 'copilot', minimumRemainingPercent: 10 }),
+                    expect.objectContaining({ provider: 'opencode', minimumRemainingPercent: 25 }),
                 ],
             }));
         });

--- a/packages/coc/test/spa/react/admin/AIProviderPage.test.tsx
+++ b/packages/coc/test/spa/react/admin/AIProviderPage.test.tsx
@@ -42,10 +42,12 @@ function makeProps(overrides: Partial<AIProviderPageProps> = {}): AIProviderPage
         providerAvailability: {
             codex: { available: true },
             claude: { available: false, error: 'SDK not installed' },
+            opencode: { available: false, error: 'SDK not installed' },
         },
         sdkInstallStatuses: {
             codex: 'installed',
             claude: 'not-installed',
+            opencode: 'not-installed',
         },
         sdkInstallErrors: {},
         onInstallSdk: vi.fn(),
@@ -173,7 +175,7 @@ describe('AIProviderPage', () => {
 
     it('shows provider health count', () => {
         renderPage();
-        expect(screen.getByText(/2 \/ 3/)).toBeDefined();
+        expect(screen.getByText(/2 \/ 4/)).toBeDefined();
     });
 
     it('shows "All providers available" when all are available', () => {
@@ -181,6 +183,7 @@ describe('AIProviderPage', () => {
             providerAvailability: {
                 codex: { available: true },
                 claude: { available: true },
+                opencode: { available: true },
             },
         });
         expect(screen.getByText('All providers available')).toBeDefined();
@@ -188,15 +191,16 @@ describe('AIProviderPage', () => {
 
     it('shows unavailable count when some providers are down', () => {
         renderPage();
-        expect(screen.getByText(/1 unavailable/)).toBeDefined();
+        expect(screen.getByText(/2 unavailable/)).toBeDefined();
     });
 
     // ────────────── Provider routing table ──────────────
-    it('renders three provider rows in the routing table', () => {
+    it('renders four provider rows in the routing table', () => {
         renderPage();
         expect(screen.getByTestId('provider-row-copilot')).toBeDefined();
         expect(screen.getByTestId('provider-row-codex')).toBeDefined();
         expect(screen.getByTestId('provider-row-claude')).toBeDefined();
+        expect(screen.getByTestId('provider-row-opencode')).toBeDefined();
     });
 
     it('renders provider avatars with SVG icons', () => {
@@ -216,8 +220,8 @@ describe('AIProviderPage', () => {
 
     it('renders install status badges', () => {
         renderPage();
-        expect(screen.getByTestId('sdk-install-badge-installed')).toBeDefined();
-        expect(screen.getByTestId('sdk-install-badge-not-installed')).toBeDefined();
+        expect(screen.queryByTestId('sdk-install-badge-installed')).toBeDefined();
+        expect(screen.getAllByTestId('sdk-install-badge-not-installed').length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders "Built in" badge for copilot', () => {
@@ -287,9 +291,11 @@ describe('AIProviderPage', () => {
         expect(screen.getByTestId('auto-provider-rule-claude')).toBeDefined();
         expect(screen.getByTestId('auto-provider-rule-codex')).toBeDefined();
         expect(screen.getByTestId('auto-provider-rule-copilot')).toBeDefined();
+        expect(screen.getByTestId('auto-provider-rule-opencode')).toBeDefined();
         expect((screen.getByTestId('auto-provider-threshold-claude') as HTMLInputElement).value).toBe('33');
         expect((screen.getByTestId('auto-provider-threshold-codex') as HTMLInputElement).value).toBe('33');
         expect((screen.getByTestId('auto-provider-threshold-copilot') as HTMLInputElement).value).toBe('10');
+        expect((screen.getByTestId('auto-provider-threshold-opencode') as HTMLInputElement).value).toBe('25');
         expect((screen.getByTestId('auto-provider-weekly-threshold-claude') as HTMLInputElement).value).toBe('33');
         expect((screen.getByTestId('auto-provider-fallback') as HTMLSelectElement).value).toBe('copilot');
     });
@@ -324,11 +330,12 @@ describe('AIProviderPage', () => {
 
         fireEvent.click(screen.getByTestId('auto-provider-move-down-claude'));
         expect(props.setAutoRoutingConfig).toHaveBeenLastCalledWith(expect.objectContaining({
-            rules: [
+            rules: expect.arrayContaining([
                 expect.objectContaining({ provider: 'codex' }),
                 expect.objectContaining({ provider: 'claude' }),
                 expect.objectContaining({ provider: 'copilot' }),
-            ],
+                expect.objectContaining({ provider: 'opencode' }),
+            ]),
         }));
 
         fireEvent.change(screen.getByTestId('auto-provider-fallback'), { target: { value: 'claude' } });
@@ -850,7 +857,7 @@ describe('AIProviderPage', () => {
         renderPage();
         expect(screen.getByText('default')).toBeDefined();
         const configLabels = screen.getAllByText('config');
-        expect(configLabels.length).toBe(2);
+        expect(configLabels.length).toBe(3);
     });
 
     // ────────────── Provider notes ──────────────

--- a/packages/forge/src/ai/index.ts
+++ b/packages/forge/src/ai/index.ts
@@ -99,6 +99,8 @@ export {
     SDK_PROVIDER_CODEX,
     CLAUDE_PROVIDER,
     SDK_PROVIDER_CLAUDE,
+    OPENCODE_PROVIDER,
+    SDK_PROVIDER_OPENCODE,
     // Codex SDK Service and auth
     registerCodexSDKService,
     CodexSDKService,
@@ -109,6 +111,11 @@ export {
     registerClaudeSDKService,
     mapClaudeRateLimitInfoToQuota,
     type ClaudeRateLimitInfo,
+    // OpenCode SDK Service
+    OpenCodeSDKService,
+    registerOpenCodeSDKService,
+    flattenOpenCodeProvidersToModelInfo,
+    parseOpenCodeModelRef,
     // Model Metadata Store
     modelMetadataStore,
     resolveReasoningEffort,

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -186,6 +186,8 @@ export {
     SDK_PROVIDER_CODEX,
     CLAUDE_PROVIDER,
     SDK_PROVIDER_CLAUDE,
+    OPENCODE_PROVIDER,
+    SDK_PROVIDER_OPENCODE,
     // Codex SDK Service
     registerCodexSDKService,
     CodexSDKService,
@@ -196,6 +198,11 @@ export {
     registerClaudeSDKService,
     mapClaudeRateLimitInfoToQuota,
     type ClaudeRateLimitInfo,
+    // OpenCode SDK Service
+    OpenCodeSDKService,
+    registerOpenCodeSDKService,
+    flattenOpenCodeProvidersToModelInfo,
+    parseOpenCodeModelRef,
     // Model Metadata Store
     modelMetadataStore,
     resolveReasoningEffort,


### PR DESCRIPTION
- **feat(coc-agent-sdk): add OpenCode SDK provider adapter**
- **test(coc): update config tests for opencode provider field**
- **feat(coc): add OpenCode provider support across the application**
- **fix(coc): remove unused getOpenCodeSdkService from AgentProvidersQuotaContext**
- **fix(coc-agent-sdk): add missing rewindSession to OpenCodeSDKService**
- **feat(spa): use real OpenCode logomark for provider avatar**
