### PR TITLE
pr/f00a1d1ef perfforge collapse ahead behind into one

### DIFF
--- a/packages/coc/src/server/git/git-info-cache.ts
+++ b/packages/coc/src/server/git/git-info-cache.ts
@@ -5,14 +5,15 @@
  *   - Fresh entry (age ≤ STALE_THRESHOLD_MS): return cached data immediately.
  *   - Stale / missing entry: await the in-flight fetch (or trigger one) before returning.
  *
- * A background interval (REFRESH_PERIOD_MS) proactively re-fetches all known workspaces
- * so that most batch requests hit the fresh branch.
+ * A background interval (REFRESH_PERIOD_MS) proactively re-fetches only the workspaces a
+ * dashboard client currently has open (the "active" set), so that those views hit the
+ * fresh branch.  Workspaces nobody is viewing are not refreshed in the background; they
+ * are still served lazily on demand via the stale-then-wait path. When no client is
+ * connected (empty active set), the background tick does zero git work.
  *
  * Invalidation:  `invalidate(workspaceId)` marks an entry stale and immediately triggers
  * a fresh fetch.  Call it after any git mutation (push, pull, commit, branch switch, …).
  */
-
-import type { ProcessStore } from '@plusplusoneplusplus/forge';
 
 // ============================================================================
 // Types
