### PR TITLE
feat(coc-desktop): in-app update check with one-click download

### DIFF
--- a/packages/coc-desktop/src/main.ts
+++ b/packages/coc-desktop/src/main.ts
@@ -13,7 +13,7 @@
  */
 
 import * as path from 'path';
-import { app, BrowserWindow, Menu, Tray, dialog, nativeImage, shell } from 'electron';
+import { app, BrowserWindow, Menu, Tray, dialog, nativeImage, shell, clipboard } from 'electron';
 import { attachOrStart, defaultDataDir, ServerHandle } from './server-controller';
 import { splashDataUrl } from './splash';
 import { detectAgentClis, missingAgentClis, runFirstRunPreflight } from './agent-preflight';
@@ -21,6 +21,12 @@ import { augmentPathWithBundledAgents } from './agent-bin-path';
 import { shutdownServer, shouldOpenExternally } from './lifecycle';
 import { resolveIconPath } from './app-icon';
 import { APP_NAME, buildAboutPanelOptions, readDesktopVersion } from './app-identity';
+import {
+    checkForUpdate,
+    getSkippedVersion,
+    setSkippedVersion,
+    UpdatePrompt,
+} from './update-check';
 
 // Brand the app identity before anything builds the menu / dock / About panel.
 // In dev (electron launched against this package) this fixes the menu-bar name,
@@ -202,6 +208,88 @@ function runAgentPreflight(): void {
     }
 }
 
+/**
+ * In-app update check. Polls GitHub Releases for a newer published build and, if
+ * one exists, shows a non-blocking dialog so the user can upgrade "from the app
+ * directly" — one click opens the platform installer in the system browser.
+ *
+ * Auto (on-launch) checks honour a "Skip This Version" choice so we never nag for
+ * a version the user already declined. A manual "Check for Updates…" invocation
+ * (`auto = false`) ignores the skip marker and also reports "you're up to date".
+ *
+ * True silent auto-install is intentionally not used: macOS refuses to apply
+ * updates to an unsigned app, so a notify + one-click-download flow is the only
+ * thing that works across both unsigned platforms today. See `update-check.ts`.
+ *
+ * Never blocks startup and never throws — any failure is swallowed.
+ */
+async function runUpdateCheck(auto: boolean): Promise<void> {
+    try {
+        const result = await checkForUpdate({ currentVersion: app.getVersion() });
+        if (result.reason !== 'newer' || !result.prompt || !result.release) {
+            if (!auto) {
+                // Manual check: give explicit feedback even when nothing is new.
+                const upToDate = result.reason === 'up-to-date';
+                void dialog.showMessageBox({
+                    type: upToDate ? 'info' : 'warning',
+                    title: upToDate ? 'You’re up to date' : 'Update Check Failed',
+                    message: upToDate
+                        ? `CoC ${app.getVersion()} is the latest version.`
+                        : 'Could not check for updates. Please try again later.',
+                    buttons: ['OK'],
+                    noLink: true,
+                });
+            }
+            return;
+        }
+        // Auto checks respect a previously skipped version; manual checks don't.
+        if (auto && getSkippedVersion(defaultDataDir()) === result.release.version) {
+            return;
+        }
+        process.stdout.write(`[coc-desktop] update available: ${result.release.version}\n`);
+        await promptForUpdate(result.prompt);
+    } catch {
+        // Update checking is a nicety — it must never break the app.
+    }
+}
+
+/**
+ * Render an {@link UpdatePrompt} as a native dialog and act on the choice. Maps
+ * the chosen button by its label (not index) so the platform-specific button
+ * sets in `formatUpdatePrompt` stay decoupled from this handler.
+ */
+async function promptForUpdate(prompt: UpdatePrompt): Promise<void> {
+    const { response } = await dialog.showMessageBox({
+        type: 'info',
+        title: prompt.title,
+        message: prompt.message,
+        detail: prompt.detail,
+        buttons: prompt.buttons,
+        defaultId: 0,
+        cancelId: prompt.buttons.length - 1,
+        noLink: true,
+    });
+    const choice = prompt.buttons[response];
+    switch (choice) {
+        case 'Download':
+            void shell.openExternal(prompt.downloadUrl);
+            break;
+        case 'Copy fix command':
+            if (prompt.quarantineFix) {
+                clipboard.writeText(prompt.quarantineFix);
+            }
+            // Then still send them to the download — the fix is a post-install step.
+            void shell.openExternal(prompt.downloadUrl);
+            break;
+        case 'Skip This Version':
+            setSkippedVersion(defaultDataDir(), prompt.version);
+            break;
+        default:
+            // "Later" (or dialog dismissed): do nothing; re-prompt next launch.
+            break;
+    }
+}
+
 /** Surface a fatal startup error in the (re-shown) splash window. */
 function showSplashError(message: string): void {
     if (!splashWindow || splashWindow.isDestroyed()) {
@@ -255,6 +343,8 @@ function createTray(): void {
             },
         },
         { type: 'separator' },
+        { label: 'Check for Updates…', click: () => void runUpdateCheck(false) },
+        { type: 'separator' },
         { label: 'Quit CoC', click: () => app.quit() },
     ]);
     tray.setContextMenu(menu);
