### PR TITLE
fix(coc-agent-sdk): spawn agent CLIs from app.asar.unpacked in packaged desktop

### DIFF
--- a/packages/coc-agent-sdk/src/asar-path.ts
+++ b/packages/coc-agent-sdk/src/asar-path.ts
@@ -1,0 +1,40 @@
+/**
+ * Map a path that resolves *inside* an Electron `app.asar` archive to the
+ * `app.asar.unpacked` copy on disk, when that copy exists.
+ *
+ * Why this is needed: in a packaged desktop build, `require.resolve()` returns
+ * paths inside `app.asar` (a single archive file). `fs.existsSync` succeeds on
+ * those paths because Electron's fs shim transparently redirects reads — but
+ * `child_process.spawn` does NOT go through that shim:
+ *   - spawning a native binary at an `app.asar/...` path fails with `ENOTDIR`
+ *     (the OS sees `app.asar` as a file, not a directory), and
+ *   - handing such a path to the *system* `node` (which has no asar support at
+ *     all) fails to load the module.
+ * electron-builder unpacks the agent CLIs to `app.asar.unpacked`, so the real,
+ * spawnable file lives there. This rewrites the path accordingly.
+ *
+ * It is a no-op when the path contains no `app.asar` segment (the normal CLI
+ * install, where binaries are plain files), so it is safe to call
+ * unconditionally from code shared by the CLI and the desktop app.
+ */
+
+import * as fs from 'fs';
+
+export function preferUnpackedPath(
+    p: string,
+    existsSync: (filePath: string) => boolean = fs.existsSync,
+): string {
+    // Only rewrite a real `app.asar` *segment* (bounded by path separators),
+    // never an unrelated substring like `app.asared`.
+    const unpacked = p.replace(/([\\/])app\.asar([\\/])/g, '$1app.asar.unpacked$2');
+    if (unpacked !== p) {
+        try {
+            if (existsSync(unpacked)) {
+                return unpacked;
+            }
+        } catch {
+            // Fall through to the original path on any fs error.
+        }
+    }
+    return p;
+}

--- a/packages/coc-agent-sdk/src/claude-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/claude-sdk-service.ts
@@ -38,6 +38,7 @@ import type { ToolCall } from './tool-call';
 import type { ClaudeImageSource, ClaudeImageSkip } from './image-converter';
 import { sdkServiceRegistry, CLAUDE_PROVIDER } from './sdk-service-registry';
 import { dynamicImportModule } from './sdk-esm-loader';
+import { preferUnpackedPath } from './asar-path';
 import { getSDKLogger } from './logger';
 import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
 import { cocToolBridgeServer } from './llm-tools/bridge-server';
@@ -334,6 +335,13 @@ interface ClaudeQueryOptions {
         resume?: string;
         /** Use a stable UUID for a newly-created Claude Code transcript session. */
         sessionId?: string;
+        /**
+         * Absolute path to the Claude Code native binary. Set in packaged
+         * desktop builds so the SDK spawns the unpacked binary instead of its
+         * own `require.resolve` result, which points inside `app.asar` and
+         * fails to spawn (`ENOTDIR`).
+         */
+        pathToClaudeCodeExecutable?: string;
     };
 }
 
@@ -670,7 +678,15 @@ export class ClaudeSDKService implements ISDKService {
         });
     }
 
