### PR TITLE
feat(coc): create_conversation inherits parent chat provider/model/effort

### DIFF
--- a/packages/coc/src/server/executors/chat-tool-builder.ts
+++ b/packages/coc/src/server/executors/chat-tool-builder.ts
@@ -100,6 +100,7 @@ export function buildChatToolBundle(options: ChatToolBundleOptions): ChatToolBun
             options.store,
             options.workspaceId,
             options.enqueueChat,
+            options.processId,
         ));
     }
 

--- a/packages/coc/src/server/executors/prompt-builder.ts
+++ b/packages/coc/src/server/executors/prompt-builder.ts
@@ -519,17 +519,20 @@ export function buildSearchConversationsAddon(
  * @param store        ProcessStore — used to validate the target workspace exists.
  * @param workspaceId  The caller's current workspace; the default enqueue target.
  * @param enqueueChat  Bound in-process enqueue capability; when omitted, no tool.
+ * @param parentProcessId The current chat's processId; the spawned conversation
+ *                        inherits its resolved provider/model/reasoningEffort.
  */
 export function buildCreateConversationAddon(
     store: ProcessStore | undefined,
     workspaceId: string | undefined,
     enqueueChat: EnqueueChatFn | undefined,
+    parentProcessId?: string,
 ): { tools: Tool<any>[]; suffix: string } {
     if (!store || !enqueueChat) {
         return { tools: [], suffix: '' };
     }
 
-    const { tool } = createCreateConversationTool({ store, workspaceId, enqueueChat });
+    const { tool } = createCreateConversationTool({ store, workspaceId, enqueueChat, parentProcessId });
 
     // No prose suffix — the create_conversation tool description carries its own guidance.
     return { tools: [tool], suffix: '' };

--- a/packages/coc/src/server/llm-tools/create-conversation-tool.ts
+++ b/packages/coc/src/server/llm-tools/create-conversation-tool.ts
@@ -69,6 +69,15 @@ export interface CreateConversationToolOptions {
     workspaceId?: string;
     /** Bound in-process enqueue capability. */
     enqueueChat: EnqueueChatFn;
+    /**
+     * The parent chat's processId — the conversation in which this tool was
+     * built/invoked. The handler reads the parent process record's resolved
+     * `provider` / `model` / `reasoningEffort` from its `metadata` and inherits
+     * them onto the spawned conversation (per-field overridable by the explicit
+     * `provider` / `model` params; `reasoningEffort` is always inherited).
+     * Mirrors the `search_conversations` addon's `processId` threading.
+     */
+    parentProcessId?: string;
 }
 
 export interface CreateConversationSuccess {
@@ -109,7 +118,7 @@ const DEFAULT_PRIORITY = 'normal';
  * @param options Tool options (store + caller workspace + enqueue capability).
  */
 export function createCreateConversationTool(options: CreateConversationToolOptions) {
-    const { store, workspaceId: callerWorkspaceId, enqueueChat } = options;
+    const { store, workspaceId: callerWorkspaceId, enqueueChat, parentProcessId } = options;
 
     const tool = defineTool<CreateConversationArgs>('create_conversation', {
         description:
@@ -219,8 +228,49 @@ export function createCreateConversationTool(options: CreateConversationToolOpti
                 };
             }
 
+            // --- inherit provider/model/reasoningEffort from the parent chat --
+            // The tool is built per chat turn, so `parentProcessId` identifies
+            // the conversation in which this tool was invoked. Read the parent's
+            // resolved values from its process metadata (the same authoritative
+            // fields the follow-up executor reads — see follow-up-executor.ts).
+            // Resolution is per-field: an explicit `provider`/`model` param wins
+            // for that field only; everything else inherits from the parent.
+            // `reasoningEffort` has no param and is always inherited.
+            const parent = parentProcessId ? await store.getProcess(parentProcessId) : undefined;
+            const parentProvider =
+                typeof parent?.metadata?.provider === 'string' ? parent.metadata.provider : undefined;
+            const parentModel =
+                typeof parent?.metadata?.model === 'string' ? parent.metadata.model : undefined;
+            const parentEffort =
+                typeof parent?.metadata?.reasoningEffort === 'string' ? parent.metadata.reasoningEffort : undefined;
+
+            // Per-field override: explicit param wins; otherwise inherit parent.
+            const resolvedProvider = args.provider ?? parentProvider;
+            const resolvedModel = model ?? parentModel;
+            const resolvedEffort = parentEffort;
+
+            // Only a missing provider is fatal. A resolvable parent whose model /
+            // reasoningEffort are absent falls back to provider defaults below.
+            if (!resolvedProvider) {
+                return {
+                    error:
+                        'Cannot determine a provider for the new conversation: no parent chat ' +
+                        'context was available to inherit from, and no explicit `provider` was supplied.',
+                };
+            }
+
             // --- build + validate the task spec, then enqueue in-process ------
+            // Setting `payload.provider` makes the enqueue path treat the
+            // provider as explicit, so the inherited provider also suppresses
+            // global default-provider auto-routing. Resolved model goes onto
+            // `config.model` (with the existing `payload.model` mirror) and the
+            // inherited effort onto `config.reasoningEffort`; `config.effortTier`
+            // is intentionally never set (resolved values are equivalent).
             const title = typeof args.title === 'string' && args.title.trim() ? args.title.trim() : undefined;
+            const config: Record<string, unknown> = {
+                ...(resolvedModel ? { model: resolvedModel } : {}),
+                ...(resolvedEffort ? { reasoningEffort: resolvedEffort } : {}),
+            };
             const taskSpec: Record<string, unknown> = {
                 type: 'chat',
                 priority,
@@ -231,10 +281,10 @@ export function createCreateConversationTool(options: CreateConversationToolOpti
                     mode,
                     prompt,
                     workspaceId: requestedWorkspaceId,
-                    ...(args.provider ? { provider: args.provider } : {}),
-                    ...(model ? { model } : {}),
+                    provider: resolvedProvider,
+                    ...(resolvedModel ? { model: resolvedModel } : {}),
                 },
-                ...(model ? { config: { model } } : {}),
+                ...(Object.keys(config).length > 0 ? { config } : {}),
             };
 
             // Reuse the canonical enqueue validation/normalization (config shape,

--- a/packages/coc/test/server/executors/create-conversation-addon.test.ts
+++ b/packages/coc/test/server/executors/create-conversation-addon.test.ts
@@ -111,8 +111,9 @@ describe('buildChatToolBundle create_conversation wiring', () => {
         expect(tool).toBeDefined();
 
         // Invoking with no workspaceId should fall back to options.workspaceId and
-        // enqueue a chat task scoped to that workspace.
-        await (tool as any).handler({ prompt: 'hello' });
+        // enqueue a chat task scoped to that workspace. An explicit provider is
+        // supplied because this bundle has no parent process to inherit one from.
+        await (tool as any).handler({ prompt: 'hello', provider: 'copilot' });
         expect(enqueueChat).toHaveBeenCalledTimes(1);
         const input = enqueueChat.mock.calls[0][0];
         expect(input.type).toBe('chat');

--- a/packages/coc/test/server/executors/create-conversation-enqueue-binding.test.ts
+++ b/packages/coc/test/server/executors/create-conversation-enqueue-binding.test.ts
@@ -48,17 +48,30 @@ function freshState(): QueueGlobalState {
     };
 }
 
+const PARENT_PID = 'queue_parent';
+
 function setup(state: QueueGlobalState = freshState()) {
     const registry = new RepoQueueRegistry();
     const store = createMockProcessStore();
     (store.getWorkspaces as any).mockResolvedValue([{ id: WS_ID, rootPath: ROOT }]);
+    // Seed the parent chat the spawned conversation inherits provider/model/effort
+    // from. Without a resolvable parent (or explicit provider) the handler errors.
+    void store.addProcess({
+        id: PARENT_PID,
+        metadata: { type: 'chat', provider: 'copilot' },
+    } as any);
     // autoStart:false → enqueued tasks stay queued (no SDK execution in the test).
     const bridge = new MultiRepoQueueRouter(registry, store, { autoStart: false });
 
     const enqueueChat = (input: CreateTaskInput): Promise<string> =>
         enqueueViaBridge(input, bridge, state, ROOT, store);
 
-    const { tool } = createCreateConversationTool({ store: store as any, workspaceId: WS_ID, enqueueChat });
+    const { tool } = createCreateConversationTool({
+        store: store as any,
+        workspaceId: WS_ID,
+        enqueueChat,
+        parentProcessId: PARENT_PID,
+    });
     return { bridge, store, tool };
 }
 

--- a/packages/coc/test/server/llm-tools/create-conversation-tool.test.ts
+++ b/packages/coc/test/server/llm-tools/create-conversation-tool.test.ts
@@ -19,28 +19,61 @@ const invocationStub = {
     arguments: {},
 };
 
-function makeStore(workspaceIds: string[] = ['ws-1']): ProcessStore {
+/** Parent process metadata the handler inherits provider/model/reasoningEffort from. */
+type ParentMeta = { provider?: string; model?: string; reasoningEffort?: string };
+
+/** Default parent so the common success path has a provider to inherit. */
+const DEFAULT_PARENT_ID = 'queue_parent';
+const DEFAULT_PARENT_META: ParentMeta = { provider: 'copilot' };
+
+function makeStore(
+    workspaceIds: string[] = ['ws-1'],
+    processes: Record<string, { id: string; metadata?: ParentMeta }> = {},
+): ProcessStore {
     const store: Partial<ProcessStore> = {
         getWorkspaces: vi.fn().mockResolvedValue(
             workspaceIds.map(id => ({ id, name: id, rootPath: `/repo/${id}` })),
         ),
+        getProcess: vi.fn(async (id: string) => processes[id] as never),
     };
     return store as ProcessStore;
 }
 
+interface MakeToolOpts {
+    workspaceId?: string;
+    storeWorkspaces?: string[];
+    taskId?: string;
+    /** Parent processId in scope. Pass `null` for a non-chat context (no parent). */
+    parentProcessId?: string | null;
+    /** Parent process metadata; omit a field to model an absent inherited value. */
+    parentMeta?: ParentMeta;
+}
+
 /** Build a tool wired to a stub enqueue that captures the CreateTaskInput it receives. */
-function makeTool(opts?: { workspaceId?: string; storeWorkspaces?: string[]; taskId?: string }) {
+function makeTool(opts?: MakeToolOpts) {
     const captured: { input?: CreateTaskInput } = {};
     const enqueueChat = vi.fn(async (input: CreateTaskInput) => {
         captured.input = input;
         return opts?.taskId ?? 'task-123';
     });
+
+    const parentProcessId = opts && 'parentProcessId' in opts ? opts.parentProcessId : DEFAULT_PARENT_ID;
+    const parentMeta = opts?.parentMeta ?? DEFAULT_PARENT_META;
+    const processes = parentProcessId
+        ? { [parentProcessId]: { id: parentProcessId, metadata: parentMeta } }
+        : {};
+
     const { tool } = createCreateConversationTool({
-        store: makeStore(opts?.storeWorkspaces),
+        store: makeStore(opts?.storeWorkspaces, processes),
         workspaceId: opts?.workspaceId ?? 'ws-1',
         enqueueChat,
+        parentProcessId: parentProcessId ?? undefined,
     });
     return { tool, enqueueChat, captured };
+}
+
+function payloadOf(input: CreateTaskInput): Record<string, unknown> {
+    return input.payload as Record<string, unknown>;
 }
 
 function asSuccess(result: CreateConversationResult): CreateConversationSuccess {
@@ -188,5 +221,134 @@ describe('createCreateConversationTool', () => {
         );
         expect('error' in result && result.error).toMatch(/invalid priority/i);
         expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    // ---- parent inheritance (AC-01 / AC-02) -------------------------------
+
+    it('inherits provider/model/reasoningEffort from the parent for { prompt } only', async () => {
+        const { tool, captured } = makeTool({
+            parentMeta: { provider: 'claude', model: 'claude-sonnet-4-6', reasoningEffort: 'high' },
+        });
+        await tool.handler({ prompt: 'spawned' }, invocationStub);
+        const payload = payloadOf(captured.input!);
+        expect(payload.provider).toBe('claude');
+        expect(captured.input!.config?.model).toBe('claude-sonnet-4-6');
+        expect(captured.input!.config?.reasoningEffort).toBe('high');
+    });
+
+    it('reads the parent process via store.getProcess(parentProcessId)', async () => {
+        const getProcess = vi.fn(async (_id: string) => ({
+            id: 'queue_p1',
+            metadata: { provider: 'claude', model: 'claude-opus-4-8', reasoningEffort: 'medium' },
+        }) as never);
+        const store = {
+            getWorkspaces: vi.fn().mockResolvedValue([{ id: 'ws-1', name: 'ws-1', rootPath: '/repo/ws-1' }]),
+            getProcess,
+        } as unknown as ProcessStore;
+        const captured: { input?: CreateTaskInput } = {};
+        const { tool } = createCreateConversationTool({
+            store,
+            workspaceId: 'ws-1',
+            enqueueChat: async input => { captured.input = input; return 'task-1'; },
+            parentProcessId: 'queue_p1',
+        });
+        await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect(getProcess).toHaveBeenCalledWith('queue_p1');
+        expect(payloadOf(captured.input!).provider).toBe('claude');
+    });
+
+    it('explicit model overrides parent model; provider + effort still inherited', async () => {
+        const { tool, captured } = makeTool({
+            parentMeta: { provider: 'claude', model: 'claude-sonnet-4-6', reasoningEffort: 'high' },
+        });
+        await tool.handler({ prompt: 'hi', model: 'claude-opus-4-8' }, invocationStub);
+        const payload = payloadOf(captured.input!);
+        expect(payload.provider).toBe('claude');
+        expect(captured.input!.config?.model).toBe('claude-opus-4-8');
+        expect(captured.input!.config?.reasoningEffort).toBe('high');
+    });
+
+    it('explicit provider overrides parent provider; model + effort still inherited', async () => {
+        const { tool, captured } = makeTool({
+            parentMeta: { provider: 'copilot', model: 'gpt-5', reasoningEffort: 'low' },
+        });
+        await tool.handler({ prompt: 'hi', provider: 'claude' }, invocationStub);
+        const payload = payloadOf(captured.input!);
+        expect(payload.provider).toBe('claude');
+        // model 'gpt-5' is inherited but coerced to the claude provider default downstream.
+        expect(captured.input!.config?.reasoningEffort).toBe('low');
+    });
+
+    it('reasoningEffort is always inherited and exposes no schema param', async () => {
+        const { tool, captured } = makeTool({
+            parentMeta: { provider: 'claude', model: 'claude-opus-4-8', reasoningEffort: 'xhigh' },
+        });
+        await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect(captured.input!.config?.reasoningEffort).toBe('xhigh');
+
+        const props = (tool.parameters as { properties: Record<string, unknown> }).properties;
+        expect(props.reasoningEffort).toBeUndefined();
+    });
+
+    it('falls back to provider default (no error) when parent has provider but no model', async () => {
+        const { tool, enqueueChat, captured } = makeTool({
+            parentMeta: { provider: 'claude' },
+        });
+        const result = await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect('error' in result).toBe(false);
+        expect(enqueueChat).toHaveBeenCalledTimes(1);
+        expect(payloadOf(captured.input!).provider).toBe('claude');
+        // No inherited model → config.model stays undefined; the executor resolves
+        // the provider's default later. The key point is no error is returned.
+        expect(captured.input!.config?.model).toBeUndefined();
+    });
+
+    it('errors (and does NOT enqueue) with no resolvable parent and no explicit provider', async () => {
+        const { tool, enqueueChat } = makeTool({ parentProcessId: null });
+        const result = await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect('error' in result && result.error).toMatch(/provider/i);
+        expect(enqueueChat).not.toHaveBeenCalled();
+    });
+
+    it('spawns with explicit provider+model even when no parent is resolvable', async () => {
+        const { tool, enqueueChat, captured } = makeTool({ parentProcessId: null });
+        const result = await tool.handler(
+            { prompt: 'hi', provider: 'claude', model: 'claude-opus-4-8' },
+            invocationStub,
+        );
+        expect('error' in result).toBe(false);
+        expect(enqueueChat).toHaveBeenCalledTimes(1);
+        expect(payloadOf(captured.input!).provider).toBe('claude');
+        expect(captured.input!.config?.model).toBe('claude-opus-4-8');
+    });
+
+    it('inherited provider is set on payload (suppresses default-provider auto-routing)', async () => {
+        // Setting payload.provider makes the enqueue path treat the provider as
+        // explicit, so resolveDefaultProviderForTask skips auto-routing.
+        const { tool, captured } = makeTool({ parentMeta: { provider: 'claude' } });
+        await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect(payloadOf(captured.input!).provider).toBe('claude');
+    });
+
+    it('inherits parent settings even when targeting a different workspace', async () => {
+        const { tool, captured } = makeTool({
+            workspaceId: 'ws-1',
+            storeWorkspaces: ['ws-1', 'ws-2'],
+            parentMeta: { provider: 'claude', model: 'claude-opus-4-8', reasoningEffort: 'high' },
+        });
+        await tool.handler({ prompt: 'hi', workspaceId: 'ws-2' }, invocationStub);
+        const payload = payloadOf(captured.input!);
+        expect(payload.workspaceId).toBe('ws-2');
+        expect(payload.provider).toBe('claude');
+        expect(captured.input!.config?.reasoningEffort).toBe('high');
+    });
+
+    it('mode defaults to ask and is never read from the parent', async () => {
+        const { tool, captured } = makeTool({
+            // A parent "mode" must not leak into the spawned conversation.
+            parentMeta: { provider: 'claude', model: 'claude-opus-4-8' } as ParentMeta & { mode?: string },
+        });
+        await tool.handler({ prompt: 'hi' }, invocationStub);
+        expect(payloadOf(captured.input!).mode).toBe('ask');
     });
 });


### PR DESCRIPTION
The create_conversation tool is built per chat turn, so thread the
parent conversation's processId into the tool (mirroring the
search_conversations addon) and have the handler read the parent
process record's resolved provider/model/reasoningEffort from metadata.

Resolution is per-field: an explicit `provider`/`model` param wins for
that field only; everything else inherits from the parent.
reasoningEffort is always inherited (no caller override). The inherited
provider is set on payload.provider, which makes the enqueue path treat
it as explicit and suppresses default-provider auto-routing. Only a
missing provider (no parent AND no explicit param) is fatal; an absent
model/effort falls back to provider defaults. No new persistent state;
config.effortTier is never set.

Tests: parent inheritance, per-field override, always-inherit effort,
provider-default fallback, hard-error with no resolvable provider,
explicit-provider spawn without a parent, cross-workspace inheritance,
and mode-not-inherited. Updated the addon + enqueue-binding integration
tests to seed a parent / pass an explicit provider.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
