### PR TITLE
feat(release): support alpha/pre-release tags in the desktop release pipeline

### DIFF
--- a/.github/skills/coc-knowledge/references/monorepo.md
+++ b/.github/skills/coc-knowledge/references/monorepo.md
@@ -35,7 +35,7 @@ Published workspaces (`coc`, `coc-workflow`, `forge`, `coc-agent-sdk`, `coc-memo
 2. Version packages: `npm run version-packages` (applies changesets, updates `package.json` versions and changelogs)
 3. Publish: `npm run publish-packages` (builds all packages then runs `changeset publish`)
 
-**CI release:** `.github/workflows/release.yml` runs on pushes to `main`. When pending changesets exist, `changesets/action` opens a "Version Packages" PR. When the PR is merged (no pending changesets), it publishes changed packages to npm.
+**CI desktop release:** `.github/workflows/release.yml` fires on `v*.*.*` tags (stable) and `v*.*.*-*` tags (pre-release, e.g. `-alpha.1`, `-beta.1`, `-rc.1`). It builds macOS (DMG) and Windows (NSIS) desktop binaries in parallel, then creates a draft GitHub Release with all artifacts attached. Pre-release tags produce a release marked as pre-release on GitHub. npm package publishing is done manually via `npm run publish-packages`.
 
 **Changesets config:** `.changeset/config.json` — independent versioning, public access, `main` as base branch, `updateInternalDependencies: "patch"`.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
 # Build and publish the CoC desktop binaries when a release tag is pushed.
-# Fires only for tags shaped like v1.2.3 (see AC-01). ci.yml is left untouched.
+# Fires for stable tags (v1.2.3) and pre-release tags (v1.2.3-alpha.1, -beta.2, -rc.1, …).
+# Pre-release tags produce a GitHub Release marked as pre-release. ci.yml is left untouched.
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 # create-release needs the injected GITHUB_TOKEN to create a GitHub Release.
 permissions:
@@ -129,27 +131,48 @@ jobs:
           fi
           echo "Attaching ${#files[@]} file(s) to the release:"
           printf '  %s\n' "${files[@]}"
+
+          # Detect pre-release: tag has a suffix after the semver (e.g. -alpha.1, -beta.2, -rc.1).
+          VERSION="${TAG#v}"
+          if echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-'; then
+            IS_PRERELEASE=true
+            PRERELEASE_FLAG="--prerelease"
+          else
+            IS_PRERELEASE=false
+            PRERELEASE_FLAG=""
+          fi
+
           # Install/troubleshooting notes. The builds are not yet code-signed or
           # notarized, so macOS Gatekeeper reports the downloaded app as
           # "damaged" — document the quarantine workaround so testers aren't blocked.
-          VERSION="${TAG#v}"
           notes_file="$(mktemp)"
-          cat > "$notes_file" <<EOF
-          ## Install
+          {
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              cat <<EOF
+> [!WARNING]
+> **Pre-release build** — This is an early/unstable release. Expect rough edges and possible breaking changes. Please [report issues](../../issues) if you hit problems.
 
-          ### macOS (Apple Silicon)
-          1. Open \`CoC-${VERSION}-arm64.dmg\` and drag **CoC** into your Applications folder.
-          2. On first launch macOS may say **"CoC is damaged and can't be opened."** This build is **not yet code-signed or notarized**, so Gatekeeper blocks the downloaded file — it is **not** actually corrupt. Clear the download quarantine flag, then open it normally:
-             \`\`\`
-             xattr -dr com.apple.quarantine /Applications/CoC.app
-             \`\`\`
-             (Adjust the path if you installed CoC elsewhere.)
+EOF
+            fi
+            cat <<EOF
+## Install
 
-          ### Windows
-          Run \`CoC.Setup.${VERSION}.exe\`. SmartScreen may warn about an unknown publisher — choose **More info → Run anyway**. This installer is also unsigned for now.
-          EOF
+### macOS (Apple Silicon)
+1. Open \`CoC-${VERSION}-arm64.dmg\` and drag **CoC** into your Applications folder.
+2. On first launch macOS may say **"CoC is damaged and can't be opened."** This build is **not yet code-signed or notarized**, so Gatekeeper blocks the downloaded file — it is **not** actually corrupt. Clear the download quarantine flag, then open it normally:
+   \`\`\`
+   xattr -dr com.apple.quarantine /Applications/CoC.app
+   \`\`\`
+   (Adjust the path if you installed CoC elsewhere.)
+
+### Windows
+Run \`CoC.Setup.${VERSION}.exe\`. SmartScreen may warn about an unknown publisher — choose **More info → Run anyway**. This installer is also unsigned for now.
+EOF
+          } > "$notes_file"
+
           gh release create "$TAG" \
             --draft \
+            $PRERELEASE_FLAG \
             --title "CoC $TAG" \
             --notes-file "$notes_file" \
             "${files[@]}"

--- a/packages/coc/src/server/work-items/work-item-store.ts
+++ b/packages/coc/src/server/work-items/work-item-store.ts
@@ -170,6 +170,11 @@ export class FileWorkItemStore implements WorkItemStore {
         this.scopeResolver = options.scopeResolver;
     }
 
+    /** Wait for all queued writes to settle. Useful in tests before cleaning up temp dirs. */
+    async drainWrites(): Promise<void> {
+        await this.writeQueue;
+    }
+
     // ── Path helpers ────────────────────────────────────────────
 
     private workItemsDir(repoId: string): string {

--- a/packages/coc/test/server/work-items/work-item-ai-routes.test.ts
+++ b/packages/coc/test/server/work-items/work-item-ai-routes.test.ts
@@ -162,6 +162,7 @@ describe('Work Item AI Routes', () => {
 
     afterEach(async () => {
         await stopServer();
+        await store.drainWrites();
         await fs.rm(tmpDir, { recursive: true, force: true });
     });
 


### PR DESCRIPTION
Tags shaped like v1.2.3-alpha.1 (or -beta.N, -rc.N, etc.) now trigger the
release workflow. The create-release step detects the pre-release suffix and
passes --prerelease to gh release create, so the GitHub release is correctly
marked as pre-release rather than appearing as a stable release. The release
notes also prepend a visible warning banner for pre-release builds.

Also fixes the stale monorepo.md knowledge-base entry that described
release.yml as a changeset publisher — it is the desktop release pipeline.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
