### PR TITLE
feat(coc): let Implement banner switch between multiple plan files

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -556,6 +556,13 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         () => createdFiles.find(f => f.filePath.endsWith('.plan.md'))?.filePath ?? '',
         [createdFiles],
     );
+    // Detect ALL .plan.md files (AC-01), preserving conversation scan order. The
+    // first equals `detectedPlanFile` (default effective plan); the rest power the
+    // Implement banner's plan-file selector when 2+ plans exist.
+    const detectedPlanFiles = useMemo(
+        () => createdFiles.filter(f => f.filePath.endsWith('.plan.md')).map(f => f.filePath),
+        [createdFiles],
+    );
     // Detect a canvas written with purpose 'plan' as an alternative plan source
     // when no .plan.md file was created (file-based plans take precedence).
     const detectedPlanCanvas = useMemo(
@@ -572,6 +579,14 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const effectivePlanCanvasId = detectedPlanFile || (planPath && !persistedPlanCanvasId)
         ? undefined
         : (detectedPlanCanvas?.canvasId ?? persistedPlanCanvasId);
+    // Switchable plan set for the Implement banner selector: only the
+    // auto-detected multi-file case. An explicit task-provided plan path or a
+    // canvas-backed plan keeps the banner single-file (no selector) — see the
+    // multi-plan-file-switcher constraints.
+    const switchablePlanFiles = useMemo(
+        () => (planPath || effectivePlanCanvasId ? [] : detectedPlanFiles),
+        [planPath, effectivePlanCanvasId, detectedPlanFiles],
+    );
 
     // Detect goal.md or *.goal.md created mid-conversation for direct Ralph launch
     const detectedGoalFile = useMemo(
@@ -2207,6 +2222,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     {effectiveView === 'thread' && !showSubAgentDetail && isTerminal && !planChatBusy && resolveLoadedTaskMode(task) === 'ask' && effectivePlanPath && (
                         <ImplementPlanCard
                             planFilePath={effectivePlanPath}
+                            planFiles={switchablePlanFiles}
                             planCanvasId={effectivePlanCanvasId}
                             workspaceId={workspaceId}
                             workingDirectory={workingDirectory}

--- a/packages/coc/src/server/spa/client/react/features/chat/ImplementPlanCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ImplementPlanCard.tsx
@@ -77,6 +77,14 @@ export interface ImplementTarget {
 export interface ImplementPlanCardProps {
     planFilePath: string;
     /**
+     * All detected `.plan.md` files for this chat, in conversation scan order
+     * (AC-01). When 2+ are present the card renders a plan-file selector and
+     * tracks the chosen file for the implement action, status pill, button
+     * label, and prior-runs list (AC-02/AC-03). An empty or single-element list
+     * keeps the card's single-file behavior byte-for-byte unchanged.
+     */
+    planFiles?: string[];
+    /**
      * When the plan lives in a canvas instead of a `.plan.md` file, this is the
      * canvas id. The content is read from the canvas and embedded inline in the
      * prompt (the plan has no on-disk path); `planFilePath` is treated as a
@@ -155,6 +163,13 @@ function buildCanvasPrompt(planLabel: string, planContent: string): string {
     ].join('\n');
 }
 
+/** File basename (last path segment) for a plan-file dropdown label. */
+function planFileBasename(filePath: string): string {
+    const normalized = filePath.replace(/\\/g, '/');
+    const idx = normalized.lastIndexOf('/');
+    return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}
+
 /** Resolve a target to a CocClient routing ref: remote → object marker, local → id. */
 function toCloneRef(target: ImplementTarget | undefined, fallbackId: string | undefined): CloneRef | undefined {
     if (target?.isRemote && target.baseUrl) {
@@ -167,6 +182,7 @@ function toCloneRef(target: ImplementTarget | undefined, fallbackId: string | un
 
 export function ImplementPlanCard({
     planFilePath,
+    planFiles = [],
     planCanvasId,
     workspaceId,
     workingDirectory,
@@ -201,13 +217,28 @@ export function ImplementPlanCard({
     const [error, setError] = useState<string | null>(null);
     const [expanded, setExpanded] = useState(false);
 
-    const latestRun = existingRuns.length > 0 ? existingRuns[existingRuns.length - 1] : null;
+    // ── Plan-file selector (AC-02/AC-03) ───────────────────────────────
+    // The selector appears only in the auto-detected multi-file case. With 0–1
+    // files the card falls back to `planFilePath` so single-file behavior is
+    // byte-for-byte unchanged. Selection is ephemeral local state, defaulting to
+    // the first detected file (which equals `planFilePath`).
+    const showFileSelector = planFiles.length > 1;
+    const [selectedPlanFile, setSelectedPlanFile] = useState<string>(planFiles[0] ?? planFilePath);
+    const activePlanFilePath = showFileSelector ? selectedPlanFile : planFilePath;
+
+    // Prior runs filtered to the selected plan file (AC-03), matched against each
+    // record's `planFilePath`. Single-file keeps the full, unfiltered list.
+    const filteredRuns = showFileSelector
+        ? existingRuns.filter(r => r.planFilePath === activePlanFilePath)
+        : existingRuns;
+
+    const latestRun = filteredRuns.length > 0 ? filteredRuns[filteredRuns.length - 1] : null;
     const latestIsActive = latestRun ? isActiveStatus(latestRun.liveStatus) : false;
-    const hasRuns = existingRuns.length > 0;
+    const hasRuns = filteredRuns.length > 0;
 
     async function readSourcePlanContent(): Promise<string> {
         try {
-            const blob = await sourceClient.explorer.readTrustedBlob(planFilePath);
+            const blob = await sourceClient.explorer.readTrustedBlob(activePlanFilePath);
             if (blob.encoding === 'base64') {
                 try {
                     return typeof atob === 'function' ? atob(blob.content) : blob.content;
@@ -252,15 +283,15 @@ export function ImplementPlanCard({
             let context: { files: string[] } | undefined;
             if (planCanvasId) {
                 const planContent = await readSourceCanvasContent(planCanvasId);
-                prompt = buildCanvasPrompt(planFilePath, planContent);
+                prompt = buildCanvasPrompt(activePlanFilePath, planContent);
                 context = undefined;
             } else if (isRemote) {
                 const planContent = await readSourcePlanContent();
-                prompt = buildRemotePrompt(planFilePath, planContent);
+                prompt = buildRemotePrompt(activePlanFilePath, planContent);
                 context = undefined;
             } else {
-                prompt = `Read and implement the plan file at ${planFilePath}`;
-                context = { files: [planFilePath] };
+                prompt = `Read and implement the plan file at ${activePlanFilePath}`;
+                context = { files: [activePlanFilePath] };
             }
 
             const result = await targetClient.queue.enqueue({
@@ -284,7 +315,7 @@ export function ImplementPlanCard({
             if (sourceProcessId) {
                 const record: ImplementationRecord = {
                     processId,
-                    planFilePath,
+                    planFilePath: activePlanFilePath,
                     enqueuedAt: new Date().toISOString(),
                     targetWorkspaceId,
                     targetLabel: selectedTarget?.label,
@@ -327,23 +358,43 @@ export function ImplementPlanCard({
                     </span>
                     <span
                         className="min-w-0 flex-1 truncate text-[11px] font-mono text-[#848484]"
-                        title={`Start a new autopilot session to execute the plan.\n${planFilePath}`}
+                        title={`Start a new autopilot session to execute the plan.\n${activePlanFilePath}`}
                     >
-                        {planFilePath}
+                        {activePlanFilePath}
                     </span>
+
+                    {showFileSelector && (
+                        <div className="flex shrink-0 items-center gap-1" data-testid="implement-plan-card-file">
+                            <label htmlFor="implement-plan-card-file-select" className="text-[11px] text-[#57606a] dark:text-[#8b949e]">
+                                Plan
+                            </label>
+                            <select
+                                id="implement-plan-card-file-select"
+                                data-testid="implement-plan-card-file-select"
+                                value={selectedPlanFile}
+                                onChange={(e) => setSelectedPlanFile(e.target.value)}
+                                disabled={disabled}
+                                className="text-[11px] rounded border border-[#d0d7de] dark:border-[#3c3c3c] bg-white dark:bg-[#0d1117] text-[#1f2328] dark:text-[#c9d1d9] px-1 py-0.5 max-w-[12rem] truncate disabled:opacity-60"
+                            >
+                                {planFiles.map(p => (
+                                    <option key={p} value={p}>{planFileBasename(p)}</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
 
                     {hasRuns && latestRun && (
                         <button
                             type="button"
                             data-testid="implement-plan-card-status-pill"
                             onClick={() => onViewRun?.(latestRun.processId, latestRun.targetWorkspaceId)}
-                            title={`started ${formatRelativeTime(latestRun.enqueuedAt)}${existingRuns.length > 1 ? ` · ${existingRuns.length} runs total` : ''}${describeRunTarget(latestRun) ? ` · ${describeRunTarget(latestRun)}` : ''}`}
+                            title={`started ${formatRelativeTime(latestRun.enqueuedAt)}${filteredRuns.length > 1 ? ` · ${filteredRuns.length} runs total` : ''}${describeRunTarget(latestRun) ? ` · ${describeRunTarget(latestRun)}` : ''}`}
                             className="inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-black/[0.04] dark:bg-white/[0.06] text-[#57606a] dark:text-[#8b949e] hover:bg-black/[0.08] dark:hover:bg-white/[0.1]"
                         >
                             <span data-testid="implement-plan-card-view-btn" className="contents">
                                 {STATUS_CONFIG[latestRun.liveStatus].emoji} {STATUS_CONFIG[latestRun.liveStatus].label}
                                 {latestRun.isRemoteTarget ? ' ☁️' : ''}
-                                {existingRuns.length > 1 && ` · ${existingRuns.length}`}
+                                {filteredRuns.length > 1 && ` · ${filteredRuns.length}`}
                                 {' →'}
                             </span>
                         </button>
@@ -394,7 +445,7 @@ export function ImplementPlanCard({
                     </p>
                 )}
 
-                {existingRuns.length > 1 && (
+                {filteredRuns.length > 1 && (
                     <div className="border-t border-[#d0d7de] dark:border-[#3c3c3c] px-2.5 py-1">
                         <button
                             type="button"
@@ -402,11 +453,11 @@ export function ImplementPlanCard({
                             onClick={() => setExpanded(!expanded)}
                             className="text-[11px] text-[#57606a] dark:text-[#8b949e] hover:text-[#1f2328] dark:hover:text-[#c9d1d9]"
                         >
-                            {expanded ? '▾ Hide runs' : `▸ Show all ${existingRuns.length} runs`}
+                            {expanded ? '▾ Hide runs' : `▸ Show all ${filteredRuns.length} runs`}
                         </button>
                         {expanded && (
                             <div className="mt-1 space-y-1" data-testid="implement-plan-card-run-list">
-                                {[...existingRuns].reverse().map((run, i) => (
+                                {[...filteredRuns].reverse().map((run, i) => (
                                     <div key={run.processId + '-' + i} className="flex items-center gap-2 text-[11px] text-[#57606a] dark:text-[#8b949e]">
                                         <span>{STATUS_CONFIG[run.liveStatus].emoji} {STATUS_CONFIG[run.liveStatus].label}</span>
                                         <span>· {formatRelativeTime(run.enqueuedAt)}</span>

--- a/packages/coc/test/server/spa/client/repos/ImplementPlanCard.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ImplementPlanCard.test.tsx
@@ -793,4 +793,206 @@ describe('ImplementPlanCard', () => {
         fireEvent.click(screen.getByTestId('implement-plan-card-view-btn'));
         expect(onViewRun).toHaveBeenCalledWith('queue_impl-r', 'ws-remote');
     });
+
+    // ── Plan-file selector (multi-plan-file-switcher AC-02/AC-03) ───────
+
+    const PLAN_016 = '/repo/plans/016-alpha.plan.md';
+    const PLAN_017 = '/repo/plans/017-beta.plan.md';
+    const PLAN_018 = '/repo/plans/018-gamma.plan.md';
+
+    it('hides the plan-file selector with no planFiles prop (single-file unchanged)', () => {
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                onImplemented={onImplemented}
+            />,
+        );
+        expect(screen.queryByTestId('implement-plan-card-file-select')).toBeNull();
+        // Path text is still rendered exactly as before.
+        expect(screen.getByText(PLAN_016)).toBeTruthy();
+    });
+
+    it('hides the plan-file selector when only one plan file is detected', () => {
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016]}
+                onImplemented={onImplemented}
+            />,
+        );
+        expect(screen.queryByTestId('implement-plan-card-file-select')).toBeNull();
+    });
+
+    it('renders the plan-file selector with basename labels in scan order for 2+ files', () => {
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016, PLAN_017, PLAN_018]}
+                onImplemented={onImplemented}
+            />,
+        );
+        const select = screen.getByTestId('implement-plan-card-file-select') as HTMLSelectElement;
+        expect(select).toBeTruthy();
+        // Defaults to the first detected file.
+        expect(select.value).toBe(PLAN_016);
+        // Option labels are basenames only, in conversation scan order.
+        expect(Array.from(select.options).map(o => o.textContent)).toEqual([
+            '016-alpha.plan.md',
+            '017-beta.plan.md',
+            '018-gamma.plan.md',
+        ]);
+        // The displayed full path reflects the default selection.
+        expect(screen.getByText(PLAN_016)).toBeTruthy();
+    });
+
+    it('switching the selected plan file updates the displayed path and enqueued file', async () => {
+        mockEnqueue.mockResolvedValue({ task: { id: 'task-017' } });
+
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016, PLAN_017, PLAN_018]}
+                workspaceId="ws-1"
+                workingDirectory="/repo"
+                onImplemented={onImplemented}
+            />,
+        );
+
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('implement-plan-card-file-select'), {
+                target: { value: PLAN_017 },
+            });
+        });
+
+        // Displayed path follows the selection.
+        expect(screen.getByText(PLAN_017)).toBeTruthy();
+        expect(screen.queryByText(PLAN_016)).toBeNull();
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('implement-plan-card-btn'));
+        });
+
+        await waitFor(() => expect(mockEnqueue).toHaveBeenCalledTimes(1));
+        const payload = mockEnqueue.mock.calls[0][0];
+        expect(payload.payload.context.files).toEqual([PLAN_017]);
+        expect(payload.payload.prompt).toBe(`Read and implement the plan file at ${PLAN_017}`);
+    });
+
+    it('persists the selected plan file path in the implementation record', async () => {
+        mockEnqueue.mockResolvedValue({ task: { id: 'task-018' } });
+        mockProcessUpdate.mockResolvedValue({ process: {} });
+
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016, PLAN_017, PLAN_018]}
+                workspaceId="ws-1"
+                onImplemented={onImplemented}
+                sourceProcessId="queue_source-1"
+                sourceMetadata={{ type: 'chat' }}
+                onRecordPersisted={onRecordPersisted}
+            />,
+        );
+
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('implement-plan-card-file-select'), {
+                target: { value: PLAN_018 },
+            });
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('implement-plan-card-btn'));
+        });
+
+        await waitFor(() => expect(mockProcessUpdate).toHaveBeenCalledTimes(1));
+        const rec = mockProcessUpdate.mock.calls[0][1].set.implementations[0];
+        expect(rec.planFilePath).toBe(PLAN_018);
+    });
+
+    it('filters the status pill and button label to the selected plan file (AC-03)', () => {
+        const runs: ExistingRun[] = [
+            { processId: 'queue_r16', planFilePath: PLAN_016, enqueuedAt: new Date().toISOString(), liveStatus: 'completed' },
+            { processId: 'queue_r17', planFilePath: PLAN_017, enqueuedAt: new Date().toISOString(), liveStatus: 'running' },
+        ];
+
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016, PLAN_017, PLAN_018]}
+                onImplemented={onImplemented}
+                existingRuns={runs}
+                onViewRun={onViewRun}
+            />,
+        );
+
+        // Default file (016) has a completed run → pill + "Implement again".
+        expect(screen.getByTestId('implement-plan-card-status-pill').textContent).toContain('Completed');
+        expect(screen.getByTestId('implement-plan-card-btn').textContent).toContain('Implement again');
+
+        // Switch to 018 (no prior runs) → no pill, "Implement →".
+        fireEvent.change(screen.getByTestId('implement-plan-card-file-select'), {
+            target: { value: PLAN_018 },
+        });
+        expect(screen.queryByTestId('implement-plan-card-status-pill')).toBeNull();
+        expect(screen.getByTestId('implement-plan-card-btn').textContent).toContain('Implement →');
+
+        // Switch to 017 (its own running run) → pill back, scoped to 017.
+        fireEvent.change(screen.getByTestId('implement-plan-card-file-select'), {
+            target: { value: PLAN_017 },
+        });
+        expect(screen.getByTestId('implement-plan-card-status-pill').textContent).toContain('Running');
+    });
+
+    it('navigates to the selected file\'s latest run from the status pill', () => {
+        const runs: ExistingRun[] = [
+            { processId: 'queue_r16', planFilePath: PLAN_016, enqueuedAt: new Date().toISOString(), liveStatus: 'completed' },
+            { processId: 'queue_r17', planFilePath: PLAN_017, enqueuedAt: new Date().toISOString(), liveStatus: 'running' },
+        ];
+
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016, PLAN_017, PLAN_018]}
+                onImplemented={onImplemented}
+                existingRuns={runs}
+                onViewRun={onViewRun}
+            />,
+        );
+
+        fireEvent.change(screen.getByTestId('implement-plan-card-file-select'), {
+            target: { value: PLAN_017 },
+        });
+        fireEvent.click(screen.getByTestId('implement-plan-card-view-btn'));
+        expect(onViewRun).toHaveBeenCalledWith('queue_r17', undefined);
+    });
+
+    it('scopes the expandable run list to the selected plan file', () => {
+        const runs: ExistingRun[] = [
+            { processId: 'queue_r16a', planFilePath: PLAN_016, enqueuedAt: new Date(Date.now() - 60000).toISOString(), liveStatus: 'failed' },
+            { processId: 'queue_r16b', planFilePath: PLAN_016, enqueuedAt: new Date().toISOString(), liveStatus: 'completed' },
+            { processId: 'queue_r17', planFilePath: PLAN_017, enqueuedAt: new Date().toISOString(), liveStatus: 'running' },
+        ];
+
+        render(
+            <ImplementPlanCard
+                planFilePath={PLAN_016}
+                planFiles={[PLAN_016, PLAN_017]}
+                onImplemented={onImplemented}
+                existingRuns={runs}
+                onViewRun={onViewRun}
+            />,
+        );
+
+        // 016 has two runs → expandable list appears and shows two entries.
+        const expandBtn = screen.getByTestId('implement-plan-card-expand-btn');
+        expect(expandBtn.textContent).toContain('Show all 2 runs');
+        fireEvent.click(expandBtn);
+        const list = screen.getByTestId('implement-plan-card-run-list');
+        expect(list.querySelectorAll('button').length).toBe(2);
+
+        // 017 has a single run → no expandable list at all.
+        fireEvent.change(screen.getByTestId('implement-plan-card-file-select'), {
+            target: { value: PLAN_017 },
+        });
+        expect(screen.queryByTestId('implement-plan-card-expand-btn')).toBeNull();
+    });
 });

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -1229,6 +1229,37 @@ describe('ChatDetail', () => {
             expect(detectBlock).not.toContain('findLast');
         });
 
+        // ── Multi-plan-file switcher (AC-01/AC-02) ──────────────────────
+        it('detects ALL .plan.md files in scan order via detectedPlanFiles', () => {
+            expect(source).toContain('const detectedPlanFiles');
+            const block = source.substring(
+                source.indexOf('const detectedPlanFiles'),
+                source.indexOf('const detectedPlanFiles') + 200,
+            );
+            // .filter() collects every match (not just the first), .map() to paths.
+            expect(block).toContain('createdFiles.filter');
+            expect(block).toContain(".endsWith('.plan.md')");
+            expect(block).toContain('.map(');
+        });
+
+        it('builds switchablePlanFiles, gating out explicit-path and canvas-backed plans', () => {
+            expect(source).toContain('const switchablePlanFiles');
+            const block = source.substring(
+                source.indexOf('const switchablePlanFiles'),
+                source.indexOf('const switchablePlanFiles') + 200,
+            );
+            // Single-file when an explicit plan path or a canvas-backed plan exists.
+            expect(block).toContain('planPath');
+            expect(block).toContain('effectivePlanCanvasId');
+            expect(block).toContain('detectedPlanFiles');
+        });
+
+        it('passes planFiles={switchablePlanFiles} to ImplementPlanCard', () => {
+            const cardBlock = source.match(/<ImplementPlanCard[\s\S]*?\/>/);
+            expect(cardBlock).not.toBeNull();
+            expect(cardBlock![0]).toContain('planFiles={switchablePlanFiles}');
+        });
+
         it('builds scratchpad candidates from linked, known, created, and plan paths', () => {
             expect(source).toContain('buildScratchpadCandidates');
             expect(source).toContain('linkedNotePath: scratchpad.linkedNotePath');


### PR DESCRIPTION
When a chat creates 2+ *.plan.md files, ChatDetail now detects all of
them (in conversation scan order) and ImplementPlanCard renders a
plan-file selector. The selected file drives the displayed path, the
enqueued plan, the status pill, the Implement/Implement-again label, and
the per-file prior-runs list (matched against ImplementationRecord
.planFilePath). Single-file, explicit-path, and canvas-backed plans keep
the unchanged single-file banner. Selection is ephemeral local state.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
