### PR TITLE
feat(desktop): add prerelease update channel support

### DIFF
--- a/packages/coc-desktop/src/app-menu.ts
+++ b/packages/coc-desktop/src/app-menu.ts
@@ -16,6 +16,7 @@
  */
 
 import type { MenuItemConstructorOptions } from 'electron';
+import type { UpdateChannel } from './update-check';
 
 /** Click handlers the application menu needs wired from `main.ts`. */
 export interface AppMenuHandlers {
@@ -25,24 +26,31 @@ export interface AppMenuHandlers {
      * marker.
      */
     onCheckForUpdates: () => void;
+    /** The currently active update channel, used to render the channel checkmarks. */
+    currentChannel?: UpdateChannel;
+    /** Invoked when the user selects a new update channel from the menu. */
+    onSetUpdateChannel?: (channel: UpdateChannel) => void;
 }
 
 /** The "Check for Updates…" label — shared so tests and both platforms agree. */
 export const CHECK_FOR_UPDATES_LABEL = 'Check for Updates…';
 
+/** The "Update Channel" submenu label. */
+export const UPDATE_CHANNEL_LABEL = 'Update Channel';
+
 /**
  * Build the full application-menu template for the given platform.
  *
  * On both macOS and Windows the menu carries a "Check for Updates…" item placed
- * directly after "About <app>" (across the separator that follows it) and
- * separated from the rest of the menu by a separator. The template is a complete
- * custom menubar — it reconstructs the standard Edit/View/Window items (via
- * roles) so setting it does not strip the default editing/window commands.
+ * directly after "About <app>" (across the separator that follows it), followed
+ * by an "Update Channel" submenu (Stable / Prerelease). The template is a
+ * complete custom menubar — it reconstructs the standard Edit/View/Window items
+ * (via roles) so setting it does not strip the default editing/window commands.
  *
- *   - macOS: a custom app submenu (About, Check for Updates…, Services, the
- *     Hide/Quit cluster) plus the standard Edit/View/Window menus.
+ *   - macOS: a custom app submenu (About, Check for Updates…, Update Channel,
+ *     Services, the Hide/Quit cluster) plus the standard Edit/View/Window menus.
  *   - Windows: the standard File/Edit/View/Window menus plus a Help menu holding
- *     "About <app>" then "Check for Updates…".
+ *     "About <app>" then "Check for Updates…" and "Update Channel".
  *
  * Linux is out of scope (the app keeps Electron's default menu there); callers
  * should not invoke this for Linux, but the non-darwin branch is used if they do.
@@ -52,9 +60,8 @@ export function buildAppMenuTemplate(
     appName: string,
     handlers: AppMenuHandlers,
 ): MenuItemConstructorOptions[] {
-    // "About <app>" — explicit label (with the `about` role for the branded
-    // About panel) so the item reads "About CoC" on every platform and the
-    // ordering relative to "Check for Updates…" is self-describing in tests.
+    const channel = handlers.currentChannel ?? 'stable';
+
     const aboutItem: MenuItemConstructorOptions = {
         label: `About ${appName}`,
         role: 'about',
@@ -62,6 +69,23 @@ export function buildAppMenuTemplate(
     const checkForUpdatesItem: MenuItemConstructorOptions = {
         label: CHECK_FOR_UPDATES_LABEL,
         click: handlers.onCheckForUpdates,
+    };
+    const updateChannelItem: MenuItemConstructorOptions = {
+        label: UPDATE_CHANNEL_LABEL,
+        submenu: [
+            {
+                label: 'Stable',
+                type: 'radio',
+                checked: channel === 'stable',
+                click: () => handlers.onSetUpdateChannel?.('stable'),
+            },
+            {
+                label: 'Prerelease',
+                type: 'radio',
+                checked: channel === 'prerelease',
+                click: () => handlers.onSetUpdateChannel?.('prerelease'),
+            },
+        ],
     };
 
     if (platform === 'darwin') {
@@ -72,6 +96,7 @@ export function buildAppMenuTemplate(
                     aboutItem,
                     { type: 'separator' },
                     checkForUpdatesItem,
+                    updateChannelItem,
                     { type: 'separator' },
                     { role: 'services' },
                     { type: 'separator' },
@@ -90,7 +115,7 @@ export function buildAppMenuTemplate(
 
     // Windows (and any other non-darwin platform a caller passes): the default
     // menu has no "About", so a Help submenu hosts "About <app>" followed
-    // directly (across a separator) by "Check for Updates…".
+    // directly (across a separator) by "Check for Updates…" and "Update Channel".
     return [
         { role: 'fileMenu' },
         { role: 'editMenu' },
@@ -98,7 +123,7 @@ export function buildAppMenuTemplate(
         { role: 'windowMenu' },
         {
             label: 'Help',
-            submenu: [aboutItem, { type: 'separator' }, checkForUpdatesItem],
+            submenu: [aboutItem, { type: 'separator' }, checkForUpdatesItem, updateChannelItem],
         },
     ];
 }

--- a/packages/coc-desktop/src/main.ts
+++ b/packages/coc-desktop/src/main.ts
@@ -25,6 +25,9 @@ import {
     checkForUpdate,
     getSkippedVersion,
     setSkippedVersion,
+    getUpdateChannel,
+    setUpdateChannel,
+    UpdateChannel,
     UpdatePrompt,
 } from './update-check';
 import { buildAppMenuTemplate, buildTrayMenuTemplate } from './app-menu';
@@ -226,7 +229,8 @@ function runAgentPreflight(): void {
  */
 async function runUpdateCheck(auto: boolean): Promise<void> {
     try {
-        const result = await checkForUpdate({ currentVersion: app.getVersion() });
+        const channel = getUpdateChannel(defaultDataDir(), app.getVersion());
+        const result = await checkForUpdate({ currentVersion: app.getVersion(), channel });
         if (result.reason !== 'newer' || !result.prompt || !result.release) {
             if (!auto) {
                 // Manual check: give explicit feedback even when nothing is new.
@@ -360,12 +364,18 @@ function createTray(): void {
  * Linux is intentionally left on Electron's default menu (the action stays
  * tray-only there), so we only override the menu on macOS and Windows.
  */
-function setupApplicationMenu(): void {
+function setupApplicationMenu(currentChannel?: UpdateChannel): void {
     if (process.platform !== 'darwin' && process.platform !== 'win32') {
         return;
     }
+    const channel = currentChannel ?? getUpdateChannel(defaultDataDir(), app.getVersion());
     const template = buildAppMenuTemplate(process.platform, app.name, {
         onCheckForUpdates: () => void runUpdateCheck(false),
+        currentChannel: channel,
+        onSetUpdateChannel: (ch) => {
+            setUpdateChannel(defaultDataDir(), ch);
+            setupApplicationMenu(ch);
+        },
     });
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }

--- a/packages/coc-desktop/src/update-check.ts
+++ b/packages/coc-desktop/src/update-check.ts
@@ -23,12 +23,20 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-/** GitHub "latest published release" endpoint for this repo. */
+/** GitHub "latest published release" endpoint (stable only — ignores prereleases). */
 export const LATEST_RELEASE_API =
     'https://api.github.com/repos/plusplusoneplusplus/shortcuts/releases/latest';
 
+/** GitHub "list releases" endpoint — includes both stable and prerelease builds. */
+export const RELEASES_LIST_API =
+    'https://api.github.com/repos/plusplusoneplusplus/shortcuts/releases?per_page=20';
+
 /** The one-line command that clears macOS download quarantine for an unsigned build. */
 export const MAC_QUARANTINE_FIX = 'xattr -dr com.apple.quarantine /Applications/CoC.app';
+
+/** Update channel preference. Stable considers only published non-prerelease releases;
+ *  Prerelease considers both prerelease and stable releases. */
+export type UpdateChannel = 'stable' | 'prerelease';
 
 /** A single downloadable file attached to a release. */
 export interface ReleaseAsset {
@@ -48,6 +56,8 @@ export interface ReleaseInfo {
     notes: string;
     /** Downloadable installer assets. */
     assets: ReleaseAsset[];
+    /** True when GitHub marked this release as a prerelease. */
+    isPrerelease: boolean;
 }
 
 /**
@@ -83,7 +93,44 @@ export function parseLatestRelease(json: unknown): ReleaseInfo | null {
         htmlUrl: typeof obj.html_url === 'string' ? obj.html_url : '',
         notes: typeof obj.body === 'string' ? obj.body : '',
         assets,
+        isPrerelease: typeof obj.prerelease === 'boolean' ? obj.prerelease : false,
     };
+}
+
+/**
+ * Parse a GitHub `/releases` list response into an array of {@link ReleaseInfo}.
+ * Returns an empty array when the payload is not a JSON array or all entries fail
+ * to parse, so the caller can treat "no usable releases" uniformly.
+ */
+export function parseReleaseList(json: unknown): ReleaseInfo[] {
+    if (!Array.isArray(json)) {
+        return [];
+    }
+    return json
+        .map((item) => parseLatestRelease(item))
+        .filter((r): r is ReleaseInfo => r !== null);
+}
+
+/**
+ * Select the best candidate release from a list for the given channel.
+ *
+ * - Stable channel: only non-prerelease releases are eligible.
+ * - Prerelease channel: all releases are eligible (prerelease and stable).
+ *
+ * Among eligible releases, the one with the highest semver is returned.
+ * Returns `null` when no eligible release exists.
+ */
+export function selectCandidate(
+    releases: ReleaseInfo[],
+    channel: UpdateChannel,
+): ReleaseInfo | null {
+    const candidates = releases.filter((r) => channel === 'prerelease' || !r.isPrerelease);
+    if (candidates.length === 0) {
+        return null;
+    }
+    return candidates.reduce((best, r) =>
+        compareVersions(r.version, best.version) > 0 ? r : best,
+    );
 }
 
 /** Strip a leading "v"/"V" and surrounding whitespace from a version/tag string. */
@@ -91,22 +138,38 @@ export function normalizeVersion(v: string): string {
     return v.trim().replace(/^v/i, '');
 }
 
+/** True when `version` contains a prerelease suffix (e.g. "-alpha.1", "-rc.2"). */
+export function isPrerelease(version: string): boolean {
+    return normalizeVersion(version).includes('-');
+}
+
+/** Infer the default update channel from the installed version string. */
+export function inferChannel(version: string): UpdateChannel {
+    return isPrerelease(version) ? 'prerelease' : 'stable';
+}
+
 /**
- * Compare two dotted numeric versions. Returns 1 if `a > b`, -1 if `a < b`, 0 if
- * equal. Leading "v" is tolerated. Numeric segments are compared left-to-right;
- * a missing segment counts as 0 (so "3.4" === "3.4.0"). Any non-numeric
- * pre-release tail (e.g. "-beta.1") is ignored for ordering — a pragmatic choice
- * that keeps the common release case correct without a full semver parser.
+ * Compare two semver strings. Returns 1 if `a > b`, -1 if `a < b`, 0 if equal.
+ * Leading "v" is tolerated. Numeric base segments are compared left-to-right; a
+ * missing segment counts as 0 (so "3.4" === "3.4.0"). When the base segments are
+ * equal, prerelease ordering follows the semver spec: a version without a
+ * prerelease suffix is higher than one with (so "3.4.8" > "3.4.8-alpha.1"), and
+ * when both have a prerelease suffix the suffixes are compared lexicographically.
  */
 export function compareVersions(a: string, b: string): number {
-    const segs = (v: string): number[] =>
-        normalizeVersion(v)
-            .split('-')[0]
-            .split('.')
-            .map((s) => parseInt(s, 10))
-            .map((n) => (Number.isFinite(n) ? n : 0));
-    const av = segs(a);
-    const bv = segs(b);
+    const parse = (v: string): { nums: number[]; pre: string } => {
+        const normalized = normalizeVersion(v);
+        const dashIdx = normalized.indexOf('-');
+        const numPart = dashIdx >= 0 ? normalized.slice(0, dashIdx) : normalized;
+        const pre = dashIdx >= 0 ? normalized.slice(dashIdx + 1) : '';
+        const nums = numPart.split('.').map((s) => {
+            const n = parseInt(s, 10);
+            return Number.isFinite(n) ? n : 0;
+        });
+        return { nums, pre };
+    };
+    const { nums: av, pre: aPre } = parse(a);
+    const { nums: bv, pre: bPre } = parse(b);
     const len = Math.max(av.length, bv.length);
     for (let i = 0; i < len; i++) {
         const diff = (av[i] ?? 0) - (bv[i] ?? 0);
@@ -114,7 +177,11 @@ export function compareVersions(a: string, b: string): number {
             return diff > 0 ? 1 : -1;
         }
     }
-    return 0;
+    // Base versions are equal — apply semver prerelease ordering.
+    if (!aPre && !bPre) return 0;
+    if (!aPre) return 1;  // stable beats prerelease of same base
+    if (!bPre) return -1; // prerelease loses to stable of same base
+    return aPre < bPre ? -1 : aPre > bPre ? 1 : 0;
 }
 
 /** True iff `latest` is strictly newer than `current`. */
@@ -214,15 +281,14 @@ export function formatUpdatePrompt(
 }
 
 // ---------------------------------------------------------------------------
-// "Skip this version" persistence
+// Persistent settings: skip-version and update-channel
 //
-// Mirrors agent-preflight's marker pattern: a small JSON file in the shared data
-// dir, namespaced to the desktop app so it never collides with the CLI's files.
-// A skipped version suppresses the *automatic* launch prompt for that exact
-// version only; an explicit "Check for Updates…" always re-checks.
+// Both are stored as fields in a shared desktop-update.json in the app data
+// dir. Writes always merge with existing content so neither field clobbers
+// the other.
 // ---------------------------------------------------------------------------
 
-/** Injectable filesystem seams for the skipped-version marker. */
+/** Injectable filesystem seams for the settings store. */
 export interface UpdateStore {
     readText?: (filePath: string) => string;
     writeText?: (filePath: string, data: string) => void;
@@ -235,15 +301,36 @@ function markerPath(dataDir: string): string {
     return path.join(dataDir, MARKER_FILENAME);
 }
 
-/** The version the user chose to skip, or `null` if none/unreadable. */
-export function getSkippedVersion(dataDir: string, store: UpdateStore = {}): string | null {
+/** Read existing marker data, returning an empty object on any error. */
+function readMarker(
+    dataDir: string,
+    store: UpdateStore,
+): Record<string, unknown> {
     const readText = store.readText ?? ((p) => fs.readFileSync(p, 'utf8'));
     try {
-        const parsed = JSON.parse(readText(markerPath(dataDir))) as { skipVersion?: string };
-        return typeof parsed?.skipVersion === 'string' ? parsed.skipVersion : null;
+        return JSON.parse(readText(markerPath(dataDir))) as Record<string, unknown>;
     } catch {
-        return null;
+        return {};
     }
+}
+
+/** Write `data` to the marker file, merging with existing content. */
+function writeMarker(
+    dataDir: string,
+    data: Record<string, unknown>,
+    store: UpdateStore,
+): void {
+    const ensureDir = store.ensureDir ?? ((d) => { fs.mkdirSync(d, { recursive: true }); });
+    const writeText = store.writeText ?? ((p, text) => fs.writeFileSync(p, text));
+    ensureDir(dataDir);
+    const existing = readMarker(dataDir, store);
+    writeText(markerPath(dataDir), JSON.stringify({ ...existing, ...data }));
+}
+
+/** The version the user chose to skip, or `null` if none/unreadable. */
+export function getSkippedVersion(dataDir: string, store: UpdateStore = {}): string | null {
+    const parsed = readMarker(dataDir, store);
+    return typeof parsed?.skipVersion === 'string' ? parsed.skipVersion : null;
 }
 
 /** Record a version the user wants to skip in the automatic launch prompt. */
@@ -252,13 +339,39 @@ export function setSkippedVersion(
     version: string,
     store: UpdateStore = {},
 ): void {
-    const ensureDir = store.ensureDir ?? ((d) => { fs.mkdirSync(d, { recursive: true }); });
-    const writeText = store.writeText ?? ((p, data) => fs.writeFileSync(p, data));
     try {
-        ensureDir(dataDir);
-        writeText(markerPath(dataDir), JSON.stringify({ skipVersion: normalizeVersion(version) }));
+        writeMarker(dataDir, { skipVersion: normalizeVersion(version) }, store);
     } catch {
         // Best-effort: a failed write only means we may re-prompt next launch.
+    }
+}
+
+/**
+ * Read the persisted update channel. Falls back to the channel inferred from
+ * `currentVersion` when no preference has been saved yet.
+ */
+export function getUpdateChannel(
+    dataDir: string,
+    currentVersion: string,
+    store: UpdateStore = {},
+): UpdateChannel {
+    const parsed = readMarker(dataDir, store);
+    if (parsed?.updateChannel === 'stable' || parsed?.updateChannel === 'prerelease') {
+        return parsed.updateChannel as UpdateChannel;
+    }
+    return inferChannel(currentVersion);
+}
+
+/** Persist the user's update channel preference. */
+export function setUpdateChannel(
+    dataDir: string,
+    channel: UpdateChannel,
+    store: UpdateStore = {},
+): void {
+    try {
+        writeMarker(dataDir, { updateChannel: channel }, store);
+    } catch {
+        // Best-effort.
     }
 }
 
@@ -274,8 +387,10 @@ export interface UpdateCheckOptions {
     platform?: NodeJS.Platform;
     /** Fetch implementation; defaults to global `fetch`. */
     fetchFn?: typeof fetch;
-    /** Releases endpoint; defaults to {@link LATEST_RELEASE_API}. */
+    /** Releases list endpoint; defaults to {@link RELEASES_LIST_API}. */
     apiUrl?: string;
+    /** Update channel; defaults to the channel inferred from `currentVersion`. */
+    channel?: UpdateChannel;
 }
 
 /** Why no prompt was produced, for logging / "Check for Updates…" feedback. */
@@ -289,14 +404,18 @@ export interface UpdateCheckResult {
 }
 
 /**
- * Fetch the latest release and decide whether to prompt. Never throws — a
- * network or parse failure resolves to `{ reason: 'error' }` so the caller (a
- * fire-and-forget launch check) can simply do nothing.
+ * Fetch the release list and decide whether to prompt. Replaces the former
+ * single `/releases/latest` call with a `/releases?per_page=20` list fetch so
+ * the active channel (stable or prerelease) can select the appropriate candidate.
+ *
+ * Never throws — a network or parse failure resolves to `{ reason: 'error' }` so
+ * the caller (a fire-and-forget launch check) can simply do nothing.
  */
 export async function checkForUpdate(opts: UpdateCheckOptions): Promise<UpdateCheckResult> {
     const platform = opts.platform ?? process.platform;
     const fetchFn = opts.fetchFn ?? globalThis.fetch;
-    const apiUrl = opts.apiUrl ?? LATEST_RELEASE_API;
+    const apiUrl = opts.apiUrl ?? RELEASES_LIST_API;
+    const channel = opts.channel ?? inferChannel(opts.currentVersion);
     const miss = (reason: UpdateCheckReason): UpdateCheckResult => ({
         reason,
         release: null,
@@ -312,7 +431,11 @@ export async function checkForUpdate(opts: UpdateCheckOptions): Promise<UpdateCh
         if (!res.ok) {
             return miss('error');
         }
-        const release = parseLatestRelease(await res.json());
+        const releases = parseReleaseList(await res.json());
+        if (releases.length === 0) {
+            return miss('error');
+        }
+        const release = selectCandidate(releases, channel);
         if (!release) {
             return miss('error');
         }

--- a/packages/coc-desktop/test/app-menu.test.ts
+++ b/packages/coc-desktop/test/app-menu.test.ts
@@ -14,6 +14,7 @@ import {
     buildAppMenuTemplate,
     buildTrayMenuTemplate,
     CHECK_FOR_UPDATES_LABEL,
+    UPDATE_CHANNEL_LABEL,
 } from '../src/app-menu';
 
 type Item = MenuItemConstructorOptions;
@@ -49,12 +50,18 @@ describe('buildAppMenuTemplate — macOS', () => {
         expect(appSubmenu[aboutIdx].role).toBe('about');
     });
 
-    it('separates "Check for Updates…" from the hide/quit cluster with a separator', () => {
+    it('places "Update Channel" directly after "Check for Updates…"', () => {
         const checkIdx = labelIdx(appSubmenu, CHECK_FOR_UPDATES_LABEL);
-        expect(isSeparator(appSubmenu[checkIdx + 1])).toBe(true);
+        const channelIdx = labelIdx(appSubmenu, UPDATE_CHANNEL_LABEL);
+        expect(channelIdx).toBe(checkIdx + 1);
+    });
+
+    it('separates the update items from the hide/quit cluster with a separator', () => {
+        const channelIdx = labelIdx(appSubmenu, UPDATE_CHANNEL_LABEL);
+        expect(isSeparator(appSubmenu[channelIdx + 1])).toBe(true);
         const hideIdx = roleIdx(appSubmenu, 'hide');
         const quitIdx = roleIdx(appSubmenu, 'quit');
-        expect(hideIdx).toBeGreaterThan(checkIdx);
+        expect(hideIdx).toBeGreaterThan(channelIdx);
         expect(quitIdx).toBeGreaterThan(hideIdx);
     });
 
@@ -76,6 +83,79 @@ describe('buildAppMenuTemplate — macOS', () => {
         expect(typeof check.click).toBe('function');
         (check.click as () => void)();
         expect(handlers.onCheckForUpdates).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('buildAppMenuTemplate — Update Channel submenu', () => {
+    it('shows "Stable" checked and "Prerelease" unchecked when channel is stable', () => {
+        const onSetUpdateChannel = vi.fn();
+        const template = buildAppMenuTemplate('darwin', 'CoC', {
+            onCheckForUpdates: vi.fn(),
+            currentChannel: 'stable',
+            onSetUpdateChannel,
+        });
+        const appSubmenu = submenuOf(template[0]);
+        const channelItem = appSubmenu.find((i) => i.label === UPDATE_CHANNEL_LABEL)!;
+        const sub = submenuOf(channelItem);
+        const stableItem = sub.find((i) => i.label === 'Stable')!;
+        const preItem = sub.find((i) => i.label === 'Prerelease')!;
+        expect(stableItem.checked).toBe(true);
+        expect(preItem.checked).toBe(false);
+        expect(stableItem.type).toBe('radio');
+        expect(preItem.type).toBe('radio');
+    });
+
+    it('shows "Prerelease" checked when channel is prerelease', () => {
+        const template = buildAppMenuTemplate('darwin', 'CoC', {
+            onCheckForUpdates: vi.fn(),
+            currentChannel: 'prerelease',
+            onSetUpdateChannel: vi.fn(),
+        });
+        const appSubmenu = submenuOf(template[0]);
+        const channelItem = appSubmenu.find((i) => i.label === UPDATE_CHANNEL_LABEL)!;
+        const sub = submenuOf(channelItem);
+        expect(sub.find((i) => i.label === 'Stable')!.checked).toBe(false);
+        expect(sub.find((i) => i.label === 'Prerelease')!.checked).toBe(true);
+    });
+
+    it('calls onSetUpdateChannel with the correct channel when clicked', () => {
+        const onSetUpdateChannel = vi.fn();
+        const template = buildAppMenuTemplate('darwin', 'CoC', {
+            onCheckForUpdates: vi.fn(),
+            currentChannel: 'stable',
+            onSetUpdateChannel,
+        });
+        const appSubmenu = submenuOf(template[0]);
+        const channelItem = appSubmenu.find((i) => i.label === UPDATE_CHANNEL_LABEL)!;
+        const sub = submenuOf(channelItem);
+        (sub.find((i) => i.label === 'Prerelease')!.click as () => void)();
+        expect(onSetUpdateChannel).toHaveBeenCalledWith('prerelease');
+        (sub.find((i) => i.label === 'Stable')!.click as () => void)();
+        expect(onSetUpdateChannel).toHaveBeenCalledWith('stable');
+    });
+
+    it('defaults to stable checkmark when currentChannel is not provided', () => {
+        const template = buildAppMenuTemplate('darwin', 'CoC', {
+            onCheckForUpdates: vi.fn(),
+        });
+        const appSubmenu = submenuOf(template[0]);
+        const channelItem = appSubmenu.find((i) => i.label === UPDATE_CHANNEL_LABEL)!;
+        const sub = submenuOf(channelItem);
+        expect(sub.find((i) => i.label === 'Stable')!.checked).toBe(true);
+    });
+
+    it('also appears in the Windows Help menu', () => {
+        const template = buildAppMenuTemplate('win32', 'CoC', {
+            onCheckForUpdates: vi.fn(),
+            currentChannel: 'prerelease',
+            onSetUpdateChannel: vi.fn(),
+        });
+        const help = template.find((i) => i.label === 'Help')!;
+        const items = submenuOf(help);
+        const channelItem = items.find((i) => i.label === UPDATE_CHANNEL_LABEL)!;
+        expect(channelItem).toBeDefined();
+        const sub = submenuOf(channelItem);
+        expect(sub.find((i) => i.label === 'Prerelease')!.checked).toBe(true);
     });
 });
 

--- a/packages/coc-desktop/test/update-check.test.ts
+++ b/packages/coc-desktop/test/update-check.test.ts
@@ -12,14 +12,21 @@ import {
     normalizeVersion,
     compareVersions,
     isNewerVersion,
+    isPrerelease,
+    inferChannel,
     parseLatestRelease,
+    parseReleaseList,
+    selectCandidate,
     pickDownloadUrl,
     formatUpdatePrompt,
     getSkippedVersion,
     setSkippedVersion,
+    getUpdateChannel,
+    setUpdateChannel,
     checkForUpdate,
     MAC_QUARANTINE_FIX,
     LATEST_RELEASE_API,
+    RELEASES_LIST_API,
     ReleaseInfo,
     UpdateStore,
 } from '../src/update-check';
@@ -31,16 +38,18 @@ function release(over: Partial<ReleaseInfo> = {}): ReleaseInfo {
         htmlUrl: 'https://github.com/plusplusoneplusplus/shortcuts/releases/tag/v3.4.6',
         notes: 'notes',
         assets: [],
+        isPrerelease: false,
         ...over,
     };
 }
 
-/** A GitHub-style /releases/latest payload, deliberately loosely typed. */
+/** A GitHub-style release payload, deliberately loosely typed. */
 function ghPayload(over: Record<string, unknown> = {}): unknown {
     return {
         tag_name: 'v3.4.6',
         html_url: 'https://example.com/rel',
         body: 'release body',
+        prerelease: false,
         assets: [
             {
                 name: 'CoC-3.4.6-arm64.dmg',
@@ -53,6 +62,21 @@ function ghPayload(over: Record<string, unknown> = {}): unknown {
         ],
         ...over,
     };
+}
+
+/** A GitHub-style prerelease payload. */
+function ghPrePayload(tag = 'v3.4.8-alpha.1', over: Record<string, unknown> = {}): unknown {
+    return ghPayload({
+        tag_name: tag,
+        prerelease: true,
+        assets: [
+            {
+                name: `CoC-${tag.replace(/^v/, '')}-arm64.dmg`,
+                browser_download_url: `https://example.com/CoC-${tag.replace(/^v/, '')}-arm64.dmg`,
+            },
+        ],
+        ...over,
+    });
 }
 
 /** A fetch stub returning the given JSON with a chosen ok/status. */
@@ -72,6 +96,30 @@ describe('normalizeVersion', () => {
     });
 });
 
+describe('isPrerelease', () => {
+    it('detects a prerelease suffix', () => {
+        expect(isPrerelease('3.4.8-alpha.1')).toBe(true);
+        expect(isPrerelease('v3.4.8-rc.2')).toBe(true);
+    });
+
+    it('returns false for stable versions', () => {
+        expect(isPrerelease('3.4.8')).toBe(false);
+        expect(isPrerelease('v3.4.8')).toBe(false);
+    });
+});
+
+describe('inferChannel', () => {
+    it('returns prerelease for a version with a prerelease suffix', () => {
+        expect(inferChannel('3.4.8-alpha.1')).toBe('prerelease');
+        expect(inferChannel('v3.5.0-rc.1')).toBe('prerelease');
+    });
+
+    it('returns stable for a clean semver', () => {
+        expect(inferChannel('3.4.8')).toBe('stable');
+        expect(inferChannel('v3.4.8')).toBe('stable');
+    });
+});
+
 describe('compareVersions', () => {
     it('orders by numeric segments, not lexically', () => {
         expect(compareVersions('3.4.10', '3.4.2')).toBe(1); // 10 > 2, not "10" < "2"
@@ -79,7 +127,7 @@ describe('compareVersions', () => {
         expect(compareVersions('4.0.0', '3.9.9')).toBe(1);
     });
 
-    it('treats equal versions as 0 and tolerates a leading v', () => {
+    it('treats equal stable versions as 0 and tolerates a leading v', () => {
         expect(compareVersions('3.4.6', '3.4.6')).toBe(0);
         expect(compareVersions('v3.4.6', '3.4.6')).toBe(0);
     });
@@ -89,9 +137,21 @@ describe('compareVersions', () => {
         expect(compareVersions('3.4.1', '3.4')).toBe(1);
     });
 
-    it('ignores a pre-release tail for ordering', () => {
-        expect(compareVersions('3.4.6-beta.1', '3.4.6')).toBe(0);
+    it('stable is greater than prerelease of the same base (semver spec)', () => {
+        expect(compareVersions('3.4.8', '3.4.8-alpha.1')).toBe(1);
+        expect(compareVersions('3.4.8-alpha.1', '3.4.8')).toBe(-1);
+        expect(compareVersions('3.4.6', '3.4.6-beta.1')).toBe(1);
+    });
+
+    it('higher base beats lower base regardless of prerelease tag', () => {
         expect(compareVersions('3.5.0-rc.1', '3.4.6')).toBe(1);
+        expect(compareVersions('3.5.0', '3.4.6-rc.1')).toBe(1);
+    });
+
+    it('compares prerelease suffixes lexicographically when bases are equal', () => {
+        expect(compareVersions('3.4.8-alpha.2', '3.4.8-alpha.1')).toBe(1);
+        expect(compareVersions('3.4.8-alpha.1', '3.4.8-alpha.1')).toBe(0);
+        expect(compareVersions('3.4.8-beta.1', '3.4.8-alpha.9')).toBe(1);
     });
 
     it('treats non-numeric segments as 0 rather than NaN', () => {
@@ -105,6 +165,11 @@ describe('isNewerVersion', () => {
         expect(isNewerVersion('3.4.6', '3.4.6')).toBe(false);
         expect(isNewerVersion('3.4.2', '3.4.6')).toBe(false);
     });
+
+    it('stable 3.4.8 is newer than prerelease 3.4.8-alpha.1', () => {
+        expect(isNewerVersion('3.4.8', '3.4.8-alpha.1')).toBe(true);
+        expect(isNewerVersion('3.4.8-alpha.1', '3.4.8')).toBe(false);
+    });
 });
 
 describe('parseLatestRelease', () => {
@@ -115,11 +180,25 @@ describe('parseLatestRelease', () => {
         expect(info!.tag).toBe('v3.4.6');
         expect(info!.htmlUrl).toBe('https://example.com/rel');
         expect(info!.notes).toBe('release body');
+        expect(info!.isPrerelease).toBe(false);
         expect(info!.assets).toHaveLength(2);
         expect(info!.assets[0]).toEqual({
             name: 'CoC-3.4.6-arm64.dmg',
             url: 'https://example.com/CoC-3.4.6-arm64.dmg',
         });
+    });
+
+    it('reads the prerelease flag from the GitHub payload', () => {
+        const pre = parseLatestRelease(ghPayload({ prerelease: true }));
+        expect(pre!.isPrerelease).toBe(true);
+
+        const stable = parseLatestRelease(ghPayload({ prerelease: false }));
+        expect(stable!.isPrerelease).toBe(false);
+    });
+
+    it('defaults isPrerelease to false when the field is absent', () => {
+        const info = parseLatestRelease({ tag_name: 'v3.4.6', html_url: '', body: '', assets: [] });
+        expect(info!.isPrerelease).toBe(false);
     });
 
     it('returns null when there is no usable tag', () => {
@@ -144,6 +223,63 @@ describe('parseLatestRelease', () => {
 
         const noAssets = parseLatestRelease(ghPayload({ assets: undefined }));
         expect(noAssets!.assets).toEqual([]);
+    });
+});
+
+describe('parseReleaseList', () => {
+    it('returns an empty array for a non-array payload', () => {
+        expect(parseReleaseList(null)).toEqual([]);
+        expect(parseReleaseList({})).toEqual([]);
+        expect(parseReleaseList('not an array')).toEqual([]);
+    });
+
+    it('returns an empty array for an empty list', () => {
+        expect(parseReleaseList([])).toEqual([]);
+    });
+
+    it('parses a mixed stable/prerelease list', () => {
+        const list = parseReleaseList([ghPayload(), ghPrePayload()]);
+        expect(list).toHaveLength(2);
+        expect(list[0].isPrerelease).toBe(false);
+        expect(list[1].isPrerelease).toBe(true);
+    });
+
+    it('silently skips entries that fail to parse', () => {
+        const list = parseReleaseList([ghPayload(), { tag_name: '' }, null, ghPrePayload()]);
+        expect(list).toHaveLength(2);
+    });
+});
+
+describe('selectCandidate', () => {
+    const stable = release({ version: '3.4.8', tag: 'v3.4.8', isPrerelease: false });
+    const pre1 = release({ version: '3.4.8-alpha.1', tag: 'v3.4.8-alpha.1', isPrerelease: true });
+    const pre2 = release({ version: '3.4.9-alpha.1', tag: 'v3.4.9-alpha.1', isPrerelease: true });
+
+    it('on stable channel, skips prerelease releases', () => {
+        const candidate = selectCandidate([pre1, pre2], 'stable');
+        expect(candidate).toBeNull();
+    });
+
+    it('on stable channel, picks the highest stable release', () => {
+        const older = release({ version: '3.4.6', isPrerelease: false });
+        const candidate = selectCandidate([older, stable, pre1], 'stable');
+        expect(candidate!.version).toBe('3.4.8');
+    });
+
+    it('on prerelease channel, considers all releases and picks the highest', () => {
+        const candidate = selectCandidate([stable, pre1, pre2], 'prerelease');
+        // 3.4.9-alpha.1 > 3.4.8 > 3.4.8-alpha.1
+        expect(candidate!.version).toBe('3.4.9-alpha.1');
+    });
+
+    it('on prerelease channel, stable beats prerelease of same base', () => {
+        const candidate = selectCandidate([stable, pre1], 'prerelease');
+        expect(candidate!.version).toBe('3.4.8');
+    });
+
+    it('returns null for an empty list', () => {
+        expect(selectCandidate([], 'stable')).toBeNull();
+        expect(selectCandidate([], 'prerelease')).toBeNull();
     });
 });
 
@@ -255,14 +391,76 @@ describe('skip-version persistence', () => {
         };
         expect(() => setSkippedVersion(dataDir, '3.4.6', throwingStore)).not.toThrow();
     });
+
+    it('preserves updateChannel when setSkippedVersion is called', () => {
+        const { store } = memStore();
+        setUpdateChannel(dataDir, 'prerelease', store);
+        setSkippedVersion(dataDir, '3.4.8', store);
+        // Both fields survive
+        expect(getSkippedVersion(dataDir, store)).toBe('3.4.8');
+        expect(getUpdateChannel(dataDir, '3.4.0', store)).toBe('prerelease');
+    });
+});
+
+describe('update-channel persistence', () => {
+    function memStore(): { store: UpdateStore; files: Map<string, string> } {
+        const files = new Map<string, string>();
+        return {
+            files,
+            store: {
+                readText: (p) => {
+                    if (!files.has(p)) throw new Error('ENOENT');
+                    return files.get(p)!;
+                },
+                writeText: (p, data) => void files.set(p, data),
+                ensureDir: () => undefined,
+            },
+        };
+    }
+
+    const dataDir = path.join('/fake', 'coc');
+
+    it('round-trips a saved channel', () => {
+        const { store } = memStore();
+        setUpdateChannel(dataDir, 'prerelease', store);
+        expect(getUpdateChannel(dataDir, '3.4.0', store)).toBe('prerelease');
+
+        setUpdateChannel(dataDir, 'stable', store);
+        expect(getUpdateChannel(dataDir, '3.4.0-alpha.1', store)).toBe('stable');
+    });
+
+    it('infers stable channel from a stable installed version when nothing is saved', () => {
+        const { store } = memStore();
+        expect(getUpdateChannel(dataDir, '3.4.8', store)).toBe('stable');
+    });
+
+    it('infers prerelease channel from a prerelease installed version when nothing is saved', () => {
+        const { store } = memStore();
+        expect(getUpdateChannel(dataDir, '3.4.8-alpha.1', store)).toBe('prerelease');
+    });
+
+    it('preserves skipVersion when setUpdateChannel is called', () => {
+        const { store } = memStore();
+        setSkippedVersion(dataDir, '3.4.8', store);
+        setUpdateChannel(dataDir, 'prerelease', store);
+        expect(getSkippedVersion(dataDir, store)).toBe('3.4.8');
+        expect(getUpdateChannel(dataDir, '3.4.0', store)).toBe('prerelease');
+    });
+
+    it('does not throw on write failure', () => {
+        const throwingStore: UpdateStore = {
+            ensureDir: () => { throw new Error('EACCES'); },
+        };
+        expect(() => setUpdateChannel(dataDir, 'stable', throwingStore)).not.toThrow();
+    });
 });
 
 describe('checkForUpdate', () => {
-    it('reports a newer release with a platform-specific prompt', async () => {
+    it('reports a newer stable release with a platform-specific prompt', async () => {
         const result = await checkForUpdate({
             currentVersion: '3.4.2',
             platform: 'darwin',
-            fetchFn: fakeFetch(ghPayload()),
+            fetchFn: fakeFetch([ghPayload()]),
         });
         expect(result.reason).toBe('newer');
         expect(result.release!.version).toBe('3.4.6');
@@ -272,7 +470,7 @@ describe('checkForUpdate', () => {
     it('reports up-to-date when the latest equals the current version', async () => {
         const result = await checkForUpdate({
             currentVersion: '3.4.6',
-            fetchFn: fakeFetch(ghPayload()),
+            fetchFn: fakeFetch([ghPayload()]),
         });
         expect(result.reason).toBe('up-to-date');
         expect(result.prompt).toBeNull();
@@ -281,7 +479,7 @@ describe('checkForUpdate', () => {
     it('reports up-to-date when the current version is newer (dev/pre-release)', async () => {
         const result = await checkForUpdate({
             currentVersion: '4.0.0',
-            fetchFn: fakeFetch(ghPayload()),
+            fetchFn: fakeFetch([ghPayload()]),
         });
         expect(result.reason).toBe('up-to-date');
     });
@@ -289,12 +487,20 @@ describe('checkForUpdate', () => {
     it('reports error on a non-ok HTTP response', async () => {
         const result = await checkForUpdate({
             currentVersion: '3.4.2',
-            fetchFn: fakeFetch(ghPayload(), { ok: false }),
+            fetchFn: fakeFetch([ghPayload()], { ok: false }),
         });
         expect(result.reason).toBe('error');
     });
 
-    it('reports error on an unparseable payload', async () => {
+    it('reports error on an unparseable payload (empty list)', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.2',
+            fetchFn: fakeFetch([]),
+        });
+        expect(result.reason).toBe('error');
+    });
+
+    it('reports error when the payload is not a list at all', async () => {
         const result = await checkForUpdate({
             currentVersion: '3.4.2',
             fetchFn: fakeFetch({ message: 'Not Found' }),
@@ -318,13 +524,119 @@ describe('checkForUpdate', () => {
         expect(result.reason).toBe('error');
     });
 
-    it('defaults to the project releases endpoint', async () => {
+    it('defaults to the releases list endpoint', async () => {
         let calledWith = '';
         const spyFetch = (async (url: string) => {
             calledWith = url;
-            return { ok: true, json: async () => ghPayload() };
+            return { ok: true, json: async () => [ghPayload()] };
         }) as unknown as typeof fetch;
         await checkForUpdate({ currentVersion: '3.4.2', fetchFn: spyFetch });
-        expect(calledWith).toBe(LATEST_RELEASE_API);
+        expect(calledWith).toBe(RELEASES_LIST_API);
+    });
+
+    it('LATEST_RELEASE_API constant is still exported for reference', () => {
+        expect(typeof LATEST_RELEASE_API).toBe('string');
+        expect(LATEST_RELEASE_API).toContain('/releases/latest');
+    });
+
+    // ------------------------------------------------------------------
+    // Plan acceptance-criteria scenarios
+    // ------------------------------------------------------------------
+
+    it('[AC] /releases/latest returning 404 is not a concern — list API works for prereleases', async () => {
+        // The old endpoint would 404 for a repo whose only release is a prerelease.
+        // The new list-based approach succeeds because the list endpoint includes prereleases.
+        const result = await checkForUpdate({
+            currentVersion: '3.4.6',
+            channel: 'prerelease',
+            fetchFn: fakeFetch([ghPrePayload('v3.4.8-alpha.1')]),
+        });
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.8-alpha.1');
+    });
+
+    it('[AC] installed prerelease detects newer prerelease builds', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.8-alpha.1',
+            channel: 'prerelease',
+            fetchFn: fakeFetch([ghPrePayload('v3.4.8-alpha.2')]),
+        });
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.8-alpha.2');
+    });
+
+    it('[AC] installed stable stays on stable channel by default (no prerelease offered)', async () => {
+        // List contains a prerelease and a stable older than current — nothing newer on stable channel.
+        const result = await checkForUpdate({
+            currentVersion: '3.4.8',
+            fetchFn: fakeFetch([
+                ghPrePayload('v3.4.9-alpha.1'),
+                ghPayload({ tag_name: 'v3.4.6' }),
+            ]),
+        });
+        // inferChannel('3.4.8') → 'stable', so prerelease is excluded
+        expect(result.reason).toBe('up-to-date');
+    });
+
+    it('[AC] stable user sees prerelease after opting into the prerelease channel', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.8',
+            channel: 'prerelease',
+            fetchFn: fakeFetch([ghPrePayload('v3.4.9-alpha.1')]),
+        });
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.9-alpha.1');
+    });
+
+    it('[AC] installed prerelease treats matching stable as newer', async () => {
+        const result = await checkForUpdate({
+            currentVersion: '3.4.8-alpha.1',
+            channel: 'prerelease',
+            // List only has the stable 3.4.8 — it should supersede the prerelease
+            fetchFn: fakeFetch([ghPayload({ tag_name: 'v3.4.8', prerelease: false })]),
+        });
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.8');
+    });
+
+    it('[AC] malformed or empty release list returns { reason: "error" }', async () => {
+        const empty = await checkForUpdate({
+            currentVersion: '3.4.0',
+            fetchFn: fakeFetch([]),
+        });
+        expect(empty.reason).toBe('error');
+
+        const malformed = await checkForUpdate({
+            currentVersion: '3.4.0',
+            fetchFn: fakeFetch('garbage'),
+        });
+        expect(malformed.reason).toBe('error');
+    });
+
+    it('[AC] stable channel: existing latest-release behavior valid for stable releases', async () => {
+        // A list containing only non-prerelease releases behaves identically to the
+        // old /releases/latest flow for stable users.
+        const result = await checkForUpdate({
+            currentVersion: '3.4.2',
+            platform: 'win32',
+            channel: 'stable',
+            fetchFn: fakeFetch([ghPayload()]),
+        });
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.6');
+        expect(result.prompt!.buttons).toContain('Download');
+    });
+
+    it('[AC] auto check skips a prerelease that was skipped — list API with skip marker', async () => {
+        // Not testing `main.ts` wiring here; just verifying that a newer prerelease
+        // is surfaced so the caller can apply the skip-marker filter separately.
+        const result = await checkForUpdate({
+            currentVersion: '3.4.8-alpha.1',
+            channel: 'prerelease',
+            fetchFn: fakeFetch([ghPrePayload('v3.4.8-alpha.2')]),
+        });
+        // The module reports 'newer'; it's main.ts that checks the skip marker.
+        expect(result.reason).toBe('newer');
+        expect(result.release!.version).toBe('3.4.8-alpha.2');
     });
 });


### PR DESCRIPTION
The update checker previously called /releases/latest, which GitHub ignores for
prerelease-only repos, causing "Could not check for updates" on 3.4.8-alpha.1.

Replace the single endpoint with /releases?per_page=20 and add channel-aware
candidate selection:
- Stable channel (default for non-prerelease installs): only stable releases.
- Prerelease channel (default for prerelease installs): all releases.

compareVersions now follows the semver spec — stable 3.4.8 is newer than
3.4.8-alpha.1. Channel preference persists in desktop-update.json alongside
the existing skipVersion field (both writes now merge to avoid data loss).

An "Update Channel" submenu (Stable / Prerelease radio items) appears in the
app menu on macOS and Windows so users can switch channels at any time.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