@@ -39,8 +40,8 @@ interface GitInfoEntry {
 // Constants
 // ============================================================================
 
-export const REFRESH_PERIOD_MS = 30_000;
-export const STALE_THRESHOLD_MS = 90_000;
+export const REFRESH_PERIOD_MS = 300_000;
+export const STALE_THRESHOLD_MS = 600_000;
 
 const BACKGROUND_CONCURRENCY = 4;
 
@@ -52,7 +53,7 @@ const BACKGROUND_CONCURRENCY = 4;
  * Per-workspace git-info cache with background refresh and invalidation.
  *
  * Lifecycle:
- *   1. `start(store, fetchFn)` — begin background refresh; call once after server start.
+ *   1. `start(fetchFn, getActiveWorkspaceIds)` — begin background refresh; call once after server start.
  *   2. `getOrFetch(workspaceId)` — serve requests (stale-then-wait).
  *   3. `invalidate(workspaceId)` — called on any git mutation (hooks into broadcastGitChanged).
  *   4. `dispose()` — stop background timer; call during server shutdown.
@@ -61,7 +62,7 @@ export class GitInfoCacheService {
     private entries = new Map<string, GitInfoEntry>();
     private timer: ReturnType<typeof setInterval> | null = null;
     private fetchFn: ((workspaceId: string) => Promise<GitInfoResult>) | null = null;
-    private store: ProcessStore | null = null;
+    private getActiveWorkspaceIds: (() => string[]) | null = null;
 
     // ──────────────────────────────────────────────────────────────────────────
     // Lifecycle
@@ -70,12 +71,17 @@ export class GitInfoCacheService {
     /**
      * Start the background refresh interval.
      *
-     * @param store    Used by the background job to enumerate known workspaces.
-     * @param fetchFn  Async function that fetches git-info for one workspace by ID.
+     * @param fetchFn               Async function that fetches git-info for one workspace by ID.
+     * @param getActiveWorkspaceIds Source of the workspace ids a dashboard client currently has
+     *                              open. The background job refreshes only these; an empty result
+     *                              means the tick performs no git work.
      */
-    start(store: ProcessStore, fetchFn: (workspaceId: string) => Promise<GitInfoResult>): void {
+    start(
+        fetchFn: (workspaceId: string) => Promise<GitInfoResult>,
+        getActiveWorkspaceIds: () => string[],
+    ): void {
         this.fetchFn = fetchFn;
-        this.store = store;
+        this.getActiveWorkspaceIds = getActiveWorkspaceIds;
         this.timer = setInterval(() => { this.refreshAll().catch(() => { /* best-effort */ }); }, REFRESH_PERIOD_MS);
         // Don't prevent Node.js from exiting cleanly
         if ((this.timer as any).unref) (this.timer as any).unref();
@@ -89,7 +95,7 @@ export class GitInfoCacheService {
         }
         this.entries.clear();
         this.fetchFn = null;
-        this.store = null;
+        this.getActiveWorkspaceIds = null;
     }
 
     /** Drop all cached entries without stopping the background refresh. Used by tests. */
@@ -141,12 +147,12 @@ export class GitInfoCacheService {
     // ──────────────────────────────────────────────────────────────────────────
 
     /**
-     * Background job: re-fetch all known workspaces at most CONCURRENCY at a time.
+     * Background job: re-fetch only the currently-active workspaces, at most CONCURRENCY
+     * at a time. When the active set is empty (no connected client), this is a no-op.
      */
     private async refreshAll(): Promise<void> {
-        if (!this.store) return;
-        const workspaces = await this.store.getWorkspaces();
-        const ids = workspaces.map((w: { id: string }) => w.id);
+        if (!this.getActiveWorkspaceIds) return;
+        const ids = this.getActiveWorkspaceIds();
         for (let i = 0; i < ids.length; i += BACKGROUND_CONCURRENCY) {
             const batch = ids.slice(i, i + BACKGROUND_CONCURRENCY);
             await Promise.all(batch.map((id: string) => this.triggerFetch(id).catch(() => { /* per-workspace errors are non-fatal */ })));

--- a/packages/coc/src/server/routes/api-workspace-routes.ts
+++ b/packages/coc/src/server/routes/api-workspace-routes.ts
@@ -226,8 +226,13 @@ async function fetchOneGitInfo(workspaceId: string, store: ProcessStore): Promis
 export function registerApiWorkspaceRoutes(ctx: ApiRouteContext): void {
     const { routes, store } = ctx;
 
-    // Start the git-info cache background refresh for this server instance
-    gitInfoCache.start(store, (wsId) => fetchOneGitInfo(wsId, store));
+    // Start the git-info cache background refresh for this server instance.
+    // Only workspaces a dashboard client currently has open are proactively
+    // refreshed; everything else is served lazily on demand.
+    gitInfoCache.start(
+        (wsId) => fetchOneGitInfo(wsId, store),
+        () => ctx.activeWorkspaceTracker?.getSnapshot().activeWorkspaceIds ?? [],
+    );
 
     // POST /api/workspaces — Register a workspace
     routes.push({

--- a/packages/coc/test/server/git-info-cache.test.ts
+++ b/packages/coc/test/server/git-info-cache.test.ts
@@ -10,7 +10,9 @@
  *  - invalidate: on unknown workspace → still triggers a fetch
  *  - concurrent getOrFetch calls on same cold workspace → single fetch
  *  - fetchFn error → clears inflight so next call retries
- *  - background refresh → calls fetchFn for all workspaces
+ *  - background refresh → calls fetchFn only for the active workspaces
+ *  - background refresh → empty active set triggers zero fetches
+ *  - getOrFetch on an inactive workspace → still lazily fetches
  *  - dispose → clears timer and entries
  */
 
@@ -23,13 +25,24 @@ import type { GitInfoResult } from '../../src/server/git/git-info-cache';
 const RESULT_A: GitInfoResult = { branch: 'main', dirty: false, isGitRepo: true, remoteUrl: null, ahead: 0, behind: 0 };
 const RESULT_B: GitInfoResult = { branch: 'feat/x', dirty: true, isGitRepo: true, remoteUrl: 'https://github.com/x/y.git', ahead: 1, behind: 0 };
 
-function makeStore(ids: string[] = ['ws-a']) {
-    return {
-        getWorkspaces: vi.fn().mockResolvedValue(ids.map(id => ({ id, name: id, rootPath: `/repos/${id}` }))),
-    } as any;
+/** Build a `getActiveWorkspaceIds` callback that always reports the given active ids. */
+function activeIds(ids: string[] = ['ws-a']) {
+    return vi.fn(() => ids);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GitInfoCacheService constants', () => {
+    it('uses a 5-minute proactive refresh period', () => {
+        expect(REFRESH_PERIOD_MS).toBe(300_000);
+    });
+
+    it('keeps the stale threshold above the refresh period', () => {
+        // Reads served between background cycles must hit cached data, not force a
+        // synchronous git status. Requires STALE_THRESHOLD_MS > REFRESH_PERIOD_MS.
+        expect(STALE_THRESHOLD_MS).toBeGreaterThan(REFRESH_PERIOD_MS);
+    });
+});
 
 describe('GitInfoCacheService', () => {
     let cache: GitInfoCacheService;
@@ -49,7 +62,7 @@ describe('GitInfoCacheService', () => {
     // ── Cold miss ─────────────────────────────────────────────────────────────
 
     it('fetches when no entry exists (cold miss)', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
         const result = await cache.getOrFetch('ws-a');
         expect(result).toEqual(RESULT_A);
         expect(fetchFn).toHaveBeenCalledTimes(1);
@@ -59,7 +72,7 @@ describe('GitInfoCacheService', () => {
     // ── Fresh hit ─────────────────────────────────────────────────────────────
 
     it('returns cached data immediately for fresh entry (no re-fetch)', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
         await cache.getOrFetch('ws-a');  // warm up
         fetchFn.mockClear();
 
@@ -71,7 +84,8 @@ describe('GitInfoCacheService', () => {
     // ── Stale hit ─────────────────────────────────────────────────────────────
 
     it('re-fetches when entry is stale (age > STALE_THRESHOLD_MS)', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        // Empty active set: isolate getOrFetch staleness from any background tick.
+        cache.start(fetchFn, activeIds([]));
         await cache.getOrFetch('ws-a');  // warm up
         fetchFn.mockResolvedValue(RESULT_B);
         fetchFn.mockClear();
@@ -87,7 +101,8 @@ describe('GitInfoCacheService', () => {
     // ── Entry just inside fresh window ────────────────────────────────────────
 
     it('does not re-fetch when entry age equals STALE_THRESHOLD_MS exactly', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        // Empty active set: isolate getOrFetch staleness from any background tick.
+        cache.start(fetchFn, activeIds([]));
         await cache.getOrFetch('ws-a');  // warm up
         fetchFn.mockClear();
 
@@ -103,7 +118,7 @@ describe('GitInfoCacheService', () => {
     it('concurrent getOrFetch calls on the same cold workspace share one in-flight fetch', async () => {
         let resolveA!: (v: GitInfoResult) => void;
         fetchFn.mockImplementation(() => new Promise<GitInfoResult>(r => { resolveA = r; }));
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
 
         const p1 = cache.getOrFetch('ws-a');
         const p2 = cache.getOrFetch('ws-a');
@@ -118,7 +133,8 @@ describe('GitInfoCacheService', () => {
     // ── Stale entry with in-flight ────────────────────────────────────────────
 
     it('reuses the in-flight promise when entry is stale but fetch already in flight', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        // Empty active set: isolate getOrFetch staleness from any background tick.
+        cache.start(fetchFn, activeIds([]));
         await cache.getOrFetch('ws-a');  // warm up
 
         // Force stale
@@ -141,7 +157,7 @@ describe('GitInfoCacheService', () => {
     // ── Invalidation ─────────────────────────────────────────────────────────
 
     it('invalidate marks entry stale and triggers a fresh fetch', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
         await cache.getOrFetch('ws-a');  // warm up
 
         fetchFn.mockResolvedValue(RESULT_B);
@@ -161,7 +177,7 @@ describe('GitInfoCacheService', () => {
     });
 
     it('invalidate on unknown workspace triggers a fetch', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
 
         cache.invalidate('ws-a');  // no prior entry
 
@@ -177,7 +193,7 @@ describe('GitInfoCacheService', () => {
     it('clears inflight on fetchFn error so next call retries', async () => {
         fetchFn.mockRejectedValueOnce(new Error('git error'));
         fetchFn.mockResolvedValue(RESULT_A);
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
 
         await expect(cache.getOrFetch('ws-a')).rejects.toThrow('git error');
 
@@ -188,9 +204,8 @@ describe('GitInfoCacheService', () => {
 
     // ── Background refresh ────────────────────────────────────────────────────
 
-    it('background refresh re-fetches all workspaces after REFRESH_PERIOD_MS', async () => {
-        const store = makeStore(['ws-a', 'ws-b']);
-        cache.start(store, fetchFn);
+    it('background refresh re-fetches the active workspaces after REFRESH_PERIOD_MS', async () => {
+        cache.start(fetchFn, activeIds(['ws-a', 'ws-b']));
 
         // Advance past the refresh interval
         await vi.advanceTimersByTimeAsync(REFRESH_PERIOD_MS + 100);
@@ -199,9 +214,45 @@ describe('GitInfoCacheService', () => {
         expect(fetchFn).toHaveBeenCalledWith('ws-b');
     });
 
+    it('background refresh fetches only active workspaces, not every registered one', async () => {
+        // Active set is just 'ws-a'; 'ws-b'/'ws-c' are registered but inactive.
+        cache.start(fetchFn, activeIds(['ws-a']));
+
+        await vi.advanceTimersByTimeAsync(REFRESH_PERIOD_MS + 100);
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(fetchFn).toHaveBeenCalledWith('ws-a');
+        expect(fetchFn).not.toHaveBeenCalledWith('ws-b');
+        expect(fetchFn).not.toHaveBeenCalledWith('ws-c');
+    });
+
+    it('background refresh does no git work when the active set is empty', async () => {
+        cache.start(fetchFn, activeIds([]));
+
+        await vi.advanceTimersByTimeAsync(REFRESH_PERIOD_MS + 100);
+
+        expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it('getOrFetch lazily fetches an inactive workspace and caches it', async () => {
+        // Active set never includes 'ws-b', yet a direct read must still fetch it.
+        cache.start(fetchFn, activeIds(['ws-a']));
+        fetchFn.mockResolvedValue(RESULT_B);
+
+        const result = await cache.getOrFetch('ws-b');
+        expect(result).toEqual(RESULT_B);
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(fetchFn).toHaveBeenCalledWith('ws-b');
+
+        // Cached: a second read within the fresh window does not re-fetch.
+        fetchFn.mockClear();
+        const cached = await cache.getOrFetch('ws-b');
+        expect(cached).toEqual(RESULT_B);
+        expect(fetchFn).not.toHaveBeenCalled();
+    });
+
     it('background refresh respects CONCURRENCY (only 4 at a time)', async () => {
         const ids = Array.from({ length: 8 }, (_, i) => `ws-${i}`);
-        const store = makeStore(ids);
 
         const concurrentCalls: number[] = [];
         let running = 0;
@@ -213,7 +264,7 @@ describe('GitInfoCacheService', () => {
             return RESULT_A;
         });
 
-        cache.start(store, fetchFn);
+        cache.start(fetchFn, activeIds(ids));
         await vi.advanceTimersByTimeAsync(REFRESH_PERIOD_MS + 100);
 
         expect(Math.max(...concurrentCalls)).toBeLessThanOrEqual(4);
@@ -222,7 +273,7 @@ describe('GitInfoCacheService', () => {
     // ── Dispose ───────────────────────────────────────────────────────────────
 
     it('dispose stops background refresh and clears entries', async () => {
-        cache.start(makeStore(['ws-a']), fetchFn);
+        cache.start(fetchFn, activeIds(['ws-a']));
         await cache.getOrFetch('ws-a');
 
         cache.dispose();

--- a/packages/forge/src/git/branch-service.ts
+++ b/packages/forge/src/git/branch-service.ts
@@ -272,16 +272,16 @@ export class BranchService {
                 return { ahead: 0, behind: 0 };
             }
 
-            const aheadCmd = `git rev-list --count "${trackingBranch}..${branchName}"`;
-            const behindCmd = `git rev-list --count "${branchName}..${trackingBranch}"`;
+            // A single symmetric-difference rev-list yields both counts in one process.
+            // `--left-right --count "<upstream>...<branch>"` prints "<behind>\t<ahead>":
+            // the left side counts commits the upstream has that we lack (behind), the
+            // right side counts commits we have that the upstream lacks (ahead).
+            const revListCmd = `git rev-list --left-right --count "${trackingBranch}...${branchName}"`;
+            const output = (await this.execGit(revListCmd, { cwd: repoRoot })).trim();
+            const [behindStr = '', aheadStr = ''] = output.split(/\s+/);
 
-            const [aheadStr, behindStr] = await Promise.all([
-                this.execGit(aheadCmd, { cwd: repoRoot }),
-                this.execGit(behindCmd, { cwd: repoRoot }),
-            ]);
-
-            const ahead = parseInt(aheadStr.trim(), 10) || 0;
-            const behind = parseInt(behindStr.trim(), 10) || 0;
+            const ahead = parseInt(aheadStr, 10) || 0;
+            const behind = parseInt(behindStr, 10) || 0;
 
             return { trackingBranch, ahead, behind };
         } catch (error) {

--- a/packages/forge/test/git/branch-service.test.ts
+++ b/packages/forge/test/git/branch-service.test.ts
@@ -2048,8 +2048,7 @@ describe('BranchService.dropCommit', () => {
                 .mockResolvedValueOnce({ stdout: 'refs/heads/main\n', stderr: '' }) // isDetachedHead
                 .mockResolvedValueOnce({ stdout: 'main\n', stderr: '' })            // getCurrentBranchName
                 .mockResolvedValueOnce({ stdout: 'origin/main\n', stderr: '' })     // upstream lookup
-                .mockResolvedValueOnce({ stdout: '3\n', stderr: '' })               // ahead
-                .mockResolvedValueOnce({ stdout: '1\n', stderr: '' });              // behind
+                .mockResolvedValueOnce({ stdout: '1\t3\n', stderr: '' });           // rev-list --left-right --count (behind\tahead)
 
             const result = await service.getBranchStatus('/repo', false);
 
@@ -2106,29 +2105,65 @@ describe('BranchService.dropCommit', () => {
             });
         });
 
-        it('runs ahead/behind counts in parallel', async () => {
-            const callOrder: string[] = [];
+        it('spawns a single rev-list process and parses combined "behind\\tahead" output', async () => {
             mockedExecAsync
                 .mockResolvedValueOnce({ stdout: 'abc1234\n', stderr: '' })       // getHeadHash
                 .mockResolvedValueOnce({ stdout: 'refs/heads/main\n', stderr: '' }) // isDetachedHead
                 .mockResolvedValueOnce({ stdout: 'main\n', stderr: '' })            // getCurrentBranchName
                 .mockResolvedValueOnce({ stdout: 'origin/main\n', stderr: '' })     // upstream lookup
-                .mockImplementationOnce(async () => {                               // ahead
-                    callOrder.push('ahead');
-                    return { stdout: '2\n', stderr: '' };
-                })
-                .mockImplementationOnce(async () => {                               // behind
-                    callOrder.push('behind');
-                    return { stdout: '5\n', stderr: '' };
-                });
+                .mockResolvedValueOnce({ stdout: '5\t2\n', stderr: '' });           // rev-list --left-right --count (behind\tahead)
 
             const result = await service.getBranchStatus('/repo', false);
 
             expect(result?.ahead).toBe(2);
             expect(result?.behind).toBe(5);
-            // Both calls were made (parallel via Promise.all)
-            expect(callOrder).toContain('ahead');
-            expect(callOrder).toContain('behind');
+
+            // Exactly one rev-list process is spawned (the two separate count calls were collapsed).
+            const revListCalls = mockedExecAsync.mock.calls.filter(call => String(call[0]).includes('git rev-list'));
+            expect(revListCalls).toHaveLength(1);
+            expect(revListCalls[0][0]).toBe('git rev-list --left-right --count "origin/main...main"');
+        });
+
+        it('parses "0\\t0" combined output as ahead: 0, behind: 0', async () => {
+            mockedExecAsync
+                .mockResolvedValueOnce({ stdout: 'abc1234\n', stderr: '' })       // getHeadHash
+                .mockResolvedValueOnce({ stdout: 'refs/heads/main\n', stderr: '' }) // isDetachedHead
+                .mockResolvedValueOnce({ stdout: 'main\n', stderr: '' })            // getCurrentBranchName
+                .mockResolvedValueOnce({ stdout: 'origin/main\n', stderr: '' })     // upstream lookup
+                .mockResolvedValueOnce({ stdout: '0\t0\n', stderr: '' });           // rev-list (behind\tahead)
+
+            const result = await service.getBranchStatus('/repo', false);
+
+            expect(result?.ahead).toBe(0);
+            expect(result?.behind).toBe(0);
+        });
+
+        it('parses ahead-only combined output (behind 0, ahead > 0)', async () => {
+            mockedExecAsync
+                .mockResolvedValueOnce({ stdout: 'abc1234\n', stderr: '' })       // getHeadHash
+                .mockResolvedValueOnce({ stdout: 'refs/heads/main\n', stderr: '' }) // isDetachedHead
+                .mockResolvedValueOnce({ stdout: 'main\n', stderr: '' })            // getCurrentBranchName
+                .mockResolvedValueOnce({ stdout: 'origin/main\n', stderr: '' })     // upstream lookup
+                .mockResolvedValueOnce({ stdout: '0\t4\n', stderr: '' });           // rev-list (behind\tahead)
+
+            const result = await service.getBranchStatus('/repo', false);
+
+            expect(result?.ahead).toBe(4);
+            expect(result?.behind).toBe(0);
+        });
+
+        it('parses behind-only combined output (ahead 0, behind > 0)', async () => {
+            mockedExecAsync
+                .mockResolvedValueOnce({ stdout: 'abc1234\n', stderr: '' })       // getHeadHash
+                .mockResolvedValueOnce({ stdout: 'refs/heads/main\n', stderr: '' }) // isDetachedHead
+                .mockResolvedValueOnce({ stdout: 'main\n', stderr: '' })            // getCurrentBranchName
+                .mockResolvedValueOnce({ stdout: 'origin/main\n', stderr: '' })     // upstream lookup
+                .mockResolvedValueOnce({ stdout: '7\t0\n', stderr: '' });           // rev-list (behind\tahead)
+
+            const result = await service.getBranchStatus('/repo', false);
+
+            expect(result?.ahead).toBe(0);
+            expect(result?.behind).toBe(7);
         });
     });
 });


### PR DESCRIPTION
- **perf(forge): collapse ahead/behind into one rev-list call**
- **perf(coc): scope git-info cache refresh to active workspaces, 5m period**
