### PR TITLE
pr/9e8a7dbc7 featcoc desktop add check for updates to

### DIFF
--- a/packages/coc-desktop/src/app-menu.ts
+++ b/packages/coc-desktop/src/app-menu.ts
@@ -1,0 +1,127 @@
+/**
+ * CoC Desktop — native menu templates.
+ *
+ * Pure, electron-free builders for the two native menus this app owns:
+ *
+ *   - the application menu (macOS app-menu bar / Windows menu bar), set via
+ *     `Menu.setApplicationMenu` in `main.ts`, and
+ *   - the tray context menu, set via `tray.setContextMenu` in `main.ts`.
+ *
+ * Like `update-check.ts`, this module imports NOTHING from `electron` at
+ * runtime — the only electron reference is a type-only `MenuItemConstructorOptions`
+ * import, which is erased at compile time. That keeps the template *shape* (item
+ * order, separators, roles, and which click handler is wired where) unit-testable
+ * under plain Node, while the electron wiring (`Menu.buildFromTemplate`,
+ * `setApplicationMenu`, `setContextMenu`) stays in `main.ts`.
+ */
+
+import type { MenuItemConstructorOptions } from 'electron';
+
+/** Click handlers the application menu needs wired from `main.ts`. */
+export interface AppMenuHandlers {
+    /**
+     * Invoked by "Check for Updates…". Must behave identically to the former tray
+     * item — i.e. `runUpdateCheck(false)`: always report status, ignore the skip
+     * marker.
+     */
+    onCheckForUpdates: () => void;
+}
+
+/** The "Check for Updates…" label — shared so tests and both platforms agree. */
+export const CHECK_FOR_UPDATES_LABEL = 'Check for Updates…';
+
+/**
+ * Build the full application-menu template for the given platform.
+ *
+ * On both macOS and Windows the menu carries a "Check for Updates…" item placed
+ * directly after "About <app>" (across the separator that follows it) and
+ * separated from the rest of the menu by a separator. The template is a complete
+ * custom menubar — it reconstructs the standard Edit/View/Window items (via
+ * roles) so setting it does not strip the default editing/window commands.
+ *
+ *   - macOS: a custom app submenu (About, Check for Updates…, Services, the
+ *     Hide/Quit cluster) plus the standard Edit/View/Window menus.
+ *   - Windows: the standard File/Edit/View/Window menus plus a Help menu holding
+ *     "About <app>" then "Check for Updates…".
+ *
+ * Linux is out of scope (the app keeps Electron's default menu there); callers
+ * should not invoke this for Linux, but the non-darwin branch is used if they do.
+ */
+export function buildAppMenuTemplate(
+    platform: NodeJS.Platform,
+    appName: string,
+    handlers: AppMenuHandlers,
+): MenuItemConstructorOptions[] {
+    // "About <app>" — explicit label (with the `about` role for the branded
+    // About panel) so the item reads "About CoC" on every platform and the
+    // ordering relative to "Check for Updates…" is self-describing in tests.
+    const aboutItem: MenuItemConstructorOptions = {
+        label: `About ${appName}`,
+        role: 'about',
+    };
+    const checkForUpdatesItem: MenuItemConstructorOptions = {
+        label: CHECK_FOR_UPDATES_LABEL,
+        click: handlers.onCheckForUpdates,
+    };
+
+    if (platform === 'darwin') {
+        return [
+            {
+                label: appName,
+                submenu: [
+                    aboutItem,
+                    { type: 'separator' },
+                    checkForUpdatesItem,
+                    { type: 'separator' },
+                    { role: 'services' },
+                    { type: 'separator' },
+                    { role: 'hide' },
+                    { role: 'hideOthers' },
+                    { role: 'unhide' },
+                    { type: 'separator' },
+                    { role: 'quit' },
+                ],
+            },
+            { role: 'editMenu' },
+            { role: 'viewMenu' },
+            { role: 'windowMenu' },
+        ];
+    }
+
+    // Windows (and any other non-darwin platform a caller passes): the default
+    // menu has no "About", so a Help submenu hosts "About <app>" followed
+    // directly (across a separator) by "Check for Updates…".
+    return [
+        { role: 'fileMenu' },
+        { role: 'editMenu' },
+        { role: 'viewMenu' },
+        { role: 'windowMenu' },
+        {
+            label: 'Help',
+            submenu: [aboutItem, { type: 'separator' }, checkForUpdatesItem],
+        },
+    ];
+}
+
+/** Click handlers the tray context menu needs wired from `main.ts`. */
+export interface TrayMenuHandlers {
+    onShow: () => void;
+    onHide: () => void;
+    onQuit: () => void;
+}
+
+/**
+ * Build the tray context-menu template. Intentionally does NOT include a
+ * "Check for Updates…" item — that action now lives solely in the application
+ * menu (see {@link buildAppMenuTemplate}), so the tray keeps only show/hide/quit.
+ */
+export function buildTrayMenuTemplate(
+    handlers: TrayMenuHandlers,
+): MenuItemConstructorOptions[] {
+    return [
+        { label: 'Show CoC', click: handlers.onShow },
+        { label: 'Hide CoC', click: handlers.onHide },
+        { type: 'separator' },
+        { label: 'Quit CoC', click: handlers.onQuit },
+    ];
+}

--- a/packages/coc-desktop/src/main.ts
+++ b/packages/coc-desktop/src/main.ts
@@ -27,6 +27,7 @@ import {
     setSkippedVersion,
     UpdatePrompt,
 } from './update-check';
+import { buildAppMenuTemplate, buildTrayMenuTemplate } from './app-menu';
 
 // Brand the app identity before anything builds the menu / dock / About panel.
 // In dev (electron launched against this package) this fixes the menu-bar name,
@@ -332,24 +333,41 @@ function createTray(): void {
     }
     tray = new Tray(icon);
     tray.setToolTip('CoC');
-    const menu = Menu.buildFromTemplate([
-        { label: 'Show CoC', click: () => focusMainWindow() },
-        {
-            label: 'Hide CoC',
-            click: () => {
+    // "Check for Updates…" lives in the application menu now (see
+    // setupApplicationMenu); the tray keeps only show/hide/quit.
+    const menu = Menu.buildFromTemplate(
+        buildTrayMenuTemplate({
+            onShow: () => focusMainWindow(),
+            onHide: () => {
                 if (mainWindow && !mainWindow.isDestroyed()) {
                     mainWindow.hide();
                 }
             },
-        },
-        { type: 'separator' },
-        { label: 'Check for Updates…', click: () => void runUpdateCheck(false) },
-        { type: 'separator' },
-        { label: 'Quit CoC', click: () => app.quit() },
-    ]);
+            onQuit: () => app.quit(),
+        }),
+    );
     tray.setContextMenu(menu);
     // A left-click on the tray toggles the window into view.
     tray.on('click', () => focusMainWindow());
+}
+
+/**
+ * AC-01/AC-02: install the native application menu (the macOS app-menu bar and
+ * the Windows menu bar) with a "Check for Updates…" item directly after
+ * "About CoC". Clicking it runs `runUpdateCheck(false)` — the same always-report,
+ * ignore-skip-marker behaviour the tray item used to have.
+ *
+ * Linux is intentionally left on Electron's default menu (the action stays
+ * tray-only there), so we only override the menu on macOS and Windows.
+ */
+function setupApplicationMenu(): void {
+    if (process.platform !== 'darwin' && process.platform !== 'win32') {
+        return;
+    }
+    const template = buildAppMenuTemplate(process.platform, app.name, {
+        onCheckForUpdates: () => void runUpdateCheck(false),
+    });
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
 async function bootstrap(): Promise<void> {
@@ -362,6 +380,10 @@ async function bootstrap(): Promise<void> {
             electronVersion: process.versions.electron,
         }),
     );
+
+    // AC-01: install the native application menu (with "Check for Updates…")
+    // before any window paints, so the menu bar is correct from first show.
+    setupApplicationMenu();
 
     // macOS: set the dock icon early (BrowserWindow `icon` is ignored by macOS).
     // Only override when the real icon file resolves — otherwise leave the dock

