### PR TITLE
feat(coc-desktop): wire bundled agent CLIs onto the server PATH

### DIFF
--- a/packages/coc-desktop/package.json
+++ b/packages/coc-desktop/package.json
@@ -44,7 +44,10 @@
     },
     "asar": true,
     "asarUnpack": [
-      "**/*.node"
+      "**/*.node",
+      "**/@anthropic-ai/claude-agent-sdk-*/**",
+      "**/@openai/codex-*/**",
+      "**/@github/copilot-*-*/**"
     ],
     "files": [
       "**/*",

--- a/packages/coc-desktop/src/agent-bin-path.ts
+++ b/packages/coc-desktop/src/agent-bin-path.ts
@@ -1,0 +1,225 @@
+/**
+ * CoC Desktop — bundled agent-CLI PATH resolution.
+ *
+ * The CoC server spawns the agent CLIs by bare name (`copilot`, `codex`,
+ * `claude`; see `process-resume-handler.ts`), resolving them on `PATH`. The
+ * desktop app already *bundles* those real CLIs as platform-specific packages:
+ *
+ *   - `@github/copilot-<plat>-<arch>/copilot`
+ *   - `@openai/codex-<plat>-<arch>/vendor/<triple>/bin/codex`   (nested)
+ *   - `@anthropic-ai/claude-agent-sdk-<plat>-<arch>/claude`
+ *
+ * but their directories are not on the forked server's `PATH`, so the server
+ * can't find them and the preflight nags the user to install them again. Worse,
+ * a Finder/Dock-launched macOS app inherits launchd's minimal `PATH`, so even
+ * a user-installed CLI is invisible. This module resolves the bundled binaries'
+ * directories so callers can prepend them to `PATH` — making the app
+ * self-contained for both the server and the preflight.
+ *
+ * It imports NOTHING from `electron` (unit-testable under plain Node/vitest) and
+ * every resolution is best-effort: a provider that can't be resolved is silently
+ * skipped, never throwing, so a packaging quirk degrades to today's behavior
+ * (rely on the user's PATH) instead of breaking startup.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** A bundled agent CLI and the platform-package family that ships it. */
+export interface BundledAgent {
+    /** Stable provider id — matches the coc server's provider ids. */
+    id: 'copilot' | 'codex' | 'claude';
+    /** Executable name probed on PATH / searched for (no extension). */
+    bin: string;
+    /**
+     * Scoped package *family*; the installed platform package is
+     * `${family}-${platform}-${arch}` (e.g. `@github/copilot-darwin-arm64`).
+     */
+    packageFamily: string;
+}
+
+/**
+ * The three agent CLIs the desktop app bundles. `bin` mirrors exactly what the
+ * server spawns, so a resolved directory on PATH means the runtime finds the
+ * same executable.
+ */
+export const BUNDLED_AGENTS: readonly BundledAgent[] = [
+    { id: 'copilot', bin: 'copilot', packageFamily: '@github/copilot' },
+    { id: 'codex', bin: 'codex', packageFamily: '@openai/codex' },
+    { id: 'claude', bin: 'claude', packageFamily: '@anthropic-ai/claude-agent-sdk' },
+];
+
+/** Injectable seams so tests never touch the real module graph or disk. */
+export interface BinResolveEnv {
+    /** Defaults to `process.platform`. */
+    platform?: NodeJS.Platform;
+    /** Defaults to `process.arch`. */
+    arch?: string;
+    /** Resolve a package name to its on-disk directory, or null. */
+    resolvePackageDir?: (packageName: string) => string | null;
+    /** Find an executable named `binName` under `dir` (bounded depth), or null. */
+    findExecutable?: (dir: string, binName: string) => string | null;
+}
+
+/** The installed platform package name for a bundled agent family. */
+export function platformPackageName(family: string, platform: NodeJS.Platform, arch: string): string {
+    return `${family}-${platform}-${arch}`;
+}
+
+/**
+ * Rewrite an `app.asar` path segment to `app.asar.unpacked` so a binary that
+ * electron-builder unpacked resolves to the real on-disk file (an executable
+ * inside the asar archive can't be spawned or `PATH`-resolved). Handles both
+ * POSIX and Windows separators and is a no-op in dev (no asar in the path).
+ */
+export function toUnpackedPath(p: string): string {
+    return p.replace(/([\\/])app\.asar([\\/])/g, '$1app.asar.unpacked$2');
+}
+
+/** Default package-dir resolver: locate the package's directory via Node resolution. */
+function defaultResolvePackageDir(packageName: string): string | null {
+    // Prefer resolving the package.json (gives the package root directly).
+    try {
+        return path.dirname(require.resolve(`${packageName}/package.json`));
+    } catch {
+        // Some packages block deep `package.json` resolution via "exports" — fall
+        // back to scanning the resolution roots for the package directory.
+    }
+    let roots: string[] = [];
+    try {
+        roots = require.resolve.paths(packageName) ?? [];
+    } catch {
+        return null;
+    }
+    const segments = packageName.split('/');
+    for (const root of roots) {
+        const candidate = path.join(root, ...segments);
+        try {
+            if (fs.existsSync(path.join(candidate, 'package.json'))) {
+                return candidate;
+            }
+        } catch {
+            // ignore and keep scanning
+        }
+    }
+    return null;
+}
+
+/** Default executable finder: bounded-depth search for a file named `binName`. */
+function defaultFindExecutable(dir: string, binName: string): string | null {
+    const MAX_DEPTH = 6;
+    const stack: Array<{ dir: string; depth: number }> = [{ dir, depth: 0 }];
+    while (stack.length > 0) {
+        const { dir: current, depth } = stack.pop() as { dir: string; depth: number };
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(current, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const full = path.join(current, entry.name);
+            if (entry.isFile() && entry.name === binName) {
+                return full;
+            }
+            if (entry.isDirectory() && depth < MAX_DEPTH) {
+                stack.push({ dir: full, depth: depth + 1 });
+            }
+        }
+    }
+    return null;
+}
+
+/** Candidate executable names for `bin` on the target platform. */
+function binCandidates(bin: string, platform: NodeJS.Platform): string[] {
+    return platform === 'win32' ? [`${bin}.exe`, bin] : [bin];
+}
+
+/**
+ * Resolve the directory containing one bundled agent's executable, or null when
+ * it isn't bundled/resolvable. Never throws.
+ */
+export function resolveBundledBinDir(agent: BundledAgent, env: BinResolveEnv = {}): string | null {
+    const platform = env.platform ?? process.platform;
+    const arch = env.arch ?? process.arch;
+    const resolvePackageDir = env.resolvePackageDir ?? defaultResolvePackageDir;
+    const findExecutable = env.findExecutable ?? defaultFindExecutable;
+
+    try {
+        const pkgName = platformPackageName(agent.packageFamily, platform, arch);
+        const pkgDir = resolvePackageDir(pkgName);
+        if (!pkgDir) {
+            return null;
+        }
+        // Walk the real on-disk dir (rewrite asar → asar.unpacked first).
+        const realPkgDir = toUnpackedPath(pkgDir);
+        for (const name of binCandidates(agent.bin, platform)) {
+            const found = findExecutable(realPkgDir, name);
+            if (found) {
+                return path.dirname(toUnpackedPath(found));
+            }
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Resolve the directories of every bundled agent binary for the host platform.
+ * Best-effort and de-duplicated; providers that can't be resolved are skipped.
+ */
+export function resolveBundledAgentBinDirs(
+    env: BinResolveEnv = {},
+    agents: readonly BundledAgent[] = BUNDLED_AGENTS,
+): string[] {
+    const dirs: string[] = [];
+    const seen = new Set<string>();
+    for (const agent of agents) {
+        const dir = resolveBundledBinDir(agent, env);
+        if (dir && !seen.has(dir)) {
+            seen.add(dir);
+            dirs.push(dir);
+        }
+    }
+    return dirs;
+}
+
+/**
+ * Prepend `dirs` to `basePath`, dropping any already present and de-duplicating.
+ * Uses the target platform's PATH separator; comparison is case-insensitive on
+ * Windows.
+ */
+export function prependToPath(dirs: readonly string[], basePath: string, platform: NodeJS.Platform): string {
+    const sep = platform === 'win32' ? ';' : ':';
+    const norm = (s: string) => (platform === 'win32' ? s.toLowerCase() : s);
+    const existing = basePath.split(sep).filter(Boolean);
+    const existingSet = new Set(existing.map(norm));
+    const seen = new Set<string>();
+    const prefix: string[] = [];
+    for (const dir of dirs) {
+        if (!dir) {
+            continue;
+        }
+        const key = norm(dir);
+        if (existingSet.has(key) || seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        prefix.push(dir);
+    }
+    return [...prefix, ...existing].join(sep);
+}
+
+/**
+ * Return `basePath` with the bundled agent binary directories prepended. The
+ * single entry point callers use to make both the forked server and the
+ * preflight see the bundled CLIs. Never throws; returns `basePath` unchanged
+ * when nothing resolves.
+ */
+export function augmentPathWithBundledAgents(env: BinResolveEnv = {}, basePath?: string): string {
+    const platform = env.platform ?? process.platform;
+    const base = basePath ?? process.env.PATH ?? '';
+    const dirs = resolveBundledAgentBinDirs(env);
+    return prependToPath(dirs, base, platform);
+}

--- a/packages/coc-desktop/src/agent-preflight.ts
+++ b/packages/coc-desktop/src/agent-preflight.ts
@@ -5,10 +5,13 @@
  * `claude`) when a user resumes or starts an agent session — see
  * `packages/coc/src/server/processes/process-resume-handler.ts`, which invokes
  * `copilot --yolo`, `codex …`, and `claude --dangerously-skip-permissions`.
- * Those CLIs are NOT bundled with the desktop app (per the goal: "require
- * installed + non-blocking preflight; do not bundle"). This module detects
- * whether each one is reachable on `PATH` so the app can surface non-blocking
- * install guidance on first run.
+ * This module detects whether each one is reachable on `PATH` so the app can
+ * surface non-blocking install guidance on first run.
+ *
+ * The app bundles those CLIs (see `agent-bin-path.ts`) and `main.ts` runs this
+ * check against a PATH with the bundled directories prepended — the same PATH
+ * the forked server gets — so a bundled provider reads as present and the nag
+ * only appears for one that genuinely can't be resolved.
  *
  * It imports NOTHING from `electron`, so the detection + formatting logic is
  * unit-testable under plain Node/vitest. The electron wiring (showing the

--- a/packages/coc-desktop/src/main.ts
+++ b/packages/coc-desktop/src/main.ts
@@ -17,6 +17,7 @@ import { app, BrowserWindow, Menu, Tray, dialog, nativeImage, shell } from 'elec
 import { attachOrStart, defaultDataDir, ServerHandle } from './server-controller';
 import { splashDataUrl } from './splash';
 import { detectAgentClis, missingAgentClis, runFirstRunPreflight } from './agent-preflight';
+import { augmentPathWithBundledAgents } from './agent-bin-path';
 import { shutdownServer, shouldOpenExternally } from './lifecycle';
 import { resolveIconPath } from './app-icon';
 import { APP_NAME, buildAboutPanelOptions, readDesktopVersion } from './app-identity';
@@ -156,15 +157,22 @@ async function showServedSpa(url: string): Promise<void> {
 
 /**
  * AC-06: agent-CLI preflight. On first run, detect whether the Copilot / Codex /
- * Claude CLIs are on PATH and surface non-blocking install guidance for any that
- * are missing. The CLIs are NOT bundled — we only require them to be installed.
+ * Claude CLIs are reachable and surface non-blocking install guidance for any
+ * that are missing.
+ *
+ * Detection runs against the SAME augmented PATH the forked server gets — the
+ * bundled CLI directories prepended to the host PATH — so a provider whose
+ * binary the app ships is reported as present (no spurious nag), and the check
+ * matches what the server can actually spawn. This also sidesteps the
+ * launchd-minimal PATH a Finder/Dock-launched macOS app would otherwise see.
  *
  * This must never block startup: it runs after the window is already shown, the
  * dialog is unparented and fire-and-forget, and any failure is swallowed.
  */
 function runAgentPreflight(): void {
     try {
-        const guidance = runFirstRunPreflight(defaultDataDir());
+        const pathEnv = augmentPathWithBundledAgents();
+        const guidance = runFirstRunPreflight(defaultDataDir(), { pathEnv });
         if (!guidance) {
             return;
         }
@@ -183,7 +191,7 @@ function runAgentPreflight(): void {
             .then((result) => {
                 if (result.response === 1) {
                     // Open the docs for each still-missing CLI in the system browser.
-                    for (const { cli } of missingAgentClis(detectAgentClis())) {
+                    for (const { cli } of missingAgentClis(detectAgentClis({ pathEnv }))) {
                         void shell.openExternal(cli.docsUrl);
                     }
                 }

--- a/packages/coc-desktop/src/server-controller.ts
+++ b/packages/coc-desktop/src/server-controller.ts
@@ -22,6 +22,7 @@ import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import { fork, ChildProcess } from 'child_process';
+import { augmentPathWithBundledAgents } from './agent-bin-path';
 
 /** Default loopback bind address — the server is never exposed off-box. */
 export const DEFAULT_HOST = '127.0.0.1';
@@ -121,8 +122,13 @@ export function findFreePort(host: string = DEFAULT_HOST): Promise<number> {
 
 /** Default fork: spawn `server-entry.js` as Electron's Node (`ELECTRON_RUN_AS_NODE`). */
 function defaultFork(modulePath: string, env: NodeJS.ProcessEnv): ChildProcess {
+    const merged: NodeJS.ProcessEnv = { ...process.env, ...env };
+    // Prepend the bundled agent-CLI directories so the server resolves the
+    // shipped `copilot`/`codex`/`claude` even when the host PATH lacks them
+    // (best-effort; leaves PATH unchanged when nothing bundled resolves).
+    merged.PATH = augmentPathWithBundledAgents({}, merged.PATH);
     return fork(modulePath, [], {
-        env: { ...process.env, ...env },
+        env: merged,
         stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
     });
 }

--- a/packages/coc-desktop/test/agent-bin-path.test.ts
+++ b/packages/coc-desktop/test/agent-bin-path.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit coverage for bundled agent-CLI PATH resolution.
+ *
+ * Pins the behavior that makes the desktop app self-contained: resolve the
+ * bundled `copilot`/`codex`/`claude` binary directories and prepend them to
+ * PATH for both the forked server and the preflight. All disk/module seams are
+ * injected so tests never touch the real node_modules or PATH.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import {
+    BUNDLED_AGENTS,
+    platformPackageName,
+    toUnpackedPath,
+    resolveBundledBinDir,
+    resolveBundledAgentBinDirs,
+    prependToPath,
+    augmentPathWithBundledAgents,
+    type BundledAgent,
+    type BinResolveEnv,
+} from '../src/agent-bin-path';
+// Reuse the real preflight detection to prove the augmented PATH suppresses the nag.
+import { detectAgentClis, missingAgentClis, AGENT_CLIS } from '../src/agent-preflight';
+
+const COPILOT = BUNDLED_AGENTS.find((a) => a.id === 'copilot') as BundledAgent;
+const CODEX = BUNDLED_AGENTS.find((a) => a.id === 'codex') as BundledAgent;
+const CLAUDE = BUNDLED_AGENTS.find((a) => a.id === 'claude') as BundledAgent;
+
+describe('bundled agent descriptors', () => {
+    it('lists the three providers with families matching the platform packages', () => {
+        expect(BUNDLED_AGENTS.map((a) => [a.id, a.bin, a.packageFamily])).toEqual([
+            ['copilot', 'copilot', '@github/copilot'],
+            ['codex', 'codex', '@openai/codex'],
+            ['claude', 'claude', '@anthropic-ai/claude-agent-sdk'],
+        ]);
+    });
+
+    it('covers exactly the same provider ids the preflight checks', () => {
+        expect(BUNDLED_AGENTS.map((a) => a.id).sort()).toEqual(AGENT_CLIS.map((c) => c.id).sort());
+    });
+});
+
+describe('platformPackageName', () => {
+    it('appends -<platform>-<arch> to the family', () => {
+        expect(platformPackageName('@github/copilot', 'darwin', 'arm64')).toBe('@github/copilot-darwin-arm64');
+        expect(platformPackageName('@openai/codex', 'win32', 'x64')).toBe('@openai/codex-win32-x64');
+    });
+});
+
+describe('toUnpackedPath', () => {
+    it('rewrites the app.asar segment to app.asar.unpacked (posix)', () => {
+        expect(toUnpackedPath('/A/CoC.app/Contents/Resources/app.asar/node_modules/x/bin')).toBe(
+            '/A/CoC.app/Contents/Resources/app.asar.unpacked/node_modules/x/bin',
+        );
+    });
+
+    it('rewrites the app.asar segment with Windows separators', () => {
+        expect(toUnpackedPath('C:\\r\\app.asar\\node_modules\\x')).toBe('C:\\r\\app.asar.unpacked\\node_modules\\x');
+    });
+
+    it('is a no-op when there is no asar in the path (dev mode)', () => {
+        const p = '/repo/node_modules/@github/copilot-darwin-arm64';
+        expect(toUnpackedPath(p)).toBe(p);
+    });
+
+    it('does not touch an unrelated substring like app.asared', () => {
+        // Only a real `app.asar` *segment* (bounded by separators) is rewritten.
+        expect(toUnpackedPath('/x/app.asared/y')).toBe('/x/app.asared/y');
+    });
+});
+
+describe('resolveBundledBinDir', () => {
+    const env = (overrides: Partial<BinResolveEnv>): BinResolveEnv => ({
+        platform: 'darwin',
+        arch: 'arm64',
+        ...overrides,
+    });
+
+    it('resolves a root-level binary (copilot) to its package dir', () => {
+        const dir = resolveBundledBinDir(
+            COPILOT,
+            env({
+                resolvePackageDir: (name) =>
+                    name === '@github/copilot-darwin-arm64' ? '/repo/node_modules/@github/copilot-darwin-arm64' : null,
+                findExecutable: (d, bin) => (bin === 'copilot' ? `${d}/copilot` : null),
+            }),
+        );
+        expect(dir).toBe('/repo/node_modules/@github/copilot-darwin-arm64');
+    });
+
+    it('resolves a nested binary (codex under vendor/<triple>/bin) to the nested dir', () => {
+        const pkg = '/repo/node_modules/@openai/codex-darwin-arm64';
+        const dir = resolveBundledBinDir(
+            CODEX,
+            env({
+                resolvePackageDir: () => pkg,
+                // Mimic the bounded-depth walk finding the nested executable.
+                findExecutable: (d, bin) =>
+                    bin === 'codex' ? `${d}/vendor/aarch64-apple-darwin/bin/codex` : null,
+            }),
+        );
+        expect(dir).toBe(`${pkg}/vendor/aarch64-apple-darwin/bin`);
+    });
+
+    it('rewrites asar → asar.unpacked before walking and in the result', () => {
+        const asarPkg = '/A/Resources/app.asar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64';
+        const unpackedPkg = '/A/Resources/app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64';
+        const walkedDirs: string[] = [];
+        const dir = resolveBundledBinDir(
+            CLAUDE,
+            env({
+                resolvePackageDir: () => asarPkg,
+                findExecutable: (d, bin) => {
+                    walkedDirs.push(d);
+                    return bin === 'claude' ? `${d}/claude` : null;
+                },
+            }),
+        );
+        // The walk runs against the unpacked dir, and the returned dir is unpacked.
+        expect(walkedDirs).toEqual([unpackedPkg]);
+        expect(dir).toBe(unpackedPkg);
+    });
+
+    it('prefers the .exe candidate on Windows', () => {
+        const queried: string[] = [];
+        resolveBundledBinDir(
+            COPILOT,
+            env({
+                platform: 'win32',
+                arch: 'x64',
+                resolvePackageDir: () => '/repo/nm/@github/copilot-win32-x64',
+                findExecutable: (_d, bin) => {
+                    queried.push(bin);
+                    return null;
+                },
+            }),
+        );
+        expect(queried).toEqual(['copilot.exe', 'copilot']);
+    });
+
+    it('returns null when the platform package is not installed', () => {
+        expect(
+            resolveBundledBinDir(COPILOT, env({ resolvePackageDir: () => null, findExecutable: () => '/x' })),
+        ).toBeNull();
+    });
+
+    it('returns null when the executable is not found in the package', () => {
+        expect(
+            resolveBundledBinDir(COPILOT, env({ resolvePackageDir: () => '/pkg', findExecutable: () => null })),
+        ).toBeNull();
+    });
+
+    it('never throws when a seam throws — degrades to null', () => {
+        expect(
+            resolveBundledBinDir(
+                COPILOT,
+                env({
+                    resolvePackageDir: () => {
+                        throw new Error('boom');
+                    },
+                }),
+            ),
+        ).toBeNull();
+    });
+});
+
+describe('resolveBundledAgentBinDirs', () => {
+    it('collects resolvable dirs and skips the rest', () => {
+        const dirs = resolveBundledAgentBinDirs({
+            platform: 'darwin',
+            arch: 'arm64',
+            resolvePackageDir: (name) => (name.includes('codex') ? null : `/nm/${name}`),
+            findExecutable: (d, bin) => `${d}/${bin}`,
+        });
+        // copilot + claude resolve; codex skipped.
+        expect(dirs).toEqual(['/nm/@github/copilot-darwin-arm64', '/nm/@anthropic-ai/claude-agent-sdk-darwin-arm64']);
+    });
+
+    it('de-duplicates identical directories', () => {
+        const dirs = resolveBundledAgentBinDirs({
+            platform: 'darwin',
+            arch: 'arm64',
+            resolvePackageDir: () => '/same',
+            findExecutable: () => '/same/bin', // every provider resolves to /same
+        });
+        expect(dirs).toEqual(['/same']);
+    });
+});
+
+describe('prependToPath', () => {
+    it('prepends new dirs using the POSIX separator', () => {
+        expect(prependToPath(['/a', '/b'], '/usr/bin:/bin', 'darwin')).toBe('/a:/b:/usr/bin:/bin');
+    });
+
+    it('prepends using the Windows separator', () => {
+        expect(prependToPath(['C:\\a'], 'C:\\Windows;C:\\Windows\\System32', 'win32')).toBe(
+            'C:\\a;C:\\Windows;C:\\Windows\\System32',
+        );
+    });
+
+    it('drops dirs already present and de-dups the prefix', () => {
+        expect(prependToPath(['/a', '/a', '/usr/bin'], '/usr/bin:/bin', 'darwin')).toBe('/a:/usr/bin:/bin');
+    });
+
+    it('compares case-insensitively on Windows', () => {
+        expect(prependToPath(['c:\\a'], 'C:\\A;C:\\Windows', 'win32')).toBe('C:\\A;C:\\Windows');
+    });
+
+    it('handles an empty base PATH', () => {
+        expect(prependToPath(['/a', '/b'], '', 'darwin')).toBe('/a:/b');
+    });
+});
+
+describe('augmentPathWithBundledAgents', () => {
+    it('prepends resolved bundled dirs to the given base PATH', () => {
+        const out = augmentPathWithBundledAgents(
+            {
+                platform: 'darwin',
+                arch: 'arm64',
+                resolvePackageDir: (name) => `/nm/${name}`,
+                findExecutable: (d, bin) => `${d}/${bin}`,
+            },
+            '/usr/bin:/bin',
+        );
+        expect(out).toBe(
+            [
+                '/nm/@github/copilot-darwin-arm64',
+                '/nm/@openai/codex-darwin-arm64',
+                '/nm/@anthropic-ai/claude-agent-sdk-darwin-arm64',
+                '/usr/bin',
+                '/bin',
+            ].join(':'),
+        );
+    });
+
+    it('returns the base PATH unchanged when nothing resolves', () => {
+        const out = augmentPathWithBundledAgents(
+            { platform: 'darwin', arch: 'arm64', resolvePackageDir: () => null },
+            '/usr/bin:/bin',
+        );
+        expect(out).toBe('/usr/bin:/bin');
+    });
+});
+
+describe('integration: augmented PATH suppresses the preflight nag', () => {
+    it('detects all three CLIs as installed once their bundled dirs are on PATH', () => {
+        const binDirs = {
+            '/nm/@github/copilot-darwin-arm64': 'copilot',
+            '/nm/@openai/codex-darwin-arm64/vendor/t/bin': 'codex',
+            '/nm/@anthropic-ai/claude-agent-sdk-darwin-arm64': 'claude',
+        } as Record<string, string>;
+        const pathEnv = augmentPathWithBundledAgents(
+            {
+                platform: 'darwin',
+                arch: 'arm64',
+                resolvePackageDir: (name) => `/nm/${name}`,
+                findExecutable: (d, bin) =>
+                    bin === 'codex' ? `${d}/vendor/t/bin/codex` : `${d}/${bin}`,
+            },
+            '/usr/bin',
+        );
+        // fileExists seam: a binary exists iff PATH dir maps to that exact bin name.
+        const statuses = detectAgentClis({
+            platform: 'darwin',
+            pathEnv,
+            fileExists: (p) => binDirs[path.dirname(p)] === path.basename(p),
+        });
+        expect(statuses.every((s) => s.installed)).toBe(true);
+        expect(missingAgentClis(statuses)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Problem
The app shows **"3 agent CLIs were not found on your PATH"** and the providers don't work, even though the app already **bundles** ~530 MB of agent binaries.

Root cause (traced end-to-end):
- The server spawns `copilot`/`codex`/`claude` by **bare name**, resolved on `PATH` ([process-resume-handler.ts](packages/coc/src/server/processes/process-resume-handler.ts)).
- The desktop app forked the server with an **unaugmented PATH** ([server-controller.ts](packages/coc-desktop/src/server-controller.ts)), so the bundled `@github/copilot-*`, `@openai/codex-*`, `@anthropic-ai/claude-agent-sdk-*` binaries were invisible.
- On a Finder/Dock-launched macOS app, `process.env.PATH` is launchd-minimal — so even user-installed CLIs wouldn't be found either.

## Fix (desktop-only — does not touch the coc server)
New `agent-bin-path.ts` resolves each bundled binary's directory for the host platform (resolve `<family>-<plat>-<arch>` package → locate the executable via a bounded-depth walk that handles codex's nested `vendor/<triple>/bin` layout → rewrite `app.asar` → `app.asar.unpacked`). Best-effort; never throws.
- **server-controller**: prepend the resolved dirs to the forked server's PATH.
- **main.ts**: run the preflight against the same augmented PATH, so a bundled provider reads as present and the nag only fires for one that genuinely can't resolve.
- **package.json**: `asarUnpack` the three platform packages so their binaries are guaranteed on-disk/executable.

## Verification
- Default resolvers find all three dirs in real node_modules, incl. codex's nested path; binaries confirmed present.
- A packed `.app` has the three binaries **and** their `package.json` under `app.asar.unpacked`.
- New `agent-bin-path.test.ts` (24 tests): per-provider resolution, codex nesting, asar→unpacked mapping, PATH compose/de-dup on posix+win32, best-effort skips, preflight passing when bundled dirs injected.
- Full desktop suite: **118 passing**. Build + lint clean.

Net result: the warning disappears, providers work out of the box, no user install needed — and the ~530 MB the app ships is finally used. No release tag cut; ready when you want to review/merge and then cut a version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)