@@ -304,6 +394,11 @@ async function bootstrap(): Promise<void> {
         // AC-06: warn (non-blocking) about any missing agent CLI now that the
         // window is up. The app is already usable regardless of the outcome.
         runAgentPreflight();
+        // In-app update check: only for packaged builds (a dev run has no
+        // meaningful release to compare against). Fire-and-forget; never blocks.
+        if (app.isPackaged) {
+            void runUpdateCheck(true);
+        }
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`[coc-desktop] failed to start CoC server: ${message}\n`);

--- a/packages/coc-desktop/src/update-check.ts
+++ b/packages/coc-desktop/src/update-check.ts
@@ -1,0 +1,330 @@
+/**
+ * CoC Desktop — in-app update check.
+ *
+ * Polls the project's GitHub Releases for a newer published release and surfaces
+ * a notification so the user can upgrade "from the app directly". The download is
+ * one click: it opens the platform installer (or the release page) in the system
+ * browser. This works for the current UNSIGNED builds on every platform —
+ * detection never depends on a code signature.
+ *
+ * Why not silent auto-install? On macOS the OS updater (Squirrel.Mac) refuses to
+ * apply an update to an unsigned/un-notarized app, so a true background install
+ * is impossible until the app is signed. A notify + one-click-download flow gives
+ * the same "update from the app" experience without that requirement, and on
+ * macOS it also hands the user the one-line Gatekeeper quarantine fix.
+ *
+ * This module imports NOTHING from `electron`, so the version math, release
+ * parsing, and dialog-content formatting are unit-testable under plain Node. The
+ * electron wiring (showing the dialog, opening the browser, clipboard) lives in
+ * `main.ts`. Network, filesystem, and platform seams are all injectable so tests
+ * never hit the real network or disk.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** GitHub "latest published release" endpoint for this repo. */
+export const LATEST_RELEASE_API =
+    'https://api.github.com/repos/plusplusoneplusplus/shortcuts/releases/latest';
+
+/** The one-line command that clears macOS download quarantine for an unsigned build. */
+export const MAC_QUARANTINE_FIX = 'xattr -dr com.apple.quarantine /Applications/CoC.app';
+
+/** A single downloadable file attached to a release. */
+export interface ReleaseAsset {
+    name: string;
+    url: string;
+}
+
+/** The normalized subset of a GitHub release we care about. */
+export interface ReleaseInfo {
+    /** Version with any leading "v" stripped, e.g. "3.4.6". */
+    version: string;
+    /** Raw tag, e.g. "v3.4.6". */
+    tag: string;
+    /** Human-facing release page URL. */
+    htmlUrl: string;
+    /** Release body / notes (may be empty). */
+    notes: string;
+    /** Downloadable installer assets. */
+    assets: ReleaseAsset[];
+}
+
+/**
+ * Parse the JSON returned by the GitHub releases API into a {@link ReleaseInfo}.
+ * Returns `null` when the payload is missing a usable tag (e.g. an error body or
+ * an empty `{}`), so callers can treat "couldn't determine a release" uniformly.
+ */
+export function parseLatestRelease(json: unknown): ReleaseInfo | null {
+    if (!json || typeof json !== 'object') {
+        return null;
+    }
+    const obj = json as Record<string, unknown>;
+    const tag = typeof obj.tag_name === 'string' ? obj.tag_name : '';
+    if (!tag) {
+        return null;
+    }
+    const assetsRaw = Array.isArray(obj.assets) ? obj.assets : [];
+    const assets: ReleaseAsset[] = assetsRaw
+        .map((a): ReleaseAsset | null => {
+            if (!a || typeof a !== 'object') {
+                return null;
+            }
+            const rec = a as Record<string, unknown>;
+            const name = typeof rec.name === 'string' ? rec.name : '';
+            const url =
+                typeof rec.browser_download_url === 'string' ? rec.browser_download_url : '';
+            return name && url ? { name, url } : null;
+        })
+        .filter((a): a is ReleaseAsset => a !== null);
+    return {
+        version: normalizeVersion(tag),
+        tag,
+        htmlUrl: typeof obj.html_url === 'string' ? obj.html_url : '',
+        notes: typeof obj.body === 'string' ? obj.body : '',
+        assets,
+    };
+}
+
+/** Strip a leading "v"/"V" and surrounding whitespace from a version/tag string. */
+export function normalizeVersion(v: string): string {
+    return v.trim().replace(/^v/i, '');
+}
+
+/**
+ * Compare two dotted numeric versions. Returns 1 if `a > b`, -1 if `a < b`, 0 if
+ * equal. Leading "v" is tolerated. Numeric segments are compared left-to-right;
+ * a missing segment counts as 0 (so "3.4" === "3.4.0"). Any non-numeric
+ * pre-release tail (e.g. "-beta.1") is ignored for ordering — a pragmatic choice
+ * that keeps the common release case correct without a full semver parser.
+ */
+export function compareVersions(a: string, b: string): number {
+    const segs = (v: string): number[] =>
+        normalizeVersion(v)
+            .split('-')[0]
+            .split('.')
+            .map((s) => parseInt(s, 10))
+            .map((n) => (Number.isFinite(n) ? n : 0));
+    const av = segs(a);
+    const bv = segs(b);
+    const len = Math.max(av.length, bv.length);
+    for (let i = 0; i < len; i++) {
+        const diff = (av[i] ?? 0) - (bv[i] ?? 0);
+        if (diff !== 0) {
+            return diff > 0 ? 1 : -1;
+        }
+    }
+    return 0;
+}
+
+/** True iff `latest` is strictly newer than `current`. */
+export function isNewerVersion(latest: string, current: string): boolean {
+    return compareVersions(latest, current) > 0;
+}
+
+/**
+ * Choose the best download URL for a release on the given platform:
+ *   - macOS  → the `.dmg` (preferring an arm64 build when several exist),
+ *   - Windows → the `.exe` installer,
+ * falling back to the release page when no matching asset is attached (e.g. a
+ * release whose binaries are still uploading, or a platform with no asset).
+ */
+export function pickDownloadUrl(release: ReleaseInfo, platform: NodeJS.Platform): string {
+    const byName = (pred: (name: string) => boolean): ReleaseAsset | undefined =>
+        release.assets.find((a) => pred(a.name.toLowerCase()));
+    if (platform === 'darwin') {
+        const arm = byName((n) => n.endsWith('.dmg') && n.includes('arm64'));
+        const dmg = arm ?? byName((n) => n.endsWith('.dmg'));
+        if (dmg) {
+            return dmg.url;
+        }
+    } else if (platform === 'win32') {
+        const exe = byName((n) => n.endsWith('.exe'));
+        if (exe) {
+            return exe.url;
+        }
+    }
+    return release.htmlUrl;
+}
+
+/** A renderable, electron-agnostic description of the update dialog. */
+export interface UpdatePrompt {
+    /** The available version (normalized, no leading "v") — used for "Skip". */
+    version: string;
+    title: string;
+    /** One-line summary suitable for a dialog `message`. */
+    message: string;
+    /** Multi-line body suitable for a dialog `detail`. */
+    detail: string;
+    /** Button labels in order; `main.ts` maps the chosen index to an action. */
+    buttons: string[];
+    /** Resolved best-effort download URL for this platform. */
+    downloadUrl: string;
+    /** macOS only: the quarantine fix command offered via a "Copy fix" button. */
+    quarantineFix?: string;
+}
+
+/**
+ * Build the update dialog content for a newer release. On macOS the prompt also
+ * explains the unsigned-build Gatekeeper step and offers to copy the quarantine
+ * fix command; on Windows it notes the SmartScreen "Run anyway" step.
+ */
+export function formatUpdatePrompt(
+    release: ReleaseInfo,
+    currentVersion: string,
+    platform: NodeJS.Platform,
+): UpdatePrompt {
+    const downloadUrl = pickDownloadUrl(release, platform);
+    const base: UpdatePrompt = {
+        version: release.version,
+        title: 'Update Available',
+        message: `CoC ${release.version} is available — you have ${normalizeVersion(currentVersion)}.`,
+        detail: '',
+        buttons: [],
+        downloadUrl,
+    };
+    if (platform === 'darwin') {
+        return {
+            ...base,
+            detail:
+                'Click Download to get the new DMG, then drag CoC into Applications.\n\n' +
+                'This build is not yet code-signed, so on first launch macOS may say ' +
+                '"CoC is damaged." It is not corrupt — clear the download quarantine flag:\n\n' +
+                `  ${MAC_QUARANTINE_FIX}\n\n` +
+                'Use "Copy fix command" to put that on your clipboard.',
+            buttons: ['Download', 'Copy fix command', 'Skip This Version', 'Later'],
+            quarantineFix: MAC_QUARANTINE_FIX,
+        };
+    }
+    if (platform === 'win32') {
+        return {
+            ...base,
+            detail:
+                'Click Download to get the new installer, then run it.\n\n' +
+                'This installer is not yet signed, so SmartScreen may warn about an ' +
+                'unknown publisher — choose "More info → Run anyway".',
+            buttons: ['Download', 'Skip This Version', 'Later'],
+        };
+    }
+    return {
+        ...base,
+        detail: 'Click Download to get the latest release.',
+        buttons: ['Download', 'Skip This Version', 'Later'],
+    };
+}
+
+// ---------------------------------------------------------------------------
+// "Skip this version" persistence
+//
+// Mirrors agent-preflight's marker pattern: a small JSON file in the shared data
+// dir, namespaced to the desktop app so it never collides with the CLI's files.
+// A skipped version suppresses the *automatic* launch prompt for that exact
+// version only; an explicit "Check for Updates…" always re-checks.
+// ---------------------------------------------------------------------------
+
+/** Injectable filesystem seams for the skipped-version marker. */
+export interface UpdateStore {
+    readText?: (filePath: string) => string;
+    writeText?: (filePath: string, data: string) => void;
+    ensureDir?: (dir: string) => void;
+}
+
+const MARKER_FILENAME = 'desktop-update.json';
+
+function markerPath(dataDir: string): string {
+    return path.join(dataDir, MARKER_FILENAME);
+}
+
+/** The version the user chose to skip, or `null` if none/unreadable. */
+export function getSkippedVersion(dataDir: string, store: UpdateStore = {}): string | null {
+    const readText = store.readText ?? ((p) => fs.readFileSync(p, 'utf8'));
+    try {
+        const parsed = JSON.parse(readText(markerPath(dataDir))) as { skipVersion?: string };
+        return typeof parsed?.skipVersion === 'string' ? parsed.skipVersion : null;
+    } catch {
+        return null;
+    }
+}
+
+/** Record a version the user wants to skip in the automatic launch prompt. */
+export function setSkippedVersion(
+    dataDir: string,
+    version: string,
+    store: UpdateStore = {},
+): void {
+    const ensureDir = store.ensureDir ?? ((d) => { fs.mkdirSync(d, { recursive: true }); });
+    const writeText = store.writeText ?? ((p, data) => fs.writeFileSync(p, data));
+    try {
+        ensureDir(dataDir);
+        writeText(markerPath(dataDir), JSON.stringify({ skipVersion: normalizeVersion(version) }));
+    } catch {
+        // Best-effort: a failed write only means we may re-prompt next launch.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/** Injectable seams for {@link checkForUpdate}. */
+export interface UpdateCheckOptions {
+    /** Current app version (normally `app.getVersion()`). */
+    currentVersion: string;
+    /** Target platform; defaults to `process.platform`. */
+    platform?: NodeJS.Platform;
+    /** Fetch implementation; defaults to global `fetch`. */
+    fetchFn?: typeof fetch;
+    /** Releases endpoint; defaults to {@link LATEST_RELEASE_API}. */
+    apiUrl?: string;
+}
+
+/** Why no prompt was produced, for logging / "Check for Updates…" feedback. */
+export type UpdateCheckReason = 'newer' | 'up-to-date' | 'error';
+
+/** The outcome of an update check. `release`/`prompt` are set only when newer. */
+export interface UpdateCheckResult {
+    reason: UpdateCheckReason;
+    release: ReleaseInfo | null;
+    prompt: UpdatePrompt | null;
+}
+
+/**
+ * Fetch the latest release and decide whether to prompt. Never throws — a
+ * network or parse failure resolves to `{ reason: 'error' }` so the caller (a
+ * fire-and-forget launch check) can simply do nothing.
+ */
+export async function checkForUpdate(opts: UpdateCheckOptions): Promise<UpdateCheckResult> {
+    const platform = opts.platform ?? process.platform;
+    const fetchFn = opts.fetchFn ?? globalThis.fetch;
+    const apiUrl = opts.apiUrl ?? LATEST_RELEASE_API;
+    const miss = (reason: UpdateCheckReason): UpdateCheckResult => ({
+        reason,
+        release: null,
+        prompt: null,
+    });
+    if (typeof fetchFn !== 'function') {
+        return miss('error');
+    }
+    try {
+        const res = await fetchFn(apiUrl, {
+            headers: { Accept: 'application/vnd.github+json' },
+        });
+        if (!res.ok) {
+            return miss('error');
+        }
+        const release = parseLatestRelease(await res.json());
+        if (!release) {
+            return miss('error');
+        }
+        if (!isNewerVersion(release.version, opts.currentVersion)) {
+            return { reason: 'up-to-date', release, prompt: null };
+        }
+        return {
+            reason: 'newer',
+            release,
+            prompt: formatUpdatePrompt(release, opts.currentVersion, platform),
+        };
+    } catch {
+        return miss('error');
+    }
+}

--- a/packages/coc-desktop/test/update-check.test.ts
+++ b/packages/coc-desktop/test/update-check.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for the in-app update check.
+ *
+ * The module is electron-free: version math and release parsing are pure, the
+ * skip-marker store is injectable, and checkForUpdate takes an injectable fetch,
+ * so nothing here touches the network, disk, or the Electron runtime.
+ */
+
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeVersion,
+    compareVersions,
+    isNewerVersion,
+    parseLatestRelease,
+    pickDownloadUrl,
+    formatUpdatePrompt,
+    getSkippedVersion,
+    setSkippedVersion,
+    checkForUpdate,
+    MAC_QUARANTINE_FIX,
+    LATEST_RELEASE_API,
+    ReleaseInfo,
+    UpdateStore,
+} from '../src/update-check';
+
+function release(over: Partial<ReleaseInfo> = {}): ReleaseInfo {
+    return {
+        version: '3.4.6',
+        tag: 'v3.4.6',
+        htmlUrl: 'https://github.com/plusplusoneplusplus/shortcuts/releases/tag/v3.4.6',
+        notes: 'notes',
+        assets: [],
+        ...over,
+    };
+}
+
+/** A GitHub-style /releases/latest payload, deliberately loosely typed. */
+function ghPayload(over: Record<string, unknown> = {}): unknown {
+    return {
+        tag_name: 'v3.4.6',
+        html_url: 'https://example.com/rel',
+        body: 'release body',
+        assets: [
+            {
+                name: 'CoC-3.4.6-arm64.dmg',
+                browser_download_url: 'https://example.com/CoC-3.4.6-arm64.dmg',
+            },
+            {
+                name: 'CoC.Setup.3.4.6.exe',
+                browser_download_url: 'https://example.com/CoC.Setup.3.4.6.exe',
+            },
+        ],
+        ...over,
+    };
+}
+
+/** A fetch stub returning the given JSON with a chosen ok/status. */
+function fakeFetch(json: unknown, init: { ok?: boolean } = {}): typeof fetch {
+    return (async () => ({
+        ok: init.ok ?? true,
+        json: async () => json,
+    })) as unknown as typeof fetch;
+}
+
+describe('normalizeVersion', () => {
+    it('strips a leading v (any case) and whitespace', () => {
+        expect(normalizeVersion('v3.4.6')).toBe('3.4.6');
+        expect(normalizeVersion('V3.4.6')).toBe('3.4.6');
+        expect(normalizeVersion('  3.4.6 ')).toBe('3.4.6');
+        expect(normalizeVersion('3.4.6')).toBe('3.4.6');
+    });
+});
+
+describe('compareVersions', () => {
+    it('orders by numeric segments, not lexically', () => {
+        expect(compareVersions('3.4.10', '3.4.2')).toBe(1); // 10 > 2, not "10" < "2"
+        expect(compareVersions('3.4.2', '3.4.10')).toBe(-1);
+        expect(compareVersions('4.0.0', '3.9.9')).toBe(1);
+    });
+
+    it('treats equal versions as 0 and tolerates a leading v', () => {
+        expect(compareVersions('3.4.6', '3.4.6')).toBe(0);
+        expect(compareVersions('v3.4.6', '3.4.6')).toBe(0);
+    });
+
+    it('pads missing segments with 0 (3.4 === 3.4.0)', () => {
+        expect(compareVersions('3.4', '3.4.0')).toBe(0);
+        expect(compareVersions('3.4.1', '3.4')).toBe(1);
+    });
+
+    it('ignores a pre-release tail for ordering', () => {
+        expect(compareVersions('3.4.6-beta.1', '3.4.6')).toBe(0);
+        expect(compareVersions('3.5.0-rc.1', '3.4.6')).toBe(1);
+    });
+
+    it('treats non-numeric segments as 0 rather than NaN', () => {
+        expect(compareVersions('3.x.6', '3.0.6')).toBe(0);
+    });
+});
+
+describe('isNewerVersion', () => {
+    it('is true only when strictly greater', () => {
+        expect(isNewerVersion('3.4.6', '3.4.2')).toBe(true);
+        expect(isNewerVersion('3.4.6', '3.4.6')).toBe(false);
+        expect(isNewerVersion('3.4.2', '3.4.6')).toBe(false);
+    });
+});
+
+describe('parseLatestRelease', () => {
+    it('normalizes a well-formed payload', () => {
+        const info = parseLatestRelease(ghPayload());
+        expect(info).not.toBeNull();
+        expect(info!.version).toBe('3.4.6');
+        expect(info!.tag).toBe('v3.4.6');
+        expect(info!.htmlUrl).toBe('https://example.com/rel');
+        expect(info!.notes).toBe('release body');
+        expect(info!.assets).toHaveLength(2);
+        expect(info!.assets[0]).toEqual({
+            name: 'CoC-3.4.6-arm64.dmg',
+            url: 'https://example.com/CoC-3.4.6-arm64.dmg',
+        });
+    });
+
+    it('returns null when there is no usable tag', () => {
+        expect(parseLatestRelease(null)).toBeNull();
+        expect(parseLatestRelease('nope')).toBeNull();
+        expect(parseLatestRelease({})).toBeNull();
+        expect(parseLatestRelease({ tag_name: '' })).toBeNull();
+    });
+
+    it('drops malformed assets and tolerates a missing assets array', () => {
+        const info = parseLatestRelease(
+            ghPayload({
+                assets: [
+                    { name: 'good.dmg', browser_download_url: 'https://e/good.dmg' },
+                    { name: 'no-url.dmg' },
+                    { browser_download_url: 'https://e/no-name' },
+                    'garbage',
+                ],
+            }),
+        );
+        expect(info!.assets).toEqual([{ name: 'good.dmg', url: 'https://e/good.dmg' }]);
+
+        const noAssets = parseLatestRelease(ghPayload({ assets: undefined }));
+        expect(noAssets!.assets).toEqual([]);
+    });
+});
+
+describe('pickDownloadUrl', () => {
+    it('prefers the arm64 dmg on macOS', () => {
+        const r = release({
+            assets: [
+                { name: 'CoC-3.4.6.dmg', url: 'https://e/x64.dmg' },
+                { name: 'CoC-3.4.6-arm64.dmg', url: 'https://e/arm64.dmg' },
+            ],
+        });
+        expect(pickDownloadUrl(r, 'darwin')).toBe('https://e/arm64.dmg');
+    });
+
+    it('falls back to any dmg on macOS when no arm64 build exists', () => {
+        const r = release({ assets: [{ name: 'CoC-3.4.6.dmg', url: 'https://e/any.dmg' }] });
+        expect(pickDownloadUrl(r, 'darwin')).toBe('https://e/any.dmg');
+    });
+
+    it('picks the .exe on Windows', () => {
+        const r = release({ assets: [{ name: 'CoC.Setup.3.4.6.exe', url: 'https://e/setup.exe' }] });
+        expect(pickDownloadUrl(r, 'win32')).toBe('https://e/setup.exe');
+    });
+
+    it('falls back to the release page when no matching asset exists', () => {
+        const r = release({ htmlUrl: 'https://e/page', assets: [] });
+        expect(pickDownloadUrl(r, 'darwin')).toBe('https://e/page');
+        expect(pickDownloadUrl(r, 'win32')).toBe('https://e/page');
+        expect(pickDownloadUrl(r, 'linux')).toBe('https://e/page');
+    });
+});
+
+describe('formatUpdatePrompt', () => {
+    it('macOS prompt offers the quarantine fix and the right buttons', () => {
+        const p = formatUpdatePrompt(release(), '3.4.2', 'darwin');
+        expect(p.version).toBe('3.4.6');
+        expect(p.message).toContain('3.4.6');
+        expect(p.message).toContain('3.4.2');
+        expect(p.buttons).toEqual(['Download', 'Copy fix command', 'Skip This Version', 'Later']);
+        expect(p.quarantineFix).toBe(MAC_QUARANTINE_FIX);
+        expect(p.detail).toContain(MAC_QUARANTINE_FIX);
+    });
+
+    it('Windows prompt has no copy-fix button and mentions SmartScreen', () => {
+        const p = formatUpdatePrompt(release(), '3.4.2', 'win32');
+        expect(p.buttons).toEqual(['Download', 'Skip This Version', 'Later']);
+        expect(p.quarantineFix).toBeUndefined();
+        expect(p.detail).toContain('SmartScreen');
+    });
+
+    it('normalizes a v-prefixed current version in the message', () => {
+        const p = formatUpdatePrompt(release(), 'v3.4.2', 'darwin');
+        expect(p.message).toContain('you have 3.4.2');
+    });
+
+    it('resolves the download URL for the platform', () => {
+        const r = release({
+            assets: [{ name: 'CoC.Setup.3.4.6.exe', url: 'https://e/setup.exe' }],
+            htmlUrl: 'https://e/page',
+        });
+        expect(formatUpdatePrompt(r, '3.4.2', 'win32').downloadUrl).toBe('https://e/setup.exe');
+        // No mac asset → mac prompt falls back to the release page.
+        expect(formatUpdatePrompt(r, '3.4.2', 'darwin').downloadUrl).toBe('https://e/page');
+    });
+});
+
+describe('skip-version persistence', () => {
+    function memStore(): { store: UpdateStore; files: Map<string, string> } {
+        const files = new Map<string, string>();
+        return {
+            files,
+            store: {
+                readText: (p) => {
+                    if (!files.has(p)) {
+                        throw new Error('ENOENT');
+                    }
+                    return files.get(p)!;
+                },
+                writeText: (p, data) => void files.set(p, data),
+                ensureDir: () => undefined,
+            },
+        };
+    }
+
+    const dataDir = path.join('/fake', 'coc');
+
+    it('round-trips a skipped version (normalized)', () => {
+        const { store } = memStore();
+        setSkippedVersion(dataDir, 'v3.4.6', store);
+        expect(getSkippedVersion(dataDir, store)).toBe('3.4.6');
+    });
+
+    it('returns null when no marker has been written', () => {
+        const { store } = memStore();
+        expect(getSkippedVersion(dataDir, store)).toBeNull();
+    });
+
+    it('returns null on unreadable / malformed marker JSON', () => {
+        const { store, files } = memStore();
+        files.set(path.join(dataDir, 'desktop-update.json'), 'not json');
+        expect(getSkippedVersion(dataDir, store)).toBeNull();
+    });
+
+    it('does not throw when the write fails', () => {
+        const throwingStore: UpdateStore = {
+            ensureDir: () => {
+                throw new Error('EACCES');
+            },
+        };
+        expect(() => setSkippedVersion(dataDir, '3.4.6', throwingStore)).not.toThrow();
+    });
+});
+
+describe('checkForUpdate', () => {
+    it('reports a newer release with a platform-specific prompt', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.2',
+            platform: 'darwin',
+            fetchFn: fakeFetch(ghPayload()),
+        });
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.6');
+        expect(result.prompt!.buttons).toContain('Copy fix command');
+    });
+
+    it('reports up-to-date when the latest equals the current version', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.6',
+            fetchFn: fakeFetch(ghPayload()),
+        });
+        expect(result.reason).toBe('up-to-date');
+        expect(result.prompt).toBeNull();
+    });
+
+    it('reports up-to-date when the current version is newer (dev/pre-release)', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '4.0.0',
+            fetchFn: fakeFetch(ghPayload()),
+        });
+        expect(result.reason).toBe('up-to-date');
+    });
+
+    it('reports error on a non-ok HTTP response', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.2',
+            fetchFn: fakeFetch(ghPayload(), { ok: false }),
+        });
+        expect(result.reason).toBe('error');
+    });
+
+    it('reports error on an unparseable payload', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.2',
+            fetchFn: fakeFetch({ message: 'Not Found' }),
+        });
+        expect(result.reason).toBe('error');
+    });
+
+    it('reports error (never throws) when fetch rejects', async () => {
+        const boom = (async () => {
+            throw new Error('network down');
+        }) as unknown as typeof fetch;
+        const result = await checkForUpdate({ currentVersion: '3.4.2', fetchFn: boom });
+        expect(result.reason).toBe('error');
+    });
+
+    it('reports error when no fetch implementation is available', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.2',
+            fetchFn: undefined as unknown as typeof fetch,
+        });
+        expect(result.reason).toBe('error');
+    });
+
+    it('defaults to the project releases endpoint', async () => {
+        let calledWith = '';
+        const spyFetch = (async (url: string) => {
+            calledWith = url;
+            return { ok: true, json: async () => ghPayload() };
+        }) as unknown as typeof fetch;
+        await checkForUpdate({ currentVersion: '3.4.2', fetchFn: spyFetch });
+        expect(calledWith).toBe(LATEST_RELEASE_API);
+    });
+});


### PR DESCRIPTION
Adds an electron-free update-check module that polls the project's GitHub
Releases for a newer published build and surfaces a non-blocking dialog so
users can upgrade from the app directly:

- macOS: notify + one-click DMG download + "Copy fix command" for the
  unsigned-build Gatekeeper quarantine step (silent auto-install is
  impossible on an unsigned/un-notarized app).
- Windows: notify + one-click installer download (with SmartScreen note).
- "Check for Updates…" tray item (manual check; reports up-to-date), plus
  an automatic launch check (packaged builds only) that honours a
  per-version "Skip This Version" choice.

Detection never depends on a code signature, so it works for the current
unsigned builds on both platforms. Version math, release parsing, prompt
formatting, the skip-version store, and the orchestrator are all injectable
and covered by 30 unit tests (network/fs/platform seams stubbed).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