--- a/packages/coc-desktop/test/app-menu.test.ts
+++ b/packages/coc-desktop/test/app-menu.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the native menu templates.
+ *
+ * `app-menu.ts` is electron-free (its only electron reference is an erased
+ * type-only import), so the template *shape* — item order, separators, which
+ * click handler is wired where — is asserted here under plain Node, with no
+ * Electron runtime. The electron wiring (`Menu.setApplicationMenu`,
+ * `Menu.buildFromTemplate`, `tray.setContextMenu`) lives in `main.ts`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { MenuItemConstructorOptions } from 'electron';
+import {
+    buildAppMenuTemplate,
+    buildTrayMenuTemplate,
+    CHECK_FOR_UPDATES_LABEL,
+} from '../src/app-menu';
+
+type Item = MenuItemConstructorOptions;
+
+/** The app submenu (first entry on macOS, the Help menu on Windows). */
+function submenuOf(item: Item): Item[] {
+    expect(Array.isArray(item.submenu)).toBe(true);
+    return item.submenu as Item[];
+}
+
+const labelIdx = (items: Item[], label: string): number =>
+    items.findIndex((i) => i.label === label);
+const roleIdx = (items: Item[], role: string): number =>
+    items.findIndex((i) => i.role === role);
+const isSeparator = (item: Item | undefined): boolean => item?.type === 'separator';
+
+describe('buildAppMenuTemplate — macOS', () => {
+    const handlers = { onCheckForUpdates: vi.fn() };
+    const template = buildAppMenuTemplate('darwin', 'CoC', handlers);
+    const appSubmenu = submenuOf(template[0]);
+
+    it('puts the app submenu first, labelled with the app name', () => {
+        expect(template[0].label).toBe('CoC');
+    });
+
+    it('places "Check for Updates…" directly after "About CoC" across a separator', () => {
+        const aboutIdx = labelIdx(appSubmenu, 'About CoC');
+        const checkIdx = labelIdx(appSubmenu, CHECK_FOR_UPDATES_LABEL);
+        expect(aboutIdx).toBeGreaterThanOrEqual(0);
+        expect(checkIdx).toBe(aboutIdx + 2); // about, separator, check
+        expect(isSeparator(appSubmenu[aboutIdx + 1])).toBe(true);
+        // The About item shows the branded About panel.
+        expect(appSubmenu[aboutIdx].role).toBe('about');
+    });
+
+    it('separates "Check for Updates…" from the hide/quit cluster with a separator', () => {
+        const checkIdx = labelIdx(appSubmenu, CHECK_FOR_UPDATES_LABEL);
+        expect(isSeparator(appSubmenu[checkIdx + 1])).toBe(true);
+        const hideIdx = roleIdx(appSubmenu, 'hide');
+        const quitIdx = roleIdx(appSubmenu, 'quit');
+        expect(hideIdx).toBeGreaterThan(checkIdx);
+        expect(quitIdx).toBeGreaterThan(hideIdx);
+    });
+
+    it('preserves the default cluster items (services, hide, quit)', () => {
+        for (const role of ['services', 'hide', 'quit']) {
+            expect(roleIdx(appSubmenu, role)).toBeGreaterThanOrEqual(0);
+        }
+    });
+
+    it('preserves the standard Edit/View/Window menus', () => {
+        const roles = template.map((i) => i.role);
+        expect(roles).toContain('editMenu');
+        expect(roles).toContain('viewMenu');
+        expect(roles).toContain('windowMenu');
+    });
+
+    it('wires the Check-for-Updates click to the provided handler (AC-02)', () => {
+        const check = appSubmenu.find((i) => i.label === CHECK_FOR_UPDATES_LABEL)!;
+        expect(typeof check.click).toBe('function');
+        (check.click as () => void)();
+        expect(handlers.onCheckForUpdates).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('buildAppMenuTemplate — Windows', () => {
+    const handlers = { onCheckForUpdates: vi.fn() };
+    const template = buildAppMenuTemplate('win32', 'CoC', handlers);
+
+    it('preserves the standard File/Edit/View/Window menus', () => {
+        const roles = template.map((i) => i.role);
+        expect(roles).toContain('fileMenu');
+        expect(roles).toContain('editMenu');
+        expect(roles).toContain('viewMenu');
+        expect(roles).toContain('windowMenu');
+    });
+
+    it('hosts "About CoC" then "Check for Updates…" in a Help menu', () => {
+        const help = template.find((i) => i.label === 'Help');
+        expect(help).toBeDefined();
+        const items = submenuOf(help!);
+        const aboutIdx = labelIdx(items, 'About CoC');
+        const checkIdx = labelIdx(items, CHECK_FOR_UPDATES_LABEL);
+        expect(aboutIdx).toBeGreaterThanOrEqual(0);
+        expect(items[aboutIdx].role).toBe('about');
+        expect(checkIdx).toBeGreaterThan(aboutIdx);
+        expect(isSeparator(items[aboutIdx + 1])).toBe(true);
+    });
+
+    it('wires the Check-for-Updates click to the provided handler (AC-02)', () => {
+        const items = submenuOf(template.find((i) => i.label === 'Help')!);
+        const check = items.find((i) => i.label === CHECK_FOR_UPDATES_LABEL)!;
+        (check.click as () => void)();
+        expect(handlers.onCheckForUpdates).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('buildTrayMenuTemplate', () => {
+    const handlers = { onShow: vi.fn(), onHide: vi.fn(), onQuit: vi.fn() };
+    const template = buildTrayMenuTemplate(handlers);
+
+    it('does NOT contain a "Check for Updates…" item (AC-03)', () => {
+        expect(template.some((i) => i.label === CHECK_FOR_UPDATES_LABEL)).toBe(false);
+    });
+
+    it('keeps only show / hide / quit, in order', () => {
+        const labels = template.filter((i) => i.label).map((i) => i.label);
+        expect(labels).toEqual(['Show CoC', 'Hide CoC', 'Quit CoC']);
+    });
+
+    it('wires each tray click to its handler', () => {
+        const click = (label: string) =>
+            (template.find((i) => i.label === label)!.click as () => void)();
+        click('Show CoC');
+        click('Hide CoC');
+        click('Quit CoC');
+        expect(handlers.onShow).toHaveBeenCalledTimes(1);
+        expect(handlers.onHide).toHaveBeenCalledTimes(1);
+        expect(handlers.onQuit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/coc/src/server/executors/process-lifecycle-runner.ts
+++ b/packages/coc/src/server/executors/process-lifecycle-runner.ts
@@ -503,6 +503,14 @@ export class ProcessLifecycleRunner extends BaseExecutor {
             ? modelMetadataStore.getContextWindow(processModel)
             : undefined;
 
+        // Per-chat "after tier": the effort tier this conversation was launched
+        // with, carried on the task config by resolveEffortTierConfig (the
+        // original `effortTier` is consumed at enqueue). Seed it onto the process
+        // record so the follow-up after-tier selector can read it back per
+        // conversation instead of from a workspace-global localStorage key.
+        const rawAfterEffortTier = (task.config as { afterEffortTier?: unknown }).afterEffortTier;
+        const afterEffortTier = typeof rawAfterEffortTier === 'string' ? rawAfterEffortTier : undefined;
+
         const process: AIProcess = {
             id: processId,
             type: task.type,
@@ -518,6 +526,7 @@ export class ProcessLifecycleRunner extends BaseExecutor {
                 priority: task.priority,
                 model: processModel,
                 reasoningEffort: task.config.reasoningEffort,
+                afterEffortTier,
                 mode: normalizedPayloadMode,
                 workspaceId: payload?.workspaceId || task.repoId,
                 // Use per-task provider from payload when available; fall back to

--- a/packages/coc/src/server/routes/queue-enqueue.ts
+++ b/packages/coc/src/server/routes/queue-enqueue.ts
@@ -642,6 +642,13 @@ export function resolveEffortTierConfig(input: CreateTaskInput, ctx: Pick<QueueR
 
     if (typeof rawTier !== 'string' || !EFFORT_TIER_KEYS.has(rawTier)) return;
 
+    // Preserve the launched tier on the task config so process creation can seed
+    // it onto the conversation record as `metadata.afterEffortTier` (AC-01).
+    // `effortTier` itself is consumed/deleted above (resolved into model +
+    // reasoningEffort for execution), so this dedicated field is what survives to
+    // the lifecycle runner for per-chat after-tier read-back.
+    config.afterEffortTier = rawTier;
+
     const payload = input.payload as { provider?: unknown } | undefined;
     const provider = isChatProvider(payload?.provider)
         ? payload.provider

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -242,6 +242,11 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     /** Set to true the first time we initialise effortOverride from processDetails.config.
      *  Reset to false on taskId change so every new conversation gets a fresh init. */
     const effortInitializedRef = useRef(false);
+    /** Set to true the first time we initialise the follow-up effort tier from the
+     *  conversation's `metadata.afterEffortTier` (per-conversation read-back, AC-02),
+     *  or when the user explicitly picks a tier. Prevents the init fallback from
+     *  clobbering a seeded value or an in-flight pick. Reset on taskId change. */
+    const afterTierInitializedRef = useRef(false);
     /** Tracks first mount of the model-override effect so we don't re-derive on initial render. */
     const modelOverrideMountedRef = useRef(false);
     const previousSessionProviderRef = useRef<string | null>(null);
@@ -700,6 +705,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         planPatchedRef.current = false;
         goalPatchedRef.current = false;
         effortInitializedRef.current = false;
+        afterTierInitializedRef.current = false;
         modelOverrideMountedRef.current = false;
         setEffortOverride(null);
         setInvalidScratchpadPaths(new Set());
@@ -937,16 +943,25 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         setEffortOverride(effort);
     }, []);
 
-    // Restore last-picked effort tier from localStorage on workspace switch.
+    // Restore the follow-up effort tier per conversation (AC-02). Prefer the
+    // per-conversation seed persisted on the process record
+    // (`metadata.afterEffortTier`); fall back to the workspace-global last choice,
+    // then `medium`. Runs once per chat and is finalised only once the process
+    // record loads, so a later PATCH (AC-03) or an in-flight pick is not reverted.
     useEffect(() => {
-        const key = `coc:effort-tier:${workspaceId ?? 'default'}`;
-        const stored = localStorage.getItem(key);
-        if (stored === 'low' || stored === 'medium' || stored === 'high') {
-            setSelectedFollowUpEffortTier(stored);
-        } else {
-            setSelectedFollowUpEffortTier('medium');
+        if (afterTierInitializedRef.current) return;
+        const seeded = (processDetails as any)?.metadata?.afterEffortTier;
+        if (seeded === 'very-low' || seeded === 'low' || seeded === 'medium' || seeded === 'high') {
+            afterTierInitializedRef.current = true;
+            setSelectedFollowUpEffortTier(seeded);
+            return;
         }
-    }, [workspaceId]);
+        const stored = localStorage.getItem(`coc:effort-tier:${workspaceId ?? 'default'}`);
+        setSelectedFollowUpEffortTier(stored === 'low' || stored === 'medium' || stored === 'high' ? stored : 'medium');
+        // Only lock in the fallback once the process record has actually loaded;
+        // until then a later-arriving seeded value can still take precedence.
+        if (processDetails) afterTierInitializedRef.current = true;
+    }, [processDetails, workspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // When the selected tier becomes unconfigured, fall back to the first configured tier.
     useEffect(() => {
@@ -958,9 +973,25 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [useFollowUpEffortTierMode, followUpEffortTierMap]);
 
+    // Persist the follow-up effort tier per conversation (AC-03). Apply the change
+    // optimistically, then PATCH `metadata.afterEffortTier` in the background
+    // (best-effort — keep the UI value and log on failure). This no longer writes
+    // the workspace-global `coc:effort-tier` key, so one chat's tier can't leak
+    // into another. `afterTierInitializedRef` marks the pick so the read-back
+    // init can't overwrite it if the process record loads afterwards.
     function handleFollowUpEffortTierChange(tier: EffortTierKey) {
+        afterTierInitializedRef.current = true;
         setSelectedFollowUpEffortTier(tier);
-        localStorage.setItem(`coc:effort-tier:${workspaceId ?? 'default'}`, tier);
+        if (!processId) return;
+        client.processes.patchMetadata(processId, { set: { afterEffortTier: tier } })
+            .then((data: any) => {
+                if (data?.process) {
+                    setProcessDetails((prev: any) => (prev ? { ...prev, metadata: data.process.metadata } : prev));
+                }
+            })
+            .catch((err: unknown) => {
+                console.warn('[coc-after-effort-tier] failed to persist tier', err);
+            });
     }
 
     const pinnedFile = createdFiles.at(-1);

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1544,6 +1544,17 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                             setTurnsAndRef(turns);
                             setProcessDetails(loadedProcess);
                             seedSessionTokensFromProcess(loadedProcess);
+                            // Re-hydrate the queued follow-ups from the server.
+                            // The cache-hit path paints turns from cache and
+                            // returns early, so without this a still-running chat
+                            // with pending follow-ups would show an empty
+                            // "Queued · N" section after a switch-away/return.
+                            const serverPending: any[] = loadedProcess.pendingMessages ?? [];
+                            setPendingQueue(serverPending.map((m: any) => ({
+                                id: m.id,
+                                content: m.content,
+                                status: 'queued' as const,
+                            })));
                         }).catch(() => { /* best-effort revalidation */ });
                         return;
                     }
@@ -1569,6 +1580,15 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                         setTurnsAndRef(turns);
                         setProcessDetails(loadedProcess);
                         seedSessionTokensFromProcess(loadedProcess);
+                        // Re-hydrate the queued follow-ups so a cold processId
+                        // load of a still-running chat keeps its "Queued · N"
+                        // section instead of clearing it.
+                        const serverPending: any[] = loadedProcess.pendingMessages ?? [];
+                        setPendingQueue(serverPending.map((m: any) => ({
+                            id: m.id,
+                            content: m.content,
+                            status: 'queued' as const,
+                        })));
                         setLoading(false);
                         return;
                     }

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -37,7 +37,8 @@ import { CanvasPanel } from '../canvas/CanvasPanel';
 import { SourceCanvasDock, useSourceCanvasState, useSourceCanvasContent, useSourceCanvasDirectory } from './source-canvas';
 import { readCanvasClosed, writeCanvasClosed } from './canvasClosedPreference';
 import { WhisperDiffDock, useWhisperDiffPanelState, useWhisperDiffState, WHISPER_DIFF_EVENT } from './whisper-diff';
-import type { WhisperFileDiffContext } from './conversation/tool-calls/WhisperCollapsedGroup';
+import { isCombinedWhisperDiffContext } from './conversation/tool-calls/WhisperCollapsedGroup';
+import type { WhisperDiffOpenContext } from './conversation/tool-calls/WhisperCollapsedGroup';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { hydrateAskUserBatch } from './hooks/hydrateAskUserBatch';
 import { useSendMessage } from './hooks/useSendMessage';
@@ -394,8 +395,11 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const openWhisperDiff = whisperDiff.open;
     useEffect(() => {
         const handler = (event: Event) => {
-            const detail = (event as CustomEvent).detail as WhisperFileDiffContext | undefined;
-            if (!detail || !detail.file) return;
+            const detail = (event as CustomEvent).detail as WhisperDiffOpenContext | undefined;
+            if (!detail) return;
+            // Combined contexts carry `files[]` (no `.file`); single-file contexts
+            // must carry a `.file`. Reject anything that is neither.
+            if (!isCombinedWhisperDiffContext(detail) && !detail.file) return;
             openWhisperDiff(detail);
         };
         window.addEventListener(WHISPER_DIFF_EVENT, handler as EventListener);
@@ -1299,7 +1303,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     // canvas + source canvas above (only one right column is non-null at once).
     const whisperDiffColumn = (whisperDiff.isOpen && whisperDiff.ctx) ? (
         <WhisperDiffDock
-            file={whisperDiff.ctx.file}
+            file={isCombinedWhisperDiffContext(whisperDiff.ctx) ? undefined : whisperDiff.ctx.file}
             state={whisperDiffState}
             workspaceRootPath={workspaceRootPath}
             isMobile={isMobile}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1227,7 +1227,9 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
             } else if (remembered.kind === 'whisper-diff') {
                 whisperDiff.open(remembered.ctx); // onOpen collapses the agent panel
             } else if (remembered.kind === 'agent') {
-                setActiveCanvasId(remembered.canvasId);
+                // The id is validated + applied by discovery below so a DELETED
+                // canvas silently falls back instead of surfacing CanvasPanel's
+                // load error; here we only pre-expand the panel for its arrival.
                 setCanvasPanelClosed(false);
             }
         } else if (!closed && hasRecord) {
@@ -1238,15 +1240,27 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
 
         let cancelled = false;
         // Discovery is non-critical: defer the round-trip to browser idle so the
-        // conversation paints first. It always populates the linked agent canvas
-        // id (for the collapsed rail / a remembered agent canvas), but only
-        // AUTO-EXPANDS it for a chat with no session record — `canvasPanelClosed`
-        // set above keeps a remembered "nothing open" / non-agent surface intact.
+        // conversation paints first. It populates the linked agent canvas id for
+        // the collapsed rail / auto-open, and validates a remembered agent canvas.
         const cancelIdle = runWhenIdle(() => {
             if (cancelled) return;
             client.canvases.list(workspaceId, { processId: canvasPid })
                 .then(canvases => {
-                    if (!cancelled && canvases.length > 0) {
+                    if (cancelled) return;
+                    // Restore a remembered agent canvas ONLY if it still exists — a
+                    // deleted one silently falls back to the first linked canvas
+                    // (or nothing), never CanvasPanel's "Failed to load" error.
+                    if (!closed && remembered?.kind === 'agent') {
+                        const ids = new Set(canvases.map(c => c.id));
+                        setActiveCanvasId(ids.has(remembered.canvasId)
+                            ? remembered.canvasId
+                            : (canvases[0]?.id ?? null));
+                        return;
+                    }
+                    // Otherwise populate the linked agent canvas id: auto-opens a
+                    // fresh chat (no record), or backs the collapsed rail behind a
+                    // remembered source/whisper/"nothing open" (kept collapsed above).
+                    if (canvases.length > 0) {
                         setActiveCanvasId(prev => prev ?? canvases[0].id);
                     }
                 })

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -36,6 +36,7 @@ import type { RalphGrillPlanningProgress, CanvasUpdatedEvent } from './hooks/use
 import { CanvasPanel } from '../canvas/CanvasPanel';
 import { SourceCanvasDock, useSourceCanvasState, useSourceCanvasContent, useSourceCanvasDirectory } from './source-canvas';
 import { readCanvasClosed, writeCanvasClosed } from './canvasClosedPreference';
+import { deriveOpenCanvasMemory, type OpenCanvasMemory } from './openCanvasMemory';
 import { WhisperDiffDock, useWhisperDiffPanelState, useWhisperDiffState, WHISPER_DIFF_EVENT } from './whisper-diff';
 import { isCombinedWhisperDiffContext } from './conversation/tool-calls/WhisperCollapsedGroup';
 import type { WhisperDiffOpenContext } from './conversation/tool-calls/WhisperCollapsedGroup';
@@ -206,6 +207,15 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const [activeCanvasId, setActiveCanvasId] = useState<string | null>(null);
     const [canvasLiveEvent, setCanvasLiveEvent] = useState<CanvasUpdatedEvent | null>(null);
     const [canvasPanelClosed, setCanvasPanelClosed] = useState(false);
+    // Session-scoped, per-conversation memory of which canvas surface is open in
+    // each chat (restore-open-canvas-on-chat-switch). Held in memory only — keyed
+    // by `pid = processId ?? bareTaskId`, NEVER persisted to localStorage/disk, so
+    // it is intentionally forgotten on a full reload. `openCanvasDescriptorRef`
+    // tracks the CURRENT chat's open surface continuously; the map is written only
+    // on switch-away (effect cleanup) so the new chat's record can't be clobbered
+    // before its restore runs.
+    const openCanvasMemoryRef = useRef<Map<string, OpenCanvasMemory>>(new Map());
+    const openCanvasDescriptorRef = useRef<OpenCanvasMemory>(null);
     // Thread vs. Agents (spatial sub-agent run tree) view. In the main inline
     // context the view is deep-linked via a `?view=agents` hash param, so a
     // shared/bookmarked URL reopens straight into the canvas.
@@ -1155,28 +1165,83 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         setRalphGrillPlanningProgress(null);
     }, [taskId]);
 
-    // Canvas side panel: reset on chat switch, then discover canvases linked
-    // to this process (live `canvas-updated` SSE events take over from there).
-    // Note: this no longer force-opens the panel — the persisted per-chat
-    // "closed" flag is applied by the discovery effect below, so a deliberately
-    // closed canvas stays collapsed when the user switches away and back.
+    // Keep the live open-canvas descriptor for the CURRENT chat continuously up
+    // to date (restore-open-canvas-on-chat-switch, AC-01). The snapshot effect
+    // below reads this ref on switch-away so the remembered surface survives the
+    // reset. Surfaces are mutually exclusive, so this collapses to one descriptor.
     useEffect(() => {
-        setActiveCanvasId(null);
+        openCanvasDescriptorRef.current = deriveOpenCanvasMemory({
+            activeCanvasId,
+            canvasPanelClosed,
+            sourceFileRef: sourceCanvas.fileRef,
+            whisperDiffCtx: whisperDiff.ctx,
+        });
+    }, [activeCanvasId, canvasPanelClosed, sourceCanvas.fileRef, whisperDiff.ctx]);
+
+    // Snapshot the current chat's open canvas into the session memory map on
+    // switch-AWAY (effect cleanup), keyed by the OLD pid captured in closure. The
+    // cleanup runs in React's destroy phase — before the switch effect below
+    // resets canvas state in its create phase — so the old chat's descriptor is
+    // captured intact and the new chat's record is never clobbered.
+    useEffect(() => {
+        const pid = canvasPid;
+        if (!pid) return;
+        return () => {
+            openCanvasMemoryRef.current.set(pid, openCanvasDescriptorRef.current);
+        };
+    }, [canvasPid]);
+
+    // Canvas side panel on chat switch (restore-open-canvas-on-chat-switch,
+    // AC-02): reset the previous chat's surfaces, then restore THIS chat's
+    // remembered open canvas. Restore priority — (1) the persisted deliberate-
+    // close flag wins → stay collapsed; (2) a remembered open canvas of ANY type
+    // → reopen it exactly; (3) no record → today's default (auto-open the first
+    // linked AI agent canvas). Replaces the old unconditional reset that force-
+    // closed every source/note/folder/diff canvas with no restore path.
+    useEffect(() => {
+        // Clear the previous chat's transient surfaces first; the branches below
+        // reopen the remembered one (if any) in the SAME synchronous commit, so a
+        // restored canvas never flashes closed/empty.
         setCanvasLiveEvent(null);
+        setActiveCanvasId(null);
         sourceCanvas.close();
         whisperDiff.close();
-    }, [taskId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    useEffect(() => {
-        if (!isCanvasEnabled() || !workspaceId || !canvasPid) return;
-        // Apply the persisted deliberate-close preference synchronously, before
-        // the async discovery resolves `activeCanvasId`, so a closed chat settles
+        if (!isCanvasEnabled() || !workspaceId || !canvasPid) {
+            setCanvasPanelClosed(false);
+            return;
+        }
+
+        // (1) Persisted deliberate-close flag — applied synchronously, before the
+        // async discovery resolves `activeCanvasId`, so a closed chat settles
         // straight into the collapsed rail without flashing the expanded panel.
-        setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid));
+        const closed = readCanvasClosed(workspaceId, canvasPid);
+        setCanvasPanelClosed(closed);
+
+        // (2) Restore the remembered open canvas for this chat from session memory.
+        const hasRecord = openCanvasMemoryRef.current.has(canvasPid);
+        const remembered = openCanvasMemoryRef.current.get(canvasPid) ?? null;
+        if (!closed && remembered) {
+            if (remembered.kind === 'source') {
+                sourceCanvas.open(remembered.fileRef); // onOpen collapses the agent panel
+            } else if (remembered.kind === 'whisper-diff') {
+                whisperDiff.open(remembered.ctx); // onOpen collapses the agent panel
+            } else if (remembered.kind === 'agent') {
+                setActiveCanvasId(remembered.canvasId);
+                setCanvasPanelClosed(false);
+            }
+        } else if (!closed && hasRecord) {
+            // Remembered "nothing open" (the user closed a source/note/folder/diff
+            // canvas): keep every surface collapsed instead of auto-opening.
+            setCanvasPanelClosed(true);
+        }
+
         let cancelled = false;
-        // Canvas discovery is non-critical: defer the round-trip to browser idle
-        // so the conversation messages paint first (AC-03). The persisted close
-        // flag above still applies synchronously; only the network probe waits.
+        // Discovery is non-critical: defer the round-trip to browser idle so the
+        // conversation paints first. It always populates the linked agent canvas
+        // id (for the collapsed rail / a remembered agent canvas), but only
+        // AUTO-EXPANDS it for a chat with no session record — `canvasPanelClosed`
+        // set above keeps a remembered "nothing open" / non-agent surface intact.
         const cancelIdle = runWhenIdle(() => {
             if (cancelled) return;
             client.canvases.list(workspaceId, { processId: canvasPid })
@@ -1188,7 +1253,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 .catch(() => { /* canvas discovery is best-effort */ });
         });
         return () => { cancelled = true; cancelIdle(); };
-    }, [workspaceId, canvasPid]);
+    }, [taskId, workspaceId, canvasPid]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const canvasResize = useResizablePanel({
         initialWidth: 520,

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup.tsx
@@ -40,6 +40,36 @@ export interface WhisperFileDiffContext {
     workspaceId?: string;
 }
 
+/**
+ * Context emitted when a user opens the *combined* whole-group diff from the
+ * files popover footer (AC-02). Unlike the per-file context, it carries the
+ * group's full ordered file list; the panel reconstructs every reconstructable
+ * file synchronously via `buildWhisperCombinedDiff`. It rides the same window
+ * CustomEvent bridge and single docked panel slot as the per-file flow.
+ */
+export interface WhisperCombinedDiffContext {
+    /** Discriminator: this is the whole-group combined diff, not a single file. */
+    combined: true;
+    /** Every file in the group, in popover / group order (deleted ones included). */
+    files: FileEdit[];
+    /** Reconstructable edit/create/apply_patch calls captured in this group. */
+    toolCalls: WhisperDiffToolCall[];
+    /** Commits detected in this group; carried for parity (unused in the combined path). */
+    commits: DetectedCommit[];
+    /** Workspace/clone routing id, carried unchanged from the single-file flow. */
+    workspaceId?: string;
+}
+
+/** Either a single clicked file or the whole-group combined diff. */
+export type WhisperDiffOpenContext = WhisperFileDiffContext | WhisperCombinedDiffContext;
+
+/** Type guard: true when the open context is the whole-group combined diff. */
+export function isCombinedWhisperDiffContext(
+    ctx: WhisperDiffOpenContext,
+): ctx is WhisperCombinedDiffContext {
+    return (ctx as WhisperCombinedDiffContext).combined === true;
+}
+
 interface ToolLike {
     toolName: string;
     status?: string;
@@ -70,10 +100,11 @@ export interface WhisperCollapsedGroupProps {
     workspaceId?: string;
     renderToolTree: (toolId: string, depth: number) => React.ReactNode;
     /**
-     * Opens the transient read-only diff panel for a clicked changed file. When
-     * omitted, file popover rows stay non-interactive (hover-only) as before.
+     * Opens the transient read-only diff panel for a clicked changed file, or
+     * — from the multi-file popover footer — the whole-group combined diff. When
+     * omitted, file popover rows and the footer stay non-interactive (hover-only).
      */
-    onOpenFileDiff?: (ctx: WhisperFileDiffContext) => void;
+    onOpenFileDiff?: (ctx: WhisperDiffOpenContext) => void;
 }
 
 function formatDuration(startTime?: number, endTime?: number): string {
@@ -625,9 +656,11 @@ interface FileHoverPopoverProps {
     onMouseLeave: () => void;
     /** When provided, active (non-deleted) rows open the file's diff on click/Enter/Space. */
     onFileClick?: (file: FileEdit) => void;
+    /** When provided, the multi-file summary footer opens the combined diff on click/Enter/Space. */
+    onOpenCombined?: () => void;
 }
 
-function FileHoverPopover({ files, anchorRef, popoverRef, onMouseEnter, onMouseLeave, onFileClick }: FileHoverPopoverProps) {
+function FileHoverPopover({ files, anchorRef, popoverRef, onMouseEnter, onMouseLeave, onFileClick, onOpenCombined }: FileHoverPopoverProps) {
     if (!anchorRef.current) return null;
     const rect = anchorRef.current.getBoundingClientRect();
     const rowHeight = 28;
@@ -706,8 +739,23 @@ function FileHoverPopover({ files, anchorRef, popoverRef, onMouseEnter, onMouseL
             })}
             {files.length > 1 && (
                 <div
-                    className="flex items-center gap-2 px-2.5 py-1.5 text-xs border-t border-[#e0e0e0] dark:border-[#3c3c3c] font-medium"
+                    className={cn(
+                        'flex items-center gap-2 px-2.5 py-1.5 text-xs border-t border-[#e0e0e0] dark:border-[#3c3c3c] font-medium',
+                        // Becomes the "view all changes" control when a handler is wired.
+                        onOpenCombined && 'cursor-pointer hover:bg-[#e1effe] dark:hover:bg-[#1f2d42]',
+                    )}
                     data-testid="file-popover-footer"
+                    role={onOpenCombined ? 'button' : undefined}
+                    tabIndex={onOpenCombined ? 0 : undefined}
+                    aria-label={onOpenCombined ? 'Open combined diff for all files' : undefined}
+                    onClick={onOpenCombined ? (e) => { e.stopPropagation(); onOpenCombined(); } : undefined}
+                    onKeyDown={onOpenCombined ? (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onOpenCombined();
+                        }
+                    } : undefined}
                 >
                     <span className="text-[#848484] flex-1">
                         {files.length} file{files.length !== 1 ? 's' : ''}
@@ -737,9 +785,11 @@ interface FileHoverSpanProps {
     showInlineTotals?: boolean;
     /** When provided, active file rows open the file's diff on click/Enter/Space. */
     onFileClick?: (file: FileEdit) => void;
+    /** When provided, the multi-file footer opens the combined diff on click/Enter/Space. */
+    onOpenCombined?: () => void;
 }
 
-function FileHoverSpan({ text, files, testId, showInlineTotals = true, onFileClick }: FileHoverSpanProps) {
+function FileHoverSpan({ text, files, testId, showInlineTotals = true, onFileClick, onOpenCombined }: FileHoverSpanProps) {
     const [hovered, setHovered] = useState(false);
     const anchorRef = useRef<HTMLSpanElement | null>(null);
     const popoverRef = useRef<HTMLDivElement | null>(null);
@@ -792,6 +842,7 @@ function FileHoverSpan({ text, files, testId, showInlineTotals = true, onFileCli
                     onMouseEnter={showPopover}
                     onMouseLeave={hidePopover}
                     onFileClick={onFileClick}
+                    onOpenCombined={onOpenCombined}
                 />
             )}
         </span>
@@ -1023,6 +1074,22 @@ export function WhisperCollapsedGroup({
     );
     const onFileClick = onOpenFileDiff ? handleFileClick : undefined;
 
+    // Opens the whole-group combined diff (every reconstructable file in one
+    // scroll). Built from the same captured tool calls + ordered fileEdits the
+    // popover shows; deleted/non-reconstructable files are surfaced by the
+    // builder downstream, so the full list is carried through unchanged.
+    const handleOpenCombined = useCallback(() => {
+        if (!onOpenFileDiff) return;
+        onOpenFileDiff({
+            combined: true,
+            files: summary.fileEdits ?? [],
+            toolCalls: groupToolCalls,
+            commits: summary.commits ?? [],
+            workspaceId,
+        });
+    }, [onOpenFileDiff, summary.fileEdits, groupToolCalls, summary.commits, workspaceId]);
+    const onOpenCombined = onOpenFileDiff ? handleOpenCombined : undefined;
+
     const headerParts: Array<{ text: string; title?: string; kind?: 'commit' | 'fixup' | 'pr' | 'file' | 'removed-file' | 'skill' | 'memory' }> = [];
     if (summary.toolCallCount > 0) {
         headerParts.push({ text: `${summary.toolCallCount} tool call${summary.toolCallCount !== 1 ? 's' : ''}` });
@@ -1080,11 +1147,11 @@ export function WhisperCollapsedGroup({
             );
         } else if (part.kind === 'file' && summary.fileEdits && summary.fileEdits.length > 0) {
             headerElements.push(
-                <FileHoverSpan key={`part-${idx}`} text={part.text} files={summary.fileEdits} testId="whisper-file-hover" onFileClick={onFileClick} />,
+                <FileHoverSpan key={`part-${idx}`} text={part.text} files={summary.fileEdits} testId="whisper-file-hover" onFileClick={onFileClick} onOpenCombined={onOpenCombined} />,
             );
         } else if (part.kind === 'removed-file' && summary.fileEdits && summary.fileEdits.length > 0) {
             headerElements.push(
-                <FileHoverSpan key={`part-${idx}`} text={part.text} files={summary.fileEdits} testId="whisper-removed-hover" showInlineTotals={false} onFileClick={onFileClick} />,
+                <FileHoverSpan key={`part-${idx}`} text={part.text} files={summary.fileEdits} testId="whisper-removed-hover" showInlineTotals={false} onFileClick={onFileClick} onOpenCombined={onOpenCombined} />,
             );
         } else if (part.kind === 'skill' && summary.skillNames && summary.skillNames.length > 0) {
             headerElements.push(

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperCombinedDiff.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperCombinedDiff.ts
@@ -1,0 +1,89 @@
+/**
+ * buildWhisperCombinedDiff — concatenates the per-file whisper diffs for a whole
+ * whisper group into one unified diff covering every reconstructable file (AC-01).
+ *
+ * The combined whisper diff panel shows the entire change across all files in a
+ * whisper group in one scroll. This builder is the synchronous, network-free
+ * source for that view: it replays the group's already-captured tool calls
+ * through the existing `buildWhisperFileDiff` once per file — in popover (group)
+ * order — and concatenates each reconstructable file's `diff --git a/… b/…`
+ * section into a single unified diff string.
+ *
+ * Files that cannot contribute a diff body are NOT reconstructed here; they are
+ * reported so the panel can list them separately ("not shown"):
+ *   - deleted files — a later shell command removed them, and no reconstructed
+ *     deletion diff is available (deletions are out of scope for the combined view).
+ *   - non-reconstructable files — Codex-style structured changes that carry no
+ *     line content, so `buildWhisperFileDiff` returns `null`.
+ *
+ * This mirrors the single-file path's decisions but drops its commit/network
+ * fallback (that stays single-file only), so the combined view opens instantly.
+ */
+import { buildWhisperFileDiff, type WhisperDiffToolCall } from './buildWhisperFileDiff';
+import type { FileEdit } from './toolGroupUtils';
+
+/** One reconstructed file section: the file summary plus its `diff --git` block. */
+export interface CombinedWhisperDiffSection {
+    file: FileEdit;
+    /** This file's reconstructed unified diff (a single `diff --git` section). */
+    diff: string;
+}
+
+export interface CombinedWhisperDiff {
+    /**
+     * One concatenated unified diff — a `diff --git a/… b/…` section per
+     * reconstructable file, in group order. Empty string when no file in the
+     * group has a reconstructable diff (the panel shows its no-diff message).
+     */
+    diffText: string;
+    /**
+     * Per-file reconstructed sections, in group order. Lets the panel render a
+     * filename divider before each file's section without re-running the builder.
+     */
+    sections: CombinedWhisperDiffSection[];
+    /** Deleted files (no diff body) — surfaced in the "not shown" list, group order. */
+    deletedFiles: FileEdit[];
+    /**
+     * Non-deleted files with no reconstructable diff (Codex structured changes
+     * with no line content) — also surfaced in the "not shown" list, group order.
+     */
+    nonReconstructableFiles: FileEdit[];
+}
+
+/**
+ * Build the combined whisper diff for a group from its captured tool calls and
+ * its ordered `fileEdits` list (popover / group order).
+ */
+export function buildWhisperCombinedDiff(
+    toolCalls: WhisperDiffToolCall[],
+    fileEdits: FileEdit[],
+): CombinedWhisperDiff {
+    const sections: CombinedWhisperDiffSection[] = [];
+    const deletedFiles: FileEdit[] = [];
+    const nonReconstructableFiles: FileEdit[] = [];
+
+    for (const file of fileEdits) {
+        // Deleted files contribute no diff body — no reconstructed deletion diff
+        // is available, so surface them in the "not shown" list instead.
+        if (file.isDeleted) {
+            deletedFiles.push(file);
+            continue;
+        }
+        const diff = buildWhisperFileDiff(toolCalls, file.path);
+        if (diff) {
+            sections.push({ file, diff });
+        } else {
+            // No reconstructable diff (e.g. Codex structured changes with no line
+            // content). The single-file path would fall back to a commit diff, but
+            // the combined path stays synchronous, so list it as "not shown".
+            nonReconstructableFiles.push(file);
+        }
+    }
+
+    return {
+        diffText: sections.map(s => s.diff).join('\n'),
+        sections,
+        deletedFiles,
+        nonReconstructableFiles,
+    };
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/openCanvasMemory.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/openCanvasMemory.ts
@@ -1,0 +1,69 @@
+/**
+ * Session-scoped, per-conversation memory of which canvas surface is currently
+ * open in a chat (restore-open-canvas-on-chat-switch).
+ *
+ * The docked right panel shows AT MOST one canvas surface at a time — the AI
+ * agent canvas, a source-file / note / folder canvas (all carried by a single
+ * `SourceCanvasFileRef`, discriminated by its `kind`), or a transient
+ * whisper-diff. This module models that single open surface as one descriptor so
+ * `ChatDetail` can snapshot it when the user switches away from a chat and
+ * reopen the SAME surface when they switch back — instead of force-closing every
+ * non-agent canvas as the chat-switch reset used to.
+ *
+ * IMPORTANT: this memory is HELD IN MEMORY ONLY (a `useRef` map keyed by
+ * `pid = processId ?? bareTaskId`). It is intentionally NOT written to
+ * `localStorage` or disk, so it is forgotten on a full page reload/restart. The
+ * separate deliberate-close flag (`canvasClosedPreference` /
+ * `coc.canvasPanel.closed.*`) is the only persisted piece and always wins over a
+ * restore.
+ */
+import type { SourceCanvasFileRef } from './source-canvas';
+import type { WhisperDiffOpenContext } from './conversation/tool-calls/WhisperCollapsedGroup';
+
+/**
+ * The single open canvas surface remembered for a chat, or `null` for the
+ * explicit "nothing open" state (e.g. after the user closes a source/note/
+ * folder/whisper-diff canvas). A chat with no record at all (never visited /
+ * untouched) is represented by the ABSENCE of a map entry — distinct from a
+ * `null` record — so the discovery effect's default auto-open only applies to
+ * truly-untouched chats.
+ */
+export type OpenCanvasMemory =
+    | { kind: 'agent'; canvasId: string }
+    | { kind: 'source'; fileRef: SourceCanvasFileRef }
+    | { kind: 'whisper-diff'; ctx: WhisperDiffOpenContext }
+    | null;
+
+/** The live canvas state `deriveOpenCanvasMemory` reads to build a descriptor. */
+export interface OpenCanvasState {
+    /** The active AI agent canvas id, or `null` when none is discovered/open. */
+    activeCanvasId: string | null;
+    /** Whether the agent canvas panel is collapsed (deliberate close / mutual exclusion). */
+    canvasPanelClosed: boolean;
+    /** The open source/note/folder canvas reference, or `null`. */
+    sourceFileRef: SourceCanvasFileRef | null;
+    /** The open whisper-diff context, or `null`. */
+    whisperDiffCtx: WhisperDiffOpenContext | null;
+}
+
+/**
+ * Derive the single open-canvas descriptor from the live canvas state.
+ *
+ * Surfaces are mutually exclusive in the docked panel, so the order encodes the
+ * "front" surface: an open source/whisper panel always sits over the (collapsed)
+ * agent canvas, so it wins; the agent canvas counts as open only when it is
+ * actually expanded (`activeCanvasId` set and NOT collapsed). Everything else is
+ * "nothing open" (`null`).
+ */
+export function deriveOpenCanvasMemory(state: OpenCanvasState): OpenCanvasMemory {
+    if (state.sourceFileRef) {
+        return { kind: 'source', fileRef: state.sourceFileRef };
+    }
+    if (state.whisperDiffCtx) {
+        return { kind: 'whisper-diff', ctx: state.whisperDiffCtx };
+    }
+    if (state.activeCanvasId && !state.canvasPanelClosed) {
+        return { kind: 'agent', canvasId: state.activeCanvasId };
+    }
+    return null;
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/WhisperDiffDock.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/WhisperDiffDock.tsx
@@ -17,13 +17,15 @@ import type { FileEdit } from '../conversation/tool-calls/toolGroupUtils';
 import type { WhisperDiffState } from './useWhisperDiffState';
 import type { UseResizablePanelReturn } from '../../../hooks/ui/useResizablePanel';
 
-function sheetTitle(file: FileEdit): string {
-    return file.path.replace(/\\/g, '/').split('/').pop() || 'Diff';
+function sheetTitle(file: FileEdit | null | undefined, state: WhisperDiffState): string {
+    // Combined ("All changes") mode has no single file — title the whole-group view.
+    if (state.combined) return 'All changes';
+    return file ? file.path.replace(/\\/g, '/').split('/').pop() || 'Diff' : 'Diff';
 }
 
 export interface WhisperDiffDockProps {
-    /** The clicked file's edit summary — drives the header (always present). */
-    file: FileEdit;
+    /** The clicked file's edit summary — drives the single-file header. Absent in combined mode. */
+    file?: FileEdit | null;
     /** Renderable diff state from `useWhisperDiffState`. */
     state: WhisperDiffState;
     /** Current workspace root, used to show a project-relative path in the header. */
@@ -49,7 +51,7 @@ export function WhisperDiffDock({
             <BottomSheet
                 isOpen
                 onClose={onClose}
-                title={sheetTitle(file)}
+                title={sheetTitle(file, state)}
                 height={90}
             >
                 <WhisperDiffPanel

--- a/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/WhisperDiffPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/WhisperDiffPanel.tsx
@@ -2,28 +2,41 @@
  * WhisperDiffPanel — inner chrome for the transient read-only whisper diff
  * panel (AC-03).
  *
- * Header shows the clicked file's name, its project-relative path, and a
- * "Whisper diff" source label so the surface is clearly the per-file edits
- * captured by a whisper group (not a persisted canvas). The body renders the
- * four explicit states produced by `useWhisperDiffState`:
- *   - `loading` → spinner (commit-diff fallback fetch in flight)
- *   - `success` → the unified diff via the shared `UnifiedDiffViewer`
- *   - `empty`   → nothing-to-show message (no reconstruction, no fallback)
- *   - `error`   → an explicit failure message (a fallback fetch threw)
+ * Two modes share the same docked slot, chosen by `state.combined`:
  *
- * This is a read-only surface: no copy/reveal/comments/Ask-AI, no save, and no
- * canvas record is ever written. Layout (docked column vs mobile BottomSheet)
- * and resizing are owned by the host (`WhisperDiffDock`); this is inner chrome.
+ *  - Single-file (the default): the header shows the clicked file's name + its
+ *    project-relative path, and the body renders the four explicit states
+ *    produced by `useWhisperDiffState` (loading / success / empty / error).
+ *  - Combined ("All changes"): the header shows "All changes" + "N files (+X −Y)"
+ *    totals, and the body renders every reconstructable file's diff in one scroll
+ *    — each under a filename divider — followed by a trailing "not shown" list of
+ *    the group's deleted / non-reconstructable files. The empty case (nothing
+ *    reconstructable) shows the same no-diff message rather than a blank body.
+ *
+ * This is a read-only surface in both modes: no copy/reveal/comments/Ask-AI, no
+ * save, and no canvas record is ever written. Layout (docked column vs mobile
+ * BottomSheet) and resizing are owned by the host (`WhisperDiffDock`); this is
+ * inner chrome.
  */
 import { Spinner } from '../../../ui/Spinner';
 import { UnifiedDiffViewer } from '../../git/diff/UnifiedDiffViewer';
 import { getSourceCanvasDisplayPath } from '../source-canvas/resolve';
 import type { FileEdit } from '../conversation/tool-calls/toolGroupUtils';
-import type { WhisperDiffState } from './useWhisperDiffState';
+import type { CombinedWhisperDiffView, WhisperDiffState } from './useWhisperDiffState';
 
 function basename(p: string): string {
     const normalized = p.replace(/\\/g, '/');
     return normalized.split('/').pop() || p;
+}
+
+/** "N files (+X −Y)" — mirrors the popover footer's totals formatting. */
+function combinedTotalsLabel(combined: CombinedWhisperDiffView): string {
+    const { fileCount, totalInsertions, totalDeletions } = combined;
+    const parts: string[] = [];
+    if (totalInsertions > 0) parts.push(`+${totalInsertions}`);
+    if (totalDeletions > 0) parts.push(`−${totalDeletions}`);
+    const totals = parts.length ? ` (${parts.join(' ')})` : '';
+    return `${fileCount} file${fileCount !== 1 ? 's' : ''}${totals}`;
 }
 
 const headerBtnClass =
@@ -31,8 +44,11 @@ const headerBtnClass =
     'hover:text-[#1e1e1e] dark:hover:text-[#cccccc] hover:bg-black/[0.06] dark:hover:bg-white/[0.08]';
 
 export interface WhisperDiffPanelProps {
-    /** The clicked file's edit summary — drives the header (always present). */
-    file: FileEdit;
+    /**
+     * The clicked file's edit summary — drives the single-file header. Absent in
+     * combined mode (the header is derived from `state.combined` instead).
+     */
+    file?: FileEdit | null;
     /** Renderable diff state from `useWhisperDiffState`. */
     state: WhisperDiffState;
     /** Current workspace root, used to show a project-relative path in the header. */
@@ -47,9 +63,26 @@ export function WhisperDiffPanel({
     workspaceRootPath,
     onClose,
 }: WhisperDiffPanelProps) {
-    const fullPath = file.path;
-    const path = getSourceCanvasDisplayPath(fullPath, workspaceRootPath);
-    const fileName = basename(path) || 'Diff';
+    const combined = state.combined;
+
+    // ── Header (single-file vs combined) ──────────────────────────────────────
+    let headerTitle: string;
+    let headerSubtitle: string;
+    let headerSubtitleTitle: string | undefined;
+    let headerSubtitleTestId: string;
+    if (combined) {
+        headerTitle = 'All changes';
+        headerSubtitle = combinedTotalsLabel(combined);
+        headerSubtitleTitle = undefined;
+        headerSubtitleTestId = 'whisper-diff-totals';
+    } else {
+        const fullPath = file?.path ?? '';
+        const relPath = getSourceCanvasDisplayPath(fullPath, workspaceRootPath);
+        headerTitle = basename(relPath) || 'Diff';
+        headerSubtitle = relPath;
+        headerSubtitleTitle = fullPath;
+        headerSubtitleTestId = 'whisper-diff-path';
+    }
 
     // `idle` only shows for the single render between the panel opening and the
     // diff effect resolving — treat it as loading so the body never flashes blank.
@@ -66,14 +99,14 @@ export function WhisperDiffPanel({
                         className="text-sm font-semibold text-[#1e1e1e] dark:text-[#cccccc] truncate"
                         data-testid="whisper-diff-filename"
                     >
-                        {fileName}
+                        {headerTitle}
                     </div>
                     <div
                         className="text-xs text-[#848484] truncate mt-0.5"
-                        title={fullPath}
-                        data-testid="whisper-diff-path"
+                        title={headerSubtitleTitle}
+                        data-testid={headerSubtitleTestId}
                     >
-                        {path}
+                        {headerSubtitle}
                     </div>
                 </div>
                 <div className="flex items-center gap-0.5 shrink-0">
@@ -89,43 +122,154 @@ export function WhisperDiffPanel({
                 </div>
             </div>
             <div className="flex-1 min-h-0 overflow-auto" data-testid="whisper-diff-body">
-                {status === 'loading' && (
-                    <div
-                        className="flex items-center gap-2 p-4 text-xs text-[#848484]"
-                        data-testid="whisper-diff-loading"
-                    >
-                        <Spinner size="sm" /> Loading diff for {fileName}…
-                    </div>
-                )}
-                {status === 'error' && (
-                    <div className="p-4 text-xs" data-testid="whisper-diff-error">
-                        <div className="font-medium text-[#cc4444] dark:text-[#f48771]">
-                            {`Couldn't load the diff for ${fileName}`}
-                        </div>
-                        {state.error && (
-                            <div className="mt-1 text-[#848484]">{state.error}</div>
-                        )}
-                    </div>
-                )}
-                {status === 'empty' && (
-                    <div
-                        className="p-4 text-xs text-[#848484]"
-                        data-testid="whisper-diff-empty"
-                    >
-                        {state.error || 'No diff is available for this file.'}
-                    </div>
-                )}
-                {status === 'success' && (
-                    <div className="p-2">
-                        <UnifiedDiffViewer
-                            diff={state.diffText}
-                            fileName={fileName}
-                            showLineNumbers
-                            data-testid="whisper-diff-viewer"
-                        />
-                    </div>
+                {combined ? (
+                    <CombinedDiffBody
+                        combined={combined}
+                        status={status}
+                        error={state.error}
+                        workspaceRootPath={workspaceRootPath}
+                    />
+                ) : (
+                    <SingleFileDiffBody
+                        status={status}
+                        diffText={state.diffText}
+                        error={state.error}
+                        fileName={headerTitle}
+                    />
                 )}
             </div>
         </div>
+    );
+}
+
+function SingleFileDiffBody({
+    status,
+    diffText,
+    error,
+    fileName,
+}: {
+    status: WhisperDiffState['status'];
+    diffText: string;
+    error: string;
+    fileName: string;
+}) {
+    return (
+        <>
+            {status === 'loading' && (
+                <div
+                    className="flex items-center gap-2 p-4 text-xs text-[#848484]"
+                    data-testid="whisper-diff-loading"
+                >
+                    <Spinner size="sm" /> Loading diff for {fileName}…
+                </div>
+            )}
+            {status === 'error' && (
+                <div className="p-4 text-xs" data-testid="whisper-diff-error">
+                    <div className="font-medium text-[#cc4444] dark:text-[#f48771]">
+                        {`Couldn't load the diff for ${fileName}`}
+                    </div>
+                    {error && <div className="mt-1 text-[#848484]">{error}</div>}
+                </div>
+            )}
+            {status === 'empty' && (
+                <div className="p-4 text-xs text-[#848484]" data-testid="whisper-diff-empty">
+                    {error || 'No diff is available for this file.'}
+                </div>
+            )}
+            {status === 'success' && (
+                <div className="p-2">
+                    <UnifiedDiffViewer
+                        diff={diffText}
+                        fileName={fileName}
+                        showLineNumbers
+                        data-testid="whisper-diff-viewer"
+                    />
+                </div>
+            )}
+        </>
+    );
+}
+
+function CombinedDiffBody({
+    combined,
+    status,
+    error,
+    workspaceRootPath,
+}: {
+    combined: CombinedWhisperDiffView;
+    status: WhisperDiffState['status'];
+    error: string;
+    workspaceRootPath?: string | null;
+}) {
+    const notShown = [...combined.deletedFiles, ...combined.nonReconstructableFiles];
+    return (
+        <>
+            {status === 'empty' ? (
+                // Nothing in the group has a reconstructable diff — show the
+                // no-diff message rather than a blank body.
+                <div className="p-4 text-xs text-[#848484]" data-testid="whisper-diff-empty">
+                    {error || 'No diff is available for these files.'}
+                </div>
+            ) : (
+                combined.sections.map((section) => {
+                    const relPath = getSourceCanvasDisplayPath(section.file.path, workspaceRootPath);
+                    return (
+                        <div
+                            key={section.file.path}
+                            data-testid="whisper-diff-file-section"
+                            data-path={section.file.path}
+                        >
+                            <div
+                                className="sticky-0 px-3 py-1.5 text-xs font-medium text-[#1e1e1e] dark:text-[#cccccc] bg-[#f3f3f3] dark:bg-[#2a2a2b] border-b border-[#e0e0e0] dark:border-[#3c3c3c] truncate"
+                                title={section.file.path}
+                                data-testid="whisper-diff-file-divider"
+                            >
+                                {relPath}
+                            </div>
+                            <div className="p-2">
+                                <UnifiedDiffViewer
+                                    diff={section.diff}
+                                    fileName={basename(relPath)}
+                                    showLineNumbers
+                                    data-testid="whisper-diff-section-viewer"
+                                />
+                            </div>
+                        </div>
+                    );
+                })
+            )}
+            {notShown.length > 0 && (
+                <div
+                    className="px-3 py-2 text-xs text-[#848484] border-t border-[#e0e0e0] dark:border-[#3c3c3c]"
+                    data-testid="whisper-diff-not-shown"
+                >
+                    <div className="font-medium text-[#1e1e1e] dark:text-[#cccccc] mb-1">
+                        Not shown
+                    </div>
+                    {combined.deletedFiles.map((f) => (
+                        <div
+                            key={f.path}
+                            className="truncate"
+                            title={f.path}
+                            data-testid="whisper-diff-not-shown-item"
+                            data-path={f.path}
+                        >
+                            {getSourceCanvasDisplayPath(f.path, workspaceRootPath)} — deleted
+                        </div>
+                    ))}
+                    {combined.nonReconstructableFiles.map((f) => (
+                        <div
+                            key={f.path}
+                            className="truncate"
+                            title={f.path}
+                            data-testid="whisper-diff-not-shown-item"
+                            data-path={f.path}
+                        >
+                            {getSourceCanvasDisplayPath(f.path, workspaceRootPath)} — no diff available
+                        </div>
+                    ))}
+                </div>
+            )}
+        </>
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffPanelState.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffPanelState.ts
@@ -2,7 +2,7 @@
  * useWhisperDiffPanelState — open/close state for the transient read-only
  * whisper diff panel (AC-03).
  *
- * Holds the single active `WhisperFileDiffContext` (a new `open()` *replaces*
+ * Holds the single active `WhisperDiffOpenContext` (a new `open()` *replaces*
  * the previous one — single document, no tabs/history). `onOpen` fires
  * synchronously whenever the panel opens so the host can close the other
  * mutually-exclusive right-side panels (scratchpad / source canvas / agent
@@ -13,7 +13,7 @@
  * derived from the held context by `useWhisperDiffState`.
  */
 import { useCallback, useRef, useState } from 'react';
-import type { WhisperFileDiffContext } from '../conversation/tool-calls/WhisperCollapsedGroup';
+import type { WhisperDiffOpenContext } from '../conversation/tool-calls/WhisperCollapsedGroup';
 
 export interface UseWhisperDiffPanelStateOptions {
     /**
@@ -27,9 +27,9 @@ export interface UseWhisperDiffPanelStateReturn {
     /** Whether the panel currently has a file diff to show. */
     isOpen: boolean;
     /** The active clicked-file context, or `null` when closed. */
-    ctx: WhisperFileDiffContext | null;
+    ctx: WhisperDiffOpenContext | null;
     /** Open (or replace the content of) the panel with a new clicked-file context. */
-    open: (ctx: WhisperFileDiffContext) => void;
+    open: (ctx: WhisperDiffOpenContext) => void;
     /** Close the panel and clear its content. */
     close: () => void;
 }
@@ -37,12 +37,12 @@ export interface UseWhisperDiffPanelStateReturn {
 export function useWhisperDiffPanelState(
     options: UseWhisperDiffPanelStateOptions = {},
 ): UseWhisperDiffPanelStateReturn {
-    const [ctx, setCtx] = useState<WhisperFileDiffContext | null>(null);
+    const [ctx, setCtx] = useState<WhisperDiffOpenContext | null>(null);
     // Ref so a changing `onOpen` identity never re-creates the stable `open`.
     const onOpenRef = useRef(options.onOpen);
     onOpenRef.current = options.onOpen;
 
-    const open = useCallback((next: WhisperFileDiffContext) => {
+    const open = useCallback((next: WhisperDiffOpenContext) => {
         setCtx(next);
         onOpenRef.current?.();
     }, []);

--- a/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffState.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffState.ts
@@ -24,27 +24,91 @@ import { useEffect, useMemo, useState } from 'react';
 import { getCocClientForWorkspace } from '../../../repos/cloneRegistry';
 import { getSpaCocClientErrorMessage } from '../../../api/cocClient';
 import { buildWhisperFileDiff } from '../conversation/tool-calls/buildWhisperFileDiff';
-import type { WhisperFileDiffContext } from '../conversation/tool-calls/WhisperCollapsedGroup';
-import type { FileEdit } from '../conversation/tool-calls/toolGroupUtils';
+import {
+    buildWhisperCombinedDiff,
+    type CombinedWhisperDiffSection,
+} from '../conversation/tool-calls/buildWhisperCombinedDiff';
+import {
+    isCombinedWhisperDiffContext,
+    type WhisperDiffOpenContext,
+} from '../conversation/tool-calls/WhisperCollapsedGroup';
+import { computeFileEditTotals, type FileEdit } from '../conversation/tool-calls/toolGroupUtils';
 
 export type WhisperDiffStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
+/**
+ * Combined-mode payload — present only when the panel was opened from the
+ * files-popover footer (the whole-group "All changes" view, AC-03). It carries
+ * everything the panel needs to render the header totals, the per-file dividers,
+ * and the trailing "not shown" list, all built synchronously by
+ * `buildWhisperCombinedDiff`.
+ */
+export interface CombinedWhisperDiffView {
+    /** Per-file reconstructed sections in group order (a divider + diff each). */
+    sections: CombinedWhisperDiffSection[];
+    /** Deleted files (no diff body) — listed under "not shown". */
+    deletedFiles: FileEdit[];
+    /** Non-reconstructable files (no line content) — listed under "not shown". */
+    nonReconstructableFiles: FileEdit[];
+    /** Total file count in the group, for the "N files" header. */
+    fileCount: number;
+    /** Combined insertions across the whole group (header totals). */
+    totalInsertions: number;
+    /** Combined deletions across the whole group (header totals). */
+    totalDeletions: number;
+}
 
 export interface WhisperDiffState {
     status: WhisperDiffStatus;
     /** The reconstructed or fetched unified diff text (success only). */
     diffText: string;
-    /** The clicked file's summary, for the panel header (null when idle). */
+    /** The clicked file's summary, for the panel header (null when idle/combined). */
     file: FileEdit | null;
     /** Failure / empty explanation, shown in the error/empty state. */
     error: string;
+    /** Combined-mode payload — present only when opened in combined mode. */
+    combined?: CombinedWhisperDiffView;
 }
 
 const IDLE: WhisperDiffState = { status: 'idle', diffText: '', file: null, error: '' };
 
 export function useWhisperDiffState(
-    ctx: WhisperFileDiffContext | null,
+    ctx: WhisperDiffOpenContext | null,
 ): WhisperDiffState {
+    // Combined mode (the whole-group "All changes" view) is fully synchronous and
+    // has no commit/network fallback, so it is built in render rather than driven
+    // through the async single-file state machine below. The single-file machine
+    // must never see a combined context — it reads `.file`, which a combined
+    // context does not carry — so split the union here.
+    const combinedCtx = ctx && isCombinedWhisperDiffContext(ctx) ? ctx : null;
+    const singleCtx = ctx && !isCombinedWhisperDiffContext(ctx) ? ctx : null;
+
     const [state, setState] = useState<WhisperDiffState>(IDLE);
+
+    // Combined: reuse the AC-01 builder; pure + synchronous. `combinedCtx` is
+    // held in panel state (stable identity) in the app, and nothing in this
+    // branch calls setState, so recomputing on a fresh ctx cannot loop.
+    const combined = useMemo<WhisperDiffState | null>(() => {
+        if (!combinedCtx) return null;
+        const built = buildWhisperCombinedDiff(combinedCtx.toolCalls, combinedCtx.files);
+        const { totalInsertions, totalDeletions } = computeFileEditTotals(combinedCtx.files);
+        const view: CombinedWhisperDiffView = {
+            sections: built.sections,
+            deletedFiles: built.deletedFiles,
+            nonReconstructableFiles: built.nonReconstructableFiles,
+            fileCount: combinedCtx.files.length,
+            totalInsertions,
+            totalDeletions,
+        };
+        const hasDiff = built.sections.length > 0;
+        return {
+            status: hasDiff ? 'success' : 'empty',
+            diffText: built.diffText,
+            file: null,
+            error: hasDiff ? '' : 'No diff is available for these files.',
+            combined: view,
+        };
+    }, [combinedCtx]);
 
     // The effect must NOT depend on the `ctx` object reference: callers (and
     // tests) may pass a freshly-constructed context on every render, which would
@@ -56,23 +120,23 @@ export function useWhisperDiffState(
     // 1. Primary reconstruction is pure + synchronous; compute it in render. Its
     //    string (or null) result is value-stable, so it is safe as an effect dep.
     const reconstructed = useMemo(
-        () => (ctx ? buildWhisperFileDiff(ctx.toolCalls, ctx.file.path) : null),
-        [ctx],
+        () => (singleCtx ? buildWhisperFileDiff(singleCtx.toolCalls, singleCtx.file.path) : null),
+        [singleCtx],
     );
     // Stable identity for the commit fallback set.
     const commitKey = useMemo(
-        () => (ctx?.commits ?? []).map((c) => c.fullHash || c.shortHash || '').join(','),
-        [ctx],
+        () => (singleCtx?.commits ?? []).map((c) => c.fullHash || c.shortHash || '').join(','),
+        [singleCtx],
     );
-    const filePath = ctx?.file.path;
-    const wsId = ctx?.workspaceId;
+    const filePath = singleCtx?.file.path;
+    const wsId = singleCtx?.workspaceId;
 
     useEffect(() => {
-        if (!ctx) {
+        if (!singleCtx) {
             setState(IDLE);
             return;
         }
-        const file = ctx.file;
+        const file = singleCtx.file;
 
         // 1. Primary: reconstruct the diff from the group's captured tool calls.
         if (reconstructed) {
@@ -82,7 +146,7 @@ export function useWhisperDiffState(
 
         // 2. Fallback: commit-backed single-file diff. Requires both a workspace
         //    to route through and at least one detected commit.
-        const commits = ctx.commits ?? [];
+        const commits = singleCtx.commits ?? [];
         if (!wsId || commits.length === 0) {
             setState({
                 status: 'empty',
@@ -139,5 +203,7 @@ export function useWhisperDiffState(
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filePath, wsId, commitKey, reconstructed]);
 
-    return state;
+    // Combined mode short-circuits the single-file machine (whose effect parks at
+    // IDLE while a combined context is held).
+    return combined ?? state;
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/whisperDiffEvent.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/whisper-diff/whisperDiffEvent.ts
@@ -13,12 +13,16 @@
  * tool calls + detected commits), so dispatch must be synchronous within the
  * same window — no structured clone is involved.
  */
-import type { WhisperFileDiffContext } from '../conversation/tool-calls/WhisperCollapsedGroup';
+import type { WhisperDiffOpenContext } from '../conversation/tool-calls/WhisperCollapsedGroup';
 
 export const WHISPER_DIFF_EVENT = 'coc-open-whisper-diff';
 
-/** Dispatch a request to open the whisper diff panel for a clicked file. */
-export function dispatchOpenWhisperDiff(ctx: WhisperFileDiffContext): void {
+/**
+ * Dispatch a request to open the whisper diff panel — either for a single
+ * clicked file or for the whole-group combined diff (AC-02). Both ride the same
+ * event + docked slot; opening one replaces whatever the dock currently shows.
+ */
+export function dispatchOpenWhisperDiff(ctx: WhisperDiffOpenContext): void {
     if (typeof window === 'undefined') return;
     window.dispatchEvent(new CustomEvent(WHISPER_DIFF_EVENT, { detail: ctx }));
 }

--- a/packages/coc/src/server/spa/client/react/features/stats/UsageStatsView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/stats/UsageStatsView.tsx
@@ -211,7 +211,11 @@ export function UsageStatsView() {
     const [days, setDays] = useState<number | undefined>(30);
     const { data, loading, error, reload } = useTokenUsageStats(days);
 
-    const grandTotal = data ? sumUsage(data.entries) : null;
+    // A malformed/empty response (e.g. `{}` with no `entries`) must not crash the
+    // render — normalise to a nullable array and gate every entries-dependent
+    // branch on it instead of on `data` truthiness.
+    const entries = data?.entries ?? null;
+    const grandTotal = entries ? sumUsage(entries) : null;
 
     return (
         <div className="flex flex-col h-full overflow-hidden bg-[var(--vscode-editor-background)] text-[var(--vscode-foreground)]">
@@ -261,13 +265,13 @@ export function UsageStatsView() {
                     </div>
                 )}
 
-                {!loading && !error && data && data.entries.length === 0 && (
+                {!loading && !error && entries && entries.length === 0 && (
                     <p className="p-6 text-sm text-[var(--vscode-descriptionForeground)]">
                         No token usage data found. Run some AI tasks to see stats here.
                     </p>
                 )}
 
-                {!loading && !error && data && data.entries.length > 0 && grandTotal && (
+                {!loading && !error && entries && entries.length > 0 && grandTotal && (
                     <table className="w-full text-xs border-collapse">
                         <thead className="sticky top-0 bg-[var(--vscode-editor-background)] z-10">
                             <tr>
@@ -277,7 +281,7 @@ export function UsageStatsView() {
                             </tr>
                         </thead>
                         <tbody>
-                            {data.entries.map((entry, i) => (
+                            {entries.map((entry, i) => (
                                 <DateGroupRow
                                     key={entry.date}
                                     entry={entry}
@@ -300,7 +304,7 @@ export function UsageStatsView() {
                                 </td>
                             </tr>
                             {data.models.map(model => {
-                                const total = sumByModel(data.entries, model);
+                                const total = sumByModel(entries, model);
                                 return (
                                     <tr key={model} className="border-b border-[var(--vscode-panel-border)] font-semibold bg-[var(--vscode-editor-background)]">
                                         <td className={`${tdClass} text-[var(--vscode-descriptionForeground)] truncate max-w-[200px]`} title={model}>

--- a/packages/coc/test/server/process-lifecycle-runner-after-effort-tier.test.ts
+++ b/packages/coc/test/server/process-lifecycle-runner-after-effort-tier.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { QueuedTask } from '@plusplusoneplusplus/forge';
+import { ProcessLifecycleRunner } from '../../src/server/executors/process-lifecycle-runner';
+import { createMockProcessStore } from './helpers/mock-process-store';
+
+/**
+ * AC-01 coverage: the lifecycle runner seeds `metadata.afterEffortTier` onto the
+ * created process from the launched effort tier carried on `task.config`.
+ *
+ * `resolveEffortTierConfig` consumes the submitted `config.effortTier` (resolving
+ * it into model + reasoningEffort) but preserves the original tier choice as
+ * `config.afterEffortTier`, which the runner records here so the follow-up
+ * after-tier selector can read it back per conversation.
+ */
+describe('ProcessLifecycleRunner persisted metadata.afterEffortTier', () => {
+    function runTask(task: QueuedTask, store = createMockProcessStore()) {
+        const runner = new ProcessLifecycleRunner(store, undefined, () => undefined, 'claude');
+        return runner.run(task, {
+            cancelledTasks: new Set(),
+            executeFollowUpFn: async () => undefined,
+            executeByTypeFn: async () => ({ response: 'done.' }),
+            getWorkingDirectoryFn: () => undefined,
+        }).then((result) => ({ result, store }));
+    }
+
+    function makeChatTask(id: string, config: Record<string, unknown>): QueuedTask {
+        return {
+            id,
+            repoId: 'ws-effort',
+            type: 'chat',
+            priority: 'normal',
+            status: 'running',
+            createdAt: Date.parse('2026-06-29T00:00:00.000Z'),
+            payload: {
+                kind: 'chat',
+                mode: 'autopilot',
+                prompt: 'Do the thing.',
+                workspaceId: 'ws-effort',
+            },
+            config: config as QueuedTask['config'],
+            displayName: 'Chat',
+        };
+    }
+
+    it('seeds metadata.afterEffortTier from the launched tier on task config', async () => {
+        const task = makeChatTask('chat-high', { afterEffortTier: 'high' });
+
+        const { result, store } = await runTask(task);
+
+        expect(result.success).toBe(true);
+        const process = await store.getProcess('queue_chat-high');
+        expect(process?.metadata?.afterEffortTier).toBe('high');
+    });
+
+    it('preserves a very-low after tier', async () => {
+        const task = makeChatTask('chat-very-low', { afterEffortTier: 'very-low' });
+
+        const { result, store } = await runTask(task);
+
+        expect(result.success).toBe(true);
+        const process = await store.getProcess('queue_chat-very-low');
+        expect(process?.metadata?.afterEffortTier).toBe('very-low');
+    });
+
+    it('leaves afterEffortTier undefined when no tier was launched', async () => {
+        const task = makeChatTask('chat-none', {});
+
+        const { result, store } = await runTask(task);
+
+        expect(result.success).toBe(true);
+        const process = await store.getProcess('queue_chat-none');
+        expect(process?.metadata?.afterEffortTier).toBeUndefined();
+    });
+
+    it('ignores a non-string afterEffortTier on the config', async () => {
+        const task = makeChatTask('chat-bad', { afterEffortTier: 42 });
+
+        const { result, store } = await runTask(task);
+
+        expect(result.success).toBe(true);
+        const process = await store.getProcess('queue_chat-bad');
+        expect(process?.metadata?.afterEffortTier).toBeUndefined();
+    });
+});

--- a/packages/coc/test/server/queue-enqueue-effort-tier.test.ts
+++ b/packages/coc/test/server/queue-enqueue-effort-tier.test.ts
@@ -39,6 +39,9 @@ describe('resolveEffortTierConfig', () => {
         expect(input.config.model).toBe('claude-configured-high');
         expect(input.config.reasoningEffort).toBe('xhigh');
         expect((input.config as Record<string, unknown>).effortTier).toBeUndefined();
+        // The launched tier is preserved as `afterEffortTier` so process
+        // creation can seed it onto the conversation record (AC-01).
+        expect((input.config as Record<string, unknown>).afterEffortTier).toBe('high');
     });
 
     it('falls back to provider defaults when no stored tiers exist', () => {
@@ -127,6 +130,55 @@ describe('resolveEffortTierConfig', () => {
 
         expect(input.config.model).toBe('auto-effort-model');
         expect(input.config.reasoningEffort).toBeUndefined();
+        expect((input.config as Record<string, unknown>).effortTier).toBeUndefined();
+    });
+});
+
+describe('resolveEffortTierConfig — afterEffortTier carrier (AC-01)', () => {
+    it('preserves the launched very-low tier as afterEffortTier', () => {
+        const input = makeInput({
+            payload: { kind: 'chat', mode: 'autopilot', prompt: 'test', provider: 'claude' },
+            config: { effortTier: 'very-low' } as CreateTaskInput['config'] & { effortTier: string },
+        });
+
+        resolveEffortTierConfig(input, makeContext());
+
+        expect((input.config as Record<string, unknown>).afterEffortTier).toBe('very-low');
+        expect((input.config as Record<string, unknown>).effortTier).toBeUndefined();
+    });
+
+    it('records the tier even when no tier entry resolves to a model', () => {
+        // The user picked the tier, so the choice must be recorded for read-back
+        // even if the provider has no matching tier mapping (model/effort stay
+        // unresolved, but afterEffortTier still reflects intent).
+        const input = makeInput({
+            config: { effortTier: 'medium' } as CreateTaskInput['config'] & { effortTier: string },
+        });
+
+        resolveEffortTierConfig(input, makeContext({
+            getDefaultProvider: () => 'copilot',
+            getEffortTiersForProvider: () => ({}),
+        }));
+
+        expect((input.config as Record<string, unknown>).afterEffortTier).toBe('medium');
+    });
+
+    it('does not set afterEffortTier when no tier was submitted', () => {
+        const input = makeInput({ config: {} });
+
+        resolveEffortTierConfig(input, makeContext());
+
+        expect((input.config as Record<string, unknown>).afterEffortTier).toBeUndefined();
+    });
+
+    it('does not set afterEffortTier for an invalid tier value', () => {
+        const input = makeInput({
+            config: { effortTier: 'bogus' } as CreateTaskInput['config'] & { effortTier: string },
+        });
+
+        resolveEffortTierConfig(input, makeContext());
+
+        expect((input.config as Record<string, unknown>).afterEffortTier).toBeUndefined();
         expect((input.config as Record<string, unknown>).effortTier).toBeUndefined();
     });
 });

--- a/packages/coc/test/server/routes/api-process-routes-custom-title.test.ts
+++ b/packages/coc/test/server/routes/api-process-routes-custom-title.test.ts
@@ -155,6 +155,35 @@ describe('PATCH /api/processes/:id — customTitle', () => {
         expect(loaded?.metadata?.goalFilePath).toBeUndefined();
     });
 
+    it('round-trips the per-conversation afterEffortTier (PATCH set → GET read-back)', async () => {
+        // Contract behind the per-chat after-tier feature: the client persists the
+        // follow-up effort tier with metadataPatch.set.afterEffortTier (AC-03) and
+        // reads it back from GET detail metadata on open (AC-02).
+        await addProcess('p-after-effort-tier-1', {
+            metadata: { type: 'chat', workspaceId: wsId, mode: 'ask', afterEffortTier: 'medium' },
+        });
+
+        const patchRes = await patchJSON(`${baseUrl}/api/processes/p-after-effort-tier-1`, {
+            metadataPatch: { set: { afterEffortTier: 'high' } },
+        });
+        expect(patchRes.status).toBe(200);
+        expect(JSON.parse(patchRes.body).process?.metadata?.afterEffortTier).toBe('high');
+
+        // Other metadata is preserved by the merge.
+        const loaded = await store.getProcess('p-after-effort-tier-1');
+        expect(loaded?.metadata).toMatchObject({
+            type: 'chat',
+            workspaceId: wsId,
+            mode: 'ask',
+            afterEffortTier: 'high',
+        });
+
+        // GET detail surfaces the seeded/updated tier for client read-back.
+        const getRes = await request(`${baseUrl}/api/processes/p-after-effort-tier-1`);
+        expect(getRes.status).toBe(200);
+        expect(JSON.parse(getRes.body).process?.metadata?.afterEffortTier).toBe('high');
+    });
+
     it('rejects malformed metadataPatch without mutating metadata', async () => {
         await addProcess('p-metadata-patch-3', {
             metadata: {

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-closed.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-closed.test.ts
@@ -53,13 +53,17 @@ describe('ChatDetail — persisted canvas closed wiring', () => {
         expect(clears).toBeGreaterThanOrEqual(2);
     });
 
-    it('reads the persisted flag in the canvas discovery effect', () => {
-        expect(src).toContain('setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid))');
+    it('reads the persisted flag into canvasPanelClosed on chat switch', () => {
+        // The restore refactor reads the flag into a local `closed` then applies
+        // it (replacing the old inline `setCanvasPanelClosed(readCanvasClosed(...))`).
+        expect(src).toContain('const closed = readCanvasClosed(workspaceId, canvasPid)');
+        expect(src).toContain('setCanvasPanelClosed(closed)');
     });
 
-    it('the taskId-keyed reset effect no longer force-opens the panel', () => {
-        const resetEffect = block('setActiveCanvasId(null);', '[taskId]); // eslint-disable-line');
-        expect(resetEffect).not.toContain('setCanvasPanelClosed');
+    it('the canvas-switch effect honors the close flag over the restore (no force-open)', () => {
+        // The deliberate-close flag wins: the remembered-canvas restore only runs
+        // when NOT closed, so a deliberately-closed chat stays collapsed.
+        expect(src).toContain('if (!closed && remembered)');
     });
 
     it('the source-canvas onOpen collapse is transient (does NOT persist)', () => {

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-restore.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-restore.test.ts
@@ -38,7 +38,15 @@ describe('ChatDetail — open-canvas restore wiring', () => {
     it('restores a remembered source / whisper / agent canvas on chat switch', () => {
         expect(src).toContain('sourceCanvas.open(remembered.fileRef)');
         expect(src).toContain('whisperDiff.open(remembered.ctx)');
-        expect(src).toContain('setActiveCanvasId(remembered.canvasId)');
+        // The agent canvas is restored by id through the discovery callback.
+        expect(src).toContain('remembered.canvasId');
+    });
+
+    it('silently falls back when a remembered agent canvas was deleted', () => {
+        // Discovery validates the remembered id against the linked-canvas list and
+        // only restores it when present — a deleted one falls back instead of
+        // surfacing CanvasPanel's load error (AC-03 silent fallback).
+        expect(src).toContain('ids.has(remembered.canvasId)');
     });
 
     it('the reset closes source/folder/note/diff canvases only WITH a restore path', () => {

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-restore.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-canvas-restore.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment node
+ *
+ * Source-level regression guard for the session-scoped per-chat open-canvas
+ * memory (restore-open-canvas-on-chat-switch). Runs in node, so it asserts on
+ * the ChatDetail / openCanvasMemory source text rather than behaviour — the
+ * jsdom integration test in `test/spa/react/repos/ChatDetailCanvasClosed.test.tsx`
+ * covers the runtime flow.
+ *
+ * Invariants guarded here (mirrors the goal's code-search Definition of Done):
+ *  - The open-canvas memory helper is imported and held in an in-memory ref map.
+ *  - The chat-switch effect restores a remembered source / whisper / agent canvas.
+ *  - The reset closes source/folder/note/diff canvases only WITH a restore path.
+ *  - The memory store is NEVER persisted to localStorage or disk.
+ *  - No new TODOs were left behind.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const chatDir = resolve(__dirname, '../../../../../src/server/spa/client/react/features/chat');
+const src = readFileSync(resolve(chatDir, 'ChatDetail.tsx'), 'utf-8');
+const memorySrc = readFileSync(resolve(chatDir, 'openCanvasMemory.ts'), 'utf-8');
+
+describe('ChatDetail — open-canvas restore wiring', () => {
+    it('imports the open-canvas memory helper', () => {
+        expect(src).toContain("from './openCanvasMemory'");
+        expect(src).toContain('deriveOpenCanvasMemory');
+    });
+
+    it('holds the memory in an in-memory ref map keyed by pid (not state/storage)', () => {
+        expect(src).toContain('openCanvasMemoryRef = useRef<Map<string, OpenCanvasMemory>>(new Map())');
+        expect(src).toContain('openCanvasDescriptorRef = useRef<OpenCanvasMemory>(null)');
+        // Writes go through the ref map's `.set`, never persistence helpers.
+        expect(src).toContain('openCanvasMemoryRef.current.set(pid, openCanvasDescriptorRef.current)');
+    });
+
+    it('restores a remembered source / whisper / agent canvas on chat switch', () => {
+        expect(src).toContain('sourceCanvas.open(remembered.fileRef)');
+        expect(src).toContain('whisperDiff.open(remembered.ctx)');
+        expect(src).toContain('setActiveCanvasId(remembered.canvasId)');
+    });
+
+    it('the reset closes source/folder/note/diff canvases only WITH a restore path', () => {
+        // The switch effect both clears the previous surfaces AND reopens the
+        // remembered one — there is no orphan close without a restore path.
+        expect(src).toContain('sourceCanvas.close()');
+        expect(src).toContain('whisperDiff.close()');
+        expect(src).toContain('sourceCanvas.open(remembered.fileRef)');
+        expect(src).toContain('whisperDiff.open(remembered.ctx)');
+    });
+
+    it('never persists the open-canvas memory to localStorage or disk', () => {
+        // The memory helper is pure in-memory: no storage-API CALLS anywhere in
+        // it (the doc comment may mention "localStorage" in prose, so match the
+        // `.`-qualified API usage rather than the bare word).
+        expect(memorySrc).not.toContain('localStorage.');
+        expect(memorySrc).not.toContain('sessionStorage.');
+        expect(memorySrc).not.toContain('setItem');
+        expect(memorySrc).not.toContain('getItem');
+    });
+
+    it('leaves no new TODOs in the open-canvas memory module', () => {
+        expect(memorySrc).not.toContain('TODO');
+    });
+});

--- a/packages/coc/test/spa/react/WhisperCollapsedGroup-combined-footer.test.tsx
+++ b/packages/coc/test/spa/react/WhisperCollapsedGroup-combined-footer.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * AC-02 — Open the combined diff from the files-popover footer.
+ *
+ * The multi-file popover summary footer ("N files +X −Y") becomes an interactive
+ * control: activating it (click / Enter / Space) dispatches the open event with a
+ * *combined* context (all files + the group's tool calls + workspaceId). Per-file
+ * rows keep their single-file behavior unchanged, and single-file groups never
+ * render the footer at all.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { WhisperCollapsedGroup } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup';
+import type { WhisperSummary, FileEdit } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/toolGroupUtils';
+
+// ── Mocks (mirror WhisperCollapsedGroup-header.test.tsx) ───────────────────────
+
+vi.mock('../../../src/server/spa/client/react/ui', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../src/server/spa/client/react/shared/MarkdownView', () => ({
+    MarkdownView: ({ html }: { html: string }) => (
+        <div data-testid="markdown-view" dangerouslySetInnerHTML={{ __html: html }} />
+    ),
+}));
+
+vi.mock('../../../src/server/spa/client/react/features/chat/conversation/commitDetection', () => ({
+    detectCommitsInToolGroup: () => [],
+}));
+
+vi.mock('../../../src/server/spa/client/react/features/chat/conversation/CommitStrip', () => ({
+    CommitStrip: () => null,
+}));
+
+vi.mock('../../../src/server/spa/client/react/features/chat/conversation/tool-calls/ToolCallGroupView', () => ({
+    ToolCallGroupView: () => <div data-testid="tool-call-group-view" />,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function fe(path: string, over: Partial<FileEdit> = {}): FileEdit {
+    return {
+        path,
+        insertions: 4,
+        deletions: 2,
+        netInsertions: 4,
+        netDeletions: 2,
+        isCreate: false,
+        isDeleted: false,
+        ...over,
+    };
+}
+
+function renderGroup(
+    fileEdits: FileEdit[],
+    opts: {
+        onOpenFileDiff?: (ctx: unknown) => void;
+        precedingChunks?: unknown[];
+        toolById?: Map<string, unknown>;
+        commits?: unknown[];
+    } = {},
+) {
+    const { container } = render(
+        <WhisperCollapsedGroup
+            precedingChunks={(opts.precedingChunks ?? []) as never}
+            summary={{
+                toolCallCount: 3,
+                messageCount: 0,
+                fileEditCount: fileEdits.length,
+                fileEdits,
+                ...(opts.commits ? { commitCount: opts.commits.length, commits: opts.commits } : {}),
+            } as WhisperSummary}
+            toolById={(opts.toolById ?? new Map()) as never}
+            toolsWithChildren={new Set()}
+            toolParentById={new Map()}
+            isStreaming={false}
+            groupSingleLineMessages={false}
+            workspaceId="test-ws"
+            renderToolTree={() => null}
+            onOpenFileDiff={opts.onOpenFileDiff}
+        />,
+    );
+    // Hovering the "N files" header span mounts the files popover (a portal).
+    const span = container.querySelector('[data-testid="whisper-file-hover"]') as HTMLElement;
+    if (span) fireEvent.mouseEnter(span);
+    return container;
+}
+
+function getFooter(): HTMLElement | null {
+    return document.body.querySelector('[data-testid="file-popover-footer"]');
+}
+
+const TWO_FILES = [fe('src/a.ts'), fe('src/b.ts')];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('WhisperCollapsedGroup — combined-diff footer (AC-02)', () => {
+    it('marks the multi-file footer as a keyboard-accessible button when a handler is wired', () => {
+        renderGroup(TWO_FILES, { onOpenFileDiff: vi.fn() });
+        const footer = getFooter()!;
+        expect(footer).not.toBeNull();
+        expect(footer.getAttribute('role')).toBe('button');
+        expect(footer.getAttribute('tabindex')).toBe('0');
+        expect(footer.getAttribute('aria-label')).toBe('Open combined diff for all files');
+    });
+
+    it('leaves the footer non-interactive when no handler is provided', () => {
+        renderGroup(TWO_FILES);
+        const footer = getFooter()!;
+        expect(footer).not.toBeNull();
+        expect(footer.getAttribute('role')).toBeNull();
+        expect(footer.getAttribute('tabindex')).toBeNull();
+    });
+
+    it('never renders the footer for a single-file group (no combined entry point)', () => {
+        const onOpenFileDiff = vi.fn();
+        renderGroup([fe('src/only.ts')], { onOpenFileDiff });
+        expect(getFooter()).toBeNull();
+    });
+
+    it('dispatches a combined context (all files + tool calls + workspaceId) on click', () => {
+        const onOpenFileDiff = vi.fn();
+        const toolById = new Map<string, unknown>([
+            ['t1', { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'old', new_str: 'new' } }],
+            ['t2', { toolName: 'create', args: { path: 'src/b.ts', file_text: 'hello\nworld' } }],
+        ]);
+        const precedingChunks = [
+            { kind: 'tool', key: 'k1', toolId: 't1' },
+            { kind: 'tool', key: 'k2', toolId: 't2' },
+        ];
+        renderGroup(TWO_FILES, { onOpenFileDiff, toolById, precedingChunks });
+
+        fireEvent.click(getFooter()!);
+
+        expect(onOpenFileDiff).toHaveBeenCalledTimes(1);
+        const ctx = onOpenFileDiff.mock.calls[0][0];
+        expect(ctx.combined).toBe(true);
+        expect(ctx.workspaceId).toBe('test-ws');
+        expect(ctx.files.map((f: FileEdit) => f.path)).toEqual(['src/a.ts', 'src/b.ts']);
+        expect(ctx.toolCalls).toEqual([
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'old', new_str: 'new' } },
+            { toolName: 'create', args: { path: 'src/b.ts', file_text: 'hello\nworld' } },
+        ]);
+        // The combined context is not a single-file context.
+        expect(ctx.file).toBeUndefined();
+    });
+
+    it('activates the footer on Enter and Space keys', () => {
+        const onOpenFileDiff = vi.fn();
+        renderGroup(TWO_FILES, { onOpenFileDiff });
+        const footer = getFooter()!;
+        fireEvent.keyDown(footer, { key: 'Enter' });
+        fireEvent.keyDown(footer, { key: ' ' });
+        expect(onOpenFileDiff).toHaveBeenCalledTimes(2);
+        expect(onOpenFileDiff.mock.calls.every((c) => c[0].combined === true)).toBe(true);
+    });
+
+    it('carries deleted files through in the combined context (the builder lists them as "not shown")', () => {
+        const onOpenFileDiff = vi.fn();
+        const files = [fe('src/a.ts'), fe('src/gone.ts', { isDeleted: true, isCreate: false, netInsertions: 0, netDeletions: 5 })];
+        renderGroup(files, { onOpenFileDiff });
+        fireEvent.click(getFooter()!);
+        const ctx = onOpenFileDiff.mock.calls[0][0];
+        expect(ctx.files.map((f: FileEdit) => f.path)).toEqual(['src/a.ts', 'src/gone.ts']);
+        expect(ctx.files.find((f: FileEdit) => f.path === 'src/gone.ts').isDeleted).toBe(true);
+    });
+
+    it('per-file rows still dispatch the single-file context unchanged', () => {
+        const onOpenFileDiff = vi.fn();
+        renderGroup(TWO_FILES, { onOpenFileDiff });
+        const row = document.body.querySelector('[data-testid="file-popover-row"]') as HTMLElement;
+        fireEvent.click(row);
+        expect(onOpenFileDiff).toHaveBeenCalledTimes(1);
+        const ctx = onOpenFileDiff.mock.calls[0][0];
+        expect(ctx.combined).toBeUndefined();
+        expect(ctx.file.path).toBe('src/a.ts');
+        expect(ctx.files).toBeUndefined();
+    });
+
+    it('activating the footer opens the combined diff without expanding the group', () => {
+        const onOpenFileDiff = vi.fn();
+        const container = renderGroup(TWO_FILES, { onOpenFileDiff });
+        fireEvent.click(getFooter()!);
+        const toggle = container.querySelector('[data-testid="whisper-toggle"]') as HTMLElement;
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(container.querySelector('[data-testid="whisper-expanded-content"]')).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/WhisperDiffDock.test.tsx
+++ b/packages/coc/test/spa/react/WhisperDiffDock.test.tsx
@@ -108,4 +108,32 @@ describe('WhisperDiffDock', () => {
         expect(screen.getAllByText('foo.ts').length).toBeGreaterThanOrEqual(2);
         expect(screen.getByTestId('whisper-diff-filename')).toHaveTextContent('foo.ts');
     });
+
+    it('hosts the combined "All changes" view with no single file', () => {
+        const combinedState: WhisperDiffState = {
+            status: 'success',
+            diffText: 'diff --git a/foo b/foo\n+x',
+            file: null,
+            error: '',
+            combined: {
+                sections: [{ file, diff: 'diff --git a/foo b/foo\n+x' }],
+                deletedFiles: [],
+                nonReconstructableFiles: [],
+                fileCount: 1,
+                totalInsertions: 1,
+                totalDeletions: 0,
+            },
+        };
+        render(
+            <WhisperDiffDock
+                state={combinedState}
+                isMobile
+                onClose={() => {}}
+                resize={resize}
+            />,
+        );
+        // The sheet title and header both read "All changes" even with no `file` prop.
+        expect(screen.getAllByText('All changes').length).toBeGreaterThanOrEqual(2);
+        expect(screen.getByTestId('whisper-diff-filename')).toHaveTextContent('All changes');
+    });
 });

--- a/packages/coc/test/spa/react/WhisperDiffPanel.test.tsx
+++ b/packages/coc/test/spa/react/WhisperDiffPanel.test.tsx
@@ -21,7 +21,10 @@ vi.mock('../../../src/server/spa/client/react/features/git/diff/UnifiedDiffViewe
 }));
 
 import { WhisperDiffPanel } from '../../../src/server/spa/client/react/features/chat/whisper-diff/WhisperDiffPanel';
-import type { WhisperDiffState } from '../../../src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffState';
+import type {
+    CombinedWhisperDiffView,
+    WhisperDiffState,
+} from '../../../src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffState';
 import type { FileEdit } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/toolGroupUtils';
 
 const file: FileEdit = {
@@ -36,6 +39,42 @@ const file: FileEdit = {
 
 function state(partial: Partial<WhisperDiffState>): WhisperDiffState {
     return { status: 'idle', diffText: '', file, error: '', ...partial };
+}
+
+function fileEdit(path: string, over: Partial<FileEdit> = {}): FileEdit {
+    return {
+        path,
+        insertions: 1,
+        deletions: 0,
+        netInsertions: 1,
+        netDeletions: 0,
+        isCreate: false,
+        isDeleted: false,
+        ...over,
+    };
+}
+
+function combinedView(over: Partial<CombinedWhisperDiffView> = {}): CombinedWhisperDiffView {
+    return {
+        sections: [],
+        deletedFiles: [],
+        nonReconstructableFiles: [],
+        fileCount: 0,
+        totalInsertions: 0,
+        totalDeletions: 0,
+        ...over,
+    };
+}
+
+function combinedState(view: CombinedWhisperDiffView): WhisperDiffState {
+    const hasDiff = view.sections.length > 0;
+    return {
+        status: hasDiff ? 'success' : 'empty',
+        diffText: view.sections.map((s) => s.diff).join('\n'),
+        file: null,
+        error: hasDiff ? '' : 'No diff is available for these files.',
+        combined: view,
+    };
 }
 
 describe('WhisperDiffPanel', () => {
@@ -131,5 +170,119 @@ describe('WhisperDiffPanel', () => {
         // The only button in the panel chrome is Close.
         const panel = screen.getByTestId('whisper-diff-panel');
         expect(panel.querySelectorAll('button')).toHaveLength(1);
+    });
+});
+
+describe('WhisperDiffPanel — combined "All changes" mode (AC-03)', () => {
+    const sections = [
+        { file: fileEdit('/home/u/proj/src/a.ts'), diff: 'diff --git a/src/a.ts b/src/a.ts\n+A' },
+        { file: fileEdit('/home/u/proj/src/sub/b.ts'), diff: 'diff --git a/src/sub/b.ts b/src/sub/b.ts\n+B' },
+    ];
+
+    it('shows the "All changes" header with the N-files totals instead of a filename', () => {
+        render(
+            <WhisperDiffPanel
+                state={combinedState(combinedView({
+                    sections,
+                    fileCount: 2,
+                    totalInsertions: 7,
+                    totalDeletions: 3,
+                }))}
+                workspaceRootPath="/home/u/proj"
+                onClose={() => {}}
+            />,
+        );
+        expect(screen.getByTestId('whisper-diff-filename')).toHaveTextContent('All changes');
+        expect(screen.getByTestId('whisper-diff-totals')).toHaveTextContent('2 files (+7 −3)');
+        // No single-file path subtitle in combined mode.
+        expect(screen.queryByTestId('whisper-diff-path')).toBeNull();
+    });
+
+    it('renders a filename divider before each file section, in order', () => {
+        render(
+            <WhisperDiffPanel
+                state={combinedState(combinedView({ sections, fileCount: 2 }))}
+                workspaceRootPath="/home/u/proj"
+                onClose={() => {}}
+            />,
+        );
+        const dividers = screen.getAllByTestId('whisper-diff-file-divider');
+        expect(dividers.map((d) => d.textContent)).toEqual(['src/a.ts', 'src/sub/b.ts']);
+        // One diff viewer per section, with the section's diff content.
+        const viewers = screen.getAllByTestId('whisper-diff-section-viewer');
+        expect(viewers).toHaveLength(2);
+        expect(viewers[0]).toHaveTextContent('+A');
+        expect(viewers[1]).toHaveTextContent('+B');
+        // No empty message when there are reconstructable sections.
+        expect(screen.queryByTestId('whisper-diff-empty')).toBeNull();
+    });
+
+    it('lists deleted and non-reconstructable files in the "not shown" section', () => {
+        render(
+            <WhisperDiffPanel
+                state={combinedState(combinedView({
+                    sections: [sections[0]],
+                    fileCount: 3,
+                    deletedFiles: [fileEdit('/home/u/proj/src/gone.ts', { isDeleted: true })],
+                    nonReconstructableFiles: [fileEdit('/home/u/proj/src/codex.ts')],
+                }))}
+                workspaceRootPath="/home/u/proj"
+                onClose={() => {}}
+            />,
+        );
+        const notShown = screen.getByTestId('whisper-diff-not-shown');
+        expect(notShown).toHaveTextContent('Not shown');
+        const items = screen.getAllByTestId('whisper-diff-not-shown-item');
+        expect(items.map((i) => i.getAttribute('data-path'))).toEqual([
+            '/home/u/proj/src/gone.ts',
+            '/home/u/proj/src/codex.ts',
+        ]);
+        expect(notShown).toHaveTextContent('src/gone.ts — deleted');
+        expect(notShown).toHaveTextContent('src/codex.ts — no diff available');
+    });
+
+    it('shows the no-diff message (not a blank body) when nothing is reconstructable', () => {
+        render(
+            <WhisperDiffPanel
+                state={combinedState(combinedView({
+                    sections: [],
+                    fileCount: 1,
+                    nonReconstructableFiles: [fileEdit('/home/u/proj/src/codex.ts')],
+                }))}
+                workspaceRootPath="/home/u/proj"
+                onClose={() => {}}
+            />,
+        );
+        expect(screen.getByTestId('whisper-diff-empty')).toHaveTextContent('No diff is available for these files.');
+        expect(screen.queryByTestId('whisper-diff-section-viewer')).toBeNull();
+        // The non-reconstructable file is still listed so the body is not blank.
+        expect(screen.getByTestId('whisper-diff-not-shown')).toHaveTextContent('src/codex.ts');
+    });
+
+    it('omits the "not shown" section when every file reconstructed', () => {
+        render(
+            <WhisperDiffPanel
+                state={combinedState(combinedView({ sections, fileCount: 2 }))}
+                onClose={() => {}}
+            />,
+        );
+        expect(screen.queryByTestId('whisper-diff-not-shown')).toBeNull();
+    });
+
+    it('stays read-only in combined mode — Close is the only button', () => {
+        render(
+            <WhisperDiffPanel
+                state={combinedState(combinedView({
+                    sections,
+                    fileCount: 2,
+                    deletedFiles: [fileEdit('/home/u/proj/src/gone.ts', { isDeleted: true })],
+                }))}
+                onClose={() => {}}
+            />,
+        );
+        const panel = screen.getByTestId('whisper-diff-panel');
+        expect(panel.querySelectorAll('button')).toHaveLength(1);
+        expect(screen.queryByTestId('source-canvas-copy-btn')).toBeNull();
+        expect(screen.queryByTestId('source-canvas-reveal-btn')).toBeNull();
     });
 });

--- a/packages/coc/test/spa/react/buildWhisperCombinedDiff.test.ts
+++ b/packages/coc/test/spa/react/buildWhisperCombinedDiff.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for buildWhisperCombinedDiff — concatenating the per-file whisper diffs
+ * for a whole whisper group into one combined unified diff (AC-01).
+ *
+ * Covers the DoD cases: multi-file edits, a created file, a file with only
+ * Codex-structured (no line content) changes, and a deleted file — asserting the
+ * concatenated string has one `diff --git` section per reconstructable file in
+ * group order, and that deleted / non-reconstructable files are reported
+ * separately (no diff body) so the panel can list them as "not shown".
+ */
+import { describe, it, expect } from 'vitest';
+import { buildWhisperCombinedDiff } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperCombinedDiff';
+import type { WhisperDiffToolCall } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperFileDiff';
+import type { FileEdit } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/toolGroupUtils';
+
+function fileEdit(path: string, over: Partial<FileEdit> = {}): FileEdit {
+    return {
+        path,
+        insertions: 1,
+        deletions: 0,
+        netInsertions: 1,
+        netDeletions: 0,
+        isCreate: false,
+        isDeleted: false,
+        ...over,
+    };
+}
+
+describe('buildWhisperCombinedDiff', () => {
+    it('returns empty output for no files', () => {
+        const result = buildWhisperCombinedDiff([], []);
+        expect(result.diffText).toBe('');
+        expect(result.sections).toEqual([]);
+        expect(result.deletedFiles).toEqual([]);
+        expect(result.nonReconstructableFiles).toEqual([]);
+    });
+
+    it('concatenates one `diff --git` section per reconstructable file in group order', () => {
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a1', new_str: 'A1' } },
+            { toolName: 'edit', args: { path: 'src/b.ts', old_str: 'b1', new_str: 'B1' } },
+        ];
+        // Popover order is the fileEdits order — assert it is preserved.
+        const fileEdits = [fileEdit('src/a.ts'), fileEdit('src/b.ts')];
+        const result = buildWhisperCombinedDiff(toolCalls, fileEdits);
+
+        const headers = result.diffText
+            .split('\n')
+            .filter(l => l.startsWith('diff --git'));
+        expect(headers).toEqual([
+            'diff --git a/src/a.ts b/src/a.ts',
+            'diff --git a/src/b.ts b/src/b.ts',
+        ]);
+        // Both files' changes are present, a before b.
+        expect(result.diffText).toContain('+A1');
+        expect(result.diffText).toContain('+B1');
+        expect(result.diffText.indexOf('a/src/a.ts')).toBeLessThan(
+            result.diffText.indexOf('a/src/b.ts'),
+        );
+        expect(result.sections.map(s => s.file.path)).toEqual(['src/a.ts', 'src/b.ts']);
+        expect(result.deletedFiles).toEqual([]);
+        expect(result.nonReconstructableFiles).toEqual([]);
+    });
+
+    it('respects the supplied (popover) file order, not call order', () => {
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/z.ts', old_str: 'z', new_str: 'Z' } },
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+        ];
+        // fileEdits sorted by path (as the whisper summary sorts them).
+        const fileEdits = [fileEdit('src/a.ts'), fileEdit('src/z.ts')];
+        const result = buildWhisperCombinedDiff(toolCalls, fileEdits);
+        expect(result.sections.map(s => s.file.path)).toEqual(['src/a.ts', 'src/z.ts']);
+        expect(result.diffText.indexOf('a/src/a.ts')).toBeLessThan(
+            result.diffText.indexOf('a/src/z.ts'),
+        );
+    });
+
+    it('includes a created file as a new-file section', () => {
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+            { toolName: 'create', args: { path: 'src/new.ts', file_text: 'l1\nl2' } },
+        ];
+        const fileEdits = [fileEdit('src/a.ts'), fileEdit('src/new.ts', { isCreate: true })];
+        const result = buildWhisperCombinedDiff(toolCalls, fileEdits);
+
+        expect(result.sections.map(s => s.file.path)).toEqual(['src/a.ts', 'src/new.ts']);
+        const created = result.sections.find(s => s.file.path === 'src/new.ts')!;
+        expect(created.diff).toContain('new file mode 100644');
+        expect(created.diff).toContain('--- /dev/null');
+        expect(created.diff).toContain('+l1');
+        expect(created.diff).toContain('+l2');
+        // The concatenated string carries the created file's new-file marker too.
+        expect(result.diffText).toContain('new file mode 100644');
+    });
+
+    it('reports a file with only Codex-structured (no line content) changes as non-reconstructable', () => {
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+            { toolName: 'file_change', args: { changes: [{ path: 'src/codex.ts', kind: 'update' }] } },
+        ];
+        const fileEdits = [fileEdit('src/a.ts'), fileEdit('src/codex.ts')];
+        const result = buildWhisperCombinedDiff(toolCalls, fileEdits);
+
+        // Reconstructable file is in the diff; the Codex file is not.
+        expect(result.sections.map(s => s.file.path)).toEqual(['src/a.ts']);
+        expect(result.diffText).not.toContain('src/codex.ts');
+        expect(result.nonReconstructableFiles.map(f => f.path)).toEqual(['src/codex.ts']);
+        expect(result.deletedFiles).toEqual([]);
+    });
+
+    it('reports a deleted file separately and contributes no diff body for it', () => {
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+            { toolName: 'create', args: { path: 'src/gone.ts', file_text: 'temp' } },
+        ];
+        const fileEdits = [
+            fileEdit('src/a.ts'),
+            // Marked deleted by a later shell rm — even though it has edit calls,
+            // the combined builder must not reconstruct a diff for it.
+            fileEdit('src/gone.ts', { isCreate: true, isDeleted: true }),
+        ];
+        const result = buildWhisperCombinedDiff(toolCalls, fileEdits);
+
+        expect(result.sections.map(s => s.file.path)).toEqual(['src/a.ts']);
+        expect(result.diffText).not.toContain('src/gone.ts');
+        expect(result.deletedFiles.map(f => f.path)).toEqual(['src/gone.ts']);
+        expect(result.nonReconstructableFiles).toEqual([]);
+    });
+
+    it('covers all four DoD cases together — edits, create, codex, delete', () => {
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+            { toolName: 'edit', args: { path: 'src/b.ts', old_str: 'b', new_str: 'B' } },
+            { toolName: 'create', args: { path: 'src/new.ts', file_text: 'created' } },
+            { toolName: 'file_change', args: { changes: [{ path: 'src/codex.ts', kind: 'update' }] } },
+            { toolName: 'create', args: { path: 'src/gone.ts', file_text: 'temp' } },
+        ];
+        const fileEdits = [
+            fileEdit('src/a.ts'),
+            fileEdit('src/b.ts'),
+            fileEdit('src/codex.ts'),
+            fileEdit('src/gone.ts', { isDeleted: true }),
+            fileEdit('src/new.ts', { isCreate: true }),
+        ];
+        const result = buildWhisperCombinedDiff(toolCalls, fileEdits);
+
+        // Reconstructable, in group order (deleted/codex excluded from the body).
+        expect(result.sections.map(s => s.file.path)).toEqual([
+            'src/a.ts',
+            'src/b.ts',
+            'src/new.ts',
+        ]);
+        const headers = result.diffText.split('\n').filter(l => l.startsWith('diff --git'));
+        expect(headers).toHaveLength(3);
+        expect(result.nonReconstructableFiles.map(f => f.path)).toEqual(['src/codex.ts']);
+        expect(result.deletedFiles.map(f => f.path)).toEqual(['src/gone.ts']);
+    });
+
+    it('reuses buildWhisperFileDiff output verbatim for each section', () => {
+        // The concatenation is exactly each file section joined by a newline, so a
+        // single-file group yields the same string buildWhisperFileDiff produces.
+        const toolCalls: WhisperDiffToolCall[] = [
+            { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a\nb\nc', new_str: 'a\nB\nc' } },
+        ];
+        const result = buildWhisperCombinedDiff(toolCalls, [fileEdit('src/a.ts')]);
+        expect(result.sections).toHaveLength(1);
+        expect(result.diffText).toBe(result.sections[0].diff);
+        expect(result.diffText).toContain('-b');
+        expect(result.diffText).toContain('+B');
+        expect(result.diffText).toContain(' a');
+        expect(result.diffText).toContain(' c');
+    });
+});

--- a/packages/coc/test/spa/react/features/stats/UsageStatsView.test.tsx
+++ b/packages/coc/test/spa/react/features/stats/UsageStatsView.test.tsx
@@ -84,6 +84,20 @@ describe('UsageStatsView', () => {
         expect(screen.getByText(/No token usage data found/)).toBeTruthy();
     });
 
+    it('does not crash when the response is malformed (missing entries)', () => {
+        // Regression: a `{}` payload (truthy `data`, no `entries`) — produced by a
+        // blanket fetch mock and observed flakily in CI — used to throw
+        // "Cannot read properties of undefined (reading 'reduce')" in sumUsage,
+        // crashing the whole embedded AdminPanel render. The view must tolerate it.
+        (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
+            makeHookResult({ data: {} as ClientTokenUsageStatsResponse })
+        );
+        expect(() => render(<UsageStatsView />)).not.toThrow();
+        // Controls still render; a malformed payload is neither the empty state nor a table.
+        expect(screen.getByText('↻ Refresh')).toBeTruthy();
+        expect(screen.queryByText(/No token usage data found/)).toBeNull();
+    });
+
     it('renders error state with retry button', () => {
         (useTokenUsageStats as ReturnType<typeof vi.fn>).mockReturnValue(
             makeHookResult({ error: 'Network error' })

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.ts
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.ts
@@ -1531,9 +1531,11 @@ describe('ChatDetail', () => {
             const listIdx = source.indexOf('client.canvases.list(workspaceId, { processId: canvasPid })');
             expect(idleIdx).toBeGreaterThan(-1);
             expect(listIdx).toBeGreaterThan(idleIdx);
-            // The persisted close flag still applies synchronously, before the
+            // The persisted close flag is still read synchronously, before the
             // deferred probe — guards against regressing the no-flash behaviour.
-            const closeFlagIdx = source.indexOf('setCanvasPanelClosed(readCanvasClosed(workspaceId, canvasPid))');
+            // The restore refactor reads it into a local `closed` (then applies +
+            // reuses it), replacing the old inline `setCanvasPanelClosed(readCanvasClosed(...))`.
+            const closeFlagIdx = source.indexOf('const closed = readCanvasClosed(workspaceId, canvasPid)');
             expect(closeFlagIdx).toBeGreaterThan(-1);
             expect(closeFlagIdx).toBeLessThan(idleIdx);
         });

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
@@ -45,6 +45,10 @@ const { mockState } = vi.hoisted(() => ({
         clearAttachments: vi.fn(),
         richTextValue: '',
         richTextSetValueCalls: [] as Array<[string, number?]>,
+        // Per-test toggles for the follow-up effort-tier selector (AC-02/AC-03).
+        // Default off / empty so existing tests keep the legacy model+effort UI.
+        effortLevelsEnabled: false,
+        effortTiers: {} as Record<string, { model: string; reasoningEffort: string }>,
     },
 }));
 
@@ -60,7 +64,7 @@ vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
     isForEachEnabled: () => false,
     getDefaultProvider: () => 'copilot' as const,
     getActiveProvider: () => 'copilot' as const,
-    isEffortLevelsEnabled: () => false,
+    isEffortLevelsEnabled: () => mockState.effortLevelsEnabled,
     isSessionContextAttachmentsEnabled: () => false,
     getPrewarmDebounceMs: () => 500,
     getWarmClientTtlMs: () => 300000,
@@ -169,7 +173,7 @@ vi.mock('../../../../src/server/spa/client/react/hooks/useModels', () => ({
 // useProviderEffortTiers — return empty tier map so ChatDetail renders without a real API
 vi.mock('../../../../src/server/spa/client/react/hooks/useProviderEffortTiers', () => ({
     useProviderEffortTiers: () => ({
-        tiers: {},
+        tiers: mockState.effortTiers,
         loading: false,
         error: null,
         saveError: null,
@@ -453,6 +457,9 @@ beforeEach(() => {
     mockState.clearAttachments.mockReset();
     mockState.richTextValue = '';
     mockState.richTextSetValueCalls = [];
+    mockState.effortLevelsEnabled = false;
+    mockState.effortTiers = {};
+    localStorage.clear();
     // JSDOM polyfills
     Element.prototype.scrollIntoView = vi.fn();
     // navigator.clipboard
@@ -2103,5 +2110,96 @@ describe('ChatDetail', () => {
             expect(screen.getByTestId('composer-ctx-fill')).toBeTruthy();
             expect(screen.queryByTestId('composer-ctx-segment-system')).toBeNull();
         });
+    });
+});
+
+// ── Per-conversation follow-up effort tier (AC-02 read-back, AC-03 persist) ──
+//
+// The follow-up after-tier is remembered per conversation in
+// `process.metadata.afterEffortTier` (not the workspace-global localStorage key).
+// These tests drive the real EffortTierSelector inside the real FollowUpInputArea,
+// so they exercise the init read-back + the PATCH-on-change end-to-end through the
+// fetch mock and localStorage.
+describe('ChatDetail — per-conversation after effort tier', () => {
+    // All three tiers configured so a seeded selection is never coerced to the
+    // first configured tier by the resolveEffectiveTier effect.
+    const CONFIGURED_TIERS = {
+        low: { model: 'model-low', reasoningEffort: 'low' },
+        medium: { model: 'model-medium', reasoningEffort: '' },
+        high: { model: 'model-high', reasoningEffort: 'high' },
+    };
+
+    function enableTierMode() {
+        mockState.effortLevelsEnabled = true;
+        mockState.effortTiers = { ...CONFIGURED_TIERS };
+    }
+
+    function selectorTier(): string | null {
+        return screen.getByTestId('follow-up-effort-tier-selector').getAttribute('data-tier-value');
+    }
+
+    it('AC-02: initializes the selector from the conversation\'s metadata.afterEffortTier', async () => {
+        enableTierMode();
+        const task = makeTask({ status: 'completed', processId: 'proc-1' });
+        const proc = makeProcess({ metadata: { sessionId: 'sess-1', afterEffortTier: 'high' } });
+        setupStandardFetch(task, proc);
+
+        render(<Wrap><ChatDetail taskId="task-1" workspaceId="ws-1" /></Wrap>);
+
+        await waitFor(() => expect(selectorTier()).toBe('high'));
+    });
+
+    it('AC-02: falls back to the workspace-global localStorage value when no per-conversation seed exists', async () => {
+        enableTierMode();
+        localStorage.setItem('coc:effort-tier:ws-1', 'low');
+        const task = makeTask({ status: 'completed', processId: 'proc-1' });
+        const proc = makeProcess({ metadata: { sessionId: 'sess-1' } }); // no afterEffortTier
+        setupStandardFetch(task, proc);
+
+        render(<Wrap><ChatDetail taskId="task-1" workspaceId="ws-1" /></Wrap>);
+
+        await waitFor(() => expect(selectorTier()).toBe('low'));
+    });
+
+    it('AC-02: falls back to medium when neither a seed nor a localStorage value exists', async () => {
+        enableTierMode();
+        const task = makeTask({ status: 'completed', processId: 'proc-1' });
+        const proc = makeProcess({ metadata: { sessionId: 'sess-1' } });
+        setupStandardFetch(task, proc);
+
+        render(<Wrap><ChatDetail taskId="task-1" workspaceId="ws-1" /></Wrap>);
+
+        await waitFor(() => expect(screen.getByTestId('follow-up-effort-tier-selector')).toBeTruthy());
+        expect(selectorTier()).toBe('medium');
+    });
+
+    it('AC-03: persists a tier change via PATCH metadataPatch.set.afterEffortTier and does NOT write the workspace localStorage key', async () => {
+        enableTierMode();
+        const task = makeTask({ status: 'completed', processId: 'proc-1' });
+        const proc = makeProcess({ metadata: { sessionId: 'sess-1', afterEffortTier: 'high' } });
+        setupStandardFetch(task, proc);
+
+        render(<Wrap><ChatDetail taskId="task-1" workspaceId="ws-1" /></Wrap>);
+        await waitFor(() => expect(selectorTier()).toBe('high'));
+
+        // Open the tier dropdown and pick "low".
+        fireEvent.click(screen.getByTestId('effort-tier-trigger-btn'));
+        fireEvent.click(screen.getByTestId('effort-tier-option-low'));
+
+        // UI updates immediately (optimistic).
+        await waitFor(() => expect(selectorTier()).toBe('low'));
+
+        // Persisted per conversation via PATCH /api/processes/proc-1.
+        await waitFor(() => {
+            const patchCall = fetchMock.mock.calls.find(([url, init]: any) =>
+                typeof url === 'string' && url.includes('/processes/proc-1') && init?.method === 'PATCH');
+            expect(patchCall).toBeTruthy();
+            const body = JSON.parse((patchCall as any[])[1].body);
+            expect(body.metadataPatch.set.afterEffortTier).toBe('low');
+        });
+
+        // The workspace-global key is NOT written from ChatDetail anymore — the
+        // change must not leak into other chats in the workspace.
+        expect(localStorage.getItem('coc:effort-tier:ws-1')).toBeNull();
     });
 });

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
@@ -10,6 +10,7 @@
  * sub-component wiring (FollowUpInputArea, ChatHeader, ConversationArea)
  * is verified via prop-forwarding and data-testid assertions.
  */
+/* @vitest-environment jsdom */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
@@ -1940,6 +1940,81 @@ describe('ChatDetail', () => {
                 expect(screen.getByText('Bot reply')).toBeTruthy();
             });
         });
+
+        // Regression: queued-message-survives-chat-switch.
+        // A still-running chat's submitted follow-ups ("Queued · N") must survive
+        // switching to another chat and returning. The cache-hit processId load
+        // path painted turns from cache but never re-hydrated `pendingQueue`, so
+        // the queued section blanked out on return even though the server still
+        // held the pending messages in `process.pendingMessages`.
+        it('re-hydrates the queued follow-ups from server pendingMessages on a cache-hit return', async () => {
+            const runningProc = makeProcess({
+                id: 'queue_running-1',
+                status: 'running',
+                metadata: { mode: 'autopilot', sessionId: 'sess-running' },
+                pendingMessages: [
+                    { id: 'pm-1', content: 'first queued follow-up' },
+                    { id: 'pm-2', content: 'second queued follow-up' },
+                ],
+            });
+            const otherProc = makeProcess({
+                id: 'queue_other-1',
+                status: 'running',
+                metadata: { mode: 'autopilot', sessionId: 'sess-other' },
+                pendingMessages: [],
+            });
+            setupFetch({
+                '/skills/all': { body: { merged: [] } },
+                '/processes/queue_running-1': { body: { process: runningProc } },
+                '/processes/queue_other-1': { body: { process: otherProc } },
+                '/models': { body: [] },
+            });
+
+            const { rerender } = render(<Wrap><ChatDetail key="queue_running-1" taskId="queue_running-1" /></Wrap>);
+
+            // Cold (cache-miss) processId load hydrates the queue from the server.
+            await waitFor(() => {
+                expect(screen.getByTestId('queued-followups').getAttribute('data-count')).toBe('2');
+            });
+
+            // Switch away to another still-running chat with no pending follow-ups.
+            rerender(<Wrap><ChatDetail key="queue_other-1" taskId="queue_other-1" /></Wrap>);
+            await waitFor(() => {
+                expect(screen.queryByTestId('queued-followups')).toBeNull();
+            });
+
+            // Switch back — now a cache hit. The queued section must re-appear,
+            // sourced from the server's pendingMessages (the regression: the
+            // cache-hit branch used to return early without re-syncing the queue).
+            rerender(<Wrap><ChatDetail key="queue_running-1" taskId="queue_running-1" /></Wrap>);
+            await waitFor(() => {
+                expect(screen.getByTestId('queued-followups').getAttribute('data-count')).toBe('2');
+            });
+        });
+
+        it('leaves the queued section empty when the server has no pending messages', async () => {
+            const proc = makeProcess({
+                id: 'queue_empty-1',
+                status: 'running',
+                metadata: { mode: 'autopilot', sessionId: 'sess-empty' },
+                pendingMessages: [],
+                conversationTurns: [
+                    { role: 'user', content: 'Running task', turnIndex: 0, timeline: [] },
+                ],
+            });
+            setupFetch({
+                '/skills/all': { body: { merged: [] } },
+                '/processes/queue_empty-1': { body: { process: proc } },
+                '/models': { body: [] },
+            });
+
+            render(<Wrap><ChatDetail taskId="queue_empty-1" /></Wrap>);
+
+            await waitFor(() => {
+                expect(screen.getByText('Running task')).toBeTruthy();
+            });
+            expect(screen.queryByTestId('queued-followups')).toBeNull();
+        });
     });
 
     describe('reactive title updates', () => {

--- a/packages/coc/test/spa/react/repos/ChatDetailCanvasClosed.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetailCanvasClosed.test.tsx
@@ -605,6 +605,29 @@ describe('ChatDetail — restore open canvas on chat switch', () => {
         expect(screen.getByTestId('canvas-panel-mock').getAttribute('data-canvas-id')).toBe('canvas-A2');
     });
 
+    // AC-03 silent fallback: a remembered agent canvas that was deleted while
+    // away falls back to the first linked canvas (never a load error).
+    it('silently falls back to the first linked canvas when the remembered one was deleted', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A1' }, { id: 'canvas-A2' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        act(() => {
+            mockState.sseOpts.onCanvasUpdated({ canvasId: 'canvas-A2', title: 'A2', revision: 1, editor: 'ai' });
+        });
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock').getAttribute('data-canvas-id')).toBe('canvas-A2'));
+
+        // canvas-A2 is deleted while we are away.
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A1' }];
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+
+        rerenderChat(rerender, 'task-A');
+        // Falls back to the surviving first canvas — not the deleted canvas-A2.
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock').getAttribute('data-canvas-id')).toBe('canvas-A1'));
+    });
+
     // (b) Closing the open canvas clears the chat's memory → switch-back shows
     // nothing (no source dock, no agent panel) for a chat with no linked canvas.
     it('clears memory when the open canvas is closed → switch-back shows nothing', async () => {

--- a/packages/coc/test/spa/react/repos/ChatDetailCanvasClosed.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetailCanvasClosed.test.tsx
@@ -12,8 +12,10 @@
  * and a fetch handler that serves `client.canvases.list` per conversation pid.
  */
 
+/* @vitest-environment jsdom */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act, cleanup } from '@testing-library/react';
 import React, { useEffect, type ReactNode } from 'react';
 import { AppProvider } from '../../../../src/server/spa/client/react/contexts/AppContext';
 import { QueueProvider } from '../../../../src/server/spa/client/react/contexts/QueueContext';
@@ -55,6 +57,17 @@ const { mockState } = vi.hoisted(() => ({
 }));
 
 // ── Module mocks (hoisted before imports) ──────────────────────────────────
+
+// @excalidraw/excalidraw imports `roughjs/bin/rough` without a file extension,
+// which Node's ESM loader cannot resolve (roughjs ships no `exports` map). The
+// global setup stub is not applied to ChatDetail's transitive import graph under
+// vitest 4.x, so stub it file-locally — these tests never render an Excalidraw
+// canvas (CanvasPanel / source-canvas / whisper-diff are all mocked below).
+vi.mock('@excalidraw/excalidraw', () => ({
+    Excalidraw: () => null,
+    restoreElements: (elements: unknown) => (Array.isArray(elements) ? elements : []),
+    convertToExcalidrawElements: (elements: unknown) => (Array.isArray(elements) ? elements : []),
+}));
 
 vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
     isContainerMode: () => false,
@@ -267,19 +280,26 @@ vi.mock('../../../../src/server/spa/client/react/features/chat/conversation/Conv
     ConversationMetadataPopover: () => React.createElement('div', { 'data-testid': 'metadata-popover' }),
 }));
 
-// CanvasPanel — stub exposing the close affordance the persistence wiring calls.
+// CanvasPanel — stub exposing the close affordance the persistence wiring calls
+// and the active canvas id (so restore tests can assert WHICH agent canvas shows).
 vi.mock('../../../../src/server/spa/client/react/features/canvas/CanvasPanel', () => ({
-    CanvasPanel: (props: any) => React.createElement('div', { 'data-testid': 'canvas-panel-mock' },
+    CanvasPanel: (props: any) => React.createElement('div', { 'data-testid': 'canvas-panel-mock', 'data-canvas-id': props.canvasId },
         React.createElement('button', { 'data-testid': 'canvas-close', onClick: props.onClose }, 'Close'),
     ),
 }));
 
 // source-canvas — controllable hook so a test can open the docked source canvas
-// (which collapses the agent canvas transiently) without rendering the real dock.
+// (which collapses the agent canvas transiently). The dock stub surfaces the
+// open file's kind + path and a close affordance so restore/clear tests can
+// assert the SAME canvas comes back and that closing clears the memory.
 vi.mock('../../../../src/server/spa/client/react/features/chat/source-canvas', async () => {
     const R = await import('react');
     return {
-        SourceCanvasDock: () => R.createElement('div', { 'data-testid': 'source-canvas-dock' }),
+        SourceCanvasDock: (props: any) => R.createElement('div', {
+            'data-testid': 'source-canvas-dock',
+            'data-kind': props.fileRef?.kind ?? 'code',
+            'data-path': props.fileRef?.fullPath ?? '',
+        }, R.createElement('button', { 'data-testid': 'source-canvas-close', onClick: props.onClose }, 'Close')),
         useSourceCanvasState: (opts: any) => {
             const [fileRef, setFileRef] = R.useState<any>(null);
             const onOpenRef = R.useRef(opts?.onOpen);
@@ -293,6 +313,31 @@ vi.mock('../../../../src/server/spa/client/react/features/chat/source-canvas', a
         },
         useSourceCanvasContent: () => null,
         useSourceCanvasDirectory: () => null,
+    };
+});
+
+// whisper-diff — controllable hook + dock stub mirroring source-canvas, so a
+// test can open + restore the transient whisper-diff panel.
+vi.mock('../../../../src/server/spa/client/react/features/chat/whisper-diff', async () => {
+    const R = await import('react');
+    return {
+        WHISPER_DIFF_EVENT: 'coc-open-whisper-diff',
+        WhisperDiffDock: (props: any) => R.createElement('div', {
+            'data-testid': 'whisper-diff-dock',
+            'data-path': props.file?.path ?? '',
+        }, R.createElement('button', { 'data-testid': 'whisper-diff-close', onClick: props.onClose }, 'Close')),
+        useWhisperDiffPanelState: (opts: any) => {
+            const [ctx, setCtx] = R.useState<any>(null);
+            const onOpenRef = R.useRef(opts?.onOpen);
+            onOpenRef.current = opts?.onOpen;
+            const open = R.useCallback((next: any) => {
+                onOpenRef.current?.();
+                setCtx(next);
+            }, []);
+            const close = R.useCallback(() => setCtx(null), []);
+            return { open, close, isOpen: !!ctx, ctx };
+        },
+        useWhisperDiffState: () => null,
     };
 });
 
@@ -347,6 +392,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    // Unmount mounted trees between tests. @testing-library/react's auto-cleanup
+    // is not registered under this vitest version, so without this each test's
+    // ChatDetail lingers in the DOM and `getByTestId` matches stale duplicates.
+    cleanup();
     vi.restoreAllMocks();
     delete (globalThis as any).__useSendMessage_opts;
 });
@@ -452,11 +501,13 @@ describe('ChatDetail — persisted canvas closed state (AC-02)', () => {
         await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
         expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(false);
 
-        // Switch away and back — the agent canvas auto-opens again (no persisted close).
+        // Switch away and back — the SAME source canvas is RESTORED (the open
+        // canvas is now remembered per-chat) and the close flag was never persisted.
         rerenderChat(rerender, 'task-B');
-        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+        await waitFor(() => expect(screen.queryByTestId('source-canvas-dock')).toBeNull());
         rerenderChat(rerender, 'task-A');
-        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        await waitFor(() => expect(screen.getByTestId('source-canvas-dock')).toBeTruthy());
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(false);
     });
 
     it('keeps a closed chat collapsed across a full reload (fresh mount)', async () => {
@@ -471,5 +522,155 @@ describe('ChatDetail — persisted canvas closed state (AC-02)', () => {
         renderChat('task-A');
         await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
         expect(screen.queryByTestId('canvas-panel-mock')).toBeNull();
+    });
+});
+
+describe('ChatDetail — restore open canvas on chat switch', () => {
+    function openSourceCanvas(detail: Record<string, unknown>) {
+        act(() => {
+            window.dispatchEvent(new CustomEvent('coc-open-source-canvas', { detail }));
+        });
+    }
+
+    function openWhisperDiff(path: string) {
+        act(() => {
+            window.dispatchEvent(new CustomEvent('coc-open-whisper-diff', {
+                detail: { file: { path }, toolCalls: [], commits: [] },
+            }));
+        });
+    }
+
+    // (a) Each canvas surface returns exactly as it was after switching away and
+    // back — the core restore behaviour for source / note / folder canvases.
+    it.each([
+        { kind: 'code', path: '/x.ts', label: 'source-file' },
+        { kind: 'note', path: '/notes/n.md', label: 'note' },
+        { kind: 'dir', path: '/src', label: 'folder' },
+    ])('restores a $label canvas on switch-away-and-back', async ({ kind, path }) => {
+        mockState.canvasesByPid[pidFor('task-A')] = [];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+
+        openSourceCanvas({ filePath: path, kind });
+        await waitFor(() => expect(screen.getByTestId('source-canvas-dock')).toBeTruthy());
+
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('source-canvas-dock')).toBeNull());
+
+        rerenderChat(rerender, 'task-A');
+        await waitFor(() => expect(screen.getByTestId('source-canvas-dock')).toBeTruthy());
+        const dock = screen.getByTestId('source-canvas-dock');
+        expect(dock.getAttribute('data-path')).toBe(path);
+        expect(dock.getAttribute('data-kind')).toBe(kind);
+        // Session-only memory must never touch the deliberate-close localStorage flag.
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(false);
+    });
+
+    // (a) A whisper-diff canvas returns as it was.
+    it('restores a whisper-diff canvas on switch-away-and-back', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+
+        openWhisperDiff('a.ts');
+        await waitFor(() => expect(screen.getByTestId('whisper-diff-dock')).toBeTruthy());
+
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('whisper-diff-dock')).toBeNull());
+
+        rerenderChat(rerender, 'task-A');
+        await waitFor(() => expect(screen.getByTestId('whisper-diff-dock')).toBeTruthy());
+        expect(screen.getByTestId('whisper-diff-dock').getAttribute('data-path')).toBe('a.ts');
+    });
+
+    // (a) With multiple agent canvases, the EXACT open one (the second) returns —
+    // not the first one discovery would otherwise auto-open.
+    it('restores the exact open agent canvas (not the first linked one)', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A1' }, { id: 'canvas-A2' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        // Switch to the second agent canvas (a fresh AI edit targets canvas-A2).
+        act(() => {
+            mockState.sseOpts.onCanvasUpdated({ canvasId: 'canvas-A2', title: 'A2', revision: 1, editor: 'ai' });
+        });
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock').getAttribute('data-canvas-id')).toBe('canvas-A2'));
+
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+
+        rerenderChat(rerender, 'task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+        expect(screen.getByTestId('canvas-panel-mock').getAttribute('data-canvas-id')).toBe('canvas-A2');
+    });
+
+    // (b) Closing the open canvas clears the chat's memory → switch-back shows
+    // nothing (no source dock, no agent panel) for a chat with no linked canvas.
+    it('clears memory when the open canvas is closed → switch-back shows nothing', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+
+        openSourceCanvas({ filePath: '/x.ts' });
+        await waitFor(() => expect(screen.getByTestId('source-canvas-dock')).toBeTruthy());
+
+        // Deliberate close clears the per-chat open-canvas memory.
+        fireEvent.click(screen.getByTestId('source-canvas-close'));
+        await waitFor(() => expect(screen.queryByTestId('source-canvas-dock')).toBeNull());
+
+        rerenderChat(rerender, 'task-B');
+        rerenderChat(rerender, 'task-A');
+        // Nothing is restored — the chat remembers "nothing open".
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+        expect(screen.queryByTestId('source-canvas-dock')).toBeNull();
+        expect(screen.queryByTestId('whisper-diff-dock')).toBeNull();
+    });
+
+    // (c) The deliberate-close localStorage flag still beats the restore: a chat
+    // whose agent canvas was closed stays collapsed even though memory exists.
+    it('keeps the deliberate-close flag winning over the remembered canvas', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        // Deliberately close the agent canvas (persists the close flag).
+        fireEvent.click(screen.getByTestId('canvas-close'));
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(readCanvasClosed(WS_ID, pidFor('task-A'))).toBe(true);
+
+        rerenderChat(rerender, 'task-B');
+        await waitFor(() => expect(screen.queryByTestId('canvas-panel-mock')).toBeNull());
+        rerenderChat(rerender, 'task-A');
+
+        // Flag wins → collapsed rail, never the expanded panel.
+        await waitFor(() => expect(screen.getByTestId('canvas-collapsed-rail')).toBeTruthy());
+        expect(screen.queryByTestId('canvas-panel-mock')).toBeNull();
+    });
+
+    // (d) The open-canvas memory is held in memory only — opening + restoring a
+    // source canvas must write NOTHING that encodes it to localStorage.
+    it('does not persist the open-canvas memory to localStorage', async () => {
+        mockState.canvasesByPid[pidFor('task-A')] = [{ id: 'canvas-A' }];
+        mockState.canvasesByPid[pidFor('task-B')] = [];
+        const { rerender } = renderChat('task-A');
+        await waitFor(() => expect(screen.getByTestId('canvas-panel-mock')).toBeTruthy());
+
+        openSourceCanvas({ filePath: '/secret-canvas-path.ts' });
+        await waitFor(() => expect(screen.getByTestId('source-canvas-dock')).toBeTruthy());
+
+        // Round-trip to force a memory snapshot + restore.
+        rerenderChat(rerender, 'task-B');
+        rerenderChat(rerender, 'task-A');
+        await waitFor(() => expect(screen.getByTestId('source-canvas-dock')).toBeTruthy());
+
+        // No localStorage value encodes the remembered canvas, and no deliberate-
+        // close flag was set by a mere open/restore.
+        const dump = Object.keys(localStorage)
+            .map(k => `${k}=${localStorage.getItem(k)}`)
+            .join(';');
+        expect(dump).not.toContain('/secret-canvas-path.ts');
+        expect(localStorage.getItem(canvasClosedStorageKey(WS_ID, pidFor('task-A'))!)).toBeNull();
     });
 });

--- a/packages/coc/test/spa/react/useWhisperDiffState.test.ts
+++ b/packages/coc/test/spa/react/useWhisperDiffState.test.ts
@@ -29,7 +29,11 @@ vi.mock('../../../src/server/spa/client/react/api/cocClient', () => ({
 }));
 
 import { useWhisperDiffState } from '../../../src/server/spa/client/react/features/chat/whisper-diff/useWhisperDiffState';
-import type { WhisperFileDiffContext } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup';
+import type {
+    WhisperCombinedDiffContext,
+    WhisperFileDiffContext,
+} from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/WhisperCollapsedGroup';
+import type { WhisperDiffToolCall } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/buildWhisperFileDiff';
 import type { FileEdit } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/toolGroupUtils';
 import type { DetectedCommit } from '../../../src/server/spa/client/react/features/chat/conversation/commitDetection';
 import { registerCloneBaseUrls, resetCloneRegistryForTests } from '../../../src/server/spa/client/react/repos/cloneRegistry';
@@ -232,5 +236,117 @@ describe('useWhisperDiffState', () => {
         expect(getCocClientForMock).toHaveBeenCalledWith(REMOTE_BASE_URL);
         expect(remoteGetCommitFileDiffMock).toHaveBeenCalledWith('remote-ws', 'aaaaaaa', 'x');
         expect(getCommitFileDiffMock).not.toHaveBeenCalled();
+    });
+});
+
+// ── Combined "All changes" mode (AC-03) ──────────────────────────────────────
+
+function combinedCtx(
+    files: FileEdit[],
+    toolCalls: WhisperDiffToolCall[],
+    over: Partial<WhisperCombinedDiffContext> = {},
+): WhisperCombinedDiffContext {
+    return {
+        combined: true,
+        files,
+        toolCalls,
+        commits: [],
+        workspaceId: 'ws1',
+        ...over,
+    };
+}
+
+describe('useWhisperDiffState — combined mode', () => {
+    it('builds the whole-group diff synchronously from the captured tool calls (no fetch)', async () => {
+        const { result } = renderHook(() =>
+            useWhisperDiffState(combinedCtx(
+                [fileEdit('src/a.ts'), fileEdit('src/b.ts')],
+                [
+                    { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a1', new_str: 'A1' } },
+                    { toolName: 'edit', args: { path: 'src/b.ts', old_str: 'b1', new_str: 'B1' } },
+                ],
+            )),
+        );
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        const combined = result.current.combined!;
+        expect(combined).toBeTruthy();
+        expect(combined.sections.map((s) => s.file.path)).toEqual(['src/a.ts', 'src/b.ts']);
+        expect(result.current.diffText).toContain('diff --git a/src/a.ts b/src/a.ts');
+        expect(result.current.diffText).toContain('diff --git a/src/b.ts b/src/b.ts');
+        // Combined mode is single-file-`file`-less and never falls back to a fetch.
+        expect(result.current.file).toBeNull();
+        expect(getCommitFileDiffMock).not.toHaveBeenCalled();
+    });
+
+    it('reports the header totals over every file in the group', async () => {
+        const { result } = renderHook(() =>
+            useWhisperDiffState(combinedCtx(
+                [
+                    fileEdit('src/a.ts', { netInsertions: 3, netDeletions: 1 }),
+                    fileEdit('src/b.ts', { netInsertions: 2, netDeletions: 4 }),
+                ],
+                [
+                    { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+                    { toolName: 'edit', args: { path: 'src/b.ts', old_str: 'b', new_str: 'B' } },
+                ],
+            )),
+        );
+        await waitFor(() => expect(result.current.combined).toBeTruthy());
+        const combined = result.current.combined!;
+        expect(combined.fileCount).toBe(2);
+        expect(combined.totalInsertions).toBe(5);
+        expect(combined.totalDeletions).toBe(5);
+    });
+
+    it('splits deleted and non-reconstructable files into the "not shown" lists', async () => {
+        const { result } = renderHook(() =>
+            useWhisperDiffState(combinedCtx(
+                [
+                    fileEdit('src/a.ts'),
+                    fileEdit('src/codex.ts'),
+                    fileEdit('src/gone.ts', { isDeleted: true }),
+                ],
+                [
+                    { toolName: 'edit', args: { path: 'src/a.ts', old_str: 'a', new_str: 'A' } },
+                    { toolName: 'file_change', args: { changes: [{ path: 'src/codex.ts', kind: 'update' }] } },
+                ],
+            )),
+        );
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        const combined = result.current.combined!;
+        expect(combined.sections.map((s) => s.file.path)).toEqual(['src/a.ts']);
+        expect(combined.nonReconstructableFiles.map((f) => f.path)).toEqual(['src/codex.ts']);
+        expect(combined.deletedFiles.map((f) => f.path)).toEqual(['src/gone.ts']);
+    });
+
+    it('is empty (with the combined payload) when nothing in the group is reconstructable', async () => {
+        const { result } = renderHook(() =>
+            useWhisperDiffState(combinedCtx(
+                [fileEdit('src/codex.ts'), fileEdit('src/gone.ts', { isDeleted: true })],
+                [
+                    { toolName: 'file_change', args: { changes: [{ path: 'src/codex.ts', kind: 'update' }] } },
+                ],
+            )),
+        );
+        await waitFor(() => expect(result.current.status).toBe('empty'));
+        expect(result.current.error).toMatch(/no diff/i);
+        // The combined payload is still present so the panel can list "not shown".
+        const combined = result.current.combined!;
+        expect(combined.sections).toEqual([]);
+        expect(combined.nonReconstructableFiles.map((f) => f.path)).toEqual(['src/codex.ts']);
+        expect(combined.deletedFiles.map((f) => f.path)).toEqual(['src/gone.ts']);
+    });
+
+    it('never fetches a commit fallback in combined mode even when commits exist', async () => {
+        const { result } = renderHook(() =>
+            useWhisperDiffState(combinedCtx(
+                [fileEdit('src/codex.ts')],
+                [{ toolName: 'file_change', args: { changes: [{ path: 'src/codex.ts', kind: 'update' }] } }],
+                { commits: [commit('aaaaaaa')] },
+            )),
+        );
+        await waitFor(() => expect(result.current.status).toBe('empty'));
+        expect(getCommitFileDiffMock).not.toHaveBeenCalled();
+        expect(remoteGetCommitFileDiffMock).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
- **feat(coc-desktop): add "Check for Updates…" to the native app menu**
- **feat(coc): add whisper-group combined-diff builder (AC-01)**
- **feat(coc): open combined whisper diff from files-popover footer (AC-02)**
- **feat(coc): render whisper-group combined diff in the diff panel (AC-03)**
- **feat(coc): restore the open canvas per chat across chat switches**
- **fix(coc): silently fall back when a remembered agent canvas was deleted**
- **feat(coc): seed per-chat afterEffortTier on process creation (AC-01)**
- **feat(coc): per-conversation after effort tier read-back + persist (AC-02/AC-03)**
- **fix(test): add @vitest-environment jsdom pragma to ChatDetail.test.tsx**
- **fix(coc): re-hydrate queued follow-ups on processId chat reload**
