### PR TITLE
chore(coc-desktop): bump version to 3.4.2 for release

### DIFF
--- a/packages/coc-desktop/package.json
+++ b/packages/coc-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plusplusoneplusplus/coc-desktop",
   "productName": "CoC",
-  "version": "0.1.0",
+  "version": "3.4.2",
   "private": true,
   "description": "CoC desktop app (Electron) — boots the CoC server in a forked child and points a native window at the served SPA",
   "main": "dist/main.js",


### PR DESCRIPTION
Bumps `packages/coc-desktop/package.json` to 3.4.2 to match the `v3.4.2` release tag.

Note: the release workflow overwrites this version from the tag at build time, so this commit is for repo consistency only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)