### PR TITLE
perf(coc-desktop): trim packaged image (~1.03GB → ~430MB mac artifact)

### DIFF
--- a/packages/coc-desktop/package.json
+++ b/packages/coc-desktop/package.json
@@ -50,16 +50,22 @@
       "**/*",
       "!**/*.map",
       "node_modules/@plusplusoneplusplus/coc/dist/**/*",
-      "node_modules/@plusplusoneplusplus/coc/dist/server/spa/client/dist/**/*"
+      "node_modules/@plusplusoneplusplus/coc/dist/server/spa/client/dist/**/*",
+      "!release/**",
+      "!**/@github/copilot/**/{linux,linuxmusl}-*/**",
+      "!**/@github/copilot/mxc-bin/**"
     ],
     "mac": {
       "target": [
-        "dmg",
-        "zip"
+        "dmg"
       ],
       "category": "public.app-category.developer-tools",
       "icon": "../../media/coc-icon.png",
-      "darkModeSupport": true
+      "darkModeSupport": true,
+      "files": [
+        "!**/@github/copilot/**/win32-*/**",
+        "!**/@github/copilot/**/darwin-x64/**"
+      ]
     },
     "dmg": {
       "title": "CoC ${version}"
@@ -68,7 +74,10 @@
       "target": [
         "nsis"
       ],
-      "icon": "../../media/coc-icon.png"
+      "icon": "../../media/coc-icon.png",
+      "files": [
+        "!**/@github/copilot/**/darwin-*/**"
+      ]
     },
     "nsis": {
       "oneClick": false,

--- a/packages/coc-desktop/test/packaging-config.test.ts
+++ b/packages/coc-desktop/test/packaging-config.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Contract tests for the electron-builder packaging config in package.json.
+ *
+ * These pin the image-size guardrails so a future edit can't silently re-bloat
+ * the desktop build:
+ *   1. macOS ships a single `dmg` (no duplicate `zip`) — the `coc-mac` CI
+ *      artifact otherwise carries two copies of the same app.
+ *   2. The output dir is excluded from the file glob, so a local rebuild can't
+ *      pack a previous run's `release/` artifacts into the new asar.
+ *   3. Only the host platform's @github/copilot binaries are bundled — the
+ *      package ships prebuilds/ripgrep/tgrep for every OS/arch, ~150MB+ of which
+ *      a single-platform build can never execute.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type Build = {
+    files?: string[];
+    mac?: { target?: string[]; files?: string[] };
+    win?: { files?: string[] };
+};
+
+function buildConfig(): Build {
+    const file = path.resolve(__dirname, '../package.json');
+    return (JSON.parse(fs.readFileSync(file, 'utf8')).build ?? {}) as Build;
+}
+
+describe('electron-builder packaging config', () => {
+    it('ships a single macOS dmg (no duplicate zip artifact)', () => {
+        expect(buildConfig().mac?.target).toEqual(['dmg']);
+    });
+
+    it('excludes the release/ output dir from the file glob', () => {
+        // Regression: `files: ["**/*"]` recursively packs `release/` itself, so a
+        // local rebuild slurps the prior run's dmg/zip/exe/win-unpacked into the
+        // new asar (multi-GB). The negation keeps the output dir out.
+        expect(buildConfig().files).toContain('!release/**');
+    });
+
+    describe('cross-platform @github/copilot binary pruning', () => {
+        it('drops linux/linuxmusl prebuilds and the linux-only mxc-bin everywhere', () => {
+            const files = buildConfig().files ?? [];
+            expect(files).toContain('!**/@github/copilot/**/{linux,linuxmusl}-*/**');
+            expect(files).toContain('!**/@github/copilot/mxc-bin/**');
+        });
+
+        it('drops win32 and the non-host darwin-x64 binaries from the mac build', () => {
+            const macFiles = buildConfig().mac?.files ?? [];
+            expect(macFiles).toContain('!**/@github/copilot/**/win32-*/**');
+            expect(macFiles).toContain('!**/@github/copilot/**/darwin-x64/**');
+        });
+
+        it('drops darwin binaries from the windows build', () => {
+            const winFiles = buildConfig().win?.files ?? [];
+            expect(winFiles).toContain('!**/@github/copilot/**/darwin-*/**');
+        });
+    });
+});


### PR DESCRIPTION
## Why
The `coc-mac` release artifact is **1.03 GB**. Breakdown of the 1.4 GB app:
- `app.asar.unpacked` **866 MB** — dominated by `@github/copilot` shipping prebuilds/ripgrep/tgrep for *every* OS/arch (~150 MB+ a Mac can't run) plus a linux-only `mxc-bin`.
- The `coc-mac` artifact bundles **both** `.dmg` and `.zip` — the same app twice.

## Changes (all electron-builder config)
1. **Drop the macOS `zip` target** — no auto-update is wired up, so it was unused. Halves the artifact.
2. **`!release/**`** — `files: ['**/*']` recursively packs the output dir, so local rebuilds slurp the prior run's artifacts into the new asar (multi-GB). CI dodges it via fresh checkout; this fixes the local footgun.
3. **Prune cross-platform `@github/copilot` binaries** — keep only the host platform (`darwin-arm64` / `win32`), trimming `app.asar.unpacked` 866 MB → 632 MB.

## Verified locally (clean `electron-builder --dir`)
| | before | after |
|---|---|---|
| app.asar.unpacked | 866 MB | 632 MB |
| total .app | 1.4 GB | 1.2 GB |
| only `darwin-arm64` copilot binaries remain | — | ✓ (mxc-bin removed) |

Net: `coc-mac` artifact **~1.03 GB → ~430 MB** (dmg only). Host agent-CLI binaries (claude/codex/copilot `-darwin-arm64`) are untouched — **no runtime change**.

Adds `packaging-config.test.ts` pinning all three guardrails. Full desktop suite (94 tests) passes.

> Not included (per scope): the three agent-CLI binaries themselves (claude 205 MB, codex 185 MB, copilot 142 MB) still ship. Dropping unused providers would save up to ~350 MB more — separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)