-    private resolveClaudeCliCommand(): { command: string; args: string[] } {
+    /**
+     * Absolute path to the bundled Claude Code native binary, or `undefined`
+     * when it can't be located (then callers fall back to PATH / the SDK's own
+     * resolution). In a packaged desktop build `require.resolve` returns an
+     * `app.asar` path that `fs.existsSync` accepts but `spawn` cannot execute
+     * (`ENOTDIR`); {@link preferUnpackedPath} rewrites it to the real
+     * `app.asar.unpacked` file. A no-op for a normal CLI install.
+     */
+    private resolveClaudeExecutablePath(): string | undefined {
         const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
         const nativePackageName = `${CLAUDE_AGENT_SDK_PACKAGE}-${process.platform}-${process.arch}`;
         try {
@@ -681,13 +697,21 @@ export class ClaudeSDKService implements ISDKService {
                 path.join(packageDir, 'bin', binaryName),
             ]) {
                 if (fs.existsSync(candidate)) {
-                    return { command: candidate, args: [] };
+                    return preferUnpackedPath(candidate);
                 }
             }
         } catch {
-            // Fall through to PATH lookup below.
+            // Fall through — caller handles the undefined case.
         }
+        return undefined;
+    }
 
+    private resolveClaudeCliCommand(): { command: string; args: string[] } {
+        const executable = this.resolveClaudeExecutablePath();
+        if (executable) {
+            return { command: executable, args: [] };
+        }
+        // Fall back to PATH lookup.
         return { command: 'claude', args: [] };
     }
 
@@ -907,10 +931,15 @@ export class ClaudeSDKService implements ISDKService {
             };
 
             inputGate = new ClaudeInputGate(this.buildClaudeInitialMessages(options));
