### PR TITLE
fix(coc): detect connector-created pull requests

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -136,15 +136,17 @@ input card) for chats that created pull requests — there is no top-of-thread P
 card. The
 `usePrChatStatusItems` hook unions PRs detected in the loaded turns
 (`pullRequestDetection.ts`, no new regex) with persisted bindings looked up by
-`task_id`. Detection requires PR-creation evidence per shell tool call: a
-`gh pr create` / `az repos pr create` command, a result carrying the
+`task_id`. Detection requires PR-creation evidence from the GitHub connector's
+create-pull-request tool, or per shell tool call: a `gh pr create` /
+`az repos pr create` command, a result carrying the
 `submit_commits_as_pr.py` wrapper's structured success line (a line-start
 `JSON: {... "pr_url": "...", "status": "done"}` — recognized even when surfaced
 by a later `grep`/`tail` of the wrapper's persisted stdout, since the original
 command output is often truncated under a large git dump), a known wrapper
 command whose untruncated result echoes a creating command, or output with no
-command metadata; read-only PR commands are ignored. The hook looks up bindings
-by `task_id` (`listChatBindingsForOrigin(originId, { taskId })`), resolves each
+command metadata; read-only PR commands and connector lookups are ignored. The
+hook looks up bindings by `task_id`
+(`listChatBindingsForOrigin(originId, { taskId })`), resolves each
 PR's canonical origin through `resolveCanonicalOriginId`, upserts a binding
 (`createChatBindingForOrigin`) for any freshly-detected PR so it survives reload
 with the creating turn collapsed, and fetches PR detail per row

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/pullRequestDetection.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/pullRequestDetection.ts
@@ -1,6 +1,6 @@
 /**
- * pullRequestDetection — scans shell tool call results for pull-request creation
- * output and extracts structured pull-request metadata.
+ * pullRequestDetection — scans PR-creation tool call results and extracts
+ * structured pull-request metadata.
  */
 
 export interface DetectedPullRequest {
@@ -18,7 +18,7 @@ export interface DetectedPullRequest {
 
 interface ToolCallLike {
     id: string;
-    toolName: string;
+    toolName?: string;
     name?: string;
     args?: unknown;
     result?: string;
@@ -26,6 +26,10 @@ interface ToolCallLike {
 }
 
 const SHELL_TOOL_NAMES = new Set(['powershell', 'shell', 'bash']);
+const GITHUB_PR_CREATION_TOOL_NAMES = new Set([
+    'github_create_pull_request',
+    'mcp__codex_apps__github___create_pull_request',
+]);
 
 const GITHUB_PR_URL_RE = /https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/(\d+)/g;
 
@@ -126,6 +130,10 @@ function isReadOnlyPullRequestCommand(command: string): boolean {
     return READ_ONLY_PR_PATTERNS.some(re => re.test(command));
 }
 
+function isGitHubConnectorPullRequestCreation(toolName: string): boolean {
+    return GITHUB_PR_CREATION_TOOL_NAMES.has(toolName);
+}
+
 /**
  * True when any line is the wrapper's structured success status — a `JSON: {...}`
  * line (at line start) carrying a non-empty pr_url together with status: "done".
@@ -168,15 +176,8 @@ export function detectPullRequestsInToolGroup(toolCalls: ToolCallLike[]): Detect
     const results: DetectedPullRequest[] = [];
     const seenUrls = new Set<string>();
 
-    for (const tc of toolCalls) {
-        const toolName = (tc.toolName || tc.name || '').toLowerCase();
-        if (!SHELL_TOOL_NAMES.has(toolName)) continue;
-        if (!tc.result) continue;
-
-        const command = getCommandString(tc.args);
-        if (isReadOnlyPullRequestCommand(command)) continue;
-        if (!hasPullRequestCreationEvidence(command, tc.result)) continue;
-
+    const appendGitHubPullRequests = (tc: ToolCallLike): void => {
+        if (!tc.result) return;
         GITHUB_PR_URL_RE.lastIndex = 0;
         for (const match of tc.result.matchAll(GITHUB_PR_URL_RE)) {
             const [, owner, repo, numberText] = match;
@@ -192,6 +193,23 @@ export function detectPullRequestsInToolGroup(toolCalls: ToolCallLike[]): Detect
                 toolCallId: tc.id,
             });
         }
+    };
+
+    for (const tc of toolCalls) {
+        const toolName = (tc.toolName || tc.name || '').toLowerCase();
+        if (isGitHubConnectorPullRequestCreation(toolName)) {
+            appendGitHubPullRequests(tc);
+            continue;
+        }
+
+        if (!SHELL_TOOL_NAMES.has(toolName)) continue;
+        if (!tc.result) continue;
+
+        const command = getCommandString(tc.args);
+        if (isReadOnlyPullRequestCommand(command)) continue;
+        if (!hasPullRequestCreationEvidence(command, tc.result)) continue;
+
+        appendGitHubPullRequests(tc);
 
         ADO_DEV_AZURE_PR_URL_RE.lastIndex = 0;
         for (const match of tc.result.matchAll(ADO_DEV_AZURE_PR_URL_RE)) {

--- a/packages/coc/test/spa/react/pullRequestDetection.test.ts
+++ b/packages/coc/test/spa/react/pullRequestDetection.test.ts
@@ -70,6 +70,62 @@ describe('detectPullRequestsInToolGroup', () => {
         expect(pullRequests).toEqual([]);
     });
 
+    it('detects a GitHub pull request URL from the GitHub connector create tool', () => {
+        const pullRequests = detectPullRequestsInToolGroup([
+            {
+                id: 'tool-1',
+                name: 'github_create_pull_request',
+                args: {
+                    server: 'codex_apps',
+                    arguments: {
+                        repository_full_name: 'plusplusoneplusplus/shortcuts',
+                        base: 'main',
+                        head: 'pr/5838993-show-result-size',
+                    },
+                },
+                result: JSON.stringify({
+                    url: 'https://github.com/plusplusoneplusplus/shortcuts/pull/453',
+                    number: 453,
+                    state: 'open',
+                }),
+            },
+        ]);
+
+        expect(pullRequests).toEqual<DetectedPullRequest[]>([
+            {
+                number: 453,
+                url: 'https://github.com/plusplusoneplusplus/shortcuts/pull/453',
+                provider: 'github',
+                owner: 'plusplusoneplusplus',
+                repo: 'shortcuts',
+                toolCallId: 'tool-1',
+            },
+        ]);
+    });
+
+    it('ignores read-only GitHub connector PR lookups', () => {
+        const pullRequests = detectPullRequestsInToolGroup([
+            {
+                id: 'tool-1',
+                name: 'github_get_pr_info',
+                args: {
+                    server: 'codex_apps',
+                    arguments: {
+                        repository_full_name: 'plusplusoneplusplus/shortcuts',
+                        pr_number: 453,
+                    },
+                },
+                result: JSON.stringify({
+                    url: 'https://github.com/plusplusoneplusplus/shortcuts/pull/453',
+                    number: 453,
+                    state: 'open',
+                }),
+            },
+        ]);
+
+        expect(pullRequests).toEqual([]);
+    });
+
     it('accepts "Bash" (capital B) tool name as used by Claude SDK', () => {
         // Claude SDK stores tool names with capital first letter (e.g. "Bash").
         // Regression: capitalized names were not matched against SHELL_TOOL_NAMES.


### PR DESCRIPTION
## Summary
- Detect PR URLs emitted by the GitHub connector create-pull-request tool
- Keep read-only connector PR lookups ignored
- Add regression tests and update the dashboard SPA reference

## Tests
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run test:run -- test/spa/react/pullRequestDetection.test.ts`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build:client -w packages/coc`