### PR TITLE
feat(coc): show total result size in tool-call output-truncated notice

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/ToolCallView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/tool-calls/ToolCallView.tsx
@@ -74,6 +74,11 @@ function truncateSummary(value: string, maxLength = 80): string {
     return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
 }
 
+/** Insert thousands separators without depending on the host locale (deterministic across platforms/tests). */
+function formatCount(value: number): string {
+    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
 function getAskUserQuestionSummary(args: Record<string, any>): string {
     if (typeof args.question === 'string' && args.question.trim()) {
         return truncateSummary(args.question.trim());
@@ -524,7 +529,9 @@ export function ToolCallView({
     const startTimeLabel = formatStartTime(normalizedToolCall.startTime);
     const resultText = typeof normalizedToolCall.result === 'string' ? normalizedToolCall.result : '';
     const isResultTruncated = resultText.length > MAX_RESULT_LENGTH;
-    const visibleResult = isResultTruncated ? `${resultText.slice(0, TRUNCATED_RESULT_LENGTH)}\n... (output truncated)` : resultText;
+    const visibleResult = isResultTruncated
+        ? `${resultText.slice(0, TRUNCATED_RESULT_LENGTH)}\n... (output truncated — showing ${formatCount(TRUNCATED_RESULT_LENGTH)} of ${formatCount(resultText.length)} chars)`
+        : resultText;
     const popoverResultText = name === 'apply_patch' && applyPatchText ? applyPatchText : resultText;
 
     const isShellLike = name === 'bash' || name === 'shell' || name === 'powershell';

--- a/packages/coc/test/spa/react/ToolCallView-result-truncation.test.tsx
+++ b/packages/coc/test/spa/react/ToolCallView-result-truncation.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * Tests for ToolCallView — when a long tool-call result is truncated for
+ * display, the truncation notice reports the full result size so users can
+ * see how large the complete output was.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { ToolCallView } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/ToolCallView';
+import { ToolCallVariantProvider } from '../../../src/server/spa/client/react/features/chat/conversation/tool-calls/ToolCallVariant';
+
+function expandToolCall(container: HTMLElement) {
+    const header = container.querySelector('.tool-call-header');
+    if (header) fireEvent.click(header);
+}
+
+function getBody(container: HTMLElement) {
+    return container.querySelector('.tool-call-body');
+}
+
+describe('ToolCallView — truncated result reports total size', () => {
+    it('appends the rendered + total char counts when the result is truncated', () => {
+        const result = 'x'.repeat(12345);
+        const tc = {
+            id: 'tc-big',
+            toolName: 'get_conversation',
+            args: { processId: 'queue_123' },
+            status: 'completed',
+            result,
+        };
+        const { container } = render(<ToolCallView toolCall={tc} />);
+        expandToolCall(container);
+
+        const body = getBody(container)!;
+        expect(body.textContent).toContain('output truncated');
+        // Shows how much is rendered AND the full size, with thousands separators.
+        expect(body.textContent).toContain('showing 4,900 of 12,345 chars');
+        // The full result text is not rendered in full.
+        expect(body.textContent!.length).toBeLessThan(result.length);
+    });
+
+    it('formats very large totals with thousands separators', () => {
+        const result = 'y'.repeat(1234567);
+        const tc = {
+            id: 'tc-huge',
+            toolName: 'get_conversation',
+            status: 'completed',
+            result,
+        };
+        const { container } = render(<ToolCallView toolCall={tc} />);
+        expandToolCall(container);
+
+        const body = getBody(container)!;
+        expect(body.textContent).toContain('showing 4,900 of 1,234,567 chars');
+    });
+
+    it('does not add a truncation notice for short results', () => {
+        const tc = {
+            id: 'tc-small',
+            toolName: 'get_conversation',
+            args: { processId: 'queue_123' },
+            status: 'completed',
+            result: 'short result',
+        };
+        const { container } = render(<ToolCallView toolCall={tc} />);
+        expandToolCall(container);
+
+        const body = getBody(container)!;
+        expect(body.textContent).toContain('short result');
+        expect(body.textContent).not.toContain('output truncated');
+    });
+
+    it('reports total size for the whisper-row variant too', () => {
+        // The whisper-row variant shares the same visibleResult truncation logic.
+        const result = 'z'.repeat(8000);
+        const tc = {
+            id: 'tc-whisper',
+            toolName: 'get_conversation',
+            status: 'completed',
+            result,
+        };
+        const { container } = render(
+            <ToolCallVariantProvider value="whisper-row">
+                <ToolCallView toolCall={tc} />
+            </ToolCallVariantProvider>
+        );
+        const header = container.querySelector('.tool-call-row-header');
+        if (header) fireEvent.click(header);
+
+        const body = container.querySelector('.tool-call-row-body')!;
+        expect(body.textContent).toContain('showing 4,900 of 8,000 chars');
+    });
+});


### PR DESCRIPTION
When a tool-call result exceeds the display cap, the expanded Result view
now reads "(output truncated — showing 4,900 of N chars)" so users can see
how large the full result was. formatCount inserts thousands separators
locale-independently for deterministic rendering across platforms/tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>