### PR TITLE
fix(coc-desktop): bundle the app icon so the dock shows CoC, not a black glyph

### DIFF
--- a/packages/coc-desktop/package.json
+++ b/packages/coc-desktop/package.json
@@ -49,6 +49,12 @@
       "**/@openai/codex-*/**",
       "**/@github/copilot-*-*/**"
     ],
+    "extraResources": [
+      {
+        "from": "../../media/coc-icon.png",
+        "to": "coc-icon.png"
+      }
+    ],
     "files": [
       "**/*",
       "!**/*.map",

--- a/packages/coc-desktop/src/app-icon.ts
+++ b/packages/coc-desktop/src/app-icon.ts
@@ -10,30 +10,39 @@ import * as path from 'path';
 /**
  * Candidate search order (first existing path wins):
  *
- *  1. dev layout  — main.js lives in `packages/coc-desktop/dist/`, icon is 3
+ *  1. Packaged    — bundled via electron-builder `extraResources` to
+ *     `<resourcesDir>/coc-icon.png` (i.e. `process.resourcesPath`). This is the
+ *     ONLY copy present in a production `.app`/installer: `media/` lives at the
+ *     repo root, outside the app's file glob. Without it the dock icon falls
+ *     back to a placeholder glyph.
+ *  2. dev layout  — main.js lives in `packages/coc-desktop/dist/`, icon is 3
  *     directories up at the repo root under `media/`.
- *  2. Alternate   — one directory up (e.g. a flat staging layout).
- *  3. Same-dir    — icon was copied next to main.js at pack time.
+ *  3. Alternate   — one directory up (e.g. a flat staging layout).
+ *  4. Same-dir    — icon was copied next to main.js at pack time.
  */
-const ICON_CANDIDATES = (fromDir: string): string[] => [
-    path.join(fromDir, '..', '..', '..', 'media', 'coc-icon.png'), // dev
-    path.join(fromDir, '..', 'media', 'coc-icon.png'),              // alternate
-    path.join(fromDir, 'media', 'coc-icon.png'),                    // same-dir/packaged
+const ICON_CANDIDATES = (fromDir: string, resourcesDir?: string): string[] => [
+    ...(resourcesDir ? [path.join(resourcesDir, 'coc-icon.png')] : []), // packaged (extraResources)
+    path.join(fromDir, '..', '..', '..', 'media', 'coc-icon.png'),      // dev
+    path.join(fromDir, '..', 'media', 'coc-icon.png'),                  // alternate
+    path.join(fromDir, 'media', 'coc-icon.png'),                        // same-dir
 ];
 
 /**
  * Returns the absolute path to `coc-icon.png`, or `null` if none of the
  * candidate locations contain the file.
  *
- * @param fromDir  The directory to search from (normally `__dirname` in main.ts).
- * @param existsFn Injectable file-existence check — defaults to `fs.existsSync`
- *                 so callers can substitute a mock in unit tests.
+ * @param fromDir      The directory to search from (normally `__dirname` in main.ts).
+ * @param resourcesDir Electron's `process.resourcesPath` in packaged builds; the
+ *                     bundled icon lives directly under it. Omit in dev/tests.
+ * @param existsFn     Injectable file-existence check — defaults to `fs.existsSync`
+ *                     so callers can substitute a mock in unit tests.
  */
 export function resolveIconPath(
     fromDir: string,
+    resourcesDir?: string,
     existsFn: (p: string) => boolean = require('fs').existsSync,
 ): string | null {
-    for (const candidate of ICON_CANDIDATES(fromDir)) {
+    for (const candidate of ICON_CANDIDATES(fromDir, resourcesDir)) {
         if (existsFn(candidate)) {
             return candidate;
         }

--- a/packages/coc-desktop/src/main.ts
+++ b/packages/coc-desktop/src/main.ts
@@ -45,7 +45,7 @@ const TRAY_ICON_FALLBACK_DATA_URL =
  * if the PNG cannot be found (e.g. a production asar without a bundled media/).
  */
 function loadCocIcon(): ReturnType<typeof nativeImage.createFromPath> {
-    const iconPath = resolveIconPath(__dirname);
+    const iconPath = resolveIconPath(__dirname, process.resourcesPath);
     if (iconPath) {
         return nativeImage.createFromPath(iconPath);
     }
@@ -268,16 +268,22 @@ async function bootstrap(): Promise<void> {
     app.setAboutPanelOptions(
         buildAboutPanelOptions({
             version: readDesktopVersion(__dirname),
-            iconPath: resolveIconPath(__dirname),
+            iconPath: resolveIconPath(__dirname, process.resourcesPath),
             electronVersion: process.versions.electron,
         }),
     );
 
     // macOS: set the dock icon early (BrowserWindow `icon` is ignored by macOS).
+    // Only override when the real icon file resolves — otherwise leave the dock
+    // showing the app bundle's `.icns` (set by electron-builder) rather than
+    // stamping the tiny placeholder glyph over it.
     if (process.platform === 'darwin' && app.dock) {
-        const dockIcon = loadCocIcon();
-        if (!dockIcon.isEmpty()) {
-            app.dock.setIcon(dockIcon);
+        const iconPath = resolveIconPath(__dirname, process.resourcesPath);
+        if (iconPath) {
+            const dockIcon = nativeImage.createFromPath(iconPath);
+            if (!dockIcon.isEmpty()) {
+                app.dock.setIcon(dockIcon);
+            }
         }
     }
 

--- a/packages/coc-desktop/test/app-icon.test.ts
+++ b/packages/coc-desktop/test/app-icon.test.ts
@@ -10,8 +10,10 @@ import { describe, it, expect } from 'vitest';
 import { resolveIconPath } from '../src/app-icon';
 
 const FAKE_DIR = path.join('/fake', 'app', 'dist');
+const FAKE_RESOURCES = path.join('/fake', 'app', 'Contents', 'Resources');
 
-/** The three candidates resolveIconPath tries, in order. */
+/** Candidates resolveIconPath tries, in order. */
+const PACKAGED_CANDIDATE = path.join(FAKE_RESOURCES, 'coc-icon.png');
 const [DEV_CANDIDATE, ALT_CANDIDATE, SAME_DIR_CANDIDATE] = [
     path.join(FAKE_DIR, '..', '..', '..', 'media', 'coc-icon.png'),
     path.join(FAKE_DIR, '..', 'media', 'coc-icon.png'),
@@ -20,33 +22,45 @@ const [DEV_CANDIDATE, ALT_CANDIDATE, SAME_DIR_CANDIDATE] = [
 
 describe('resolveIconPath', () => {
     it('returns null when no candidate exists', () => {
-        expect(resolveIconPath(FAKE_DIR, () => false)).toBeNull();
+        expect(resolveIconPath(FAKE_DIR, undefined, () => false)).toBeNull();
     });
 
-    it('resolves the dev-layout candidate (3 directories up from dist/)', () => {
+    it('resolves the packaged candidate under resourcesDir first', () => {
+        // The bundled extraResources copy must win over the dev layout so a
+        // production .app never falls back to the placeholder dock glyph.
+        const result = resolveIconPath(FAKE_DIR, FAKE_RESOURCES, () => true);
+        expect(result).toBe(PACKAGED_CANDIDATE);
+    });
+
+    it('resolves the bundled icon even when only resourcesDir has it', () => {
+        const result = resolveIconPath(FAKE_DIR, FAKE_RESOURCES, (p) => p === PACKAGED_CANDIDATE);
+        expect(result).toBe(PACKAGED_CANDIDATE);
+    });
+
+    it('skips the packaged candidate when no resourcesDir is given (dev)', () => {
         // Only the first candidate exists — mirrors the dev launch layout.
-        const result = resolveIconPath(FAKE_DIR, (p) => p === DEV_CANDIDATE);
+        const result = resolveIconPath(FAKE_DIR, undefined, (p) => p === DEV_CANDIDATE);
         expect(result).toBe(DEV_CANDIDATE);
     });
 
     it('falls back to the alternate candidate when the dev path is missing', () => {
-        const result = resolveIconPath(FAKE_DIR, (p) => p === ALT_CANDIDATE);
+        const result = resolveIconPath(FAKE_DIR, undefined, (p) => p === ALT_CANDIDATE);
         expect(result).toBe(ALT_CANDIDATE);
     });
 
     it('falls back to the same-dir candidate as a last resort', () => {
-        const result = resolveIconPath(FAKE_DIR, (p) => p === SAME_DIR_CANDIDATE);
+        const result = resolveIconPath(FAKE_DIR, undefined, (p) => p === SAME_DIR_CANDIDATE);
         expect(result).toBe(SAME_DIR_CANDIDATE);
     });
 
-    it('returns the first match when multiple candidates exist', () => {
-        // All exist — dev candidate should win.
-        const result = resolveIconPath(FAKE_DIR, () => true);
+    it('returns the dev candidate when resourcesDir lacks the icon', () => {
+        // Packaged path is checked but missing; dev layout wins.
+        const result = resolveIconPath(FAKE_DIR, FAKE_RESOURCES, (p) => p !== PACKAGED_CANDIDATE);
         expect(result).toBe(DEV_CANDIDATE);
     });
 
     it('does not throw for unusual or empty fromDir values', () => {
-        expect(() => resolveIconPath('', () => false)).not.toThrow();
-        expect(() => resolveIconPath('/does/not/exist/at/all', () => false)).not.toThrow();
+        expect(() => resolveIconPath('', undefined, () => false)).not.toThrow();
+        expect(() => resolveIconPath('/does/not/exist/at/all', undefined, () => false)).not.toThrow();
     });
 });


### PR DESCRIPTION
## Problem
In the packaged app the **dock icon is a black octagon** (placeholder), even though Finder/dialogs show the correct CoC icon.

## Cause
`media/coc-icon.png` lives at the **repo root**, outside the coc-desktop file glob, and nothing copied it into the bundle. So `resolveIconPath()` found nothing → `loadCocIcon()` returned the tiny `TRAY_ICON_FALLBACK_DATA_URL` glyph → `app.dock.setIcon()` stamped that **black glyph over the correct `.icns`** dock icon.

## Fix
- **package.json**: bundle `media/coc-icon.png` via electron-builder `extraResources` → `Contents/Resources/coc-icon.png` (= `process.resourcesPath`).
- **app-icon.ts**: `resolveIconPath(fromDir, resourcesDir?, existsFn?)` checks `<resourcesDir>/coc-icon.png` first — the only copy present in production.
- **main.ts**: pass `process.resourcesPath` at each call site, and only override the dock icon when a real icon resolves (never stamp the placeholder over the `.icns`).

## Verification
Packed a real `.app`: `coc-icon.png` is in `Contents/Resources` and `resolveIconPath` resolves to it (512×512, 112 KB). `app-icon.test.ts` covers packaged-candidate priority + fallthrough; full desktop suite (120 tests) passes; build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)