### PR TITLE
fix(coc-agent-sdk): spawn the unpacked Codex binary in packaged desktop builds

### DIFF
--- a/packages/coc-agent-sdk/src/codex-exec-path.ts
+++ b/packages/coc-agent-sdk/src/codex-exec-path.ts
@@ -1,0 +1,123 @@
+/**
+ * Resolve a spawnable path to the Codex native binary for packaged desktop
+ * builds, rewriting an `app.asar` path to its `app.asar.unpacked` copy.
+ *
+ * Why this is needed: `@openai/codex-sdk` spawns the native `codex` executable
+ * directly via `child_process.spawn` (it does NOT run a JS entrypoint through
+ * Node). In a packaged Electron app the SDK's own resolution lands the binary
+ * inside `app.asar`, which the OS cannot execute — `spawn` fails with `ENOTDIR`
+ * (it sees `app.asar` as a file, not a directory). electron-builder unpacks the
+ * `@openai/codex-*` packages to `app.asar.unpacked`, so the real, spawnable file
+ * lives there. We compute the same path the SDK would and hand it to the `Codex`
+ * constructor via `codexPathOverride`, pointing at the unpacked copy.
+ *
+ * This mirrors the SDK's resolution (its `findCodexPath`): platform + arch →
+ * target triple → the `@openai/codex-<platform>` vendor package, with the
+ * current layout (`vendor/<triple>/bin/codex`) and a legacy fallback
+ * (`vendor/<triple>/codex/codex`). It stays a no-op for a normal CLI / global
+ * install (no `app.asar` segment) and returns `undefined` when nothing resolves
+ * — an unsupported platform, or the optional binaries not installed — so callers
+ * simply leave the SDK to resolve the binary on its own.
+ */
+
+import { createRequire } from 'module';
+import * as path from 'path';
+import * as fs from 'fs';
+import { preferUnpackedPath } from './asar-path';
+
+const runtimeRequire = createRequire(__filename);
+
+/** `${process.platform}-${process.arch}` → Rust target triple (matches the SDK). */
+const TARGET_TRIPLE_BY_PLATFORM: Readonly<Record<string, string>> = {
+    'darwin-x64': 'x86_64-apple-darwin',
+    'darwin-arm64': 'aarch64-apple-darwin',
+    'win32-x64': 'x86_64-pc-windows-msvc',
+    'win32-arm64': 'aarch64-pc-windows-msvc',
+    'linux-x64': 'x86_64-unknown-linux-musl',
+    'linux-arm64': 'aarch64-unknown-linux-musl',
+};
+
+/** Target triple → the npm package that vendors that triple's binary. */
+const PLATFORM_PACKAGE_BY_TARGET: Readonly<Record<string, string>> = {
+    'x86_64-unknown-linux-musl': '@openai/codex-linux-x64',
+    'aarch64-unknown-linux-musl': '@openai/codex-linux-arm64',
+    'x86_64-apple-darwin': '@openai/codex-darwin-x64',
+    'aarch64-apple-darwin': '@openai/codex-darwin-arm64',
+    'x86_64-pc-windows-msvc': '@openai/codex-win32-x64',
+    'aarch64-pc-windows-msvc': '@openai/codex-win32-arm64',
+};
+
+/** Injectable seams so the resolution is unit-testable without a real install. */
+export interface CodexExecPathEnv {
+    /** Defaults to `process.platform`. */
+    platform?: NodeJS.Platform;
+    /** Defaults to `process.arch`. */
+    arch?: string;
+    /**
+     * Resolve a module request to an absolute path. Defaults to resolving the
+     * `@openai/codex-<platform>` package relative to the `@openai/codex` CLI
+     * package (exactly as the SDK does), falling back to this package's own
+     * resolution. Should throw when the request cannot be resolved.
+     */
+    resolve?: (request: string) => string;
+    /** File existence check; defaults to `fs.existsSync`. */
+    existsSync?: (p: string) => boolean;
+}
+
+/** Default resolver: mirror the SDK by resolving relative to `@openai/codex`. */
+function defaultResolve(request: string): string {
+    let base = __filename;
+    try {
+        base = runtimeRequire.resolve('@openai/codex/package.json');
+    } catch {
+        // `@openai/codex` not resolvable from here — fall back to our own require,
+        // which works when the platform package is hoisted to a shared tree.
+    }
+    return createRequire(base).resolve(request);
+}
+
+/**
+ * The spawnable Codex binary path for the current (or supplied) platform, with
+ * any `app.asar` segment rewritten to `app.asar.unpacked`. `undefined` when it
+ * cannot be resolved — callers should then let the SDK resolve on its own.
+ */
+export function resolveCodexExecutablePath(env: CodexExecPathEnv = {}): string | undefined {
+    const platform = env.platform ?? process.platform;
+    const arch = env.arch ?? process.arch;
+    const resolve = env.resolve ?? defaultResolve;
+    const existsSync = env.existsSync ?? fs.existsSync;
+
+    const triple = TARGET_TRIPLE_BY_PLATFORM[`${platform}-${arch}`];
+    if (!triple) {
+        return undefined;
+    }
+    const platformPackage = PLATFORM_PACKAGE_BY_TARGET[triple];
+    if (!platformPackage) {
+        return undefined;
+    }
+
+    let vendorRoot: string;
+    try {
+        const platformPkgJson = resolve(`${platformPackage}/package.json`);
+        vendorRoot = path.join(path.dirname(platformPkgJson), 'vendor');
+    } catch {
+        return undefined;
+    }
+
+    const binName = platform === 'win32' ? 'codex.exe' : 'codex';
+    const candidates = [
+        path.join(vendorRoot, triple, 'bin', binName), // current SDK layout
+        path.join(vendorRoot, triple, 'codex', binName), // legacy layout
+    ];
+    for (const candidate of candidates) {
+        const resolved = preferUnpackedPath(candidate, existsSync);
+        try {
+            if (existsSync(resolved)) {
+                return resolved;
+            }
+        } catch {
+            // Try the next candidate on any fs error.
+        }
+    }
+    return undefined;
+}

