### PR TITLE
feat(coc): enable create_conversation tool by default

### DIFF
--- a/packages/coc/src/server/executors/chat-tool-builder.ts
+++ b/packages/coc/src/server/executors/chat-tool-builder.ts
@@ -29,7 +29,7 @@ export interface ChatToolBundleOptions {
     workspaceId?: string;
     /**
      * Bound in-process enqueue capability. When present (and the tool is enabled
-     * by preferences), the opt-in `create_conversation` tool is included so an
+     * by preferences), the `create_conversation` tool is included so an
      * agent can spawn a brand-new chat. Absent → the addon no-ops.
      */
     enqueueChat?: EnqueueChatFn;

--- a/packages/coc/src/server/executors/executor-registry.ts
+++ b/packages/coc/src/server/executors/executor-registry.ts
@@ -53,7 +53,7 @@ export interface ExecutorRegistryOptions {
     onTitleNeeded: (processId: string, turns: ConversationTurn[]) => void;
     getWsServer?: () => import('../streaming/websocket').ProcessWebSocketServer | undefined;
     getLoopInfra?: () => import('./chat-base-executor').LoopInfraDeps | undefined;
-    /** Late-bound in-process enqueue capability for the opt-in `create_conversation` tool. */
+    /** Late-bound in-process enqueue capability for the `create_conversation` tool. */
     getEnqueueChat?: () => import('../llm-tools/create-conversation-tool').EnqueueChatFn | undefined;
     getMcpOauthManager?: () => import('../mcp-oauth').McpOauthManager | undefined;
     getDreamRunExecutor?: () => import('../dreams/dream-runner').DreamRunExecutor | undefined;

--- a/packages/coc/src/server/index.ts
+++ b/packages/coc/src/server/index.ts
@@ -358,7 +358,7 @@ export async function createExecutionServer(options: ExecutionServerOptions = {}
         // triggerInfra is created after queue infra (like loopInfra), so read it
         // lazily through this closure.
         () => triggerInfra ? { manager: triggerInfra.triggerManager } : undefined,
-        // Late-bound enqueue capability for the opt-in `create_conversation` tool;
+        // Late-bound enqueue capability for the `create_conversation` tool;
         // bound at the route layer below, read here once routes register.
         () => enqueueChatCapability,
     );

--- a/packages/coc/src/server/llm-tools/llm-tool-registry.ts
+++ b/packages/coc/src/server/llm-tools/llm-tool-registry.ts
@@ -73,8 +73,8 @@ export const LLM_TOOL_REGISTRY: readonly LlmToolMeta[] = [
     {
         name: 'create_conversation',
         label: 'Create Conversation',
-        description: 'Starts a brand-new, separate chat conversation (fire-and-forget) to delegate or spawn work. Opt-in.',
-        enabledByDefault: false,
+        description: 'Starts a brand-new, separate chat conversation (fire-and-forget) to delegate or spawn work.',
+        enabledByDefault: true,
     },
     {
         name: 'ask_user',

--- a/packages/coc/src/server/routes/index.ts
+++ b/packages/coc/src/server/routes/index.ts
@@ -227,7 +227,7 @@ export interface RegisterRoutesOptions {
     /**
      * Publish the bound in-process enqueue capability back to the server layer so
      * the late-bound getter passed to the queue infrastructure (created before
-     * routes) can hand it to executors. Powers the opt-in `create_conversation`
+     * routes) can hand it to executors. Powers the `create_conversation`
      * tool. The callback runs the same machinery `POST /api/queue` uses
      * (`prepareTaskForEnqueue` + `enqueueViaBridge`) against the shared global
      * queue state.
@@ -383,7 +383,7 @@ export function registerAllRoutes(routes: Route[], opts: RegisterRoutesOptions):
     };
 
     // Publish the bound enqueue capability so executors (created before routes)
-    // can offer the opt-in `create_conversation` tool. Reuses the exact machinery
+    // can offer the `create_conversation` tool. Reuses the exact machinery
     // `POST /api/queue` uses: provider/effort defaults resolution, then route +
     // enqueue via the per-repo queue manager.
     opts.setEnqueueChat?.(async (input: CreateTaskInput): Promise<string> => {

--- a/packages/coc/test/server/executors/create-conversation-addon.test.ts
+++ b/packages/coc/test/server/executors/create-conversation-addon.test.ts
@@ -45,7 +45,6 @@ describe('buildChatToolBundle create_conversation wiring', () => {
     });
 
     it('includes create_conversation when the capability is provided AND the tool is enabled', () => {
-        // Explicit empty disabled list enables the otherwise opt-in tool.
         writeRepoPreferences(tmpDir, WS_ID, { disabledLlmTools: [] });
 
         const result = buildChatToolBundle({
@@ -71,8 +70,8 @@ describe('buildChatToolBundle create_conversation wiring', () => {
         expect(result.tools.map(t => t.name)).not.toContain('create_conversation');
     });
 
-    it('excludes create_conversation by default (opt-in) even when the capability is present', () => {
-        // No repo preferences written → classic-mode defaults disable the opt-in tool.
+    it('includes create_conversation by default when the capability is present', () => {
+        // No repo preferences written → enabled-by-default tool is offered.
         const result = buildChatToolBundle({
             dataDir: tmpDir,
             store: makeStore(),
@@ -80,7 +79,7 @@ describe('buildChatToolBundle create_conversation wiring', () => {
             enqueueChat: vi.fn(),
         });
 
-        expect(result.tools.map(t => t.name)).not.toContain('create_conversation');
+        expect(result.tools.map(t => t.name)).toContain('create_conversation');
     });
 
     it('excludes create_conversation when explicitly disabled by repo preferences', () => {

--- a/packages/coc/test/server/llm-tools/llm-tool-registry.test.ts
+++ b/packages/coc/test/server/llm-tools/llm-tool-registry.test.ts
@@ -52,16 +52,16 @@ describe('LLM_TOOL_REGISTRY', () => {
         expect(tavily!.enabledByDefault).toBe(false);
     });
 
-    it('create_conversation is opt-in (disabled by default)', () => {
+    it('create_conversation is enabled by default', () => {
         const entry = LLM_TOOL_REGISTRY.find(t => t.name === 'create_conversation');
         expect(entry).toBeDefined();
-        expect(entry!.enabledByDefault).toBe(false);
+        expect(entry!.enabledByDefault).toBe(true);
         // Exactly one registry entry named create_conversation.
         expect(LLM_TOOL_REGISTRY.filter(t => t.name === 'create_conversation')).toHaveLength(1);
     });
 
     it('all other tools are enabled by default', () => {
-        const optIn = new Set(['tavily_web_search', 'create_conversation']);
+        const optIn = new Set(['tavily_web_search']);
         const enabledByDefaultTools = LLM_TOOL_REGISTRY.filter(t => !optIn.has(t.name));
         for (const tool of enabledByDefaultTools) {
             expect(tool.enabledByDefault).toBe(true);
@@ -74,8 +74,8 @@ describe('DEFAULT_DISABLED_LLM_TOOLS', () => {
         expect(DEFAULT_DISABLED_LLM_TOOLS).toContain('tavily_web_search');
     });
 
-    it('contains the opt-in create_conversation tool', () => {
-        expect(DEFAULT_DISABLED_LLM_TOOLS).toContain('create_conversation');
+    it('does not contain the enabled-by-default create_conversation tool', () => {
+        expect(DEFAULT_DISABLED_LLM_TOOLS).not.toContain('create_conversation');
     });
 
     it('does not contain enabled-by-default tools', () => {
@@ -125,12 +125,12 @@ describe('isLlmToolEnabled', () => {
         expect(isLlmToolEnabled('tavily_web_search', undefined)).toBe(false);
     });
 
-    it('returns false for opt-in create_conversation when disabledList is undefined (default)', () => {
-        expect(isLlmToolEnabled('create_conversation', undefined)).toBe(false);
+    it('returns true for create_conversation when disabledList is undefined (default)', () => {
+        expect(isLlmToolEnabled('create_conversation', undefined)).toBe(true);
     });
 
-    it('returns true for create_conversation when explicitly enabled (empty disabled list)', () => {
-        expect(isLlmToolEnabled('create_conversation', [])).toBe(true);
+    it('returns false for create_conversation when explicitly disabled', () => {
+        expect(isLlmToolEnabled('create_conversation', ['create_conversation'])).toBe(false);
     });
 
     it('returns true for tavily_web_search when explicitly enabled (empty disabled list)', () => {


### PR DESCRIPTION
Flip create_conversation from opt-in to enabled-by-default in the LLM
tool registry so agents can spawn new chats without first toggling it on.
Drop it from the default-disabled set, refresh the now-inaccurate
"opt-in" comments, and update registry/addon tests to assert the new
default (enabled unless explicitly disabled).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
