### PR TITLE
feat(canvas): render external links as native <a> tags with target=_blank

### DIFF
--- a/packages/coc/src/server/spa/client/tailwind.css
+++ b/packages/coc/src/server/spa/client/tailwind.css
@@ -772,6 +772,10 @@
     cursor: pointer;
 }
 
+.markdown-body a.md-link {
+    text-decoration: none;
+}
+
 .markdown-body .md-strike {
     text-decoration: line-through;
     opacity: 0.85;

--- a/packages/coc/test/server/spa/client/markdown-renderer.test.ts
+++ b/packages/coc/test/server/spa/client/markdown-renderer.test.ts
@@ -103,11 +103,48 @@ describe('renderMarkdownToHtml', () => {
             expect(html).toContain('console.log()');
         });
 
-        it('renders links', () => {
+        it('renders external https link as <a> tag with target=_blank', () => {
             const html = renderMarkdownToHtml('[Google](https://google.com)');
-            expect(html).toContain('md-link');
-            expect(html).toContain('Google');
-            expect(html).toContain('https://google.com');
+            expect(html).toContain('<a class="md-link"');
+            expect(html).toContain('href="https://google.com"');
+            expect(html).toContain('target="_blank"');
+            expect(html).toContain('rel="noopener noreferrer"');
+            expect(html).toContain('>Google</a>');
+        });
+
+        it('renders external http link as <a> tag', () => {
+            const html = renderMarkdownToHtml('[Site](http://example.com)');
+            expect(html).toContain('<a class="md-link"');
+            expect(html).toContain('href="http://example.com"');
+            expect(html).toContain('target="_blank"');
+        });
+
+        it('renders mailto link as <a> tag', () => {
+            const html = renderMarkdownToHtml('[Email](mailto:user@example.com)');
+            expect(html).toContain('<a class="md-link"');
+            expect(html).toContain('href="mailto:user@example.com"');
+            expect(html).toContain('target="_blank"');
+        });
+
+        it('renders external link with title attribute', () => {
+            const html = renderMarkdownToHtml('[Google](https://google.com "Search engine")');
+            expect(html).toContain('<a class="md-link"');
+            expect(html).toContain('title="Search engine"');
+            expect(html).toContain('>Google</a>');
+        });
+
+        it('renders local/file path link as span with data-href', () => {
+            const html = renderMarkdownToHtml('[readme](./README.md)');
+            expect(html).toContain('<span class="md-link"');
+            expect(html).toContain('data-href="./README.md"');
+            expect(html).not.toContain('<a ');
+        });
+
+        it('renders anchor link as span with data-anchor', () => {
+            const html = renderMarkdownToHtml('[Section](#heading)');
+            expect(html).toContain('md-anchor-link');
+            expect(html).toContain('data-anchor="heading"');
+            expect(html).not.toContain('<a ');
         });
     });
 

--- a/packages/forge/src/editor/rendering/markdown-renderer.ts
+++ b/packages/forge/src/editor/rendering/markdown-renderer.ts
@@ -282,7 +282,8 @@ export function applyInlineMarkdown(text: string, options?: MarkdownRenderInline
     });
     
     // Links [text](url "optional title")
-    // Add special class for anchor links (starting with #) to enable ToC navigation
+    // Add special class for anchor links (starting with #) to enable ToC navigation.
+    // External URLs (https/http/mailto) render as real <a> tags for native browser behavior.
     html = html.replace(/\[([^\]]+)\]\((\S+?)(?:\s+(?:"([^"]*)"|'([^']*)'|&quot;([^&]*)&quot;|&#039;([^&]*)&#039;))?\)/g, (
         _match,
         text,
@@ -294,11 +295,20 @@ export function applyInlineMarkdown(text: string, options?: MarkdownRenderInline
     ) => {
         const title = doubleTitle ?? singleTitle ?? escapedDoubleTitle ?? escapedSingleTitle;
         const isAnchorLink = url.startsWith('#');
-        const linkClass = isAnchorLink ? 'md-link md-anchor-link' : 'md-link';
-        const dataAttr = isAnchorLink ? ` data-anchor="${escapeHtml(url.substring(1))}"` : '';
-        const hrefAttr = isAnchorLink ? '' : ` data-href="${escapeHtml(url)}"`;
+        const isExternalUrl = /^https?:\/\/|^mailto:/i.test(url);
+
+        if (isAnchorLink) {
+            const titleText = title ? ` &quot;${escapeHtml(title)}&quot;` : '';
+            return `<span class="md-link md-anchor-link" data-anchor="${escapeHtml(url.substring(1))}"><span class="md-link-text">[${text}]</span><span class="md-link-url">(${url}${titleText})</span></span>`;
+        }
+
+        if (isExternalUrl) {
+            const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+            return `<a class="md-link" href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer"${titleAttr}>${text}</a>`;
+        }
+
         const titleText = title ? ` &quot;${escapeHtml(title)}&quot;` : '';
-        const linkHtml = `<span class="${linkClass}"${dataAttr}${hrefAttr}><span class="md-link-text">[${text}]</span><span class="md-link-url">(${url}${titleText})</span></span>`;
+        const linkHtml = `<span class="md-link" data-href="${escapeHtml(url)}"><span class="md-link-text">[${text}]</span><span class="md-link-url">(${url}${titleText})</span></span>`;
         const embed = options?.htmlEmbedEnabled ? parseHtmlEmbedTitle(title) : null;
         if (!embed || !isEmbeddableHtmlPath(url)) {
             return linkHtml;

--- a/packages/forge/test/editor/rendering/markdown-renderer.test.ts
+++ b/packages/forge/test/editor/rendering/markdown-renderer.test.ts
@@ -155,9 +155,27 @@ describe('applyInlineMarkdown', () => {
         expect(html).toContain('http://example.com');
     });
 
-    it('renders links with data-href attribute', () => {
+    it('renders external http link as <a> tag with target=_blank', () => {
         const html = applyInlineMarkdown('[text](http://example.com)');
-        expect(html).toContain('data-href="http://example.com"');
+        expect(html).toContain('<a class="md-link"');
+        expect(html).toContain('href="http://example.com"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+        expect(html).toContain('>text</a>');
+    });
+
+    it('renders external https link as <a> tag with target=_blank', () => {
+        const html = applyInlineMarkdown('[text](https://example.com)');
+        expect(html).toContain('<a class="md-link"');
+        expect(html).toContain('href="https://example.com"');
+        expect(html).toContain('target="_blank"');
+    });
+
+    it('renders mailto link as <a> tag', () => {
+        const html = applyInlineMarkdown('[email](mailto:user@example.com)');
+        expect(html).toContain('<a class="md-link"');
+        expect(html).toContain('href="mailto:user@example.com"');
+        expect(html).toContain('target="_blank"');
     });
 
     it('renders relative links with data-href attribute', () => {


### PR DESCRIPTION
[text](https://...) links in the markdown rendered preview now emit
<a class="md-link" href="..." target="_blank" rel="noopener noreferrer">
instead of <span data-href> spans, giving native browser behavior
(right-click → open in new tab, middle-click, status-bar URL preview).
Local/file-path and anchor (#) links keep the existing span approach.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