+            // In a packaged desktop build the SDK's own `require.resolve` of the
+            // native binary yields an unspawnable `app.asar` path; pass the
+            // unpacked path explicitly so sessions launch.
+            const claudeExecutable = this.resolveClaudeExecutablePath();
             const queryOptions: ClaudeQueryOptions = {
                 prompt: inputGate.stream(),
                 abortController,
                 options: {
+                    ...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
                     ...(options.workingDirectory ? { cwd: options.workingDirectory } : {}),
                     additionalDirectories: this.resolveAdditionalDirectories(options),
                     ...(model ? { model } : {}),

--- a/packages/coc-agent-sdk/src/sdk-client-factory.ts
+++ b/packages/coc-agent-sdk/src/sdk-client-factory.ts
@@ -12,6 +12,7 @@ import type { CopilotClient, CopilotClientOptions } from '@github/copilot-sdk';
 import { ensureFolderTrusted } from './trusted-folder';
 import { getAIServiceLogger } from './logger';
 import { getCachedCopilotSdk } from './sdk-esm-loader';
+import { preferUnpackedPath } from './asar-path';
 import {
     resolveWorkspaceExecutionContext,
     translatePathForHostFilesystem,
@@ -135,7 +136,11 @@ export function createSdkClient(options: CopilotClientOptions = {}): CopilotClie
         (process.versions as Record<string, string | undefined>).electron &&
         !clientOptions.connection
     ) {
-        const copilotCliPath = findCopilotCliPath();
+        // The copilot CLI is launched by the *system* node, which has no asar
+        // support — so an `app.asar` path fails to load. Rewrite it to the
+        // unpacked copy on disk (no-op for a normal CLI install).
+        const rawCopilotCliPath = findCopilotCliPath();
+        const copilotCliPath = rawCopilotCliPath ? preferUnpackedPath(rawCopilotCliPath) : undefined;
         const systemNode = resolveSystemNodePath();
         if (copilotCliPath && systemNode) {
             clientOptions.connection = sdk.RuntimeConnection.forStdio({

--- a/packages/coc-agent-sdk/test/asar-path.test.ts
+++ b/packages/coc-agent-sdk/test/asar-path.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit coverage for app.asar → app.asar.unpacked path rewriting.
+ *
+ * Regression context: in packaged desktop builds, agent-CLI paths resolved via
+ * `require.resolve` point inside `app.asar`, which `spawn` (native binary) and
+ * the system `node` (copilot) cannot execute. preferUnpackedPath rewrites them
+ * to the unpacked copy when it exists, and is a no-op for plain CLI installs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { preferUnpackedPath } from '../src/asar-path';
+
+const MAC_ASAR = '/Applications/CoC.app/Contents/Resources/app.asar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude';
+const MAC_UNPACKED = '/Applications/CoC.app/Contents/Resources/app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude';
+
+describe('preferUnpackedPath', () => {
+    it('rewrites an app.asar path to app.asar.unpacked when the unpacked file exists', () => {
+        expect(preferUnpackedPath(MAC_ASAR, (p) => p === MAC_UNPACKED)).toBe(MAC_UNPACKED);
+    });
+
+    it('keeps the original path when the unpacked copy does not exist', () => {
+        // e.g. a file that genuinely lives inside the archive and was not unpacked.
+        expect(preferUnpackedPath(MAC_ASAR, () => false)).toBe(MAC_ASAR);
+    });
+
+    it('rewrites Windows-separator asar paths', () => {
+        const win = 'C:\\Program Files\\CoC\\resources\\app.asar\\node_modules\\@github\\copilot\\index.js';
+        const winUnpacked = 'C:\\Program Files\\CoC\\resources\\app.asar.unpacked\\node_modules\\@github\\copilot\\index.js';
+        expect(preferUnpackedPath(win, (p) => p === winUnpacked)).toBe(winUnpacked);
+    });
+
+    it('is a no-op for a plain path with no asar segment (CLI install)', () => {
+        const cli = '/usr/local/lib/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude';
+        // existsSync must never even be consulted when there is no asar segment.
+        expect(
+            preferUnpackedPath(cli, () => {
+                throw new Error('existsSync should not be called');
+            }),
+        ).toBe(cli);
+    });
+
+    it('does not rewrite an unrelated substring like app.asared', () => {
+        const p = '/x/app.asared/y/claude';
+        expect(preferUnpackedPath(p, () => true)).toBe(p);
+    });
+
+    it('falls back to the original path if the existence check throws', () => {
+        expect(
+            preferUnpackedPath(MAC_ASAR, () => {
+                throw new Error('fs blew up');
+            }),
+        ).toBe(MAC_ASAR);
+    });
+
+    it('rewrites every app.asar segment in the path', () => {
+        // Defensive: the regex is global, so a (pathological) doubled segment maps fully.
+        const p = '/a/app.asar/b/app.asar/claude';
+        const expected = '/a/app.asar.unpacked/b/app.asar.unpacked/claude';
+        expect(preferUnpackedPath(p, (q) => q === expected)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Problem
In the packaged desktop app (v3.4.5), **claude and copilot sessions don't work** while codex does.

Root cause (traced + reproduced in a real packed `.app` via electron-as-node):
`require.resolve` returns paths **inside `app.asar`**. `fs.existsSync` accepts them (Electron redirects reads), but spawning does not go through that shim:
| Provider | Launch | asar failure |
|---|---|---|
| codex ✅ | electron-as-node runs `codex.js` | electron-node has asar support |
| claude ❌ | spawns the native `claude` binary directly | `spawn` → **ENOTDIR** |
| copilot ❌ | **system node** runs `@github/copilot/index.js` | system node has **no asar support** |

## Fix
`preferUnpackedPath()` rewrites an `app.asar` path to its `app.asar.unpacked` copy when the real file exists (no-op for a plain CLI install). Applied where each binary is resolved:
- **claude**: pass the unpacked binary as `pathToClaudeCodeExecutable` on every session query (and for CLI model discovery) — otherwise the SDK's own `require.resolve` default is the unspawnable asar path.
- **copilot**: rewrite the `index.js` path before handing it to the system-node connection.

## Verification (real packed .app, electron-as-node)
| | asar path | unpacked path (after fix) |
|---|---|---|
| claude | `spawn` ENOTDIR | **exit=0, "2.1.185 (Claude Code)"** ✅ |
| copilot | system node load error | **exit=0, Copilot CLI** ✅ |

Adds `asar-path.test.ts` (7 cases). 191 scoped coc-agent-sdk tests pass; build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)