### PR TITLE
fix(release): publish desktop prereleases from manual tag dispatch

### DIFF
--- a/.github/skills/coc-knowledge/references/monorepo.md
+++ b/.github/skills/coc-knowledge/references/monorepo.md
@@ -35,7 +35,7 @@ Published workspaces (`coc`, `coc-workflow`, `forge`, `coc-agent-sdk`, `coc-memo
 2. Version packages: `npm run version-packages` (applies changesets, updates `package.json` versions and changelogs)
 3. Publish: `npm run publish-packages` (builds all packages then runs `changeset publish`)
 
-**CI desktop release:** `.github/workflows/release.yml` fires on `v*.*.*` tags (stable) and `v*.*.*-*` tags (pre-release, e.g. `-alpha.1`, `-beta.1`, `-rc.1`). It builds macOS (DMG) and Windows (NSIS) desktop binaries in parallel, then creates a draft GitHub Release with all artifacts attached. Pre-release tags produce a release marked as pre-release on GitHub. npm package publishing is done manually via `npm run publish-packages`.
+**CI desktop release:** `.github/workflows/release.yml` fires on `v*.*.*` tags (stable) and `v*.*.*-*` tags (pre-release, e.g. `-alpha.1`, `-beta.1`, `-rc.1`), and can also be run manually with `workflow_dispatch` for an existing tag. It builds macOS (DMG) and Windows (NSIS) desktop binaries in parallel, then creates a GitHub Release with all artifacts attached. Stable tags produce a draft release; pre-release tags produce a non-draft release marked as pre-release on GitHub. npm package publishing is done manually via `npm run publish-packages`.
 
 **Changesets config:** `.changeset/config.json` — independent versioning, public access, `main` as base branch, `updateInternalDependencies: "patch"`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,9 +534,24 @@ jobs:
         run: npm run test:run
         working-directory: packages/coc-desktop
 
+  workflow-policy-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: Run workflow policy tests
+        run: node --test scripts/release-workflow.test.mjs
+
   ci:
     runs-on: ubuntu-latest
-    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, e2e, coc-serve-smoke, coccontainer-serve-smoke, coc-desktop-test]
+    needs: [lint, forge-test, coc-test, coc-coverage, deep-wiki-test, e2e, coc-serve-smoke, coccontainer-serve-smoke, coc-desktop-test, workflow-policy-test]
     if: always()
     steps:
       - name: Verify all required jobs succeeded
@@ -551,6 +566,7 @@ jobs:
             [coc-serve-smoke]="${{ needs.coc-serve-smoke.result }}"
             [coccontainer-serve-smoke]="${{ needs.coccontainer-serve-smoke.result }}"
             [coc-desktop-test]="${{ needs.coc-desktop-test.result }}"
+            [workflow-policy-test]="${{ needs.workflow-policy-test.result }}"
           )
           failed=0
           for job in "${!results[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,21 @@
 name: Release
 
-# Build and publish the CoC desktop binaries when a release tag is pushed.
-# Fires for stable tags (v1.2.3) and pre-release tags (v1.2.3-alpha.1, -beta.2, -rc.1, …).
-# Pre-release tags produce a GitHub Release marked as pre-release. ci.yml is left untouched.
+# Build and publish the CoC desktop binaries when a release tag is pushed or
+# when a release tag is dispatched manually.
+# Fires for stable tags (v1.2.3) and pre-release tags (v1.2.3-alpha.1, -beta.2, -rc.1, ...).
+# Pre-release tags produce a non-draft GitHub Release marked as pre-release.
+# Stable tags produce a draft GitHub Release.
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build, for example v3.4.8-alpha.1'
+        required: true
+        type: string
 
 # create-release needs the injected GITHUB_TOKEN to create a GitHub Release.
 permissions:
@@ -20,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -35,7 +45,7 @@ jobs:
       - name: Sync desktop version from tag
         shell: bash
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           VERSION="${TAG#v}"
           export VERSION
@@ -69,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -83,7 +95,7 @@ jobs:
       - name: Sync desktop version from tag
         shell: bash
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           VERSION="${TAG#v}"
           export VERSION
@@ -117,12 +129,12 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Create draft GitHub Release
+      - name: Create GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           mapfile -t files < <(find artifacts -type f | sort)
           if [ "${#files[@]}" -eq 0 ]; then
@@ -137,9 +149,11 @@ jobs:
           if echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-'; then
             IS_PRERELEASE=true
             PRERELEASE_FLAG="--prerelease"
+            DRAFT_FLAGS=()
           else
             IS_PRERELEASE=false
             PRERELEASE_FLAG=""
+            DRAFT_FLAGS=(--draft)
           fi
 
           # Install/troubleshooting notes. The builds are not yet code-signed or
@@ -149,29 +163,29 @@ jobs:
           {
             if [ "$IS_PRERELEASE" = "true" ]; then
               cat <<EOF
-> [!WARNING]
-> **Pre-release build** — This is an early/unstable release. Expect rough edges and possible breaking changes. Please [report issues](../../issues) if you hit problems.
+          > [!WARNING]
+          > **Pre-release build** — This is an early/unstable release. Expect rough edges and possible breaking changes. Please [report issues](../../issues) if you hit problems.
 
-EOF
+          EOF
             fi
             cat <<EOF
-## Install
+          ## Install
 
-### macOS (Apple Silicon)
-1. Open \`CoC-${VERSION}-arm64.dmg\` and drag **CoC** into your Applications folder.
-2. On first launch macOS may say **"CoC is damaged and can't be opened."** This build is **not yet code-signed or notarized**, so Gatekeeper blocks the downloaded file — it is **not** actually corrupt. Clear the download quarantine flag, then open it normally:
-   \`\`\`
-   xattr -dr com.apple.quarantine /Applications/CoC.app
-   \`\`\`
-   (Adjust the path if you installed CoC elsewhere.)
+          ### macOS (Apple Silicon)
+          1. Open \`CoC-${VERSION}-arm64.dmg\` and drag **CoC** into your Applications folder.
+          2. On first launch macOS may say **"CoC is damaged and can't be opened."** This build is **not yet code-signed or notarized**, so Gatekeeper blocks the downloaded file — it is **not** actually corrupt. Clear the download quarantine flag, then open it normally:
+             \`\`\`
+             xattr -dr com.apple.quarantine /Applications/CoC.app
+             \`\`\`
+             (Adjust the path if you installed CoC elsewhere.)
 
-### Windows
-Run \`CoC.Setup.${VERSION}.exe\`. SmartScreen may warn about an unknown publisher — choose **More info → Run anyway**. This installer is also unsigned for now.
-EOF
+          ### Windows
+          Run \`CoC.Setup.${VERSION}.exe\`. SmartScreen may warn about an unknown publisher — choose **More info → Run anyway**. This installer is also unsigned for now.
+          EOF
           } > "$notes_file"
 
           gh release create "$TAG" \
-            --draft \
+            "${DRAFT_FLAGS[@]}" \
             $PRERELEASE_FLAG \
             --title "CoC $TAG" \
             --notes-file "$notes_file" \

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+
+test("release workflow can be dispatched for an existing tag", () => {
+    assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+tag:/);
+    assert.match(workflow, /ref: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref \}\}/);
+    assert.match(workflow, /TAG: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}/);
+});
+
+test("release workflow accepts stable and prerelease version tags", () => {
+    assert.match(workflow, /'v\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+'/);
+    assert.match(workflow, /'v\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+-\*'/);
+});
+
+test("release workflow publishes prereleases and keeps stable releases draft", () => {
+    assert.match(workflow, /IS_PRERELEASE=true[\s\S]*PRERELEASE_FLAG="--prerelease"[\s\S]*DRAFT_FLAGS=\(\)/);
+    assert.match(workflow, /IS_PRERELEASE=false[\s\S]*PRERELEASE_FLAG=""[\s\S]*DRAFT_FLAGS=\(--draft\)/);
+    assert.match(workflow, /gh release create "\$TAG"[\s\S]*"\$\{DRAFT_FLAGS\[@\]\}"[\s\S]*\$PRERELEASE_FLAG/);
+});
+
+test("release workflow heredoc content stays inside the YAML run block", () => {
+    assert.doesNotMatch(workflow, /^>/m);
+    assert.doesNotMatch(workflow, /^## Install/m);
+    assert.doesNotMatch(workflow, /^EOF$/m);
+});


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` support for building an existing desktop release tag
- keep stable desktop releases draft while publishing prerelease tags as non-draft prereleases
- add a CI workflow policy test covering the release workflow trigger/draft behavior and heredoc indentation

## Validation
- `/opt/homebrew/bin/node --test scripts/release-workflow.test.mjs`
- `python3` YAML load for `.github/workflows/release.yml` and `.github/workflows/ci.yml`
- `git diff --check`
- `PATH=/opt/homebrew/bin:$PATH npm run lint` (passes with existing warnings)