### PR TITLE
fix: collapse cross-column text selection on mouseup in split diff

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/git/diff/SideBySideDiffViewer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/SideBySideDiffViewer.tsx
@@ -189,7 +189,6 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
             // Selection (if any) is finalized on mouse up — release the column lock so both
             // columns are selectable again for the next gesture (and for select-all).
             setSelectSide(null);
-            if (!enableComments) return;
             const clear = () => {
                 pendingSelectionRef.current = null;
                 setToolbar(t => ({ ...t, visible: false, selection: null, selectedText: '' }));
@@ -201,11 +200,17 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
 
             const startEl = findLineElement(range.startContainer, boundary);
             const endEl   = findLineElement(range.endContainer,   boundary);
-            if (!startEl || !endEl) { clear(); return; }
 
-            // reject cross-column selections
-            const startSide = startEl.closest('[data-split-side]')?.getAttribute('data-split-side');
-            const endSide   = endEl.closest('[data-split-side]')?.getAttribute('data-split-side');
+            // Reject cross-column selections. Left/right cells are interleaved per row, so a
+            // native range that spans both columns paints across both panels once the column
+            // lock is released. Collapse it so the stray highlight disappears. This must run
+            // regardless of enableComments, since the bleed affects plain split views too.
+            const startSide = startEl?.closest('[data-split-side]')?.getAttribute('data-split-side');
+            const endSide   = endEl?.closest('[data-split-side]')?.getAttribute('data-split-side');
+            if (startSide && endSide && startSide !== endSide) { sel.removeAllRanges(); }
+
+            if (!enableComments) return;
+            if (!startEl || !endEl) { clear(); return; }
             if (!startSide || startSide !== endSide) { clear(); return; }
 
             const startIdx = parseInt(startEl.getAttribute('data-diff-line-index') ?? '-1', 10);

--- a/packages/coc/test/spa/react/repos/SideBySideDiffViewer.selection.test.tsx
+++ b/packages/coc/test/spa/react/repos/SideBySideDiffViewer.selection.test.tsx
@@ -100,4 +100,23 @@ describe('SideBySideDiffViewer — column-scoped selection', () => {
         expect(after.left.some(isLocked)).toBe(false);
         expect(after.right.some(isLocked)).toBe(false);
     });
+
+    it('collapses a cross-column selection on mouse up so the highlight does not bleed', () => {
+        const { container } = render(<SideBySideDiffViewer diff={TWO_HUNK_DIFF} enableComments />);
+        const { left, right } = columns(container);
+        const removeAllRanges = vi.fn();
+
+        // Native range that starts in the left column and ends in the right column.
+        vi.spyOn(window, 'getSelection').mockReturnValue({
+            isCollapsed: false,
+            rangeCount: 1,
+            removeAllRanges,
+            getRangeAt: () => ({ startContainer: left[0], endContainer: right[0], startOffset: 0, endOffset: 0 }),
+            toString: () => 'cross column',
+        } as unknown as Selection);
+
+        fireEvent.mouseUp(left[0], { button: 0 });
+
+        expect(removeAllRanges).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Releasing the column lock on mouseup re-enabled the interleaved opposite-
column cells, so a near-cross-column drag repainted the highlight across
both panels. Detect a cross-column native range on mouseup and collapse it,
independent of enableComments since plain split views bled too. Add a
regression test asserting removeAllRanges is called.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