--- a/packages/coc-agent-sdk/src/codex-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/codex-sdk-service.ts
@@ -37,6 +37,7 @@ import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
 import { cocToolBridgeServer } from './llm-tools/bridge-server';
 import { buildCocLlmToolsMcpConfig, COC_LLM_TOOLS_MCP_SERVER_NAME } from './llm-tools/mcp-config';
 import { isSupportedCodexImagePath } from './image-converter';
+import { resolveCodexExecutablePath } from './codex-exec-path';
 import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import * as readline from 'readline';
@@ -454,6 +455,12 @@ interface CodexClient {
  */
 interface CodexConstructorOptions {
     config?: Record<string, unknown>;
+    /**
+     * Absolute path to the native `codex` binary. Set for packaged desktop
+     * builds so the SDK spawns the `app.asar.unpacked` copy instead of its own
+     * resolution, which points inside `app.asar` and fails to spawn (`ENOTDIR`).
+     */
+    codexPathOverride?: string;
 }
 
 /** Constructs a Codex client. The published SDK accepts optional `CodexOptions`. */
@@ -547,6 +554,12 @@ export class CodexSDKService implements ISDKService {
     private codexCtor: CodexClientCtor | null = null;
     private disposed = false;
     private authChecker: CodexAuthChecker | null = null;
+    /**
+     * Memoized native-binary override for packaged desktop builds. `null` means
+     * "not yet computed"; `undefined` is a computed "no override" (the SDK
+     * resolves the binary itself). See {@link resolveCodexConstructorOptions}.
+     */
+    private codexPathOverride: string | undefined | null = null;
 
     /** sessionId → active session metadata */
     private readonly sessions = new Map<string, ActiveCodexSession>();
@@ -607,7 +620,7 @@ export class CodexSDKService implements ISDKService {
                 throw new Error('Codex SDK did not export Codex');
             }
             this.codexCtor = CodexCtor;
-            this.sdk = new CodexCtor();
+            this.sdk = new CodexCtor(this.resolveCodexConstructorOptions());
             this.availabilityCache = { available: true };
         } catch {
             const installCmd = isGlobalInstall()
@@ -666,13 +679,15 @@ export class CodexSDKService implements ISDKService {
             tool_timeout_sec: CODEX_LLM_TOOLS_TIMEOUT_SEC,
             ...(mcpConfig.enabled_tools ? { enabled_tools: mcpConfig.enabled_tools } : {}),
         };
-        const client = new this.codexCtor({
-            config: {
-                mcp_servers: {
-                    [COC_LLM_TOOLS_MCP_SERVER_NAME]: serverConfig,
+        const client = new this.codexCtor(
+            this.resolveCodexConstructorOptions({
+                config: {
+                    mcp_servers: {
+                        [COC_LLM_TOOLS_MCP_SERVER_NAME]: serverConfig,
+                    },
                 },
-            },
-        });
+            }),
+        );
         return {
             client,
             cleanup: () => {
@@ -753,6 +768,24 @@ export class CodexSDKService implements ISDKService {
         const codexBinPath = this.resolveCodexBinPath();
         const rpcResult = await this.fetchRateLimitsViaRpc(codexBinPath);
         return this.mapRateLimitsToQuota(rpcResult);
+    }
+
+    /**
+     * Build the options for `new Codex(...)`, injecting `codexPathOverride` for
+     * packaged desktop builds so the SDK spawns the unpacked native binary
+     * rather than the `app.asar` path it would resolve itself (which fails to
+     * spawn with `ENOTDIR`). A no-op for normal CLI / global installs, where the
+     * override resolves to `undefined`. The override is computed once and cached.
+     */
+    private resolveCodexConstructorOptions(
+        extra: CodexConstructorOptions = {},
+    ): CodexConstructorOptions {
+        if (this.codexPathOverride === null) {
+            this.codexPathOverride = resolveCodexExecutablePath();
+        }
+        return this.codexPathOverride
+            ? { codexPathOverride: this.codexPathOverride, ...extra }
+            : { ...extra };
     }
 
     private resolveCodexBinPath(): string {

--- a/packages/coc-agent-sdk/test/ai/codex-sdk-exec-path-override.test.ts
+++ b/packages/coc-agent-sdk/test/ai/codex-sdk-exec-path-override.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Wiring coverage: the CodexSDKService must pass the resolved native-binary path
+ * to the `Codex` constructor as `codexPathOverride`, so packaged desktop builds
+ * spawn the unpacked binary instead of the unspawnable `app.asar` path.
+ *
+ * The resolver itself is covered by test/codex-exec-path.test.ts; here we mock it
+ * to a fixed value and assert it flows into the constructor options alongside any
+ * per-request `config`.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const FAKE_OVERRIDE = '/Applications/CoC.app/Contents/Resources/app.asar.unpacked/codex';
+
+vi.mock('../../src/codex-exec-path', () => ({
+    resolveCodexExecutablePath: () => FAKE_OVERRIDE,
+}));
+
+import { CodexSDKService } from '../../src/codex-sdk-service';
+import { cocToolBridgeServer } from '../../src/llm-tools/bridge-server';
+import type { Tool } from '../../src/types';
+
+function makeThread() {
+    return {
+        id: 'thread-1',
+        runStreamed: vi.fn(async () => ({
+            events: (async function* () {
+                yield { type: 'thread.started' as const, thread_id: 'thread-1' };
+                yield { type: 'item.completed' as const, item: { id: 'i1', type: 'agent_message', text: 'ok' } };
+            })(),
+        })),
+    };
+}
+
+function makeCodexCtor() {
+    const instances: Array<{ options: unknown }> = [];
+    const ctor = vi.fn(function (this: unknown, options?: unknown) {
+        instances.push({ options });
+        return { startThread: vi.fn(() => makeThread()), resumeThread: vi.fn(() => makeThread()) };
+    }) as unknown as new (options?: unknown) => unknown;
+    return { ctor, instances };
+}
+
+function tool(name: string): Tool<any> {
+    return {
+        name,
+        description: `desc ${name}`,
+        parameters: { type: 'object', properties: {} },
+        handler: vi.fn(async () => 'ok'),
+    } as Tool<any>;
+}
+
+describe('CodexSDKService codexPathOverride wiring', () => {
+    let svc: CodexSDKService | undefined;
+
+    afterEach(() => {
+        svc?.dispose();
+        svc = undefined;
+        cocToolBridgeServer.closeAll();
+    });
+
+    it('injects codexPathOverride into a per-request client and preserves config', async () => {
+        svc = new CodexSDKService();
+        const { ctor, instances } = makeCodexCtor();
+        (svc as unknown as { sdk: unknown }).sdk = {
+            startThread: vi.fn(() => makeThread()),
+            resumeThread: vi.fn(),
+        };
+        (svc as unknown as { codexCtor: unknown }).codexCtor = ctor;
+        (svc as unknown as { availabilityCache: unknown }).availabilityCache = { available: true };
+
+        // Supplying tools forces a fresh per-request client carrying mcp_servers.
+        const result = await svc.sendMessage({ prompt: 'hi', tools: [tool('ask_user')] });
+        expect(result.success).toBe(true);
+
+        expect(instances).toHaveLength(1);
+        const built = instances[0].options as {
+            codexPathOverride?: string;
+            config?: { mcp_servers?: Record<string, unknown> };
+        };
+        expect(built.codexPathOverride).toBe(FAKE_OVERRIDE);
+        expect(built.config?.mcp_servers).toBeDefined();
+    });
+});

--- a/packages/coc-agent-sdk/test/codex-exec-path.test.ts
+++ b/packages/coc-agent-sdk/test/codex-exec-path.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit coverage for resolving the spawnable Codex native binary path.
+ *
+ * Regression context: `@openai/codex-sdk` spawns the native `codex` binary
+ * directly. In packaged desktop builds the SDK resolves it inside `app.asar`,
+ * which `spawn` cannot execute (`ENOTDIR`). resolveCodexExecutablePath computes
+ * the same path and rewrites it to the `app.asar.unpacked` copy, so the desktop
+ * app can pass it as the SDK's `codexPathOverride`.
+ *
+ * The resolver is fully injectable (platform/arch/resolve/existsSync), so these
+ * tests never touch a real install or the filesystem.
+ */
+
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { resolveCodexExecutablePath, CodexExecPathEnv } from '../src/codex-exec-path';
+
+/** Packaged-app layout: the platform package lives inside app.asar. */
+const ASAR_PKG_JSON =
+    '/Applications/CoC.app/Contents/Resources/app.asar/node_modules/@openai/codex-darwin-arm64/package.json';
+const ASAR_VENDOR =
+    '/Applications/CoC.app/Contents/Resources/app.asar/node_modules/@openai/codex-darwin-arm64/vendor';
+const UNPACKED_BIN = path.join(
+    ASAR_VENDOR.replace('app.asar', 'app.asar.unpacked'),
+    'aarch64-apple-darwin',
+    'bin',
+    'codex',
+);
+
+function macEnv(over: Partial<CodexExecPathEnv> = {}): CodexExecPathEnv {
+    return {
+        platform: 'darwin',
+        arch: 'arm64',
+        resolve: (req) => {
+            if (req === '@openai/codex-darwin-arm64/package.json') {
+                return ASAR_PKG_JSON;
+            }
+            throw new Error(`unexpected resolve: ${req}`);
+        },
+        existsSync: (p) => p === UNPACKED_BIN,
+        ...over,
+    };
+}
+
+describe('resolveCodexExecutablePath', () => {
+    it('rewrites the app.asar binary to its unpacked copy (current layout)', () => {
+        expect(resolveCodexExecutablePath(macEnv())).toBe(UNPACKED_BIN);
+    });
+
+    it('falls back to the legacy vendor/<triple>/codex layout', () => {
+        const legacy = path.join(
+            ASAR_VENDOR.replace('app.asar', 'app.asar.unpacked'),
+            'aarch64-apple-darwin',
+            'codex',
+            'codex',
+        );
+        const exec = resolveCodexExecutablePath(macEnv({ existsSync: (p) => p === legacy }));
+        expect(exec).toBe(legacy);
+    });
+
+    it('picks codex.exe and the win32-x64 package on Windows', () => {
+        // Path math uses the host `path`, so feed a POSIX-style input on a POSIX
+        // test host and assert the binary name + the asar→unpacked rewrite.
+        let requested = '';
+        const exec = resolveCodexExecutablePath({
+            platform: 'win32',
+            arch: 'x64',
+            resolve: (req) => {
+                requested = req;
+                return '/root/app.asar/node_modules/@openai/codex-win32-x64/package.json';
+            },
+            existsSync: (p) => p.endsWith('codex.exe') && p.includes('app.asar.unpacked'),
+        });
+        expect(requested).toBe('@openai/codex-win32-x64/package.json');
+        expect(exec).toBeDefined();
+        expect(exec!.endsWith('codex.exe')).toBe(true);
+        expect(exec).toContain('x86_64-pc-windows-msvc');
+        expect(exec).toContain('app.asar.unpacked');
+    });
+
+    it('returns a plain (non-asar) path unchanged when the file exists (dev/global install)', () => {
+        const devPkgJson =
+            '/repo/node_modules/@openai/codex-darwin-arm64/package.json';
+        const devBin = '/repo/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex';
+        const exec = resolveCodexExecutablePath({
+            platform: 'darwin',
+            arch: 'arm64',
+            resolve: () => devPkgJson,
+            existsSync: (p) => p === devBin,
+        });
+        expect(exec).toBe(devBin);
+    });
+
+    it('returns undefined when no candidate binary exists', () => {
+        expect(resolveCodexExecutablePath(macEnv({ existsSync: () => false }))).toBeUndefined();
+    });
+
+    it('returns undefined for an unsupported platform/arch', () => {
+        const calledResolve = (): string => {
+            throw new Error('resolve should not be called for an unsupported platform');
+        };
+        expect(
+            resolveCodexExecutablePath({ platform: 'aix' as NodeJS.Platform, arch: 'ppc64', resolve: calledResolve }),
+        ).toBeUndefined();
+        expect(
+            resolveCodexExecutablePath({ platform: 'darwin', arch: 'ia32', resolve: calledResolve }),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when the platform package cannot be resolved (binaries not installed)', () => {
+        const exec = resolveCodexExecutablePath({
+            platform: 'darwin',
+            arch: 'arm64',
+            resolve: () => {
+                throw new Error('Cannot find module');
+            },
+            existsSync: () => true,
+        });
+        expect(exec).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Codex sessions failed to launch in the packaged CoC desktop app with
`spawn ENOTDIR`. `@openai/codex-sdk` spawns the native `codex` binary
directly, and its own resolution lands inside `app.asar`, which the OS
cannot execute (it sees the archive as a file, not a directory). This is the
same class of asar bug already fixed for the claude (pathToClaudeCodeExecutable)
and copilot (preferUnpackedPath) CLIs — codex was simply never given the
override.

New `codex-exec-path.ts` mirrors the SDK's binary resolution (platform+arch →
target triple → `@openai/codex-<platform>` vendor binary, current + legacy
layouts) and rewrites an `app.asar` path to its `app.asar.unpacked` copy via
preferUnpackedPath. CodexSDKService now passes the result to the `Codex`
constructor as `codexPathOverride` at both construction sites (shared client
and per-request MCP client). It is a no-op for normal CLI / global installs,
where the override resolves to undefined and the SDK resolves the binary
itself.

Tests: 7 unit tests for the resolver (asar rewrite, legacy layout, Windows
.exe, dev/global no-op, unsupported platform, binaries-not-installed) plus a
wiring test asserting codexPathOverride reaches the constructor without
dropping per-request config.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
