### PR TITLE
pr/24f83f462 testcoc add tier a e2e coverage for nest

### DIFF
--- a/.github/skills/coc-knowledge/references/admin-config.md
+++ b/.github/skills/coc-knowledge/references/admin-config.md
@@ -35,6 +35,25 @@ The AI provider admin card stores `defaultProvider` as a top-level concrete fall
 
 Namespaced config merge/source tracking is registered in `packages/coc/src/config/namespace-registry.ts`; add namespace fields there instead of expanding branch lists in `config.ts`. Default process store backend is SQLite. CLI flags > config file > defaults.
 
+## Skills Folder Sources
+
+Skill discovery draws from several folders. Two of them are config-file settings under the non-admin `skills` namespace (not the admin registry — they are surfaced through the Skills Config API/UI, not the Features card):
+
+- `skills.globalExtraFolders: string[]` (default `[]`) — read-only global skill-source folders applied across all workspaces. Entries are absolute paths or `~`-prefixed home paths; malformed/relative/empty entries are skipped, not fatal. CoC never installs or deletes into them.
+- `skills.autoDetectDefaultFolders: boolean` (default `true`) — enables auto-detection of OneDrive/CloudStorage skill folders (`~/OneDrive/.github/skills`, `~/OneDrive - Microsoft/.github/skills`, and macOS `~/Library/CloudStorage/OneDrive-*/…/.github/skills`). Set `false` to disable all default folder auto-detection.
+
+Adding a `skills.*` field touches FOUR spots (all non-admin, hand-written): the optional + required `skills` types and `DEFAULT_CONFIG` in `packages/coc/src/config.ts`, the `BASE_SCHEMA_TREE.skills` leaf in `packages/coc/src/config/schema.ts` (optional + passthrough so old config files still validate), and the hand-coded `skills` merge in `packages/coc/src/config/namespace-registry.ts` (miss the last and tsc goes red).
+
+**Persistence split.** Global disabled skills live in `preferences.json` (`globalDisabledSkills`); `globalExtraFolders` and `autoDetectDefaultFolders` live in the config file's `skills` namespace. The `GET`/`PUT /api/skills/config` endpoint spans both stores. The managed global skills directory (`dataDir/skills`, normally `~/.coc/skills`) is a fixed install target and is NOT configurable.
+
+**Resolution order** (repo → managed-global → auto-detected → global-extra → per-repo-extra → bundled) has three consumers that must agree, all in `packages/coc/src/server/executors/skill-config-resolver.ts` (except the listing helper):
+
+- `resolveSkillConfig(...)` — execution-time; existence-filtered ordered `skillDirectories[]` the agent actually uses. Reads `skills` config via the queue-executor bridge (config file = single source of truth).
+- `resolveEffectiveSkillPaths(...)` — read-only diagnostic behind `GET /api/skills/effective-paths`; keeps declared-but-missing sources so the UI can explain them (auto-detected folders surface only when their OneDrive root exists).
+- `loadSkillsForWorkspace(...)` (in `packages/coc/src/server/skills/skill-handler.ts`) — UI listing behind `GET /api/workspaces/:id/skills`; tags configured-folder skills `source: 'global-extra-folder'` and inserts them after managed-global and before per-repo extras. Has no auto-detected/bundled entries.
+
+Keep the order identical across all three if you touch one. See [rest-api.md](rest-api.md) for the endpoints and [dashboard-spa.md](dashboard-spa.md) for the Skills Config panel UI.
+
 ## Admin UI Styling
 
 The admin route uses a self-contained, Linear-inspired design system that lives in `packages/coc/src/server/spa/client/react/admin/admin-redesign.css`. The stylesheet is imported once at the top of `AdminPanel.tsx` so esbuild bundles it into the SPA's CSS. All selectors are scoped under the `.admin-redesign` root class that wraps the entire admin page — styles never leak to other dashboard surfaces, and light/dark themes are driven by the existing `<html data-theme="…">` attribute.

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -922,6 +922,36 @@ unmounts the embed, and renders the standard admin card content.
 Each tool's internal sub-tab/hash scheme (e.g. `#skills/installed`,
 `#logs?sessionId=…`) is unchanged.
 
+### Skills Config panel & folder-source grouping
+
+The Skills route's **Config** sub-tab (`features/skills/SkillsConfigPanel.tsx`)
+renders five ordered sections: **Global Skills Directory** (read-only managed
+install dir, falls back to `~/.coc/skills/` when the server omits
+`globalSkillsDir`), **Global Extra Skill Folders** (chips with add/remove/Enter +
+dedupe guard; persists `globalExtraFolders` via `skills.updateGlobalConfig`),
+**Detected Skill Folders** (an auto-detect checkbox toggling
+`autoDetectDefaultFolders`, the auto-detected entries from
+`skills.getEffectivePaths()`, a concise "No OneDrive skill folders detected."
+empty state, and skipped roots hidden in a collapsed `<details>` diagnostics
+row), **Effective Search Order** (a read-only `<ol>` from
+`getEffectivePaths()` called with NO workspaceId — global-only, with a "Showing
+global paths only" note so repo-local/per-repo paths aren't claimed to apply
+globally), and **Globally Disabled Skills** (unchanged; writes send only
+`{ globalDisabledSkills }` so existing tests pass). Source badges: `managed-global
+→ Managed`, `configured → Configured`, `auto-detected → Auto-detected`,
+`repo`/`repo-extra → Repo`, `bundled → Bundled`. Status badges:
+`available → Available`, `missing → Missing`, `no-skills → No skills`,
+`skipped → Skipped`.
+
+The skill-source taxonomy is duplicated across four shapes that must stay in
+sync: server `SkillInfo.source` (`skill-handler.ts`), coc-client `SkillSource`
+(`contracts/skills.ts`), SPA shared `SkillInfo.source` (`shared/SkillDetailPanel.tsx`),
+and `SkillFolderGroup.source` + grouping logic in the Repo Settings → Agent
+Skills tab (`features/skills/AgentSkillsPanel.tsx`). The `global-extra-folder`
+source forms its own NON-removable group (`🌐 <folderPath>`) placed after
+global/repo and before per-repo extras, since those folders are managed globally
+in the Config tab, not per-repo.
+
 ### Remote-first shell (experimental)
 
 An optional two-row navigation mode gated by `useRemoteShellEnabled()`

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -41,7 +41,7 @@ spa/client/react/
 ├── processes/          # Process detail, DAG visualization
 ├── queue/              # Queue management (EnqueueDialog, QueueView)
 ├── repos/              # Repository views, clone/add dialogs, file explorer, Monaco editor
-├── shared/             # Feature-level shared (MarkdownView, RichTextInput, SourceEditor)
+├── shared/             # Feature-level shared (MarkdownView, RichTextInput, SourceEditor, markdown-document session helpers)
 ├── tasks/              # Task/plan management, inline comments
 ├── ui/                 # UI primitives (Button, Card, Dialog, Spinner, Badge, Toast)
 ├── welcome/            # Onboarding (WelcomeTour, FirstStepsCard, FeatureTip)
@@ -340,6 +340,7 @@ present.
 | `useApi` | HTTP client wrapper |
 | `useWebSocket` | WebSocket connection management |
 | `useMarkdownPreview` | Shared markdown rendering pipeline |
+| `useMarkdownDocumentSession` | Shared markdown document loading, dirty state, save/flush, refresh, conflict, beforeunload, and keyboard-save kernel used by Notes and MarkdownReviewEditor through injected I/O adapters |
 | `useDiffComments` | Inline diff comment state |
 | `useUnseenChat` | Read/unread tracking |
 

--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -283,12 +283,19 @@ Users can add up to **10** additional notes roots per workspace — subfolders i
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/workspaces/:id/skills` | List skills |
+| GET | `/api/workspaces/:id/skills` | List skills merged for the workspace. In priority order: repo-local `.github/skills` → managed global `~/.coc/skills` → configured global extra folders (`source: 'global-extra-folder'`, tagged with `folderPath`) → per-repo extra/linked-repo folders. Name collisions resolve to the earlier (higher-priority) source. |
 | POST | `/api/workspaces/:id/skills/install` | Install skill |
 | GET | `/api/workspaces/:id/skills/:name/file?path=<rel>` | Read a file inside a skill folder |
 | DELETE | `/api/workspaces/:id/skills/:name` | Delete skill |
 | GET | `/api/skills` | Global skills |
 | POST | `/api/skills/install` | Install global skill |
+| GET | `/api/skills/config` | Global skills config: `{ globalDisabledSkills, globalSkillsDir, globalExtraFolders, autoDetectDefaultFolders }`. `globalDisabledSkills` comes from `preferences.json`; `globalSkillsDir` is the managed install dir (`dataDir/skills`, normally `~/.coc/skills`); `globalExtraFolders` and `autoDetectDefaultFolders` are read from the config file's `skills` namespace (defaulting to `[]` / `true` when absent or malformed). |
+| PUT | `/api/skills/config` | Update global skills config. Body `{ globalDisabledSkills, globalExtraFolders?, autoDetectDefaultFolders? }`. `globalDisabledSkills` persists to `preferences.json`; when present, `globalExtraFolders` (validated as an array of strings) and `autoDetectDefaultFolders` (validated as a boolean) are merged into the config file's `skills` namespace via a whole-file load-merge-write. Returns the same shape as GET. |
+| GET | `/api/skills/effective-paths` | Read-only diagnostic of the agent's effective skill search order. Global-only by default; `?workspaceId=<id>` adds workspace-scoped paths (repo-local + per-repo extra folders) and echoes the resolved `workspaceId` (unknown ids fall back to global-only, no echo). Returns `{ workspaceId?, paths: EffectiveSkillPath[] }`, each entry `{ source, scope, status, path, skillCount?, note? }`. Declared-but-missing sources are retained so the UI can explain them; auto-detected OneDrive/CloudStorage folders appear only when their root exists (surfaced as `skipped` when the root exists but lacks `.github/skills`, silent when the root is absent). |
+
+`/api/skills/config` and `/api/skills/effective-paths` are registered before the catch-all `/api/skills/:name` route and reserved in `RESERVED_GLOBAL_SKILL_NAMES` so the skill-detail route never swallows them. CoC only installs/deletes into the managed `globalSkillsDir`; configured global extra folders, auto-detected OneDrive/CloudStorage folders, and per-repo extra folders are read-only skill sources. Resolution order and the three consumers (execution, diagnostic, UI listing) are documented in [admin-config.md](admin-config.md).
+
+`EffectiveSkillPath.source` ∈ `repo` \| `managed-global` \| `auto-detected` \| `configured` \| `repo-extra` \| `bundled`; `status` ∈ `available` \| `no-skills` \| `missing` \| `skipped`; `scope` ∈ `global` \| `workspace`.
 
 ## Memory
 

--- a/packages/coc-client/src/contracts/skills.ts
+++ b/packages/coc-client/src/contracts/skills.ts
@@ -1,4 +1,11 @@
-export type SkillSource = 'global' | 'repo' | 'bundled' | 'linked-repo' | 'extra-folder';
+export type SkillSource =
+  | 'global'
+  | 'repo'
+  | 'bundled'
+  | 'linked-repo'
+  | 'extra-folder'
+  /** Skill loaded from a configured global extra folder (`skills.globalExtraFolders`). */
+  | 'global-extra-folder';
 
 export interface SkillInfo {
   name: string;

--- a/packages/coc-client/src/contracts/skills.ts
+++ b/packages/coc-client/src/contracts/skills.ts
@@ -70,10 +70,25 @@ export interface InstallSkillsResponse {
 export interface GlobalSkillsConfig {
   globalDisabledSkills: string[];
   globalSkillsDir: string;
+  /**
+   * Configured global extra skill-source folders (`skills.globalExtraFolders`).
+   * Read-only sources applied across all workspaces; CoC never installs/deletes
+   * into them. Absolute paths or `~`-prefixed home paths.
+   */
+  globalExtraFolders: string[];
+  /**
+   * Whether default skill-folder auto-detection (OneDrive/CloudStorage) is
+   * enabled (`skills.autoDetectDefaultFolders`). Defaults to true.
+   */
+  autoDetectDefaultFolders: boolean;
 }
 
 export interface UpdateGlobalSkillsConfigRequest {
   globalDisabledSkills: string[];
+  /** When provided, replaces the configured global extra skill folders. */
+  globalExtraFolders?: string[];
+  /** When provided, toggles default skill-folder auto-detection. */
+  autoDetectDefaultFolders?: boolean;
 }
 
 export interface MergedSkillsResponse {

--- a/packages/coc-client/src/contracts/skills.ts
+++ b/packages/coc-client/src/contracts/skills.ts
@@ -97,6 +97,49 @@ export interface MergedSkillsResponse {
   merged: SkillInfo[];
 }
 
+/** Origin of an effective skill-search-order path; drives the UI source badge. */
+export type EffectiveSkillPathSource =
+  | 'repo'
+  | 'managed-global'
+  | 'auto-detected'
+  | 'configured'
+  | 'repo-extra'
+  | 'bundled';
+
+/** Availability of an effective skill-search-order path; drives the UI status badge. */
+export type EffectiveSkillPathStatus = 'available' | 'no-skills' | 'missing' | 'skipped';
+
+/** Whether an effective skill-search-order path applies globally or per-workspace. */
+export type EffectiveSkillPathScope = 'global' | 'workspace';
+
+/**
+ * A single directory in the agent's effective skill search order, annotated for
+ * read-only diagnostic display. Missing/skipped declared sources are retained so
+ * the UI can explain exactly what the agent will (and will not) use.
+ */
+export interface EffectiveSkillPath {
+  source: EffectiveSkillPathSource;
+  scope: EffectiveSkillPathScope;
+  status: EffectiveSkillPathStatus;
+  /** Absolute host-filesystem path (or the raw configured value when skipped). */
+  path: string;
+  /** Installed skill count found in the directory (present only when it exists). */
+  skillCount?: number;
+  /** Optional human-readable note (e.g. why a declared folder was skipped). */
+  note?: string;
+}
+
+/**
+ * Structured effective skill search order returned by `GET /api/skills/effective-paths`.
+ * When `workspaceId` is set the list includes workspace-scoped paths (repo-local
+ * and per-repo extra folders); otherwise it is global-only.
+ */
+export interface EffectiveSkillPathsResponse {
+  /** Echoed active workspace id when the diagnostic is workspace-scoped. */
+  workspaceId?: string;
+  paths: EffectiveSkillPath[];
+}
+
 export interface WorkspaceSkillsPathResponse {
   path: string;
   skillCount: number;

--- a/packages/coc-client/src/domains/skills.ts
+++ b/packages/coc-client/src/domains/skills.ts
@@ -1,5 +1,6 @@
 import type {
   DiscoveredSkill,
+  EffectiveSkillPathsResponse,
   GlobalSkillsConfig,
   InstallSkillsRequest,
   InstallSkillsResponse,
@@ -81,6 +82,17 @@ export class SkillsClient {
     return this.transport.request<GlobalSkillsConfig>(skillsPath('/config'), {
       method: 'PUT',
       body: { ...request },
+    });
+  }
+
+  /**
+   * Fetch the agent's effective skill search order as read-only diagnostic data.
+   * Pass a `workspaceId` to include workspace-scoped paths (repo-local + per-repo
+   * extra folders); omit it for a global-only view.
+   */
+  getEffectivePaths(workspaceId?: string): Promise<EffectiveSkillPathsResponse> {
+    return this.transport.request<EffectiveSkillPathsResponse>(skillsPath('/effective-paths'), {
+      query: workspaceId ? { workspaceId } : undefined,
     });
   }
 

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -53,6 +53,22 @@ all have their own `references/*.md`.
   Claude Code discovers them as slash commands. A sidecar marker
   `.coc-<name>.json` tracks CoC-managed commands to distinguish them from
   user-authored ones.
+- **Skill-folder resolution order** is: repo-local `.github/skills` →
+  managed global `~/.coc/skills` → auto-detected OneDrive/CloudStorage →
+  configured global extra folders (`skills.globalExtraFolders`) → per-repo
+  extra folders → bundled. Three consumers must keep this order identical:
+  `resolveSkillConfig` (execution-time, existence-filtered — what the agent
+  uses) and `resolveEffectiveSkillPaths` (read-only diagnostic behind
+  `GET /api/skills/effective-paths`, keeps declared-but-missing sources) in
+  `src/server/executors/skill-config-resolver.ts`, and `loadSkillsForWorkspace`
+  (UI listing behind `GET /api/workspaces/:id/skills`, tags configured-folder
+  skills `source: 'global-extra-folder'`) in `src/server/skills/skill-handler.ts`.
+  Managed `~/.coc/skills` is the only install/delete target; extra/detected
+  folders are read-only. `skills.globalExtraFolders` +
+  `skills.autoDetectDefaultFolders` live in the config `skills` namespace, while
+  `globalDisabledSkills` lives in `preferences.json`; `GET`/`PUT
+  /api/skills/config` spans both (see
+  [admin-config.md](../../.github/skills/coc-knowledge/references/admin-config.md)).
 - **Adding an admin-exposed config setting** is ONE definition entry in
   `src/config/admin-setting-definitions.ts` (value spec, default, runtime,
   optional `runtimeFlag` + Features-card `ui` metadata) plus the

--- a/packages/coc/specs/skills-tab.spec.md
+++ b/packages/coc/specs/skills-tab.spec.md
@@ -3,7 +3,7 @@
 **Document type:** Formal UX Specification  
 **Scope:** CoC Dashboard → Skills (embedded in Admin Shell · Knowledge Group)  
 **Purpose:** Authoritative reference for validating any future UI/UX changes to the Skills tab.  
-**Version:** 2.0.0
+**Version:** 2.1.0
 
 ---
 
@@ -15,7 +15,7 @@ The view exposes three sub-tabs in a left rail:
 
 - **Installed** — list, expand, toggle, and uninstall installed global skills
 - **Gallery** — install skills from Built-in / GitHub URL / ClawHub / Local Path (formerly named "Bundled"; the legacy `#skills/bundled` URL is back-compat redirected to `#skills/gallery`)
-- **Config** — configure the global skills directory and globally disabled skills
+- **Config** — configure skill folder sources (managed global directory, global extra folders, detected folders), view the effective search order, and manage globally disabled skills
 
 Skills installed here live under `~/.coc/skills/` and are available globally across all repositories. At server startup they are also mirrored for Codex (`~/.codex/skills`) and Claude (`~/.claude/commands/<name>.md`) when the corresponding `codex.enabled` / `claude.enabled` flags are true; the mirroring is invisible to the SPA.
 
@@ -133,12 +133,51 @@ Skills installed here live under `~/.coc/skills/` and are available globally acr
 
 ### 3.3 Config Sub-Tab
 
+The Config sub-tab renders five sections in this order: **Global Skills Directory**, **Global Extra Skill Folders**, **Detected Skill Folders**, **Effective Search Order**, **Globally Disabled Skills**.
+
 **US-09 — View global skills directory**
 > As an administrator, I want to see where global skills are stored on disk.
 
 - **Given** the Config sub-tab is active
 - **When** config is loaded via `skills.getGlobalConfig()`
-- **Then** the global skills directory is shown in a monospace read-only field; falls back to `~/.coc/skills/` when the server response has no `globalSkillsDir`
+- **Then** the **Global Skills Directory** section shows the managed install directory in a monospace read-only field; falls back to `~/.coc/skills/` when the server response has no `globalSkillsDir`
+- **And** it is presented as a single read-only managed location — never a multi-value field — and does not imply CoC writes into OneDrive, extra, bundled, or repo-local folders
+
+---
+
+**US-11 — Manage global extra skill folders**
+> As an administrator, I want to add read-only skill-source folders that apply across all workspaces.
+
+- **Given** the Config sub-tab is active
+- **Then** the **Global Extra Skill Folders** section shows configured folders (from `globalExtraFolders`) as chips with a `✕` to remove
+- **When** the user types a folder path (absolute or `~`-prefixed) and clicks **Add** (or presses Enter)
+- **Then** the panel persists via `skills.updateGlobalConfig({ globalDisabledSkills, globalExtraFolders: [...current, folder] })` (deduped against the current list), then reloads effective paths
+- **When** the user clicks `✕` on a chip
+- **Then** it persists `globalExtraFolders` without that folder and reloads effective paths
+- **And** the section explains these are read-only sources CoC never installs into
+
+---
+
+**US-12 — Toggle default folder auto-detection**
+> As an administrator, I want to enable or disable OneDrive/CloudStorage skill-folder auto-detection.
+
+- **Given** the Config sub-tab is active
+- **Then** the **Detected Skill Folders** section shows an auto-detect checkbox reflecting `autoDetectDefaultFolders` (defaults to on when the field is omitted) and lists the auto-detected folders from `skills.getEffectivePaths()`
+- **When** no OneDrive skill folder exists
+- **Then** the section shows a compact "No OneDrive skill folders detected." state rather than every possible default path
+- **When** a OneDrive root exists but lacks `.github/skills`
+- **Then** that root appears only inside a collapsed `<details>` diagnostics row, not the main list
+- **When** the user toggles the checkbox
+- **Then** the panel persists `skills.updateGlobalConfig({ globalDisabledSkills, autoDetectDefaultFolders })` and reloads effective paths
+
+---
+
+**US-13 — View the effective search order**
+> As an administrator, I want to see the folders the agent will actually search, in order.
+
+- **Given** the Config sub-tab is active
+- **Then** the **Effective Search Order** section renders a read-only ordered list from `skills.getEffectivePaths()` (called global-only, with no workspaceId), each row showing a source badge, a status badge, the path, and an optional skill count
+- **And** a "Showing global paths only" note clarifies that repo-local and per-repo paths are not claimed to apply globally
 
 ---
 
@@ -193,13 +232,20 @@ Skills installed here live under `~/.coc/skills/` and are available globally acr
 
 ### 4.4 Config Sub-Tab
 
+Sections render in order: Global Skills Directory → Global Extra Skill Folders → Detected Skill Folders → Effective Search Order → Globally Disabled Skills.
+
 | Feature | Acceptance Criteria |
 |---|---|
-| Skills directory | Read-only monospace; fallback `~/.coc/skills/` |
+| Global Skills Directory | Single read-only monospace managed location; fallback `~/.coc/skills/`; never multi-value |
+| Global Extra Skill Folders | Chips with `✕`; input + Add button (Enter also adds); absolute or `~`-prefixed; deduped; persists `globalExtraFolders` |
+| Detected Skill Folders | Auto-detect checkbox bound to `autoDetectDefaultFolders` (default on); lists auto-detected entries from `getEffectivePaths`; compact "No OneDrive skill folders detected." empty state; skipped roots in a collapsed `<details>` diagnostics row |
+| Effective Search Order | Read-only ordered list from `getEffectivePaths()` (global-only, no workspaceId); source badge + status badge + path + optional skill count per row; "Showing global paths only" note |
 | Disabled chips | Red chips with `✕` to remove |
 | Add disabled | Input + Disable button; Enter key also adds; deduped against current list |
-| Save | `skills.updateGlobalConfig` on every add/remove (no batch) |
+| Save | `skills.updateGlobalConfig` on every add/remove/toggle (no batch); disabled-skill writes send only `{ globalDisabledSkills }`; folder/toggle writes add their field alongside the required disabled list |
 | Note | "Per-repo disabled skills are managed in each repo's Copilot settings" |
+
+**Source badges:** `managed-global → Managed`, `configured → Configured`, `auto-detected → Auto-detected`, `repo`/`repo-extra → Repo`, `bundled → Bundled`. **Status badges:** `available → Available`, `missing → Missing`, `no-skills → No skills`, `skipped → Skipped`. Skill listings additionally use the `global-extra-folder` source for skills loaded from configured global extra folders (see Repo Settings → Agent Skills grouping).
 
 ### 4.5 Server-Side Mirroring (background, no UI surface)
 
@@ -281,7 +327,8 @@ All routes are rooted at `/api/skills/*` and surfaced through `getSpaCocClient()
 | `skills.getGlobalConfig()` (`GET /api/skills/config`) | Config tab + installed enable state | US-03, US-09, US-10 |
 | `skills.detailGlobal(name)` (`GET /api/skills/<name>`) | Skill detail expand | US-02 |
 | `skills.deleteGlobal(name)` (`DELETE /api/skills/<name>`) | Uninstall | US-04 |
-| `skills.updateGlobalConfig({ globalDisabledSkills })` (`PUT /api/skills/config`) | Toggle / disable | US-03, US-10 |
+| `skills.updateGlobalConfig({ globalDisabledSkills, globalExtraFolders?, autoDetectDefaultFolders? })` (`PUT /api/skills/config`) | Toggle / disable / folder sources / auto-detect | US-03, US-10, US-11, US-12 |
+| `skills.getEffectivePaths()` (`GET /api/skills/effective-paths`) | Detected folders + effective search order | US-12, US-13 |
 | `skills.listBundledGlobal()` (`GET /api/skills/bundled`) | Built-in gallery list | US-05 |
 | `skills.scanGlobal({ url })` (`POST /api/skills/scan`) | Scan remote/local | US-06, US-07, US-08 |
 | `skills.installGlobal({ source\|url, skills\|skillsToInstall, replace })` (`POST /api/skills/install`) | Install | US-05, US-06, US-07, US-08 |
@@ -294,3 +341,4 @@ All routes are rooted at `/api/skills/*` and surfaced through `getSpaCocClient()
 |---|---|---|
 | 1.0.0 | 2026-03-25 | Initial specification (top-level Skills tab; sub-tabs Installed / Bundled / Config) |
 | 2.0.0 | 2026-05-29 | Embedded inside Admin shell's Knowledge group; sub-tab `bundled` renamed to `gallery` (with back-compat redirect from `#skills/bundled`); 4-source Gallery toggle (Built-in / GitHub / ClawHub / Local Path); documented Codex/Claude server-side skill mirroring as background context. |
+| 2.1.0 | 2026-07-01 | Config sub-tab expanded to five ordered sections (Global Skills Directory / Global Extra Skill Folders / Detected Skill Folders / Effective Search Order / Globally Disabled Skills); added global extra folders (`skills.globalExtraFolders`) and OneDrive/CloudStorage auto-detection toggle (`skills.autoDetectDefaultFolders`); added the effective-search-order diagnostic (`GET /api/skills/effective-paths`) with source/status badge vocab; documented the `global-extra-folder` skill source (US-11/12/13). |

--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -301,6 +301,17 @@ export interface CLIConfig {
         autoUpdate?: boolean;
         /** Bundled skills to auto-install on first serve startup if not already present */
         defaultSkills?: string[];
+        /**
+         * Additional global skill-source folders applied across all workspaces.
+         * Read-only sources (CoC never installs/deletes into them). Absolute
+         * paths or `~`-prefixed home paths.
+         */
+        globalExtraFolders?: string[];
+        /**
+         * Auto-detect default skill folders (OneDrive/CloudStorage). Default true.
+         * Set false to disable all default folder auto-detection.
+         */
+        autoDetectDefaultFolders?: boolean;
     };
     /** Work Items configuration */
     workItems?: {
@@ -603,6 +614,14 @@ export interface ResolvedCLIConfig {
         autoUpdate: boolean;
         /** Bundled skills to auto-install on first serve startup if not already present */
         defaultSkills: string[];
+        /**
+         * Additional global skill-source folders applied across all workspaces.
+         * Read-only sources (CoC never installs/deletes into them). Absolute
+         * paths or `~`-prefixed home paths.
+         */
+        globalExtraFolders: string[];
+        /** Auto-detect default skill folders (OneDrive/CloudStorage). */
+        autoDetectDefaultFolders: boolean;
     };
     /** Work Items configuration */
     workItems: {
@@ -838,6 +857,8 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
     skills: {
         autoUpdate: true,
         defaultSkills: [...DEFAULT_BUNDLED_SKILLS],
+        globalExtraFolders: [],
+        autoDetectDefaultFolders: true,
     },
     workItems: {
         hierarchy: {

--- a/packages/coc/src/config/namespace-registry.ts
+++ b/packages/coc/src/config/namespace-registry.ts
@@ -294,6 +294,8 @@ export function createConfigNamespaceRegistry(defaultBundledSkills: readonly str
                 skills: {
                     autoUpdate: override?.skills?.autoUpdate ?? base.skills?.autoUpdate ?? true,
                     defaultSkills: override?.skills?.defaultSkills ?? base.skills?.defaultSkills ?? [...defaultBundledSkills],
+                    globalExtraFolders: override?.skills?.globalExtraFolders ?? base.skills?.globalExtraFolders ?? [],
+                    autoDetectDefaultFolders: override?.skills?.autoDetectDefaultFolders ?? base.skills?.autoDetectDefaultFolders ?? true,
                 },
             }),
         },

--- a/packages/coc/src/config/schema.ts
+++ b/packages/coc/src/config/schema.ts
@@ -208,6 +208,8 @@ const BASE_SCHEMA_TREE: SchemaTree = {
     skills: {
         autoUpdate: z.boolean(),
         defaultSkills: z.array(z.string()),
+        globalExtraFolders: z.array(z.string()),
+        autoDetectDefaultFolders: z.boolean(),
     },
 };
 

--- a/packages/coc/src/server/executors/skill-config-resolver.ts
+++ b/packages/coc/src/server/executors/skill-config-resolver.ts
@@ -22,6 +22,41 @@ import {
 } from '@plusplusoneplusplus/forge';
 import { getEffectiveEnDevExtraSkillFolders } from '../endev/endev-detector';
 
+/**
+ * Enumerate default OneDrive/CloudStorage skill-folder candidates for a home
+ * directory. Returns candidate `<root>/.github/skills` paths to probe; callers
+ * are responsible for filtering to those that actually exist (existence is not
+ * checked here so the result stays deterministic and cheap to test).
+ *
+ * Covers:
+ *  - Windows-style OneDrive roots: `~/OneDrive`, `~/OneDrive - Microsoft`
+ *  - macOS CloudStorage roots: `~/Library/CloudStorage/OneDrive-*`
+ *    (dynamically named, e.g. `OneDrive-Personal`, `OneDrive-Microsoft`)
+ */
+export async function resolveDefaultOneDriveSkillDirs(homedir: string): Promise<string[]> {
+    const candidates: string[] = [];
+
+    // Windows-style fixed OneDrive roots.
+    for (const variant of ['OneDrive', 'OneDrive - Microsoft']) {
+        candidates.push(path.join(homedir, variant, '.github', 'skills'));
+    }
+
+    // macOS CloudStorage OneDrive roots (dynamically named under Library/CloudStorage).
+    const cloudStorageDir = path.join(homedir, 'Library', 'CloudStorage');
+    try {
+        const entries = await fs.promises.readdir(cloudStorageDir, { withFileTypes: true });
+        for (const entry of entries) {
+            if ((entry.isDirectory() || entry.isSymbolicLink()) && entry.name.startsWith('OneDrive')) {
+                candidates.push(path.join(cloudStorageDir, entry.name, '.github', 'skills'));
+            }
+        }
+    } catch {
+        // Non-fatal: no CloudStorage directory (non-macOS host or OneDrive not installed).
+    }
+
+    return candidates;
+}
+
 export async function resolveSkillConfig(
     store: ProcessStore,
     dataDir: string | undefined,
@@ -102,10 +137,9 @@ export async function resolveSkillConfig(
         await tryAddSkillDirectory(globalSkillsDir, globalSkillsDir);
     }
 
-    // Check OneDrive-based default skill directories (Windows)
+    // Check default OneDrive skill directories (Windows-style roots + macOS CloudStorage).
     const homedir = os.homedir();
-    for (const variant of ['OneDrive', 'OneDrive - Microsoft']) {
-        const oneDriveSkillsDir = path.join(homedir, variant, '.github', 'skills');
+    for (const oneDriveSkillsDir of await resolveDefaultOneDriveSkillDirs(homedir)) {
         await tryAddSkillDirectory(oneDriveSkillsDir, oneDriveSkillsDir);
     }
 

--- a/packages/coc/src/server/executors/skill-config-resolver.ts
+++ b/packages/coc/src/server/executors/skill-config-resolver.ts
@@ -237,3 +237,188 @@ export async function resolveSkillConfig(
         disabledSkills,
     };
 }
+
+/**
+ * A single directory in the agent's effective skill search order, annotated for
+ * diagnostic display. Unlike {@link resolveSkillConfig} — which drops any
+ * directory that does not exist — this enumeration keeps declared-but-missing
+ * sources so the UI can explain what the agent will (and will not) use.
+ */
+export interface EffectiveSkillPathEntry {
+    /** Where the path comes from; drives the UI source badge. */
+    source: 'repo' | 'managed-global' | 'auto-detected' | 'configured' | 'repo-extra' | 'bundled';
+    /** Whether the path applies globally or only to a specific workspace. */
+    scope: 'global' | 'workspace';
+    /** Availability of the path; drives the UI status badge. */
+    status: 'available' | 'no-skills' | 'missing' | 'skipped';
+    /** Absolute host-filesystem path (or the raw configured value when skipped). */
+    path: string;
+    /** Installed skill count found in the directory (present only when it exists). */
+    skillCount?: number;
+    /** Optional human-readable note (e.g. why a declared folder was skipped). */
+    note?: string;
+}
+
+/** Inputs for {@link resolveEffectiveSkillPaths}. */
+export interface ResolveEffectiveSkillPathsArgs {
+    /** CoC data directory (`~/.coc`); managed global skills live at `<dataDir>/skills`. */
+    dataDir?: string;
+    /** Home directory used for OneDrive/CloudStorage detection. Defaults to `os.homedir()`. */
+    homedir?: string;
+    /** Active workspace root; when set, repo-local + per-repo extra folders are included (scope: workspace). */
+    workspaceRootPath?: string;
+    /** Per-repo extra skill folders for the active workspace (already resolved from workspace config). */
+    extraSkillFolders?: string[];
+    /** Configured global extra skill folders (`skills.globalExtraFolders`). */
+    globalExtraFolders?: string[];
+    /** Whether OneDrive/CloudStorage auto-detection is enabled. Defaults to true. */
+    autoDetectDefaultFolders?: boolean;
+}
+
+/** Count installed skills (subdirectories containing SKILL.md) in a directory. */
+async function countInstalledSkills(dir: string): Promise<number> {
+    try {
+        const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+        let count = 0;
+        for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const hasSkillMd = await fs.promises
+                .access(path.join(dir, entry.name, 'SKILL.md'))
+                .then(() => true)
+                .catch(() => false);
+            if (hasSkillMd) count++;
+        }
+        return count;
+    } catch {
+        return 0;
+    }
+}
+
+/**
+ * Probe a declared skill directory on the host filesystem and classify it as
+ * available/no-skills/missing with a skill count.
+ */
+async function describeSkillDir(
+    hostPath: string,
+    source: EffectiveSkillPathEntry['source'],
+    scope: EffectiveSkillPathEntry['scope'],
+): Promise<EffectiveSkillPathEntry> {
+    const exists = await fs.promises.access(hostPath).then(() => true).catch(() => false);
+    if (!exists) {
+        return { source, scope, status: 'missing', path: hostPath };
+    }
+    const skillCount = await countInstalledSkills(hostPath);
+    return {
+        source,
+        scope,
+        status: skillCount > 0 ? 'available' : 'no-skills',
+        path: hostPath,
+        skillCount,
+    };
+}
+
+/**
+ * Enumerate the agent's effective skill search order as structured diagnostic
+ * data, in priority order:
+ *
+ *   repo-local → managed global → auto-detected OneDrive/CloudStorage →
+ *   configured global extra → per-repo extra → bundled
+ *
+ * Global-scoped sources are always included; workspace-scoped sources
+ * (repo-local, per-repo extra) are included only when `workspaceRootPath` is
+ * supplied — so the global Config tab can render global-only paths and repo
+ * settings can render workspace-specific paths. Auto-detected OneDrive folders
+ * are surfaced only when they actually exist, keeping the diagnostic view from
+ * being flooded with missing default paths (AC #7).
+ */
+export async function resolveEffectiveSkillPaths(
+    args: ResolveEffectiveSkillPathsArgs,
+): Promise<EffectiveSkillPathEntry[]> {
+    const homedir = args.homedir ?? os.homedir();
+    const entries: EffectiveSkillPathEntry[] = [];
+
+    // 1. Repo-local .github/skills (workspace-scoped).
+    if (args.workspaceRootPath) {
+        try {
+            const hostPath = resolvePathForHostFilesystem(args.workspaceRootPath, DEFAULT_SKILLS_SETTINGS.installPath);
+            entries.push(await describeSkillDir(hostPath, 'repo', 'workspace'));
+        } catch {
+            // Non-fatal: skip repo-local when path translation fails.
+        }
+    }
+
+    // 2. Managed global ~/.coc/skills (global-scoped).
+    if (args.dataDir) {
+        const hostPath = path.join(args.dataDir, 'skills');
+        entries.push(await describeSkillDir(hostPath, 'managed-global', 'global'));
+    }
+
+    // 3. Auto-detected OneDrive/CloudStorage — surface only those that exist.
+    if (args.autoDetectDefaultFolders !== false) {
+        for (const candidate of await resolveDefaultOneDriveSkillDirs(homedir)) {
+            const exists = await fs.promises.access(candidate).then(() => true).catch(() => false);
+            if (!exists) continue;
+            const skillCount = await countInstalledSkills(candidate);
+            entries.push({
+                source: 'auto-detected',
+                scope: 'global',
+                status: skillCount > 0 ? 'available' : 'no-skills',
+                path: candidate,
+                skillCount,
+            });
+        }
+    }
+
+    // 4. Configured global extra folders (global-scoped, read-only).
+    if (Array.isArray(args.globalExtraFolders)) {
+        for (const folder of args.globalExtraFolders) {
+            if (typeof folder !== 'string' || folder.trim().length === 0) continue;
+            const expanded = expandHomePath(folder, homedir);
+            const isAbsoluteOrWsl = path.isAbsolute(expanded)
+                || resolveWorkspaceExecutionContext(expanded).kind === 'wsl';
+            if (!isAbsoluteOrWsl) {
+                entries.push({
+                    source: 'configured',
+                    scope: 'global',
+                    status: 'skipped',
+                    path: folder,
+                    note: 'Global extra folders must be absolute paths',
+                });
+                continue;
+            }
+            try {
+                const hostPath = resolvePathForHostFilesystem(expanded);
+                entries.push(await describeSkillDir(hostPath, 'configured', 'global'));
+            } catch {
+                entries.push({ source: 'configured', scope: 'global', status: 'skipped', path: folder, note: 'Path could not be resolved' });
+            }
+        }
+    }
+
+    // 5. Per-repo extra folders (workspace-scoped).
+    if (args.workspaceRootPath && Array.isArray(args.extraSkillFolders)) {
+        for (const folder of args.extraSkillFolders) {
+            if (typeof folder !== 'string' || folder.trim().length === 0) continue;
+            try {
+                const isAbsoluteOrWsl = path.isAbsolute(folder)
+                    || resolveWorkspaceExecutionContext(folder).kind === 'wsl';
+                const hostPath = isAbsoluteOrWsl
+                    ? resolvePathForHostFilesystem(folder)
+                    : resolvePathForHostFilesystem(args.workspaceRootPath, folder);
+                entries.push(await describeSkillDir(hostPath, 'repo-extra', 'workspace'));
+            } catch {
+                entries.push({ source: 'repo-extra', scope: 'workspace', status: 'skipped', path: folder, note: 'Path could not be resolved' });
+            }
+        }
+    }
+
+    // 6. Bundled skills (global-scoped, lowest priority).
+    try {
+        const bundledDir = getBundledSkillsPath();
+        entries.push(await describeSkillDir(bundledDir, 'bundled', 'global'));
+    } catch {
+        // Non-fatal
+    }
+
+    return entries;
+}

--- a/packages/coc/src/server/executors/skill-config-resolver.ts
+++ b/packages/coc/src/server/executors/skill-config-resolver.ts
@@ -353,19 +353,38 @@ export async function resolveEffectiveSkillPaths(
         entries.push(await describeSkillDir(hostPath, 'managed-global', 'global'));
     }
 
-    // 3. Auto-detected OneDrive/CloudStorage — surface only those that exist.
+    // 3. Auto-detected OneDrive/CloudStorage. Surface existing `.github/skills`
+    // folders, and add a `skipped` diagnostic when a OneDrive root exists but has
+    // no `.github/skills` beneath it (so the UI can explain why a known root was
+    // passed over). Roots that don't exist at all stay silent, keeping the
+    // diagnostic view from being flooded with missing default paths (AC #7).
     if (args.autoDetectDefaultFolders !== false) {
         for (const candidate of await resolveDefaultOneDriveSkillDirs(homedir)) {
             const exists = await fs.promises.access(candidate).then(() => true).catch(() => false);
-            if (!exists) continue;
-            const skillCount = await countInstalledSkills(candidate);
-            entries.push({
-                source: 'auto-detected',
-                scope: 'global',
-                status: skillCount > 0 ? 'available' : 'no-skills',
-                path: candidate,
-                skillCount,
-            });
+            if (exists) {
+                const skillCount = await countInstalledSkills(candidate);
+                entries.push({
+                    source: 'auto-detected',
+                    scope: 'global',
+                    status: skillCount > 0 ? 'available' : 'no-skills',
+                    path: candidate,
+                    skillCount,
+                });
+                continue;
+            }
+            // `<root>/.github/skills` is missing. If the OneDrive root itself
+            // exists, note it as skipped; otherwise stay silent.
+            const root = path.dirname(path.dirname(candidate));
+            const rootExists = await fs.promises.access(root).then(() => true).catch(() => false);
+            if (rootExists) {
+                entries.push({
+                    source: 'auto-detected',
+                    scope: 'global',
+                    status: 'skipped',
+                    path: candidate,
+                    note: 'OneDrive root exists but has no .github/skills folder',
+                });
+            }
         }
     }
 

--- a/packages/coc/src/server/executors/skill-config-resolver.ts
+++ b/packages/coc/src/server/executors/skill-config-resolver.ts
@@ -33,6 +33,39 @@ import { getEffectiveEnDevExtraSkillFolders } from '../endev/endev-detector';
  *  - macOS CloudStorage roots: `~/Library/CloudStorage/OneDrive-*`
  *    (dynamically named, e.g. `OneDrive-Personal`, `OneDrive-Microsoft`)
  */
+/**
+ * Options controlling default and globally-configured skill folder sources.
+ * Sourced from the `skills` config namespace and plumbed in at the call site
+ * (queue-executor-bridge). Kept optional so the resolver stays testable in
+ * isolation and backward-compatible for callers that don't supply config.
+ */
+export interface SkillFolderOptions {
+    /**
+     * Configured global extra skill folders applied across all workspaces.
+     * Read-only sources (never installed/deleted into). Absolute paths or
+     * `~`-prefixed home paths; relative and malformed entries are skipped.
+     */
+    globalExtraFolders?: string[];
+    /**
+     * Auto-detect default skill folders (OneDrive/CloudStorage). Defaults to
+     * true when undefined; pass `false` to skip all default auto-detection.
+     */
+    autoDetectDefaultFolders?: boolean;
+}
+
+/**
+ * Expand a leading `~` (home directory) in a folder path. `~` alone maps to the
+ * home directory; `~/x` and `~\x` map beneath it. Any other value is returned
+ * unchanged so absolute paths pass through untouched.
+ */
+export function expandHomePath(folder: string, homedir: string): string {
+    if (folder === '~') return homedir;
+    if (folder.startsWith('~/') || folder.startsWith('~\\')) {
+        return path.join(homedir, folder.slice(2));
+    }
+    return folder;
+}
+
 export async function resolveDefaultOneDriveSkillDirs(homedir: string): Promise<string[]> {
     const candidates: string[] = [];
 
@@ -62,6 +95,7 @@ export async function resolveSkillConfig(
     dataDir: string | undefined,
     workspaceId: string | undefined,
     workingDirectory: string | undefined,
+    options?: SkillFolderOptions,
 ): Promise<{ skillDirectories?: string[]; disabledSkills?: string[] }> {
     let disabledSkills: string[] | undefined;
     let extraSkillFolders: string[] | undefined;
@@ -137,10 +171,37 @@ export async function resolveSkillConfig(
         await tryAddSkillDirectory(globalSkillsDir, globalSkillsDir);
     }
 
-    // Check default OneDrive skill directories (Windows-style roots + macOS CloudStorage).
     const homedir = os.homedir();
-    for (const oneDriveSkillsDir of await resolveDefaultOneDriveSkillDirs(homedir)) {
-        await tryAddSkillDirectory(oneDriveSkillsDir, oneDriveSkillsDir);
+
+    // Check default OneDrive skill directories (Windows-style roots + macOS
+    // CloudStorage), unless auto-detection is explicitly disabled.
+    if (options?.autoDetectDefaultFolders !== false) {
+        for (const oneDriveSkillsDir of await resolveDefaultOneDriveSkillDirs(homedir)) {
+            await tryAddSkillDirectory(oneDriveSkillsDir, oneDriveSkillsDir);
+        }
+    }
+
+    // Configured global extra skill folders (read-only, apply across all
+    // workspaces). Ordered after auto-detected folders and before per-workspace
+    // extra folders. Absolute or `~`-prefixed; relative/malformed entries skip.
+    if (Array.isArray(options?.globalExtraFolders)) {
+        for (const folder of options.globalExtraFolders) {
+            if (typeof folder !== 'string' || folder.trim().length === 0) {
+                continue;
+            }
+            try {
+                const expanded = expandHomePath(folder, homedir);
+                const isAbsoluteOrWsl = path.isAbsolute(expanded)
+                    || resolveWorkspaceExecutionContext(expanded).kind === 'wsl';
+                if (!isAbsoluteOrWsl) {
+                    continue; // global folders must be absolute (no repo root to anchor to)
+                }
+                const hostPath = resolvePathForHostFilesystem(expanded);
+                await tryAddSkillDirectory(expanded, hostPath);
+            } catch {
+                // Non-fatal: skip global extra folders when path translation fails
+            }
+        }
     }
 
     if (extraSkillFolders) {

--- a/packages/coc/src/server/queue/queue-executor-bridge.ts
+++ b/packages/coc/src/server/queue/queue-executor-bridge.ts
@@ -12,6 +12,7 @@ import { RalphSessionStore } from '../ralph/ralph-session-store';
 import { orchestrateRalphIteration } from '../ralph/orchestrate-iteration';
 import { orchestrateFinalCheck } from '../ralph/orchestrate-final-check';
 import { loadConfigFile, DEFAULT_CONFIG } from '../../config';
+import type { CLIConfig } from '../../config';
 import type { AutoProviderResolutionResult } from '../agent-providers/auto-provider-router';
 import type { AskUserAnswerInput, AskUserAnswerValue } from '../llm-tools/ask-user-tool';
 import { ASK_USER_RESUME_FAILED_MESSAGE, buildAskUserResumeMessage, buildPendingAskUserAnswerRecord } from '../llm-tools/ask-user-resume';
@@ -152,7 +153,21 @@ export class CLITaskExecutor extends BaseExecutor implements TaskExecutor {
             aiService: this.aiService,
             defaultWorkingDirectory: this.defaultWorkingDirectory,
         });
-        const skillCfg = (wsId: string | undefined, workDir?: string) => resolveSkillConfig(store, this.dataDir, wsId, workDir);
+        const skillCfg = (wsId: string | undefined, workDir?: string) => {
+            // Live-read the configured global skill-folder settings so the
+            // resolver honors `skills.globalExtraFolders` and
+            // `skills.autoDetectDefaultFolders` at execution time.
+            let skillsCfg: CLIConfig['skills'] | undefined;
+            try {
+                skillsCfg = loadConfigFile()?.skills;
+            } catch {
+                // Non-fatal: fall back to default folder resolution
+            }
+            return resolveSkillConfig(store, this.dataDir, wsId, workDir, {
+                globalExtraFolders: skillsCfg?.globalExtraFolders,
+                autoDetectDefaultFolders: skillsCfg?.autoDetectDefaultFolders,
+            });
+        };
         this.executors = new ExecutorRegistry(store, {
             approvePermissions: this.approvePermissions,
             defaultWorkingDirectory: this.defaultWorkingDirectory,

--- a/packages/coc/src/server/skills/global-skill-handler.ts
+++ b/packages/coc/src/server/skills/global-skill-handler.ts
@@ -18,6 +18,7 @@ import {
 import { sendJSON } from '../core/api-handler';
 import { parseBodyOrReject } from '../shared/handler-utils';
 import { handleAPIError, notFound, badRequest } from '../errors';
+import { loadConfigFile, writeConfigFile, getConfigFilePath, type CLIConfig } from '../../config';
 import { sortSkillsByUsage, listInstalledSkills, getSkillDetail, skillCache, loadSkillsForWorkspace, filterVisibleSkillsForWorkspace } from './skill-handler';
 import { createSkillRouteHandlers } from './skill-route-handlers';
 import type { Route } from '../types';
@@ -65,6 +66,70 @@ function writePreferences(dataDir: string, prefs: any): void {
     }
 }
 
+/**
+ * Injectable accessors for the CLI config file. Lets tests point the global
+ * extra-folder / auto-detect config at a temp file instead of the real
+ * `~/.coc/config.yaml`. Defaults to the real config functions.
+ */
+export interface GlobalSkillConfigAccess {
+    loadConfigFile: (configPath?: string) => CLIConfig | undefined;
+    writeConfigFile: (configPath: string, config: CLIConfig) => void;
+    getConfigFilePath: () => string;
+}
+
+const DEFAULT_CONFIG_ACCESS: GlobalSkillConfigAccess = { loadConfigFile, writeConfigFile, getConfigFilePath };
+
+/** Global folder-source settings surfaced by `/api/skills/config`. */
+interface GlobalSkillFolderConfig {
+    globalExtraFolders: string[];
+    autoDetectDefaultFolders: boolean;
+}
+
+/**
+ * Read `skills.globalExtraFolders` / `skills.autoDetectDefaultFolders` from the
+ * CLI config file. Missing/invalid values fall back to safe defaults
+ * (`[]` and `true`). Never throws — a malformed config yields defaults.
+ */
+function readGlobalSkillFolderConfig(access: GlobalSkillConfigAccess): GlobalSkillFolderConfig {
+    try {
+        const skills = access.loadConfigFile(access.getConfigFilePath())?.skills;
+        const folders = skills?.globalExtraFolders;
+        return {
+            globalExtraFolders: Array.isArray(folders)
+                ? folders.filter((f): f is string => typeof f === 'string')
+                : [],
+            autoDetectDefaultFolders: typeof skills?.autoDetectDefaultFolders === 'boolean'
+                ? skills.autoDetectDefaultFolders
+                : true,
+        };
+    } catch {
+        return { globalExtraFolders: [], autoDetectDefaultFolders: true };
+    }
+}
+
+/**
+ * Persist global folder-source settings into the CLI config file's `skills`
+ * namespace, preserving every other config field. Only the fields present in
+ * `patch` are written.
+ */
+function persistGlobalSkillFolderConfig(
+    access: GlobalSkillConfigAccess,
+    patch: Partial<GlobalSkillFolderConfig>,
+): void {
+    const configPath = access.getConfigFilePath();
+    let existing: CLIConfig;
+    try {
+        existing = access.loadConfigFile(configPath) ?? ({} as CLIConfig);
+    } catch {
+        existing = {} as CLIConfig;
+    }
+    const skills = { ...(existing.skills ?? {}) };
+    if (patch.globalExtraFolders !== undefined) skills.globalExtraFolders = patch.globalExtraFolders;
+    if (patch.autoDetectDefaultFolders !== undefined) skills.autoDetectDefaultFolders = patch.autoDetectDefaultFolders;
+    existing.skills = skills;
+    access.writeConfigFile(configPath, existing);
+}
+
 // ============================================================================
 // Route Registration
 // ============================================================================
@@ -72,7 +137,12 @@ function writePreferences(dataDir: string, prefs: any): void {
 /**
  * Register global skill management API routes on the given route table.
  */
-export function registerGlobalSkillRoutes(routes: Route[], store: ProcessStore, dataDir: string): void {
+export function registerGlobalSkillRoutes(
+    routes: Route[],
+    store: ProcessStore,
+    dataDir: string,
+    configAccess: GlobalSkillConfigAccess = DEFAULT_CONFIG_ACCESS,
+): void {
     const globalDir = getGlobalSkillsDir(dataDir);
 
     // GET /api/skills — List all global skills
@@ -135,14 +205,17 @@ export function registerGlobalSkillRoutes(routes: Route[], store: ProcessStore, 
         pattern: /^\/api\/skills\/config$/,
         handler: async (_req, res) => {
             const prefs = readPreferences(dataDir);
+            const folderCfg = readGlobalSkillFolderConfig(configAccess);
             sendJSON(res, 200, {
                 globalDisabledSkills: prefs?.globalDisabledSkills ?? [],
                 globalSkillsDir: globalDir,
+                globalExtraFolders: folderCfg.globalExtraFolders,
+                autoDetectDefaultFolders: folderCfg.autoDetectDefaultFolders,
             });
         },
     });
 
-    // PUT /api/skills/config — Update global disabled-skills list
+    // PUT /api/skills/config — Update global disabled-skills list + folder sources
     routes.push({
         method: 'PUT',
         pattern: /^\/api\/skills\/config$/,
@@ -153,17 +226,39 @@ export function registerGlobalSkillRoutes(routes: Route[], store: ProcessStore, 
             if (!Object.prototype.hasOwnProperty.call(body, 'globalDisabledSkills')) {
                 return handleAPIError(res, badRequest('`globalDisabledSkills` is required'));
             }
-            if (!Array.isArray(body.globalDisabledSkills)) {
+            if (!Array.isArray(body.globalDisabledSkills) || body.globalDisabledSkills.some((s: unknown) => typeof s !== 'string')) {
                 return handleAPIError(res, badRequest('`globalDisabledSkills` must be an array of strings'));
+            }
+
+            // Optional folder-source fields persisted to the config file's `skills` namespace.
+            const folderPatch: Partial<GlobalSkillFolderConfig> = {};
+            if (Object.prototype.hasOwnProperty.call(body, 'globalExtraFolders')) {
+                if (!Array.isArray(body.globalExtraFolders) || body.globalExtraFolders.some((f: unknown) => typeof f !== 'string')) {
+                    return handleAPIError(res, badRequest('`globalExtraFolders` must be an array of strings'));
+                }
+                folderPatch.globalExtraFolders = body.globalExtraFolders;
+            }
+            if (Object.prototype.hasOwnProperty.call(body, 'autoDetectDefaultFolders')) {
+                if (typeof body.autoDetectDefaultFolders !== 'boolean') {
+                    return handleAPIError(res, badRequest('`autoDetectDefaultFolders` must be a boolean'));
+                }
+                folderPatch.autoDetectDefaultFolders = body.autoDetectDefaultFolders;
             }
 
             const prefs = readPreferences(dataDir);
             prefs.globalDisabledSkills = body.globalDisabledSkills;
             writePreferences(dataDir, prefs);
 
+            if (folderPatch.globalExtraFolders !== undefined || folderPatch.autoDetectDefaultFolders !== undefined) {
+                persistGlobalSkillFolderConfig(configAccess, folderPatch);
+            }
+
+            const folderCfg = readGlobalSkillFolderConfig(configAccess);
             sendJSON(res, 200, {
                 globalDisabledSkills: body.globalDisabledSkills,
                 globalSkillsDir: globalDir,
+                globalExtraFolders: folderCfg.globalExtraFolders,
+                autoDetectDefaultFolders: folderCfg.autoDetectDefaultFolders,
             });
         },
     });

--- a/packages/coc/src/server/skills/global-skill-handler.ts
+++ b/packages/coc/src/server/skills/global-skill-handler.ts
@@ -363,7 +363,8 @@ export function registerGlobalSkillRoutes(
                 return handleAPIError(res, notFound('Workspace'));
             }
 
-            const allSkills = await loadSkillsForWorkspace(ws, dataDir, store);
+            const { globalExtraFolders } = readGlobalSkillFolderConfig(configAccess);
+            const allSkills = await loadSkillsForWorkspace(ws, dataDir, store, { globalExtraFolders });
             const visibleSkills = await filterVisibleSkillsForWorkspace(allSkills, ws, dataDir);
             const globalSkills = visibleSkills.filter(s => s.source === 'global');
             const repoSkills = visibleSkills.filter(s => s.source === 'repo');

--- a/packages/coc/src/server/skills/global-skill-handler.ts
+++ b/packages/coc/src/server/skills/global-skill-handler.ts
@@ -21,6 +21,8 @@ import { handleAPIError, notFound, badRequest } from '../errors';
 import { loadConfigFile, writeConfigFile, getConfigFilePath, type CLIConfig } from '../../config';
 import { sortSkillsByUsage, listInstalledSkills, getSkillDetail, skillCache, loadSkillsForWorkspace, filterVisibleSkillsForWorkspace } from './skill-handler';
 import { createSkillRouteHandlers } from './skill-route-handlers';
+import { resolveEffectiveSkillPaths } from '../executors/skill-config-resolver';
+import { getEffectiveEnDevExtraSkillFolders } from '../endev/endev-detector';
 import type { Route } from '../types';
 
 // ============================================================================
@@ -28,7 +30,7 @@ import type { Route } from '../types';
 // ============================================================================
 
 /** Skill names that collide with global sub-routes and must be rejected. */
-const RESERVED_GLOBAL_SKILL_NAMES = new Set(['bundled', 'scan', 'install', 'config']);
+const RESERVED_GLOBAL_SKILL_NAMES = new Set(['bundled', 'scan', 'install', 'config', 'effective-paths']);
 
 /** Remove duplicate skills by name, keeping the first occurrence. */
 function dedupByName<T extends { name: string }>(skills: T[]): T[] {
@@ -260,6 +262,49 @@ export function registerGlobalSkillRoutes(
                 globalExtraFolders: folderCfg.globalExtraFolders,
                 autoDetectDefaultFolders: folderCfg.autoDetectDefaultFolders,
             });
+        },
+    });
+
+    // GET /api/skills/effective-paths — Structured effective skill search order (read-only diagnostic)
+    //
+    // Global-only by default; pass `?workspaceId=<id>` to include workspace-scoped
+    // paths (repo-local + per-repo extra folders). Registered before /skills/:name
+    // so it is not swallowed by the catch-all skill-detail route.
+    routes.push({
+        method: 'GET',
+        pattern: /^\/api\/skills\/effective-paths$/,
+        handler: async (req, res) => {
+            const url = new URL(req.url ?? '', 'http://localhost');
+            const requestedWorkspaceId = url.searchParams.get('workspaceId') ?? undefined;
+
+            const folderCfg = readGlobalSkillFolderConfig(configAccess);
+
+            let workspaceRootPath: string | undefined;
+            let extraSkillFolders: string[] | undefined;
+            let resolvedWorkspaceId: string | undefined;
+            if (requestedWorkspaceId) {
+                try {
+                    const workspaces = await store.getWorkspaces();
+                    const ws = workspaces.find(w => w.id === requestedWorkspaceId);
+                    if (ws) {
+                        resolvedWorkspaceId = ws.id;
+                        workspaceRootPath = ws.rootPath;
+                        extraSkillFolders = await getEffectiveEnDevExtraSkillFolders(dataDir, ws);
+                    }
+                } catch {
+                    // Non-fatal: fall back to a global-only diagnostic.
+                }
+            }
+
+            const paths = await resolveEffectiveSkillPaths({
+                dataDir,
+                workspaceRootPath,
+                extraSkillFolders,
+                globalExtraFolders: folderCfg.globalExtraFolders,
+                autoDetectDefaultFolders: folderCfg.autoDetectDefaultFolders,
+            });
+
+            sendJSON(res, 200, { workspaceId: resolvedWorkspaceId, paths });
         },
     });
 

--- a/packages/coc/src/server/skills/skill-handler.ts
+++ b/packages/coc/src/server/skills/skill-handler.ts
@@ -10,6 +10,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import type { ProcessStore, WorkspaceInfo } from '@plusplusoneplusplus/forge';
 import {
     getBundledSkills,
@@ -25,6 +26,8 @@ import { handleAPIError, notFound, badRequest, internalError } from '../errors';
 import { resolveWorkspaceOrFail } from '../shared/handler-utils';
 import { createSkillRouteHandlers } from './skill-route-handlers';
 import { getRepoDataPath } from '../paths';
+import { loadConfigFile } from '../../config';
+import { expandHomePath } from '../executors/skill-config-resolver';
 import type { Route } from '../types';
 import {
     ENDEV_XDPU_SKILL_NAME,
@@ -72,6 +75,53 @@ function resolveExtraSkillFolderInstallPath(workspaceRoot: string, folder: strin
 }
 
 /**
+ * Read configured global extra skill folders (`skills.globalExtraFolders`) from
+ * the CLI config file. These are read-only skill sources applied across all
+ * workspaces (CoC never installs/deletes into them). Never throws — a missing or
+ * malformed config yields an empty list, and non-array/non-string shapes are
+ * dropped. The config loader is injectable so callers/tests can supply a
+ * hermetic config instead of reading the real `~/.coc/config.yaml`.
+ */
+export function readConfiguredGlobalExtraFolders(
+    load: () => { skills?: { globalExtraFolders?: unknown } } | undefined = loadConfigFile,
+): string[] {
+    try {
+        const folders = load()?.skills?.globalExtraFolders;
+        return Array.isArray(folders)
+            ? folders.filter((f): f is string => typeof f === 'string')
+            : [];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Resolve a configured global extra skill folder to its source + host install
+ * paths. Global extra folders are read-only sources that must be absolute (or a
+ * WSL path) after `~` expansion — there is no repo root to anchor a relative
+ * value to — so relative and malformed entries return null and are skipped,
+ * mirroring the runtime resolver's handling.
+ */
+function resolveGlobalExtraSkillFolderPaths(
+    folder: string,
+): { sourcePath: string; installPath: string } | null {
+    if (typeof folder !== 'string' || folder.trim().length === 0) {
+        return null;
+    }
+    const expanded = expandHomePath(folder, os.homedir());
+    const isAbsoluteOrWsl = path.isAbsolute(expanded)
+        || resolveWorkspaceExecutionContext(expanded).kind === 'wsl';
+    if (!isAbsoluteOrWsl) {
+        return null;
+    }
+    try {
+        return { sourcePath: expanded, installPath: resolvePathForHostFilesystem(expanded) };
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Sort skills by most-recently-used first, then alphabetically.
  * Skills with a usage timestamp are sorted most-recent-first;
  * unused skills follow in A→Z order.
@@ -101,7 +151,7 @@ export interface SkillInfo {
     references?: string[];
     scripts?: string[];
     relativePath?: string;
-    source?: 'global' | 'repo' | 'bundled' | 'linked-repo' | 'extra-folder';
+    source?: 'global' | 'repo' | 'bundled' | 'linked-repo' | 'extra-folder' | 'global-extra-folder';
     /** Workspace ID of the repo this skill was loaded from (only set when source = 'linked-repo'). */
     sourceRepoId?: string;
     /** Absolute path of the directory containing this skill. */
@@ -317,10 +367,20 @@ export async function filterVisibleSkillsForWorkspace(
         : skills.filter(skill => skill.name !== ENDEV_XDPU_SKILL_NAME);
 }
 
+/** Options for {@link loadSkillsForWorkspace}. */
+export interface LoadSkillsOptions {
+    /**
+     * Configured global extra skill folders (`skills.globalExtraFolders`),
+     * already read from config. Read-only sources listed across all workspaces.
+     */
+    globalExtraFolders?: string[];
+}
+
 export async function loadSkillsForWorkspace(
     ws: WorkspaceInfo,
     dataDir: string | undefined,
     store: ProcessStore,
+    options?: LoadSkillsOptions,
 ): Promise<SkillInfo[]> {
     const id = ws.id;
     const installPath = getSkillsInstallPath(ws.rootPath);
@@ -345,6 +405,26 @@ export async function loadSkillsForWorkspace(
     }
     const globalNames = new Set(globalSkills.map(s => s.name));
 
+    // Configured global extra folders (read-only, apply across all workspaces).
+    // Ordered after managed-global skills and before per-workspace extra folders
+    // to match the runtime resolver's priority. A skill already provided by the
+    // repo, the managed global dir, or an earlier global extra folder wins.
+    const globalExtraSkills: SkillInfo[] = [];
+    const globalExtraNames = new Set<string>();
+    for (const folder of options?.globalExtraFolders ?? []) {
+        const resolved = resolveGlobalExtraSkillFolderPaths(folder);
+        if (!resolved) continue;
+        for (const skill of listInstalledSkills(resolved.installPath)) {
+            if (localNames.has(skill.name) || globalNames.has(skill.name) || globalExtraNames.has(skill.name)) {
+                continue;
+            }
+            skill.source = 'global-extra-folder';
+            skill.folderPath = resolved.sourcePath;
+            globalExtraSkills.push(skill);
+            globalExtraNames.add(skill.name);
+        }
+    }
+
     let allWorkspaces: WorkspaceInfo[] | null = null;
     const extraSkillFolders = await getEffectiveEnDevExtraSkillFolders(dataDir, ws);
     const extraSkills: SkillInfo[] = [];
@@ -366,7 +446,7 @@ export async function loadSkillsForWorkspace(
             }
         }
         for (const skill of folderSkills) {
-            if (localNames.has(skill.name) || globalNames.has(skill.name)) continue;
+            if (localNames.has(skill.name) || globalNames.has(skill.name) || globalExtraNames.has(skill.name)) continue;
             skill.folderPath = folderSourcePath;
             if (sourceRepoId) {
                 skill.source = 'linked-repo';
@@ -378,7 +458,7 @@ export async function loadSkillsForWorkspace(
         }
     }
 
-    let skills = dedupByName([...localSkills, ...globalSkills, ...extraSkills]);
+    let skills = dedupByName([...localSkills, ...globalSkills, ...globalExtraSkills, ...extraSkills]);
     if (dataDir) {
         try {
             const repoPrefsPath = getRepoDataPath(dataDir, id, 'preferences.json');
@@ -404,8 +484,17 @@ export async function loadSkillsForWorkspace(
 /**
  * Register skill management API routes on the given route table.
  * @param dataDir - Optional data directory for reading preferences (skill usage ordering).
+ * @param readGlobalExtraFolders - Reader for configured global extra skill
+ *   folders (`skills.globalExtraFolders`); defaults to reading the CLI config
+ *   file. Injectable so tests can supply hermetic folders instead of the real
+ *   `~/.coc/config.yaml`.
  */
-export function registerSkillRoutes(routes: Route[], store: ProcessStore, dataDir?: string): void {
+export function registerSkillRoutes(
+    routes: Route[],
+    store: ProcessStore,
+    dataDir?: string,
+    readGlobalExtraFolders: () => string[] = readConfiguredGlobalExtraFolders,
+): void {
 
     // GET /api/workspaces/:id/skills — List installed skills (including global and extra folders)
     routes.push({
@@ -415,6 +504,7 @@ export function registerSkillRoutes(routes: Route[], store: ProcessStore, dataDi
             const ws = await resolveWorkspaceOrFail(store, match!, res);
             if (!ws) return;
             const wsId = ws.id;
+            const globalExtraFolders = readGlobalExtraFolders();
 
             const cached = skillCache.get(wsId);
             if (cached) {
@@ -424,7 +514,7 @@ export function registerSkillRoutes(routes: Route[], store: ProcessStore, dataDi
                 const stale = Date.now() - cached.lastUpdated > SKILL_CACHE_TTL_MS;
                 if (stale && !cached.refreshing) {
                     cached.refreshing = true;
-                    loadSkillsForWorkspace(ws, dataDir, store)
+                    loadSkillsForWorkspace(ws, dataDir, store, { globalExtraFolders })
                         .then(skills => skillCache.set(wsId, { skills, refreshing: false, lastUpdated: Date.now() }))
                         .catch(() => { cached.refreshing = false; });
                 }
@@ -432,7 +522,7 @@ export function registerSkillRoutes(routes: Route[], store: ProcessStore, dataDi
             }
 
             // Cache miss: load synchronously, populate cache, then respond
-            const rawSkills = await loadSkillsForWorkspace(ws, dataDir, store);
+            const rawSkills = await loadSkillsForWorkspace(ws, dataDir, store, { globalExtraFolders });
             skillCache.set(wsId, { skills: rawSkills, refreshing: false, lastUpdated: Date.now() });
             const skills = await filterVisibleSkillsForWorkspace(rawSkills, ws, dataDir);
             sendJSON(res, 200, { skills });
@@ -519,7 +609,7 @@ export function registerSkillRoutes(routes: Route[], store: ProcessStore, dataDi
                 return handleAPIError(res, badRequest('`path` query parameter is required'));
             }
 
-            const skills = await loadSkillsForWorkspace(ws, dataDir, store);
+            const skills = await loadSkillsForWorkspace(ws, dataDir, store, { globalExtraFolders: readGlobalExtraFolders() });
             const skill = skills.find(s => s.name === skillName);
             if (!skill || !skill.folderPath) {
                 return handleAPIError(res, notFound('Skill'));

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -1045,6 +1045,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                 id: m.id,
                 content: m.content,
                 status: 'queued' as const,
+                ...(Array.isArray(m.images) && m.images.length > 0 ? { images: m.images } : {}),
             })));
         } catch { /* keep current turns */ }
     }, [client, setTurnsAndRef]);

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -33,7 +33,7 @@ import { groupByForEachRun, getForEachEntryTimestamp, getForEachRunId, type ForE
 import { ForEachRunRow } from './ForEachRunRow';
 import { groupByMapReduceRun, getMapReduceEntryTimestamp, getMapReduceRunId, type MapReduceRunGroup, type MapReduceRunHistoryEntry } from './map-reduce-run-grouping';
 import { MapReduceRunRow } from './MapReduceRunRow';
-import { buildSpawnedTreeChatView, collectSpawnedEntryTasks, getSpawnedEntryTimestamp, isSpawnedTreeEntry, type SpawnedTreeEntry } from './spawned-tree-grouping';
+import { buildSpawnedTreeChatView, collectSpawnedEntryTasks, getSpawnedEntryTimestamp, isSpawnedTreeEntry, partitionSpawnedTreesByArchived, type SpawnedTreeEntry } from './spawned-tree-grouping';
 import { SpawnedTreeRow } from './SpawnedTreeRow';
 import { isSpawnedTreeViewEnabled, loadCollapsedSpawnedRootIds, toggleCollapsedSpawnedRoot } from './spawned-tree-view-state';
 import { getGroupPinKey, isPinnedGroupEntry, mergePinnedEntries, partitionPinnedGroups, type PinnedGroupEntry, type PinnedListEntry } from './group-pinning';
@@ -1147,12 +1147,38 @@ export function ChatListPane({
     }, [spawnedTreeEnabled, tabFilteredRunning, tabFilteredQueued, tabFilteredHistory, unseenProcessIds, workflowGroupedTaskIds]);
     const spawnedTreeGroups = spawnedTreeView.groups;
 
+    // AC-01/AC-02: when a chat that is a spawned-tree node is archived, its whole
+    // subtree must leave COMPLETED and render as a nested tree under ARCHIVED.
+    // Split each tree at the shallowest explicitly-archived node (display-only,
+    // recomputed from `archivedChatIds` each render — no cascade write): the
+    // active remainder stays in COMPLETED, the archived subtree(s) move to
+    // ARCHIVED, and a root/leaf pruned to a childless node demotes to a flat row.
+    // When the flag is off `spawnedTreeGroups` is empty, so the partition is inert.
+    const spawnedArchivePartition = useMemo(
+        () => partitionSpawnedTreesByArchived(spawnedTreeGroups, archivedChatIds, unseenProcessIds),
+        [spawnedTreeGroups, archivedChatIds, unseenProcessIds],
+    );
+    const activeSpawnedTreeGroups = spawnedArchivePartition.activeGroups;
+    const archivedSpawnedTreeGroups = spawnedArchivePartition.archivedGroups;
+
     const groupedTaskIds = useMemo(() => {
         if (spawnedTreeView.hiddenIds.size === 0) return workflowGroupedTaskIds;
         const ids = new Set(workflowGroupedTaskIds);
         for (const id of spawnedTreeView.hiddenIds) ids.add(id);
+        // Roots/leaves demoted to a childless node by archiving no longer render
+        // inside a tree — surface them back into the flat lists so an active
+        // demoted root lands in COMPLETED and an archived demoted node lands in
+        // ARCHIVED, each keyed on its own per-chat state.
+        for (const task of spawnedArchivePartition.activeTasks) {
+            ids.delete(task.id);
+            if (typeof task.processId === 'string') ids.delete(task.processId);
+        }
+        for (const task of spawnedArchivePartition.archivedTasks) {
+            ids.delete(task.id);
+            if (typeof task.processId === 'string') ids.delete(task.processId);
+        }
         return ids;
-    }, [workflowGroupedTaskIds, spawnedTreeView]);
+    }, [workflowGroupedTaskIds, spawnedTreeView, spawnedArchivePartition]);
 
     const visibleTabFilteredRunning = useMemo(
         () => tabFilteredRunning.filter(task => !taskIdentityMatches(task, groupedTaskIds)),
@@ -1171,7 +1197,7 @@ export function ChatListPane({
         const liveQueue = queued.filter((t: any) => t.kind !== 'pause-marker');
         const allRaw = [...running, ...liveQueue, ...history];
         const all = allRaw.filter((task: any) => !taskIdentityMatches(task, groupedTaskIds));
-        let chat = forEachRunGroups.length + mapReduceRunGroups.length + spawnedTreeGroups.length;
+        let chat = forEachRunGroups.length + mapReduceRunGroups.length + activeSpawnedTreeGroups.length + archivedSpawnedTreeGroups.length;
         let auto = 0;
         for (const t of all) {
             // Scheduled runs are pulled out of Chats/Automations and shown under
@@ -1189,8 +1215,8 @@ export function ChatListPane({
             if (scheduled) hasScheduledRuns = true;
             if (scheduled || processIdsWithLoops.has(t.id) || processIdsWithLoops.has(t.processId)) loops++;
         }
-        return { chat, auto, loops, all: all.length + forEachRunGroups.length + mapReduceRunGroups.length + spawnedTreeGroups.length, hasScheduledRuns };
-    }, [running, queued, history, processIdsWithLoops, groupedTaskIds, forEachRunGroups.length, mapReduceRunGroups.length, spawnedTreeGroups.length]);
+        return { chat, auto, loops, all: all.length + forEachRunGroups.length + mapReduceRunGroups.length + activeSpawnedTreeGroups.length + archivedSpawnedTreeGroups.length, hasScheduledRuns };
+    }, [running, queued, history, processIdsWithLoops, groupedTaskIds, forEachRunGroups.length, mapReduceRunGroups.length, activeSpawnedTreeGroups.length, archivedSpawnedTreeGroups.length]);
 
     // Separate archived from non-archived history (uses tab-filtered history for proper exclusions)
     const { activeHistory, filteredArchived } = useMemo(() => {
@@ -1350,11 +1376,11 @@ export function ChatListPane({
             // resolved timestamp descending. Without this sort, ralph sessions
             // would always cluster at the top regardless of recency, even
             // after lastActivityAt drift was fixed in ralph-session-grouping.
-            entries = [...unpinnedForEachRunGroups, ...unpinnedMapReduceRunGroups, ...spawnedTreeGroups, ...activityRalphGrouping.unpinnedRalphGroups, ...planned].sort((a: any, b: any) => resolveListEntryTimestamp(b) - resolveListEntryTimestamp(a)) as any;
+            entries = [...unpinnedForEachRunGroups, ...unpinnedMapReduceRunGroups, ...activeSpawnedTreeGroups, ...activityRalphGrouping.unpinnedRalphGroups, ...planned].sort((a: any, b: any) => resolveListEntryTimestamp(b) - resolveListEntryTimestamp(a)) as any;
         } else if (groupedUnpinned) {
-            entries = [...unpinnedForEachRunGroups, ...unpinnedMapReduceRunGroups, ...spawnedTreeGroups, ...groupedUnpinned].sort((a: any, b: any) => resolveListEntryTimestamp(b) - resolveListEntryTimestamp(a)) as any;
+            entries = [...unpinnedForEachRunGroups, ...unpinnedMapReduceRunGroups, ...activeSpawnedTreeGroups, ...groupedUnpinned].sort((a: any, b: any) => resolveListEntryTimestamp(b) - resolveListEntryTimestamp(a)) as any;
         } else {
-            entries = [...unpinnedForEachRunGroups, ...unpinnedMapReduceRunGroups, ...spawnedTreeGroups, ...visibleFilteredUnpinned].sort((a: any, b: any) => resolveListEntryTimestamp(b) - resolveListEntryTimestamp(a)) as any;
+            entries = [...unpinnedForEachRunGroups, ...unpinnedMapReduceRunGroups, ...activeSpawnedTreeGroups, ...visibleFilteredUnpinned].sort((a: any, b: any) => resolveListEntryTimestamp(b) - resolveListEntryTimestamp(a)) as any;
         }
         const today: typeof entries = [];
         const week: typeof entries = [];
@@ -1368,7 +1394,7 @@ export function ChatListPane({
             else older.push(entry);
         }
         return { today, week, older };
-    }, [groupedUnpinned, visibleFilteredUnpinned, unpinnedForEachRunGroups, unpinnedMapReduceRunGroups, spawnedTreeGroups, listModeConfig, historyGrouping, unseenProcessIds, activityRalphGrouping]);
+    }, [groupedUnpinned, visibleFilteredUnpinned, unpinnedForEachRunGroups, unpinnedMapReduceRunGroups, activeSpawnedTreeGroups, listModeConfig, historyGrouping, unseenProcessIds, activityRalphGrouping]);
 
     const activityCompletedEntries = useMemo(
         () => [
@@ -1506,7 +1532,7 @@ export function ChatListPane({
         const week: Array<any | RalphSession | ForEachRunGroup | MapReduceRunGroup | SpawnedTreeEntry> = [];
         const older: Array<any | RalphSession | ForEachRunGroup | MapReduceRunGroup | SpawnedTreeEntry> = [];
         const nowMs = Date.now();
-        for (const t of [...recentNonRalph, ...unpinnedRalphGroups, ...unpinnedNonRunningForEachGroups, ...unpinnedNonRunningMapReduceGroups, ...spawnedTreeGroups]) {
+        for (const t of [...recentNonRalph, ...unpinnedRalphGroups, ...unpinnedNonRunningForEachGroups, ...unpinnedNonRunningMapReduceGroups, ...activeSpawnedTreeGroups]) {
             const time = resolveListEntryTimestamp(t);
             const ageH = time ? (nowMs - time) / 3600000 : Infinity;
             if (ageH < 24) today.push(t);
@@ -1515,7 +1541,7 @@ export function ChatListPane({
         }
 
         const counts = {
-            all: allActive.length + forEachRunGroups.length + mapReduceRunGroups.length + spawnedTreeGroups.length,
+            all: allActive.length + forEachRunGroups.length + mapReduceRunGroups.length + activeSpawnedTreeGroups.length,
             running: allActive.filter(isRunningTask).length
                 + forEachRunGroups.filter(group => isRunningForEachRunGroup(group, runningIdSet)).length
                 + mapReduceRunGroups.filter(group => isRunningMapReduceRunGroup(group, runningIdSet)).length,
@@ -1534,10 +1560,11 @@ export function ChatListPane({
             week,
             older,
             archivedChats,
+            archivedSpawnedTrees: archivedSpawnedTreeGroups,
             counts,
             flatVisible,
         };
-    }, [activeTab, running, chatAllItems, chatFilter, forEachRunGroups, mapReduceRunGroups, spawnedTreeGroups, groupPins, unseenProcessIds]);
+    }, [activeTab, running, chatAllItems, chatFilter, forEachRunGroups, mapReduceRunGroups, activeSpawnedTreeGroups, archivedSpawnedTreeGroups, groupPins, unseenProcessIds]);
 
     const applyRalphGrouping = useCallback((items: any[]): Array<RalphHistoryEntry | ForEachRunGroup | MapReduceRunGroup | SpawnedTreeEntry> => {
         const forEachEntries = items.filter((entry): entry is ForEachRunGroup => entry.kind === 'for-each-run');
@@ -3057,7 +3084,7 @@ export function ChatListPane({
                                     </div>
                                 )}
 
-                                {chatGroups.archivedChats.length > 0 && (
+                                {(chatGroups.archivedChats.length > 0 || chatGroups.archivedSpawnedTrees.length > 0) && (
                                     <div data-section="archived">
                                         <button
                                             className="sticky top-0 z-[2] w-full flex items-center justify-between px-3 py-1 border-b bg-white/[0.94] dark:bg-[#1e1e1e]/[0.94] border-[#e0e0e0]/80 dark:border-[#3c3c3c]/80 hover:bg-[#f5f5f5] dark:hover:bg-[#252526] transition-colors backdrop-blur-md backdrop-saturate-150"
@@ -3068,10 +3095,11 @@ export function ChatListPane({
                                                 <span className="text-[10px]">{showArchived ? '▼' : '▶'}</span>
                                                 Archived
                                             </span>
-                                            <span className="text-[10px] leading-none font-mono tabular-nums text-[#848484] dark:text-[#a0a0a0]">{chatGroups.archivedChats.length}</span>
+                                            <span className="text-[10px] leading-none font-mono tabular-nums text-[#848484] dark:text-[#a0a0a0]">{chatGroups.archivedChats.length + chatGroups.archivedSpawnedTrees.length}</span>
                                         </button>
                                         {showArchived && (
                                             <div className="opacity-70">
+                                                {chatGroups.archivedSpawnedTrees.map(entry => renderSpawnedTreeEntry(entry, chatRangeRows))}
                                                 {chatGroups.archivedChats.map(task => renderChatListRow(task, chatGroups.archivedChats))}
                                             </div>
                                         )}
@@ -3390,6 +3418,7 @@ export function ChatListPane({
                                         + pinnedActivityEntries.length
                                         + activityCompletedEntries.length
                                         + visibleFilteredArchived.length
+                                        + archivedSpawnedTreeGroups.length
                                 }
                             </span>
                             <button
@@ -3713,7 +3742,7 @@ export function ChatListPane({
                         )}
                     </div>
                 )}
-            {visibleFilteredArchived.length > 0 && (
+            {(visibleFilteredArchived.length > 0 || archivedSpawnedTreeGroups.length > 0) && (
                 <div data-section="archived" className="-mx-2 md:-mx-4">
                     <div className="sticky top-0 z-[2] flex flex-wrap items-center gap-1.5 px-3 py-1 border-b backdrop-blur-md backdrop-saturate-150 bg-white/[0.94] dark:bg-[#1e1e1e]/[0.94] border-[#e0e0e0]/80 dark:border-[#3c3c3c]/80">
                         <button
@@ -3732,7 +3761,7 @@ export function ChatListPane({
                                 ) : null;
                             })()}
                         </button>
-                        <span className="ml-auto text-[10px] leading-none font-mono tabular-nums text-[#848484] dark:text-[#a0a0a0]">{visibleFilteredArchived.length}</span>
+                        <span className="ml-auto text-[10px] leading-none font-mono tabular-nums text-[#848484] dark:text-[#a0a0a0]">{visibleFilteredArchived.length + archivedSpawnedTreeGroups.length}</span>
                         {onMarkAllRead && unseenProcessIds && visibleFilteredArchived.some(t => unseenProcessIds.has(t.id)) && (
                             <button
                                 className="text-[10px] text-[#0078d4] dark:text-[#3794ff] hover:underline transition-colors"
@@ -3745,6 +3774,7 @@ export function ChatListPane({
                     </div>
                         {showArchived && (
                             <div className="flex flex-col">
+                                {archivedSpawnedTreeGroups.map(entry => renderSpawnedTreeEntry(entry, activityRangeRows))}
                                 {visibleFilteredArchived.map(task => renderChatListRow(task, visibleFilteredArchived, { taskStatus: 'completed' }))}
                             </div>
                         )}

--- a/packages/coc/src/server/spa/client/react/features/chat/QueuedBubble.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/QueuedBubble.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { cn } from '../../ui/cn';
+import { ImageGallery } from '../../ui/ImageGallery';
 import type { QueuedMessage } from '../../utils/chatUtils';
 
 interface QueuedItemProps {
@@ -13,10 +14,12 @@ function QueuedItem({ msg, onCancel }: QueuedItemProps) {
         onCancel?.(msg.id);
     }, [msg.id, onCancel]);
 
+    const hasImages = !!msg.images && msg.images.length > 0;
+
     return (
         <div
             className={cn(
-                'queued-item flex items-center gap-2.5',
+                'queued-item flex flex-col',
                 'px-2.5 py-1.5 mb-1 last:mb-0',
                 'rounded border border-dashed',
                 'border-[#e5e7eb] dark:border-[#3c3c3c]',
@@ -26,31 +29,36 @@ function QueuedItem({ msg, onCancel }: QueuedItemProps) {
             data-testid="queued-item"
             data-status={msg.status}
         >
-            <span
-                className="text flex-1 min-w-0 truncate"
-                data-testid="queued-item-text"
-                title={msg.content}
-            >
-                {msg.content}
-            </span>
-            {onCancel && (
-                <button
-                    type="button"
-                    className={cn(
-                        'queued-item-cancel shrink-0 inline-flex items-center justify-center',
-                        'w-5 h-5 rounded-sm text-[11px] leading-none',
-                        'text-[#6b7280] dark:text-[#9aa0a6]',
-                        'hover:bg-[#ffebe9] hover:text-[#cf222e]',
-                        'dark:hover:bg-[#3a1a1a] dark:hover:text-[#f87171]',
-                        'transition-colors',
-                    )}
-                    title="Cancel queued message"
-                    aria-label="Cancel queued message"
-                    onClick={handleCancel}
-                    data-testid="queued-item-cancel"
+            <div className="flex items-center gap-2.5">
+                <span
+                    className="text flex-1 min-w-0 truncate"
+                    data-testid="queued-item-text"
+                    title={msg.content}
                 >
-                    ✕
-                </button>
+                    {msg.content}
+                </span>
+                {onCancel && (
+                    <button
+                        type="button"
+                        className={cn(
+                            'queued-item-cancel shrink-0 inline-flex items-center justify-center',
+                            'w-5 h-5 rounded-sm text-[11px] leading-none',
+                            'text-[#6b7280] dark:text-[#9aa0a6]',
+                            'hover:bg-[#ffebe9] hover:text-[#cf222e]',
+                            'dark:hover:bg-[#3a1a1a] dark:hover:text-[#f87171]',
+                            'transition-colors',
+                        )}
+                        title="Cancel queued message"
+                        aria-label="Cancel queued message"
+                        onClick={handleCancel}
+                        data-testid="queued-item-cancel"
+                    >
+                        ✕
+                    </button>
+                )}
+            </div>
+            {hasImages && (
+                <ImageGallery images={msg.images!} />
             )}
         </div>
     );

--- a/packages/coc/src/server/spa/client/react/features/chat/hooks/useChatSSE.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/hooks/useChatSSE.ts
@@ -287,6 +287,9 @@ export function useChatSSE({
                             id: pendingMessage.id,
                             content: pendingMessage.content,
                             status: 'queued' as const,
+                            ...(Array.isArray(pendingMessage.images) && pendingMessage.images.length > 0
+                                ? { images: pendingMessage.images }
+                                : {}),
                         }];
                     });
                 }

--- a/packages/coc/src/server/spa/client/react/features/chat/spawned-tree-grouping.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/spawned-tree-grouping.ts
@@ -276,3 +276,127 @@ export function buildSpawnedTreeChatView(
     }
     return { entries, groups, hiddenIds };
 }
+
+/** True when this node is *explicitly* archived (its own id/processId is in `archivedIds`). */
+function isNodeExplicitlyArchived(node: SpawnedTreeNode, archivedIds: ReadonlySet<string>): boolean {
+    return getTaskIds(node.task).some(id => archivedIds.has(id));
+}
+
+/** Wrap a finalized node as a spawned-tree entry (mirrors {@link groupBySpawnedTree}). */
+function entryFromNode(node: SpawnedTreeNode): SpawnedTreeEntry {
+    return {
+        kind: 'spawned-tree',
+        rootProcessId: getSpawnedNodeId(node),
+        root: node,
+        descendantCount: node.descendantCount,
+        latestTimestamp: node.subtreeLatestTimestamp,
+        hasUnseen: node.hasUnseen,
+    };
+}
+
+/**
+ * Recursively split one node into its active remainder plus every archived
+ * subtree root reachable through active ancestors.
+ *
+ * If the node is explicitly archived, the WHOLE subtree (unchanged) becomes an
+ * archived root — deeper archived descendants do not re-root, so the subtree
+ * travels together (display-only semantics; on unarchive of an ancestor they
+ * re-root naturally on the next recompute). Otherwise the node stays active: its
+ * children are split, archived branches peel off, and a fresh active node is
+ * finalized over just the surviving children so aggregate fields
+ * (descendantCount / subtree-latest / unseen) reflect the pruned shape.
+ */
+function splitNodeByArchived(
+    node: SpawnedTreeNode,
+    archivedIds: ReadonlySet<string>,
+    unseenIds?: Set<string>,
+): { active: SpawnedTreeNode | null; archivedRoots: SpawnedTreeNode[] } {
+    if (isNodeExplicitlyArchived(node, archivedIds)) {
+        return { active: null, archivedRoots: [node] };
+    }
+    const activeChildren: SpawnedTreeNode[] = [];
+    const archivedRoots: SpawnedTreeNode[] = [];
+    for (const child of node.children) {
+        const split = splitNodeByArchived(child, archivedIds, unseenIds);
+        if (split.active) {activeChildren.push(split.active);}
+        archivedRoots.push(...split.archivedRoots);
+    }
+    const active = makeNode(node.task);
+    active.children = activeChildren;
+    finalizeNode(active, unseenIds);
+    return { active, archivedRoots };
+}
+
+/**
+ * The result of partitioning spawned-tree groups by effective-archived state.
+ *
+ * A node is *effectively archived* when it, or any ancestor in its spawn tree,
+ * is explicitly in `archivedIds`. Trees split at the SHALLOWEST explicitly-
+ * archived node in every chain: that node + its subtree move to the archived
+ * side; the rest stays active. Roots pruned down to zero descendants are
+ * returned as plain tasks (flat rendering) rather than single-node groups, so
+ * they slot back into the flat COMPLETED / ARCHIVED lists.
+ */
+export interface SpawnedTreeArchivePartition {
+    /** Active trees (root still has ≥1 descendant) — stay in COMPLETED. */
+    activeGroups: SpawnedTreeEntry[];
+    /** Active roots left childless after pruning — render flat in COMPLETED. */
+    activeTasks: any[];
+    /** Archived subtrees (root has ≥1 descendant) rooted at the shallowest archived node — render as trees in ARCHIVED. */
+    archivedGroups: SpawnedTreeEntry[];
+    /** Archived roots with no descendants — render flat in ARCHIVED. */
+    archivedTasks: any[];
+    /** Every identity id (root + descendants) that is effectively archived. */
+    effectiveArchivedIds: Set<string>;
+}
+
+/**
+ * Partition spawned-tree groups by effective-archived state (display-only,
+ * recomputed each render from the per-chat `archivedIds` set — no cascade write
+ * onto descendants).
+ *
+ * When `archivedIds` is empty the input groups pass through untouched (same
+ * array reference for `activeGroups`), so the non-archived path stays a no-op.
+ */
+export function partitionSpawnedTreesByArchived(
+    groups: SpawnedTreeEntry[],
+    archivedIds?: ReadonlySet<string> | null,
+    unseenIds?: Set<string>,
+): SpawnedTreeArchivePartition {
+    if (!archivedIds || archivedIds.size === 0) {
+        return {
+            activeGroups: groups,
+            activeTasks: [],
+            archivedGroups: [],
+            archivedTasks: [],
+            effectiveArchivedIds: new Set(),
+        };
+    }
+
+    const activeGroups: SpawnedTreeEntry[] = [];
+    const activeTasks: any[] = [];
+    const archivedGroups: SpawnedTreeEntry[] = [];
+    const archivedTasks: any[] = [];
+    const effectiveArchivedIds = new Set<string>();
+
+    for (const group of groups) {
+        const { active, archivedRoots } = splitNodeByArchived(group.root, archivedIds, unseenIds);
+        if (active) {
+            if (active.children.length > 0) {activeGroups.push(entryFromNode(active));}
+            else {activeTasks.push(active.task);}
+        }
+        for (const root of archivedRoots) {
+            const entry = entryFromNode(root);
+            for (const id of getTaskIds(root.task)) {effectiveArchivedIds.add(id);}
+            for (const id of collectSpawnedDescendantIds(entry)) {effectiveArchivedIds.add(id);}
+            if (root.children.length > 0) {archivedGroups.push(entry);}
+            else {archivedTasks.push(root.task);}
+        }
+    }
+
+    // Preserve the incoming latest-activity-descending order of the surviving trees.
+    activeGroups.sort((a, b) => b.latestTimestamp - a.latestTimestamp);
+    archivedGroups.sort((a, b) => b.latestTimestamp - a.latestTimestamp);
+
+    return { activeGroups, activeTasks, archivedGroups, archivedTasks, effectiveArchivedIds };
+}

--- a/packages/coc/src/server/spa/client/react/features/git/diff/SideBySideDiffViewer.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/diff/SideBySideDiffViewer.tsx
@@ -207,7 +207,7 @@ export const SideBySideDiffViewer = forwardRef<UnifiedDiffViewerHandle, UnifiedD
             // regardless of enableComments, since the bleed affects plain split views too.
             const startSide = startEl?.closest('[data-split-side]')?.getAttribute('data-split-side');
             const endSide   = endEl?.closest('[data-split-side]')?.getAttribute('data-split-side');
-            if (startSide && endSide && startSide !== endSide) { sel.removeAllRanges(); }
+            if (startSide && endSide && startSide !== endSide && typeof sel.removeAllRanges === 'function') { sel.removeAllRanges(); }
 
             if (!enableComments) return;
             if (!startEl || !endEl) { clear(); return; }

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditor.tsx
@@ -34,6 +34,10 @@ import { useQueue } from '../../../contexts/QueueContext';
 import { isGoalFile } from '../../../shared/goal-file-utils';
 import { RalphLaunchDialog } from '../../../shared/RalphLaunchDialog';
 import { isRalphEnabled } from '../../../utils/config';
+import {
+    useMarkdownDocumentKeyboardShortcuts,
+    useMarkdownDocumentSession,
+} from '../../../shared/markdown-document/useMarkdownDocumentSession';
 
 export type NoteViewMode = 'rich' | 'source';
 
@@ -87,8 +91,6 @@ export interface NoteEditorProps {
      *  No range highlight is applied. */
     scrollToLine?: number | null;
 }
-
-type SaveState = 'idle' | 'saving' | 'saved' | 'error' | 'conflict';
 
 /**
  * Find contiguous changed regions in the editor document from word diff chunks.
@@ -189,11 +191,6 @@ export function NoteEditor({
     root,
     scrollToLine,
 }: NoteEditorProps) {
-    const [loading, setLoading] = useState(false);
-    const [refreshCounter, setRefreshCounter] = useState(0);
-    const [loadError, setLoadError] = useState<string | null>(null);
-    const [saveState, setSaveState] = useState<SaveState>('idle');
-    const [dirty, setDirty] = useState(false);
     const [uploadingImage, setUploadingImage] = useState(false);
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number; selectedText: string } | null>(null);
     const [frontMatterResult, setFrontMatterResult] = useState<NoteFrontMatterParseResult>({ kind: 'none' });
@@ -217,10 +214,6 @@ export function NoteEditor({
     const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
     const [gitInitialized, setGitInitialized] = useState(false);
 
-    // Optimistic locking state
-    const mtimeRef = useRef<number | null>(null);
-    const [conflictContent, setConflictContent] = useState<string | null>(null);
-
     // AI edit navigator state
     const [aiEditCount, setAiEditCount] = useState(0);
     const [aiEditsVisible, setAiEditsVisible] = useState(true);
@@ -234,15 +227,10 @@ export function NoteEditor({
 
     // Source mode state
     const [viewMode, setViewModeRaw] = useState<NoteViewMode>(initialViewMode ?? 'rich');
-    const [rawMarkdown, setRawMarkdown] = useState('');
     const [sourceDirty, setSourceDirty] = useState(false);
     const viewModeRef = useRef(viewMode);
     viewModeRef.current = viewMode;
 
-    const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const sourceSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const pendingContentRef = useRef<string | null>(null);
-    const pendingSourceContentRef = useRef<string | null>(null);
     const lastSaveAtRef = useRef(0);
     const notePathRef = useRef(notePath);
     const workspaceIdRef = useRef(workspaceId);
@@ -260,6 +248,119 @@ export function NoteEditor({
     rootRef.current = root;
     frontMatterResultRef.current = frontMatterResult;
     onNotFoundRef.current = onNotFound;
+
+    const loadedThreadsRef = useRef<CommentThread[]>([]);
+    const contentLoadedRef = useRef(false);
+
+    const documentSession = useMarkdownDocumentSession({
+        workspaceId,
+        documentPath: notePath,
+        io,
+        root,
+        autosaveDebounceMs: 1500,
+        flushBeforeLoad: true,
+        onBeforeLoad: () => {
+            setViewModeRaw('rich');
+            setFrontMatterResult({ kind: 'none' });
+            setSourceDirty(false);
+            contentLoadedRef.current = false;
+            aiEditRegionsRef.current = [];
+            setAiEditCount(0);
+            setAiEditsVisible(false);
+            setTocEntries([]);
+            setTocOpen(false);
+            setTocActiveIndex(null);
+        },
+        onLoaded: ({ content }) => {
+            const parsedFrontMatter = parseNoteFrontMatter(content);
+            setFrontMatterResult(parsedFrontMatter);
+            const richMarkdown = parsedFrontMatter.kind === 'valid'
+                ? parsedFrontMatter.frontMatter.body
+                : content;
+            let html = markdownToHtml(richMarkdown);
+            html = rewriteHtmlImageSrc(html, ioRef.current, workspaceIdRef.current, rootRef.current);
+
+            const ed = editorRef.current;
+            if (ed && !ed.isDestroyed) {
+                ed.commands.setContent(html, { emitUpdate: false });
+                ed.commands.setTextSelection?.(1);
+                resetEditorHistory(ed);
+                setSourceDirty(false);
+                contentLoadedRef.current = true;
+
+                if (commentsEnabled) {
+                    if (threadsProp) {
+                        loadedThreadsRef.current = threadsProp;
+                        for (const thread of threadsProp) {
+                            if (thread.status === 'resolved') continue;
+                            const result = findAnchorInDoc(ed.state.doc, thread.anchor);
+                            if (result) {
+                                applyCommentMark(ed, thread.id, result.from, result.to);
+                            }
+                        }
+                    } else {
+                        commentBackendRef.current.loadThreads(workspaceIdRef.current, notePathRef.current ?? '').then((threads) => {
+                            const edInner = editorRef.current;
+                            if (!edInner || edInner.isDestroyed) return;
+                            loadedThreadsRef.current = threads;
+                            for (const thread of threads) {
+                                if (thread.status === 'resolved') continue;
+                                const result = findAnchorInDoc(edInner.state.doc, thread.anchor);
+                                if (result) {
+                                    applyCommentMark(edInner, thread.id, result.from, result.to);
+                                }
+                            }
+                        }).catch(() => { /* non-fatal — comments just won't highlight */ });
+                    }
+                }
+            }
+        },
+        onLoadError: (err) => {
+            if (err instanceof Error && err.message.includes('404')) {
+                onNotFoundRef.current?.();
+                return true;
+            }
+            return false;
+        },
+        onSaved: () => {
+            lastSaveAtRef.current = Date.now();
+            setSourceDirty(false);
+            const path = notePathRef.current;
+            if (commentsEnabled && editor && path) {
+                const threads = loadedThreadsRef.current;
+                for (const thread of threads) {
+                    if (thread.status === 'resolved') continue;
+                    const freshAnchor = buildAnchorFromMark(editor, thread.id);
+                    if (freshAnchor && freshAnchor.quotedText !== thread.anchor.quotedText) {
+                        commentBackendRef.current.updateThreadAnchor(workspaceIdRef.current, path, thread.id, thread.status)
+                            .catch(() => { /* non-fatal */ });
+                        thread.anchor = freshAnchor;
+                    }
+                }
+            }
+        },
+        onDiscardDirty: () => {
+            setSourceDirty(false);
+        },
+    });
+
+    const rawMarkdown = documentSession.content;
+    const setRawMarkdown = documentSession.setContent;
+    const loading = documentSession.loading;
+    const loadError = documentSession.loadError;
+    const saveState = documentSession.saveState;
+    const dirty = documentSession.dirty;
+    const setDirty = documentSession.setDirty;
+    const mtimeRef = documentSession.mtimeRef;
+    const conflictContent = documentSession.conflictContent;
+    const setConflictContent = documentSession.setConflictContent;
+    const pendingContentRef = documentSession.pendingContentRef;
+    const flushSave = documentSession.flushSave;
+    const queueSave = documentSession.queueSave;
+    const discardPending = documentSession.discardPending;
+
+    const rawMarkdownRef = useRef(rawMarkdown);
+    rawMarkdownRef.current = rawMarkdown;
 
     // View mode setter that also notifies parent
     const setViewMode = useCallback((mode: NoteViewMode) => {
@@ -353,125 +454,27 @@ export function NoteEditor({
         return false;
     }, []);
 
-    // ── Autosave ────────────────────────────────────────────────────────────
-
-    // Ref to track loaded threads for re-anchoring
-    const loadedThreadsRef = useRef<CommentThread[]>([]);
-
-    const flushSave = useCallback(async () => {
-        if (saveTimerRef.current) {
-            clearTimeout(saveTimerRef.current);
-            saveTimerRef.current = null;
-        }
-        const content = pendingContentRef.current;
-        const path = notePathRef.current;
-        if (content === null || !path) return;
-        pendingContentRef.current = null;
-        setSaveState('saving');
-        try {
-            const result = await ioRef.current.saveContent(
-                workspaceIdRef.current, path, content,
-                mtimeRef.current ?? undefined,
-                rootRef.current,
-            );
-            mtimeRef.current = result.mtime;
-            lastSaveAtRef.current = Date.now();
-            setSaveState('saved');
-            setDirty(false);
-            setTimeout(() => setSaveState((s) => (s === 'saved' ? 'idle' : s)), 3000);
-
-            // Re-anchor threads after save to keep context fresh
-            if (commentsEnabled && editor) {
-                const threads = loadedThreadsRef.current;
-                for (const thread of threads) {
-                    if (thread.status === 'resolved') continue;
-                    const freshAnchor = buildAnchorFromMark(editor, thread.id);
-                    if (freshAnchor && freshAnchor.quotedText !== thread.anchor.quotedText) {
-                        commentBackendRef.current.updateThreadAnchor(workspaceIdRef.current, path, thread.id, thread.status)
-                            .catch(() => { /* non-fatal */ });
-                        thread.anchor = freshAnchor;
-                    }
-                }
-            }
-        } catch (err: any) {
-            if (err?.status === 409) {
-                setConflictContent(err.currentContent ?? null);
-                setSaveState('conflict');
-                pendingContentRef.current = content;
-            } else {
-                setSaveState('error');
-            }
-        }
-    }, [editor, commentsEnabled]);
-
     function scheduleSave(ed: { getHTML: () => string }) {
-        if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
         let md = htmlToMarkdown(ed.getHTML());
         md = rewriteImageSrcToRelative(md);
         const currentFrontMatter = frontMatterResultRef.current;
         if (currentFrontMatter.kind === 'valid') {
             md = composeMarkdownWithFrontMatter(currentFrontMatter.frontMatter, md);
         }
-        pendingContentRef.current = md;
-        saveTimerRef.current = setTimeout(() => flushSave(), 1500);
-    }
-
-    // ── Source mode: save raw markdown directly ─────────────────────────────
-
-    const flushSourceSave = useCallback(async () => {
-        if (sourceSaveTimerRef.current) {
-            clearTimeout(sourceSaveTimerRef.current);
-            sourceSaveTimerRef.current = null;
-        }
-        const content = pendingSourceContentRef.current;
-        const path = notePathRef.current;
-        if (content === null || !path) return;
-        pendingSourceContentRef.current = null;
-        setSaveState('saving');
-        try {
-            const result = await ioRef.current.saveContent(
-                workspaceIdRef.current, path, content,
-                mtimeRef.current ?? undefined,
-                rootRef.current,
-            );
-            mtimeRef.current = result.mtime;
-            lastSaveAtRef.current = Date.now();
-            setSaveState('saved');
-            setSourceDirty(false);
-            setDirty(false);
-            setTimeout(() => setSaveState((s) => (s === 'saved' ? 'idle' : s)), 3000);
-        } catch (err: any) {
-            if (err?.status === 409) {
-                setConflictContent(err.currentContent ?? null);
-                setSaveState('conflict');
-                pendingSourceContentRef.current = content;
-            } else {
-                setSaveState('error');
-            }
-        }
-    }, []);
-
-    function scheduleSourceSave() {
-        if (sourceSaveTimerRef.current) clearTimeout(sourceSaveTimerRef.current);
-        sourceSaveTimerRef.current = setTimeout(() => flushSourceSave(), 1500);
+        queueSave(md);
     }
 
     // ── Source mode: handle textarea change ─────────────────────────────────
 
     const handleSourceChange = useCallback((content: string) => {
         setRawMarkdown(content);
-        pendingSourceContentRef.current = content;
         setSourceDirty(true);
-        setDirty(true);
-        scheduleSourceSave();
-    }, []);
+        queueSave(content);
+    }, [queueSave, setRawMarkdown]);
 
     // ── Source mode: image paste ────────────────────────────────────────────
 
     const sourceTextareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-    const rawMarkdownRef = useRef(rawMarkdown);
-    rawMarkdownRef.current = rawMarkdown;
 
     const handleSourcePaste = useCallback(async (e: React.ClipboardEvent<HTMLDivElement>) => {
         const items = e.clipboardData?.items;
@@ -515,10 +518,8 @@ export function NoteEditor({
                             newContent = currentMd + mdImg;
                         }
                         setRawMarkdown(newContent);
-                        pendingSourceContentRef.current = newContent;
                         setSourceDirty(true);
-                        setDirty(true);
-                        scheduleSourceSave();
+                        queueSave(newContent);
                     } catch (err) {
                         console.error('Failed to upload pasted image:', err);
                     } finally {
@@ -539,10 +540,8 @@ export function NoteEditor({
             const end = textarea.selectionEnd;
             const newContent = currentMd.slice(0, start) + pastedText + currentMd.slice(end);
             setRawMarkdown(newContent);
-            pendingSourceContentRef.current = newContent;
             setSourceDirty(true);
-            setDirty(true);
-            scheduleSourceSave();
+            queueSave(newContent);
             const restoreSelection = () => {
                 textarea.focus();
                 const nextPos = start + pastedText.length;
@@ -551,7 +550,7 @@ export function NoteEditor({
             if (typeof requestAnimationFrame === 'function') requestAnimationFrame(restoreSelection);
             else setTimeout(restoreSelection, 0);
         }
-    }, [rawMarkdown]);
+    }, [queueSave, setRawMarkdown]);
 
     // ── Mode toggle logic ──────────────────────────────────────────────────
 
@@ -572,21 +571,7 @@ export function NoteEditor({
     }, [flushSave, setViewMode]);
 
     const switchToRich = useCallback(async () => {
-        // Save dirty source content first
-        const pendingSource = pendingSourceContentRef.current;
-        if (pendingSource !== null) {
-            const path = notePathRef.current;
-            if (path) {
-                try {
-                    await ioRef.current.saveContent(workspaceIdRef.current, path, pendingSource, undefined, rootRef.current);
-                    pendingSourceContentRef.current = null;
-                } catch { /* continue anyway */ }
-            }
-        }
-        if (sourceSaveTimerRef.current) {
-            clearTimeout(sourceSaveTimerRef.current);
-            sourceSaveTimerRef.current = null;
-        }
+        await flushSave();
         // Convert raw markdown to HTML and load into Tiptap
         const ed = editorRef.current;
         if (ed && !ed.isDestroyed) {
@@ -602,11 +587,7 @@ export function NoteEditor({
             resetEditorHistory(ed);
 
             // Cancel any save triggered by setContent
-            pendingContentRef.current = null;
-            if (saveTimerRef.current) {
-                clearTimeout(saveTimerRef.current);
-                saveTimerRef.current = null;
-            }
+            discardPending();
 
             // Re-anchor comments
             if (commentsEnabled) {
@@ -623,21 +604,17 @@ export function NoteEditor({
         setSourceDirty(false);
         setDirty(false);
         setViewMode('rich');
-    }, [rawMarkdown, commentsEnabled, setViewMode]);
+    }, [rawMarkdown, commentsEnabled, setViewMode, flushSave, discardPending, setDirty]);
 
     // ── Conflict resolution handlers ────────────────────────────────────────
 
     const handleConflictKeepMine = useCallback(async () => {
         mtimeRef.current = null;
         setConflictContent(null);
-        setSaveState('idle');
+        documentSession.setSaveState('idle');
         // Re-trigger save without mtime check (force overwrite)
-        if (viewModeRef.current === 'source') {
-            await flushSourceSave();
-        } else {
-            await flushSave();
-        }
-    }, [flushSave, flushSourceSave]);
+        await flushSave({ expectedMtime: null });
+    }, [flushSave, mtimeRef, setConflictContent, documentSession]);
 
     const handleConflictLoadDisk = useCallback(() => {
         if (!conflictContent) return;
@@ -654,23 +631,18 @@ export function NoteEditor({
             resetEditorHistory(ed);
         }
         setRawMarkdown(conflictContent);
-        pendingContentRef.current = null;
-        pendingSourceContentRef.current = null;
-        if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-        if (sourceSaveTimerRef.current) clearTimeout(sourceSaveTimerRef.current);
+        discardPending();
         setDirty(false);
         setSourceDirty(false);
         setConflictContent(null);
-        setSaveState('idle');
+        documentSession.setSaveState('idle');
         // Refresh mtime from disk
         ioRef.current.loadContent(workspaceIdRef.current, notePathRef.current!, rootRef.current)
             .then(r => { mtimeRef.current = r.mtime; })
             .catch(() => {});
-    }, [conflictContent]);
+    }, [conflictContent, discardPending, documentSession, mtimeRef, setConflictContent, setDirty, setRawMarkdown]);
 
     // ── Apply comment marks from threads prop ─────────────────────────────────
-
-    const contentLoadedRef = useRef(false);
 
     useEffect(() => {
         if (!editor || !threadsProp || !notePath || !contentLoadedRef.current || !commentsEnabled) return;
@@ -684,128 +656,11 @@ export function NoteEditor({
         }
     }, [threadsProp, editor, notePath, commentsEnabled]);
 
-    // ── Load content on path change ─────────────────────────────────────────
-    //
-    // The editor is kept mounted (hidden behind a loading overlay) so the
-    // TipTap instance is never destroyed during note switches.  This means
-    // editorRef.current is always a live editor once it has been created,
-    // and we can safely call setContent on it from the fetch callback.
-
-    const flushSaveRef = useRef(flushSave);
-    flushSaveRef.current = flushSave;
-
-    useEffect(() => {
-        flushSaveRef.current();
-
-        // Reset to rich mode when switching notes
-        setViewModeRaw('rich');
-        setRawMarkdown('');
-        setFrontMatterResult({ kind: 'none' });
-        setSourceDirty(false);
-        contentLoadedRef.current = false;
-        // Reset optimistic locking state
-        mtimeRef.current = null;
-        setConflictContent(null);
-        // Clear AI edit decorations from previous note
-        aiEditRegionsRef.current = [];
-        setAiEditCount(0);
-        setAiEditsVisible(false);
-        // Reset TOC state
-        setTocEntries([]);
-        setTocOpen(false);
-        setTocActiveIndex(null);
-
-        if (!notePath) {
-            editorRef.current?.commands.clearContent({ emitUpdate: false });
-            setLoadError(null);
-            setLoading(false);
-            return;
-        }
-
-        let cancelled = false;
-        setLoading(true);
-        setLoadError(null);
-        setSaveState('idle');
-
-        ioRef.current
-            .loadContent(workspaceId, notePath, rootRef.current)
-            .then(({ content, mtime }) => {
-                if (cancelled) return;
-                mtimeRef.current = mtime;
-                const parsedFrontMatter = parseNoteFrontMatter(content);
-                setFrontMatterResult(parsedFrontMatter);
-                const richMarkdown = parsedFrontMatter.kind === 'valid'
-                    ? parsedFrontMatter.frontMatter.body
-                    : content;
-                let html = markdownToHtml(richMarkdown);
-                html = rewriteHtmlImageSrc(html, ioRef.current, workspaceId, rootRef.current);
-
-                const ed = editorRef.current;
-                if (ed && !ed.isDestroyed) {
-                    ed.commands.setContent(html, { emitUpdate: false });
-                    ed.commands.setTextSelection?.(1);
-                    resetEditorHistory(ed);
-                    pendingContentRef.current = null;
-                    if (saveTimerRef.current) {
-                        clearTimeout(saveTimerRef.current);
-                        saveTimerRef.current = null;
-                    }
-                    setDirty(false);
-                    setRawMarkdown(content);
-                    contentLoadedRef.current = true;
-
-                    if (commentsEnabled) {
-                        if (threadsProp) {
-                            loadedThreadsRef.current = threadsProp;
-                            for (const thread of threadsProp) {
-                                if (thread.status === 'resolved') continue;
-                                const result = findAnchorInDoc(ed.state.doc, thread.anchor);
-                                if (result) {
-                                    applyCommentMark(ed, thread.id, result.from, result.to);
-                                }
-                            }
-                        } else {
-                            commentBackendRef.current.loadThreads(workspaceId, notePath).then((threads) => {
-                                if (cancelled) return;
-                                const edInner = editorRef.current;
-                                if (!edInner || edInner.isDestroyed) return;
-                                loadedThreadsRef.current = threads;
-                                for (const thread of threads) {
-                                    if (thread.status === 'resolved') continue;
-                                    const result = findAnchorInDoc(edInner.state.doc, thread.anchor);
-                                    if (result) {
-                                        applyCommentMark(edInner, thread.id, result.from, result.to);
-                                    }
-                                }
-                            }).catch(() => { /* non-fatal — comments just won't highlight */ });
-                        }
-                    }
-                }
-            })
-            .catch((err) => {
-                if (cancelled) return;
-                if (err?.message?.includes('404')) {
-                    onNotFoundRef.current?.();
-                    return;
-                }
-                setLoadError(err?.message ?? 'Failed to load note');
-            })
-            .finally(() => {
-                if (!cancelled) setLoading(false);
-            });
-
-        return () => {
-            cancelled = true;
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [notePath, workspaceId, refreshCounter]);
-
     // ── Flush on unmount ────────────────────────────────────────────────────
 
     useEffect(() => {
         return () => {
             flushSave();
-            if (sourceSaveTimerRef.current) clearTimeout(sourceSaveTimerRef.current);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -984,7 +839,6 @@ export function NoteEditor({
             if (Date.now() - lastSaveAtRef.current < 1000) return;
             // Skip reload if user has unsaved edits
             if (pendingContentRef.current !== null) return;
-            if (pendingSourceContentRef.current !== null) return;
             ioRef.current.loadContent(workspaceIdRef.current, notePath, rootRef.current).then(({ content, mtime }) => {
                 mtimeRef.current = mtime;
                 // Skip redundant reload — content already matches what's displayed
@@ -1077,72 +931,23 @@ export function NoteEditor({
         };
     }, [notePath]);
 
-    // ── Ctrl+S / Cmd+S: suppress browser dialog & flush save ──────────────
-
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 's') {
-                e.preventDefault();
-                if (viewMode === 'source') {
-                    flushSourceSave();
-                } else {
-                    flushSave();
-                }
-            }
-            if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'M' || e.key === 'm')) {
-                if (viewMode === 'source') return; // comments not available in source mode
-                e.preventDefault();
-                onCommentCreateRef.current?.();
-            }
-        };
-        document.addEventListener('keydown', handler);
-        return () => document.removeEventListener('keydown', handler);
-    }, [flushSave, flushSourceSave, viewMode]);
-
     // ── Manual refresh ──────────────────────────────────────────────────────
 
     const handleRefresh = useCallback(() => {
-        if (dirty || sourceDirty) {
-            if (!window.confirm('You have unsaved changes. Discard and refresh?')) return;
-            if (saveTimerRef.current) {
-                clearTimeout(saveTimerRef.current);
-                saveTimerRef.current = null;
-            }
-            pendingContentRef.current = null;
-            if (sourceSaveTimerRef.current) {
-                clearTimeout(sourceSaveTimerRef.current);
-                sourceSaveTimerRef.current = null;
-            }
-            pendingSourceContentRef.current = null;
-            setDirty(false);
-            setSourceDirty(false);
-        }
-        setRefreshCounter(c => c + 1);
-    }, [dirty, sourceDirty]);
+        documentSession.refresh();
+    }, [documentSession]);
 
-    // ── Ctrl/Cmd+Shift+R keyboard shortcut for refresh ─────────────────────
-
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'R') {
+    useMarkdownDocumentKeyboardShortcuts({
+        onSave: flushSave,
+        onRefresh: handleRefresh,
+        onKeyDown: (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'M' || e.key === 'm')) {
+                if (viewModeRef.current === 'source') return;
                 e.preventDefault();
-                handleRefresh();
+                onCommentCreateRef.current?.();
             }
-        };
-        document.addEventListener('keydown', handler);
-        return () => document.removeEventListener('keydown', handler);
-    }, [handleRefresh]);
-
-    // ── beforeunload guard ──────────────────────────────────────────────────
-
-    useEffect(() => {
-        if (!dirty) return;
-        const handler = (e: BeforeUnloadEvent) => {
-            e.preventDefault();
-        };
-        window.addEventListener('beforeunload', handler);
-        return () => window.removeEventListener('beforeunload', handler);
-    }, [dirty]);
+        },
+    });
 
     const isEmpty = notePath === null;
 
@@ -1292,7 +1097,7 @@ export function NoteEditor({
                                 >{sourceDirty && viewMode === 'source' ? 'MD ●' : 'MD'}</button>
                             </div>
                             {viewMode === 'source' && sourceDirty && (
-                                <button className="save-btn" onClick={flushSourceSave} disabled={saveState === 'saving'} data-testid="note-source-save-btn">
+                                <button className="save-btn" onClick={() => flushSave()} disabled={saveState === 'saving'} data-testid="note-source-save-btn">
                                     {saveState === 'saving' ? 'Saving…' : 'Save'}
                                 </button>
                             )}
@@ -1418,7 +1223,7 @@ export function NoteEditor({
                         notePath={notePath}
                         currentContent={rawMarkdown}
                         gitInitialized={gitInitialized}
-                        onReload={() => setRefreshCounter(c => c + 1)}
+                        onReload={() => documentSession.refresh()}
                         onClose={() => setVersionHistoryOpen(false)}
                     />
                 )}
@@ -1507,7 +1312,7 @@ export function NoteEditor({
                 {saveState === 'error' && (
                     <span className="text-red-500">
                         Save failed{' '}
-                        <button className="underline" onClick={() => viewMode === 'source' ? flushSourceSave() : flushSave()}>
+                        <button className="underline" onClick={() => flushSave()}>
                             Retry
                         </button>
                     </span>

--- a/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditorIO.ts
+++ b/packages/coc/src/server/spa/client/react/features/notes/editor/NoteEditorIO.ts
@@ -1,27 +1,17 @@
 /**
- * NoteEditorIO — injectable content I/O contract for NoteEditor.
+ * NoteEditorIO — notes-era compatibility alias for MarkdownDocumentIO.
  *
  * Decouples loading/saving markdown, uploading images, and resolving image
- * URLs from the notes-specific REST API so the editor shell can be reused
- * by other backends (e.g. MarkdownReviewEditor).
+ * URLs from the notes-specific REST API. New markdown editor surfaces should
+ * depend on the generic shared MarkdownDocumentIO contract directly.
  */
 
 import { notesApi } from '../notesApi';
+import type { MarkdownDocumentIO } from '../../../shared/markdown-document/MarkdownDocumentIO';
 
 // ── Contract ────────────────────────────────────────────────────────────────
 
-export interface NoteEditorIO {
-    /** Fetch the markdown content for a given path. */
-    loadContent(workspaceId: string, path: string, root?: string): Promise<{ content: string; path: string; mtime: number }>;
-    /** Persist markdown content at the given path. */
-    saveContent(workspaceId: string, path: string, markdown: string, expectedMtime?: number, root?: string): Promise<{ path: string; updated: boolean; mtime: number }>;
-    /** Upload an image (base64 data-URL) and return the relative path to reference it. */
-    uploadImage(workspaceId: string, fileName: string, dataUrl: string, root?: string): Promise<{ path: string }>;
-    /** Build a fully-qualified URL the browser can use to fetch an image by its relative path. */
-    imageApiUrl(workspaceId: string, relativePath: string, root?: string): string;
-    /** Build a URL to serve a local image file (absolute path) via the server proxy. */
-    localImageApiUrl(workspaceId: string, absolutePath: string): string;
-}
+export type NoteEditorIO = MarkdownDocumentIO;
 
 // ── Default (notes-backed) implementation ───────────────────────────────────
 

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PrFilesPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PrFilesPanel.tsx
@@ -1,9 +1,13 @@
 /**
- * Files Changed tab — minimal read-only file list with AI action triggers.
+ * Files Changed tab — split layout: changed-files tree/list on the left,
+ * inline side-by-side diff panel on the right.
  *
- * No inline diff rendering. Clicking a file opens the pop-out window
- * (#popout/git-review/pr/<prId>) with all PR files loaded into the
- * file-list rail for full diff review.
+ * Clicking a file selects it and renders that file's diff inline in the
+ * right panel (the new default path). The per-file diff is sliced lazily
+ * from the already-fetched combined unified `diffText` for the selected
+ * file only — no per-file fetch and no up-front rendering of every file's
+ * hunks. The separate pop-out window (#popout/git-review/pr/<prId>) remains
+ * reachable via an explicit "Pop out" button in the diff panel header.
  *
  * Display rules for the file list:
  *  - Tree mode (default): folders are collapsible and single-child
@@ -17,6 +21,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { cn } from '../../ui';
 import type { FileChange } from '../git/diff/FileTree';
+import { SideBySideDiffViewer } from '../git/diff/SideBySideDiffViewer';
+import { extractFileDiffFromCombined } from '../git/diff/diffSource';
 import {
     buildFileTree,
     collectFolderPaths,
@@ -34,14 +40,20 @@ import { ClassifyDiffAiControls } from '../git/diff/ClassifyDiffAiControls';
 
 export interface PrFilesPanelProps {
     files: FileChange[];
-    /** When true (small viewports), the file list stacks vertically. */
+    /**
+     * Combined unified diff text for the whole PR. Sliced per-file (lazily,
+     * for the selected file only) to drive the inline diff panel. When
+     * omitted/empty the panel shows a prompt instead of a diff.
+     */
+    diffText?: string;
+    /** When true (small viewports), the split stacks vertically. */
     isMobile?: boolean;
     /** Workspace ID — enables classification and scoped AI provider preference. */
     workspaceId?: string;
     /** Classification key — enables focused-diff filter bar when provided. */
     classificationKey?: ClassificationKey;
-    /** Called when user clicks a file — opens pop-out for diff review. */
-    onFileClick?: (filePath: string) => void;
+    /** Explicit pop-out action — opens the separate review window for the file. */
+    onPopOut?: (filePath: string) => void;
 }
 
 type ViewMode = 'tree' | 'flat';
@@ -270,7 +282,7 @@ function ClassificationFilterBar({ classification, aiSelection }: Classification
 
 // ── Main component ──────────────────────────────────────────────────
 
-export function PrFilesPanel({ files, isMobile = false, workspaceId, classificationKey, onFileClick }: PrFilesPanelProps) {
+export function PrFilesPanel({ files, diffText, isMobile = false, workspaceId, classificationKey, onPopOut }: PrFilesPanelProps) {
     const [search, setSearch] = useState('');
     const [viewMode, setViewMode] = useState<ViewMode>('tree');
 
@@ -317,19 +329,28 @@ export function PrFilesPanel({ files, isMobile = false, workspaceId, classificat
 
     function handleFileSelect(path: string) {
         setActivePath(path);
-        onFileClick?.(path);
     }
+
+    // Lazy per-file slice: compute the diff for the SELECTED file only, from
+    // the already-fetched combined diff. No other file's hunks are rendered.
+    const activeDiff = useMemo(
+        () => (diffText && activePath ? extractFileDiffFromCombined(diffText, activePath) : null),
+        [diffText, activePath],
+    );
 
     return (
         <div
             className={cn(
-                'flex h-full min-h-0',
-                isMobile ? 'flex-col' : 'flex-col',
+                'flex h-full min-h-0 gap-2',
+                isMobile ? 'flex-col' : 'flex-row',
             )}
             data-testid="pr-files-panel"
         >
             <div
-                className="flex min-h-0 w-full flex-col overflow-hidden rounded-[5px] border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+                className={cn(
+                    'flex min-h-0 flex-col overflow-hidden rounded-[5px] border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900',
+                    isMobile ? 'max-h-[45%] w-full shrink-0' : 'w-full max-w-[380px] shrink-0',
+                )}
                 data-testid="pr-file-list-panel"
             >
                 <header className="flex min-h-[30px] shrink-0 flex-wrap items-center justify-between gap-x-1.5 gap-y-1 border-b border-gray-200 bg-gray-50 px-2 py-1 dark:border-gray-700 dark:bg-gray-800/60">
@@ -416,6 +437,82 @@ export function PrFilesPanel({ files, isMobile = false, workspaceId, classificat
                         />
                     )}
                 </div>
+            </div>
+
+            <PrInlineDiffPanel
+                filePath={activePath}
+                diff={activeDiff}
+                hasFiles={files.length > 0}
+                onPopOut={onPopOut}
+            />
+        </div>
+    );
+}
+
+// ── Inline diff panel ────────────────────────────────────────────────
+
+interface PrInlineDiffPanelProps {
+    /** Path of the currently selected file (drives the diff shown). */
+    filePath: string;
+    /** Per-file diff slice for the selected file, or null when unavailable. */
+    diff: string | null;
+    /** Whether the PR has any changed files (drives the empty-state copy). */
+    hasFiles: boolean;
+    onPopOut?: (filePath: string) => void;
+}
+
+/**
+ * Right-hand panel of the Files tab. Renders the selected file's diff with
+ * the shared {@link SideBySideDiffViewer}. Only the selected file is ever
+ * rendered, so large PRs never build every file's hunks up front.
+ */
+function PrInlineDiffPanel({ filePath, diff, hasFiles, onPopOut }: PrInlineDiffPanelProps) {
+    return (
+        <div
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[5px] border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+            data-testid="pr-diff-panel"
+        >
+            <header className="flex min-h-[30px] shrink-0 items-center justify-between gap-1.5 border-b border-gray-200 bg-gray-50 px-2 py-1 dark:border-gray-700 dark:bg-gray-800/60">
+                <span
+                    className="min-w-0 truncate font-mono text-[12px] text-gray-700 dark:text-gray-300"
+                    title={filePath || undefined}
+                    data-testid="pr-diff-panel-path"
+                >
+                    {filePath || 'Diff'}
+                </span>
+                {onPopOut && filePath && (
+                    <button
+                        type="button"
+                        onClick={() => onPopOut(filePath)}
+                        title="Open this file in the pop-out review window"
+                        className="inline-flex h-5 shrink-0 items-center gap-1 rounded border border-gray-300 bg-white px-1.5 text-[10px] font-semibold uppercase leading-none text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                        data-testid="pr-diff-popout"
+                    >
+                        ⧉ Pop out
+                    </button>
+                )}
+            </header>
+            <div
+                className="min-h-0 min-w-0 flex-1 overflow-auto p-1.5"
+                data-testid="pr-diff-panel-scroll"
+            >
+                {diff ? (
+                    <SideBySideDiffViewer
+                        diff={diff}
+                        fileName={filePath}
+                        showLineNumbers
+                        data-testid="pr-inline-diff"
+                    />
+                ) : (
+                    <div
+                        className="flex h-full items-center justify-center px-3 py-6 text-center text-[12px] text-gray-500 dark:text-gray-400"
+                        data-testid="pr-diff-panel-empty"
+                    >
+                        {hasFiles
+                            ? 'Select a file to view its diff.'
+                            : 'No file changes in this pull request.'}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/pull-requests/PullRequestDetail.tsx
@@ -95,6 +95,10 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
     const [commits, setCommits] = useState<PullRequestCommit[]>([]);
     const [commitsError, setCommitsError] = useState<string | null>(null);
     const [diff, setDiff] = useState<FileChange[]>(EMPTY_FILES);
+    // Raw combined unified diff text — retained (alongside the parsed file
+    // list) so the Files tab can slice per-file hunks for the inline diff
+    // panel without a second fetch.
+    const [rawDiff, setRawDiff] = useState<string>('');
     const [diffError, setDiffError] = useState<string | null>(null);
     const [checks, setChecks] = useState<PullRequestCheck[]>([]);
     const [checksError, setChecksError] = useState<string | null>(null);
@@ -152,7 +156,9 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
         if (!assistantOpen) toggleAssistant();
     }, [assistantOpen, toggleAssistant]);
 
-    const handleFileClick = useCallback((filePath: string) => {
+    // Explicit pop-out action for the Files tab. Inline (right-panel) diff is
+    // now the default click path; this opens the separate review window.
+    const handlePopOut = useCallback((_filePath: string) => {
         const url = buildGitPrPopOutUrl(workspaceId, String(repoId), String(prId), originId, lookupCloneBaseUrl(workspaceId));
         const win = window.open(url, `coc-git-review-pr-${prId}`, 'width=1200,height=800');
         if (win) {
@@ -174,6 +180,7 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
         if (!force) setLoading(true);
         setError(null);
         setDiff(EMPTY_FILES);
+        setRawDiff('');
         setDiffError(null);
         setCommits([]);
         setCommitsError(null);
@@ -193,7 +200,7 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
                 .catch(() => [] as CommentThread[]),
             cloneClient.pullRequests
                 .getDiffForOrigin(originId, prIdStr, providerOptions)
-                .then(text => ({ kind: 'ok' as const, parsed: parseDiffFileList(text) }))
+                .then(text => ({ kind: 'ok' as const, parsed: parseDiffFileList(text), raw: text }))
                 .catch((err: unknown) => ({
                     kind: 'err' as const,
                     message: getSpaCocClientErrorMessage(err, 'Failed to load diff'),
@@ -218,6 +225,7 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
                 setThreads(threadsData);
                 if (diffResult.kind === 'ok') {
                     setDiff(diffResult.parsed);
+                    setRawDiff(diffResult.raw);
                 } else {
                     setDiffError(diffResult.message);
                 }
@@ -612,10 +620,11 @@ export function PullRequestDetail({ repoId, workspaceId, remoteUrl, prId, onBack
                         <div className="min-h-0 flex-1">
                             <PrFilesPanel
                                 files={diff}
+                                diffText={rawDiff}
                                 isMobile={isMobile}
                                 workspaceId={workspaceId}
                                 classificationKey={classificationKey}
-                                onFileClick={handleFileClick}
+                                onPopOut={handlePopOut}
                             />
                         </div>
                     </div>

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -269,7 +269,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                 title={t.shortcut}
                 onClick={() => onTab(t.key)}
                 className={
-                    'relative inline-flex items-center gap-1.5 h-[30px] px-2.5 rounded-md text-[13px] whitespace-nowrap shrink-0 transition-colors ' +
+                    'relative inline-flex items-center gap-1.5 h-[26px] px-2.5 rounded-md text-[13px] whitespace-nowrap shrink-0 transition-colors ' +
                     (isActive
                         ? 'font-bold text-[#0969da] dark:text-[#79c0ff] shadow-[inset_0_-2px_0_#0969da] dark:shadow-[inset_0_-2px_0_#3794ff]'
                         : 'font-semibold text-[#656d76] dark:text-[#999] hover:text-[#1f2328] dark:hover:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2a2a]')
@@ -283,7 +283,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
 
     return (
         <div
-            className="relative flex items-center gap-0.5 h-[42px] flex-shrink-0 px-3 border-b border-[#d0d7de] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e]"
+            className="relative flex items-center gap-0.5 h-[32px] flex-shrink-0 px-3 border-b border-[#d0d7de] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e]"
             data-testid="remote-sub-bar"
         >
             {/* Hidden width-measurement mirror of every clone tab (drives overflow). */}
@@ -292,7 +292,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                     <span
                         key={t.key}
                         data-measure-key={t.key}
-                        className={'inline-flex items-center gap-1.5 h-[30px] px-2.5 text-[13px] whitespace-nowrap ' + (activeTab === t.key ? 'font-bold' : 'font-semibold')}
+                        className={'inline-flex items-center gap-1.5 h-[26px] px-2.5 text-[13px] whitespace-nowrap ' + (activeTab === t.key ? 'font-bold' : 'font-semibold')}
                     >
                         {t.label}
                         {badge(t.key, true)}
@@ -305,7 +305,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
             {remoteTabs.map(t => renderTab(t, 'remote-scope-tab'))}
 
             {/* divider */}
-            <span className="w-px h-[22px] bg-[#d8dee4] dark:bg-[#3c3c3c] mx-2 flex-shrink-0" aria-hidden />
+            <span className="w-px h-[18px] bg-[#d8dee4] dark:bg-[#3c3c3c] mx-2 flex-shrink-0" aria-hidden />
 
             {/* ── Clone scope ── */}
             <div className="relative flex-shrink-0" ref={cloneRef}>
@@ -315,7 +315,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                     aria-haspopup="menu"
                     aria-expanded={cloneOpen}
                     title={ws.name}
-                    className="relative inline-flex items-center gap-1.5 h-[30px] px-2.5 rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#2a2a2a] text-[13px] font-semibold text-[#1f2328] dark:text-[#cccccc] hover:border-[#0078d4] dark:hover:border-[#0078d4] transition-colors"
+                    className="relative inline-flex items-center gap-1.5 h-[26px] px-2.5 rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#2a2a2a] text-[13px] font-semibold text-[#1f2328] dark:text-[#cccccc] hover:border-[#0078d4] dark:hover:border-[#0078d4] transition-colors"
                 >
                     <span className="inline-block w-2 h-2 rounded-full flex-shrink-0" style={{ background: cloneStatusColor(cloneStatus[cloneId], remoteColor) }} aria-hidden />
                     <span className="max-w-[160px] truncate">{ws.name}</span>
@@ -453,7 +453,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                         title="More"
                         onClick={() => setOvOpen(o => !o)}
                         className={
-                            'inline-flex items-center justify-center h-[30px] px-2 rounded-md text-[15px] leading-none transition-colors ' +
+                            'inline-flex items-center justify-center h-[26px] px-2 rounded-md text-[15px] leading-none transition-colors ' +
                             (overflowActive
                                 ? 'font-bold text-[#0969da] dark:text-[#79c0ff] shadow-[inset_0_-2px_0_#0969da] dark:shadow-[inset_0_-2px_0_#3794ff]'
                                 : 'text-[#656d76] dark:text-[#999] hover:text-[#1f2328] dark:hover:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2a2a]')
@@ -498,7 +498,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                 data-testid="subbar-ask"
                 title={`Ask AI about ${ws.name} (read-only)`}
                 onClick={() => queueDispatch({ type: 'OPEN_DIALOG', workspaceId: cloneId, mode: 'ask' })}
-                className="inline-flex items-center gap-1 h-[28px] px-2.5 rounded-md text-[12px] font-semibold bg-yellow-500 hover:bg-yellow-600 dark:bg-yellow-400 dark:hover:bg-yellow-300 text-[#1e1e1e] transition-colors flex-shrink-0 ml-1"
+                className="inline-flex items-center gap-1 h-[24px] px-2.5 rounded-md text-[12px] font-semibold bg-yellow-500 hover:bg-yellow-600 dark:bg-yellow-400 dark:hover:bg-yellow-300 text-[#1e1e1e] transition-colors flex-shrink-0 ml-1"
             >
                 Ask
             </button>
@@ -506,7 +506,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                 data-testid="subbar-queue"
                 title={`Queue a task on ${ws.name}${branch ? ' (' + branch + ')' : ''}`}
                 onClick={() => queueDispatch({ type: 'OPEN_DIALOG', workspaceId: cloneId })}
-                className="inline-flex items-center gap-1 h-[28px] px-2.5 rounded-md text-[12px] font-semibold bg-[#1f883d] hover:bg-[#1a7f37] dark:bg-[#238636] dark:hover:bg-[#2ea043] text-white transition-colors flex-shrink-0"
+                className="inline-flex items-center gap-1 h-[24px] px-2.5 rounded-md text-[12px] font-semibold bg-[#1f883d] hover:bg-[#1a7f37] dark:bg-[#238636] dark:hover:bg-[#2ea043] text-white transition-colors flex-shrink-0"
             >
                 <span className="text-[14px] leading-none">+</span>
                 Queue

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -446,7 +446,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
             {!isMobile && !chromeless && (
             <div
                 className="repo-detail-header px-3 border-b border-[#d0d7de] dark:border-[#3c3c3c] flex flex-row items-center bg-white dark:bg-[#1e1e1e] gap-2"
-                style={{ minHeight: 44 }}
+                style={{ minHeight: 32 }}
             >
                 <>
                     {/* Title — original styling: color dot + bold name */}
@@ -493,7 +493,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                         title={t.shortcut}
                                         aria-current={isActive ? 'page' : undefined}
                                         className={cn(
-                                            'repo-sub-tab relative inline-flex items-center gap-1.5 min-h-[32px] px-2.5 rounded-md text-[13px] whitespace-nowrap shrink-0 transition-colors',
+                                            'repo-sub-tab relative inline-flex items-center gap-1.5 min-h-[26px] px-2.5 rounded-md text-[13px] whitespace-nowrap shrink-0 transition-colors',
                                             isActive
                                                 ? 'active bg-[#ddf4ff] dark:bg-[#3794ff]/20 text-[#0969da] dark:text-[#79c0ff] font-bold ring-1 ring-inset ring-[#0969da]/30 dark:ring-[#3794ff]/40'
                                                 : 'font-semibold text-[#656d76] dark:text-[#999] hover:text-[#1f2328] dark:hover:text-[#cccccc] hover:bg-[#f6f8fa] dark:hover:bg-[#2a2a2a]'
@@ -536,7 +536,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                             />
                                         )}
                                         {isActive && (
-                                            <span className="absolute left-1.5 right-1.5 -bottom-[5px] h-[3px] rounded-sm bg-[#0969da] dark:bg-[#3794ff]" />
+                                            <span className="absolute left-1.5 right-1.5 -bottom-[2px] h-[3px] rounded-sm bg-[#0969da] dark:bg-[#3794ff]" />
                                         )}
                                     </button>
                                 </Fragment>
@@ -565,7 +565,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                             onClick={() => queueDispatch({ type: 'OPEN_DIALOG', workspaceId: ws.id })}
                                             title="Queue a new AI task (Alt+Q). Drop CoC context here to attach it first."
                                             data-testid="repo-queue-task-btn"
-                                            className="!h-[30px] !rounded-md !px-2.5 !text-[13px] !font-semibold !min-h-0 !shadow-[0_1px_0_rgba(31,35,40,0.1)]"
+                                            className="!h-[26px] !rounded-md !px-2.5 !text-[13px] !font-semibold !min-h-0 !shadow-[0_1px_0_rgba(31,35,40,0.1)]"
                                         >
                                             Queue Task
                                         </Button>
@@ -584,7 +584,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                             onClick={() => queueDispatch({ type: 'OPEN_DIALOG', workspaceId: ws.id, mode: 'ask' })}
                                             title="Ask AI a question (read-only). Drop CoC context here to attach it first."
                                             data-testid="repo-ask-btn"
-                                            className="!h-[30px] !rounded-md !px-2.5 !text-[13px] !font-semibold !min-h-0 !bg-yellow-500 hover:!bg-yellow-600 dark:!bg-yellow-400 dark:hover:!bg-yellow-300 !text-[#1e1e1e] !border-transparent !shadow-[0_1px_0_rgba(31,35,40,0.1)]"
+                                            className="!h-[26px] !rounded-md !px-2.5 !text-[13px] !font-semibold !min-h-0 !bg-yellow-500 hover:!bg-yellow-600 dark:!bg-yellow-400 dark:hover:!bg-yellow-300 !text-[#1e1e1e] !border-transparent !shadow-[0_1px_0_rgba(31,35,40,0.1)]"
                                         >
                                             Ask
                                         </Button>
@@ -620,10 +620,10 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                     : 'flex items-center gap-1';
                                 const secondaryItemCls = isOverflow
                                     ? '!font-semibold !w-full !justify-start !min-h-[34px] !h-[34px] !px-2 !rounded-md !bg-transparent !border-transparent !text-[#1f2328] dark:!text-[#cccccc] hover:!bg-[#f6f8fa] dark:hover:!bg-[#2d2d2d]'
-                                    : '!font-semibold !h-[30px] !rounded-md !px-2.5 !text-[13px] !min-h-0 !bg-[#f6f8fa] dark:!bg-[#2a2a2a] !border-[#d0d7de] dark:!border-[#3c3c3c] !text-[#1f2328] dark:!text-[#cccccc] hover:!bg-[#eaeef2] dark:hover:!bg-[#333]';
+                                    : '!font-semibold !h-[26px] !rounded-md !px-2.5 !text-[13px] !min-h-0 !bg-[#f6f8fa] dark:!bg-[#2a2a2a] !border-[#d0d7de] dark:!border-[#3c3c3c] !text-[#1f2328] dark:!text-[#cccccc] hover:!bg-[#eaeef2] dark:hover:!bg-[#333]';
                                 const primaryItemCls = isOverflow
                                     ? secondaryItemCls
-                                    : '!font-semibold !h-[30px] !rounded-md !px-2.5 !text-[13px] !min-h-0 !bg-[#1f883d] hover:!bg-[#1a7f37] dark:!bg-[#238636] dark:hover:!bg-[#2ea043] !text-white !border-transparent !shadow-[0_1px_0_rgba(31,35,40,0.1)]';
+                                    : '!font-semibold !h-[26px] !rounded-md !px-2.5 !text-[13px] !min-h-0 !bg-[#1f883d] hover:!bg-[#1a7f37] dark:!bg-[#238636] dark:hover:!bg-[#2ea043] !text-white !border-transparent !shadow-[0_1px_0_rgba(31,35,40,0.1)]';
                                 return (
                                 <div
                                     className={containerCls}
@@ -677,7 +677,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                     aria-haspopup="menu"
                                     title="More actions"
                                     data-testid="repo-overflow-toggle-btn"
-                                    className="inline-flex items-center justify-center h-[30px] w-[31px] rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#2a2a2a] text-[#656d76] dark:text-[#999] hover:bg-[#eaeef2] dark:hover:bg-[#333] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#0969da]"
+                                    className="inline-flex items-center justify-center h-[26px] w-[31px] rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#2a2a2a] text-[#656d76] dark:text-[#999] hover:bg-[#eaeef2] dark:hover:bg-[#333] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#0969da]"
                                 >
                                     <span className="text-[15px] leading-none -mt-1" aria-hidden>…</span>
                                 </button>

--- a/packages/coc/src/server/spa/client/react/features/skills/AgentSkillsPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/skills/AgentSkillsPanel.tsx
@@ -159,7 +159,7 @@ export interface SkillFolderGroup {
     key: string;
     label: string;
     folderPath: string;
-    source: 'global' | 'repo' | 'linked-repo' | 'extra-folder';
+    source: 'global' | 'repo' | 'linked-repo' | 'extra-folder' | 'global-extra-folder';
     skills: Skill[];
     repoId?: string;
     isRemovable: boolean;
@@ -193,6 +193,27 @@ export function groupSkillsByFolder(
             folderPath: repoSkills[0].folderPath ?? '',
             source: 'repo',
             skills: repoSkills,
+            isRemovable: false,
+        });
+    }
+
+    // Configured global extra folders (read-only, config-managed). Grouped per
+    // folderPath and placed after global/repo but before per-repo extra folders.
+    // Not removable here — they are managed in the Skills > Config tab, not per-repo.
+    const globalExtraSkills = skills.filter(s => s.source === 'global-extra-folder');
+    const seenGlobalExtra = new Set<string>();
+    for (const skill of globalExtraSkills) {
+        const folder = skill.folderPath ?? '';
+        if (seenGlobalExtra.has(folder)) continue;
+        seenGlobalExtra.add(folder);
+
+        const groupSkills = globalExtraSkills.filter(s => (s.folderPath ?? '') === folder);
+        groups.push({
+            key: `global-extra:${folder}`,
+            label: `🌐 ${folder}`,
+            folderPath: folder,
+            source: 'global-extra-folder',
+            skills: groupSkills,
             isRemovable: false,
         });
     }
@@ -295,6 +316,17 @@ function buildSources(
                 repoId: group.repoId,
                 folderPath: group.folderPath,
             });
+        } else if (group.source === 'global-extra-folder') {
+            // Config-managed global source — surfaced but not removable per-repo.
+            items.push({
+                id: `group:${group.key}`,
+                kind: 'extra',
+                name: group.folderPath.split(/[\\/]/).filter(Boolean).pop() || group.folderPath,
+                path: group.folderPath,
+                count: group.skills.length,
+                removable: false,
+                folderPath: group.folderPath,
+            });
         } else {
             items.push({
                 id: `group:${group.key}`,
@@ -315,7 +347,7 @@ function getSkillKind(skill: Skill): SourceKind {
     const s = skill.source;
     if (s === 'global') return 'global';
     if (s === 'linked-repo') return 'linked';
-    if (s === 'extra-folder') return 'extra';
+    if (s === 'extra-folder' || s === 'global-extra-folder') return 'extra';
     return 'repo';
 }
 

--- a/packages/coc/src/server/spa/client/react/features/skills/McpServersPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/skills/McpServersPanel.tsx
@@ -1,56 +1,34 @@
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import './mcp-servers-redesign.css';
-import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
-import { getApiBase } from '../../utils/config';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
 import type {
     McpServerDetail as ClientMcpServerDetail,
     McpConfigScope,
     McpServerAuthStatus,
     McpServerToolsResult,
+    McpServerCreateRequest,
+    McpServerUpdateRequest,
     McpDiscoveredTool,
 } from '@plusplusoneplusplus/coc-client';
+import { isMcpToolEnabled } from './mcpToolsAllowList';
 import {
-    isMcpToolEnabled,
-    applyMcpToolToggle,
-    enableAllMcpTools,
-    disableAllMcpTools,
-    normalizeEnabledMcpTools,
-    type EnabledMcpToolsMap,
-} from './mcpToolsAllowList';
+    buildMcpServerListModel,
+    type DiscoveryState,
+    type FilterTab,
+    type InspectorTab,
+    type McpAuthFlowState,
+    type McpServerEntry,
+    type McpServerSource,
+    type McpServerSources,
+} from './mcp-server-list-model';
+import { useMcpServerInspectorController } from './useMcpServerInspectorController';
 
-type DiscoveryState = 'idle' | 'loading' | 'loaded' | 'error';
-
-export type McpServerSource = 'global' | 'workspace';
-export type McpServerEntry = {
-    name: string;
-    type: string;
-    url?: string;
-    command?: string;
-    source?: McpServerSource;
-    effective?: boolean;
-    overriddenBy?: McpServerSource;
-    /** Derived status from the server response. */
-    status?: 'ok' | 'auth' | 'off' | 'err';
-    /** Auth state for remote servers (absent on stdio). */
-    authStatus?: McpServerAuthStatus;
-    /** Token expiry (epoch seconds), when known. */
-    authExpiresAt?: number;
-    /** User-provided description from config file. */
-    description?: string;
-};
-
-export type McpServerSourceSection = {
-    configPath: string;
-    fileExists: boolean;
-    success: boolean;
-    error?: string;
-    servers: McpServerEntry[];
-};
-
-export type McpServerSources = {
-    global: McpServerSourceSection;
-    workspace: McpServerSourceSection;
-};
+export type {
+    McpServerSource,
+    McpServerEntry,
+    McpServerSourceSection,
+    McpServerSources,
+} from './mcp-server-list-model';
 
 interface McpServersPanelProps {
     workspaceId?: string;
@@ -71,70 +49,6 @@ interface McpServersPanelProps {
     onRefresh?: () => void;
     /** Called after a server is added or deleted so the parent can refresh the list. */
     onMutate?: () => void;
-}
-
-type FilterTab = 'all' | 'active' | 'auth' | 'disabled';
-
-type InspectorTab = 'overview' | 'tools' | 'configuration' | 'source' | 'activity';
-
-/**
- * Local state for a server's OAuth flow. `starting` → `authorizing` → `completed`
- * (or `failed`). Stored only in the panel — server-side state lives in the
- * McpOauthManager and is fetched via `/api/mcp-oauth/pending/:id`.
- */
-type McpAuthFlowState =
-    | { phase: 'starting' }
-    | { phase: 'authorizing'; requestId: string; authorizationUrl?: string }
-    | { phase: 'completed'; requestId: string }
-    | { phase: 'failed'; requestId: string; error: string };
-
-const AUTH_POLL_INTERVAL_MS = 2_000;
-const AUTH_POLL_TIMEOUT_MS = 10 * 60 * 1_000;
-
-/**
- * Resolve the dot color for a row.
- *
- * Trust the server-derived `status` field when present — it already accounts
- * for cached OAuth tokens. The legacy fallback (treat any HTTP/SSE server as
- * "auth") is kept for older responses that pre-date authStatus.
- */
-function getServerStatus(server: McpServerEntry, isEnabled: boolean): 'ok' | 'auth' | 'off' | 'err' {
-    if (!isEnabled) return 'off';
-    if (server.status) return server.status;
-    if (server.type === 'http' || server.type === 'sse') return 'auth';
-    return 'ok';
-}
-
-function needsAuth(server: McpServerEntry): boolean {
-    if (server.type !== 'http' && server.type !== 'sse') return false;
-    if (!server.authStatus) return true; // legacy response — assume needs auth
-    return server.authStatus === 'required' || server.authStatus === 'expired';
-}
-
-function isRemote(server: McpServerEntry): boolean {
-    return server.type === 'http' || server.type === 'sse';
-}
-
-function getServerDescription(server: McpServerEntry, isEnabled: boolean): string {
-    const base = server.description || server.url || server.command || '';
-    if (!isEnabled) return `Disabled · ${base.toLowerCase()}`;
-    return base;
-}
-
-function getTransportPillClass(type: string): string {
-    if (type === 'stdio') return 'accent';
-    if (type === 'http' || type === 'sse') return 'done';
-    return '';
-}
-
-function getSourcePillInfo(server: McpServerEntry): { label: string; cls: string } {
-    if (server.overriddenBy === 'workspace' || server.source === 'workspace') {
-        return server.overriddenBy === 'workspace'
-            ? { label: 'user override', cls: 'warn' }
-            : { label: 'repo config', cls: 'muted' };
-    }
-    if (server.source === 'global') return { label: 'global', cls: 'muted' };
-    return { label: 'repo config', cls: 'muted' };
 }
 
 function ChevronIcon() {
@@ -453,12 +367,13 @@ function InspectorToolsPane({
     );
 }
 
-function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }: {
+function InspectorConfigPane({ server, detail, workspaceId, updateServer, migrateServer, deleteServer }: {
     server: McpServerEntry;
     detail: ClientMcpServerDetail | null | 'loading';
     workspaceId: string;
-    onSaved: () => void;
-    onDeleted: () => void;
+    updateServer: (serverName: string, request: McpServerUpdateRequest) => Promise<void>;
+    migrateServer: (serverName: string, targetScope: McpConfigScope) => Promise<void>;
+    deleteServer: (serverName: string) => Promise<void>;
 }) {
     const loaded = detail && detail !== 'loading' ? detail : null;
 
@@ -500,8 +415,7 @@ function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }
         setArgsError('');
         try {
             const args = argsText.split('\n').map(s => s.trim()).filter(Boolean);
-            await getSpaCocClient().workspaces.updateMcpServer(workspaceId, server.name, { args });
-            onSaved();
+            await updateServer(server.name, { args });
         } catch (e) {
             setArgsError(getSpaCocClientErrorMessage(e, 'Failed to save args'));
         } finally {
@@ -514,8 +428,7 @@ function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }
         setToolScope(scope);
         setScopeSaving(true);
         try {
-            await getSpaCocClient().workspaces.updateMcpServer(workspaceId, server.name, { toolScope: scope });
-            onSaved();
+            await updateServer(server.name, { toolScope: scope });
         } catch {
             // revert
             if (loaded) setToolScope(loaded.toolScope);
@@ -530,8 +443,7 @@ function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }
         setConfigScope(targetScope);
         setMigrateSaving(true);
         try {
-            await getSpaCocClient().workspaces.migrateMcpServer(workspaceId, server.name, targetScope as McpConfigScope);
-            onSaved();
+            await migrateServer(server.name, targetScope);
         } catch {
             setConfigScope(prevScope);
         } finally {
@@ -544,12 +456,11 @@ function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }
         setEnvSaving(true);
         setEnvError('');
         try {
-            await getSpaCocClient().workspaces.updateMcpServer(workspaceId, server.name, {
+            await updateServer(server.name, {
                 env: { [newEnvKey.trim()]: newEnvValue },
             });
             setNewEnvKey('');
             setNewEnvValue('');
-            onSaved();
         } catch (e) {
             setEnvError(getSpaCocClientErrorMessage(e, 'Failed to add env var'));
         } finally {
@@ -561,8 +472,7 @@ function InspectorConfigPane({ server, detail, workspaceId, onSaved, onDeleted }
         if (!workspaceId) return;
         setDeleteSaving(true);
         try {
-            await getSpaCocClient().workspaces.deleteMcpServer(workspaceId, server.name);
-            onDeleted();
+            await deleteServer(server.name);
         } catch {
             setDeleteConfirm(false);
         } finally {
@@ -781,14 +691,15 @@ function InspectorActivityPane() {
     );
 }
 
-function ServerInspector({ server, activeTab, onTabChange, detail, workspaceId, onSaved, onDeleted, tools }: {
+function ServerInspector({ server, activeTab, onTabChange, detail, workspaceId, updateServer, migrateServer, deleteServer, tools }: {
     server: McpServerEntry;
     activeTab: InspectorTab;
     onTabChange: (tab: InspectorTab) => void;
     detail: ClientMcpServerDetail | null | 'loading';
     workspaceId: string;
-    onSaved: () => void;
-    onDeleted: () => void;
+    updateServer: (serverName: string, request: McpServerUpdateRequest) => Promise<void>;
+    migrateServer: (serverName: string, targetScope: McpConfigScope) => Promise<void>;
+    deleteServer: (serverName: string) => Promise<void>;
     tools: {
         enabled: boolean;
         result: McpServerToolsResult | undefined;
@@ -845,8 +756,9 @@ function ServerInspector({ server, activeTab, onTabChange, detail, workspaceId, 
                         server={server}
                         detail={detail}
                         workspaceId={workspaceId}
-                        onSaved={onSaved}
-                        onDeleted={onDeleted}
+                        updateServer={updateServer}
+                        migrateServer={migrateServer}
+                        deleteServer={deleteServer}
                     />
                 )}
                 {activeTab === 'source' && <InspectorSourcePane server={server} detail={detail} />}
@@ -856,7 +768,7 @@ function ServerInspector({ server, activeTab, onTabChange, detail, workspaceId, 
     );
 }
 
-function AddServerCard({ workspaceId, onAdded }: { workspaceId?: string; onAdded?: () => void }) {
+function AddServerCard({ workspaceId, addServer }: { workspaceId?: string; addServer: (request: McpServerCreateRequest) => Promise<void> }) {
     const [transport, setTransport] = useState<'stdio' | 'http' | 'sse'>('stdio');
     const [name, setName] = useState('');
     const [desc, setDesc] = useState('');
@@ -884,7 +796,7 @@ function AddServerCard({ workspaceId, onAdded }: { workspaceId?: string; onAdded
             for (const row of envRows) {
                 if (row.key.trim()) envObj[row.key.trim()] = row.value;
             }
-            await getSpaCocClient().workspaces.addMcpServer(workspaceId, {
+            await addServer({
                 name: name.trim(),
                 type: transport,
                 command: transport === 'stdio' ? (command.trim() || undefined) : undefined,
@@ -898,7 +810,6 @@ function AddServerCard({ workspaceId, onAdded }: { workspaceId?: string; onAdded
             // Reset form
             setName(''); setDesc(''); setCommand('npx'); setArgsText(''); setUrl('');
             setEnvRows([{ key: '', value: '' }]); setToolScope('all'); setScope('workspace');
-            onAdded?.();
         } catch (e) {
             setError(getSpaCocClientErrorMessage(e, 'Failed to add server'));
         } finally {
@@ -1197,212 +1108,16 @@ export function McpServersPanel({
 }: McpServersPanelProps) {
     const [filterTab, setFilterTab] = useState<FilterTab>('all');
     const [searchQuery, setSearchQuery] = useState('');
-    const [expandedServer, setExpandedServer] = useState<string | null>(null);
-    const [inspectorTab, setInspectorTab] = useState<InspectorTab>('overview');
-    const [detailCache, setDetailCache] = useState<Record<string, ClientMcpServerDetail | null | 'loading'>>({});
 
-    // ── Live tool discovery (AC-02) ──────────────────────────────────────────
-    const [discovery, setDiscovery] = useState<Record<string, McpServerToolsResult>>({});
-    const [discoveryState, setDiscoveryState] = useState<DiscoveryState>('idle');
-    const [discoveryError, setDiscoveryError] = useState<string | null>(null);
-
-    // ── Per-tool allow-list (AC-03) ──────────────────────────────────────────
-    const [toolsAllowList, setToolsAllowList] = useState<EnabledMcpToolsMap>(() => ({ ...(enabledMcpTools ?? {}) }));
-    const [toolsSaving, setToolsSaving] = useState(false);
-    // Keep local allow-list in sync when the parent reloads the config.
-    useEffect(() => {
-        setToolsAllowList({ ...(enabledMcpTools ?? {}) });
-    }, [enabledMcpTools]);
-
-    const fetchTools = useCallback(async (forceReload = false) => {
-        if (!workspaceId) return;
-        setDiscoveryState('loading');
-        setDiscoveryError(null);
-        try {
-            const resp = await getSpaCocClient().workspaces.discoverMcpTools(
-                workspaceId,
-                forceReload ? { forceReload: true } : undefined,
-            );
-            setDiscovery(resp.servers ?? {});
-            setDiscoveryState('loaded');
-        } catch (e) {
-            setDiscoveryError(getSpaCocClientErrorMessage(e, 'Failed to discover tools'));
-            setDiscoveryState('error');
-        }
-    }, [workspaceId]);
-
-    // Eager discovery on mount / workspace change.
-    useEffect(() => { void fetchTools(); }, [fetchTools]);
-
-    const persistToolsAllowList = useCallback(async (nextMap: EnabledMcpToolsMap) => {
-        if (!workspaceId) return;
-        let prev: EnabledMcpToolsMap = {};
-        setToolsAllowList(curr => { prev = curr; return nextMap; }); // optimistic
-        setToolsSaving(true);
-        try {
-            await getSpaCocClient().workspaces.updateMcpConfig(workspaceId, {
-                enabledMcpServers: enabledMcpServers ?? null,
-                enabledMcpTools: normalizeEnabledMcpTools(nextMap),
-            });
-        } catch (e) {
-            setToolsAllowList(prev); // revert
-            setDiscoveryError(getSpaCocClientErrorMessage(e, 'Failed to save tool settings'));
-        } finally {
-            setToolsSaving(false);
-        }
-    }, [workspaceId, enabledMcpServers]);
-
-    const discoveredToolNames = useCallback((serverName: string): string[] => {
-        const r = discovery[serverName];
-        return r && r.status === 'ok' ? r.tools.map(t => t.name) : [];
-    }, [discovery]);
-
-    const handleToolToggle = useCallback((serverName: string, toolName: string, on: boolean) => {
-        void persistToolsAllowList(
-            applyMcpToolToggle(toolsAllowList, serverName, discoveredToolNames(serverName), toolName, on),
-        );
-    }, [persistToolsAllowList, toolsAllowList, discoveredToolNames]);
-
-    const handleEnableAllTools = useCallback((serverName: string) => {
-        void persistToolsAllowList(enableAllMcpTools(toolsAllowList, serverName));
-    }, [persistToolsAllowList, toolsAllowList]);
-
-    const handleDisableAllTools = useCallback((serverName: string) => {
-        void persistToolsAllowList(disableAllMcpTools(toolsAllowList, serverName));
-    }, [persistToolsAllowList, toolsAllowList]);
-
-    /** Row-level tool count label, e.g. "12", "8/12", "…", "!", or "—". */
-    const toolCountFor = useCallback((server: McpServerEntry): { text: string; title?: string } => {
-        if (!isEnabled(server.name) || server.effective === false) return { text: '—' };
-        const r = discovery[server.name];
-        if (!r) {
-            return discoveryState === 'loading' || discoveryState === 'idle'
-                ? { text: '…' }
-                : { text: '—' };
-        }
-        if (r.status === 'error') return { text: '!', title: r.error };
-        const total = r.tools.length;
-        const enabledCount = r.tools.filter(t => isMcpToolEnabled(toolsAllowList[server.name], t.name)).length;
-        return { text: enabledCount === total ? String(total) : `${enabledCount}/${total}`, title: `${enabledCount} of ${total} tools enabled` };
-    }, [discovery, discoveryState, isEnabled, toolsAllowList]);
-    /** Per-server OAuth flow state — drives the Authenticate button label and spinner. */
-    const [authFlow, setAuthFlow] = useState<Record<string, McpAuthFlowState>>({});
-    const authPollersRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
-
-    // Tear down any open pollers when the panel unmounts to avoid stray fetches.
-    useEffect(() => () => {
-        for (const t of Object.values(authPollersRef.current)) clearInterval(t);
-        authPollersRef.current = {};
-    }, []);
-
-    const setFlow = useCallback((serverName: string, next: McpAuthFlowState | null) => {
-        setAuthFlow(prev => {
-            if (next === null) {
-                if (!(serverName in prev)) return prev;
-                const copy = { ...prev };
-                delete copy[serverName];
-                return copy;
-            }
-            return { ...prev, [serverName]: next };
-        });
-    }, []);
-
-    const startPolling = useCallback((serverName: string, requestId: string) => {
-        // Replace any existing poller for this server
-        const existing = authPollersRef.current[serverName];
-        if (existing) clearInterval(existing);
-
-        const apiBase = getApiBase();
-        const url = `${apiBase}/mcp-oauth/pending/${encodeURIComponent(requestId)}`;
-        const startedAt = Date.now();
-
-        const tick = async () => {
-            try {
-                const r = await fetch(url);
-                if (r.ok) {
-                    const entry = await r.json() as { status?: string; error?: string };
-                    if (entry.status === 'completed') {
-                        clearInterval(authPollersRef.current[serverName]);
-                        delete authPollersRef.current[serverName];
-                        setFlow(serverName, { phase: 'completed', requestId });
-                        onRefresh?.();
-                        return;
-                    } else if (entry.status === 'failed') {
-                        clearInterval(authPollersRef.current[serverName]);
-                        delete authPollersRef.current[serverName];
-                        setFlow(serverName, { phase: 'failed', requestId, error: entry.error ?? 'Authorization failed' });
-                        return;
-                    }
-                }
-            } catch {
-                // transient network error — keep polling
-            }
-            // Always check timeout so a stuck/gone entry doesn't poll forever.
-            if (Date.now() - startedAt > AUTH_POLL_TIMEOUT_MS) {
-                clearInterval(authPollersRef.current[serverName]);
-                delete authPollersRef.current[serverName];
-                setFlow(serverName, { phase: 'failed', requestId, error: 'Authorization timed out' });
-            }
-        };
-
-        authPollersRef.current[serverName] = setInterval(tick, AUTH_POLL_INTERVAL_MS);
-    }, [onRefresh, setFlow]);
-
-    const handleAuthenticate = useCallback(async (serverName: string) => {
-        setFlow(serverName, { phase: 'starting' });
-        try {
-            const r = await fetch(`${getApiBase()}/mcp-oauth/start`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ serverName, workspaceId: workspaceId || undefined }),
-            });
-            if (!r.ok) {
-                const text = await r.text().catch(() => '');
-                throw new Error(text || `Failed to start OAuth flow (${r.status})`);
-            }
-            const result = await r.json() as {
-                requestId?: string;
-                authorizationUrl?: string;
-                alreadyAuthenticated?: boolean;
-            };
-
-            if (result.alreadyAuthenticated) {
-                setFlow(serverName, { phase: 'completed', requestId: '' });
-                onRefresh?.();
-                return;
-            }
-            if (!result.requestId) {
-                throw new Error('Server did not return a request id');
-            }
-
-            if (result.authorizationUrl) {
-                window.open(result.authorizationUrl, '_blank', 'noopener,noreferrer');
-            }
-            setFlow(serverName, {
-                phase: 'authorizing',
-                requestId: result.requestId,
-                authorizationUrl: result.authorizationUrl,
-            });
-            startPolling(serverName, result.requestId);
-        } catch (err) {
-            setFlow(serverName, {
-                phase: 'failed',
-                requestId: '',
-                error: err instanceof Error ? err.message : String(err),
-            });
-        }
-    }, [onRefresh, setFlow, startPolling, workspaceId]);
-
-    const fetchDetail = useCallback(async (name: string) => {
-        if (!workspaceId || detailCache[name] !== undefined) return;
-        setDetailCache(prev => ({ ...prev, [name]: 'loading' }));
-        try {
-            const detail = await getSpaCocClient().workspaces.getMcpServerDetail(workspaceId, name);
-            setDetailCache(prev => ({ ...prev, [name]: detail }));
-        } catch {
-            setDetailCache(prev => ({ ...prev, [name]: null }));
-        }
-    }, [workspaceId, detailCache]);
+    // Workspace-scoped state (detail cache, discovery, allow-list, OAuth flow,
+    // expanded row, inspector tab) plus mutation actions all live in the
+    // controller so switching workspaces never reuses another repo's state.
+    const controller = useMcpServerInspectorController(workspaceId, {
+        enabledMcpServers,
+        enabledMcpTools,
+        onRefresh,
+        onMutate,
+    });
 
     const legacySources: McpServerSources | undefined = sources ?? (availableServers.length > 0 ? {
         global: {
@@ -1419,61 +1134,18 @@ export function McpServersPanel({
         },
     } : undefined);
 
-    const allServers = availableServers;
-
-    const counts = useMemo(() => {
-        const active = allServers.filter(s => isEnabled(s.name) && s.effective !== false && getServerStatus(s, true) === 'ok').length;
-        const authCount = allServers.filter(s => getServerStatus(s, isEnabled(s.name)) === 'auth').length;
-        const disabled = allServers.filter(s => !isEnabled(s.name) || s.effective === false).length;
-        return { all: allServers.length, active, auth: authCount, disabled };
-    }, [allServers, isEnabled]);
-
-    const filteredServers = useMemo(() => {
-        let list = allServers;
-
-        if (filterTab === 'active') {
-            list = list.filter(s => isEnabled(s.name) && s.effective !== false && getServerStatus(s, true) === 'ok');
-        } else if (filterTab === 'auth') {
-            list = list.filter(s => getServerStatus(s, isEnabled(s.name)) === 'auth');
-        } else if (filterTab === 'disabled') {
-            list = list.filter(s => !isEnabled(s.name) || s.effective === false);
-        }
-
-        const q = searchQuery.trim().toLowerCase();
-        if (q) {
-            list = list.filter(s =>
-                s.name.toLowerCase().includes(q) ||
-                (s.description ?? '').toLowerCase().includes(q)
-            );
-        }
-
-        return list;
-    }, [allServers, filterTab, searchQuery, isEnabled]);
-
-    const handleToggleExpand = useCallback((name: string) => {
-        if (expandedServer === name) {
-            setExpandedServer(null);
-        } else {
-            setExpandedServer(name);
-            setInspectorTab('overview');
-            fetchDetail(name);
-        }
-    }, [expandedServer, fetchDetail]);
-
-    // After a detail-mutating save, invalidate the cached detail so it re-fetches on next open
-    const handleDetailSaved = useCallback((serverName: string) => {
-        setDetailCache(prev => {
-            const next = { ...prev };
-            delete next[serverName];
-            return next;
-        });
-    }, []);
-
-    const handleServerDeleted = useCallback(() => {
-        setExpandedServer(null);
-        onMutate?.();
-        onRefresh?.();
-    }, [onMutate, onRefresh]);
+    const { discovery, discoveryState, discoveryError, toolsAllowList, authFlow } = controller;
+    const model = useMemo(() => buildMcpServerListModel({
+        servers: availableServers,
+        isEnabled,
+        filterTab,
+        searchQuery,
+        discovery,
+        discoveryState,
+        toolsAllowList,
+        authFlow,
+    }), [availableServers, isEnabled, filterTab, searchQuery, discovery, discoveryState, toolsAllowList, authFlow]);
+    const { counts, rows } = model;
 
     if (loading) {
         return (
@@ -1540,7 +1212,7 @@ export function McpServersPanel({
                 {onRefresh && (
                     <button
                         className="mcp-btn"
-                        onClick={() => { onRefresh(); void fetchTools(true); }}
+                        onClick={() => { onRefresh(); controller.refetchTools(true); }}
                         disabled={loading}
                         type="button"
                     >
@@ -1554,22 +1226,14 @@ export function McpServersPanel({
 
             {/* Server list */}
             <div className="mcp-server-list" data-testid="mcp-server-list">
-                {filteredServers.length === 0 ? (
+                {rows.length === 0 ? (
                     <div className="mcp-empty-state">
                         {searchQuery ? `No servers matching "${searchQuery}"` : 'No MCP servers configured.'}
                     </div>
                 ) : (
-                    filteredServers.map(server => {
-                        const enabled = isEnabled(server.name);
-                        const isOverridden = server.effective === false;
-                        const status = getServerStatus(server, enabled);
-                        const description = getServerDescription(server, enabled);
-                        const transportCls = getTransportPillClass(server.type);
-                        const sourcePill = getSourcePillInfo(server);
-                        const isExpanded = expandedServer === server.name;
-                        const flow = authFlow[server.name];
-                        const showAuthBtn = isRemote(server) && enabled && (needsAuth(server) || (flow && flow.phase !== 'completed'));
-                        const toolCount = toolCountFor(server);
+                    rows.map(row => {
+                        const { server, enabled, isOverridden, status, description, transportCls, sourcePill, toolCount, flow, showAuthBtn } = row;
+                        const isExpanded = controller.expandedServer === server.name;
 
                         return (
                             <React.Fragment key={server.name}>
@@ -1579,7 +1243,7 @@ export function McpServersPanel({
                                 >
                                     <button
                                         className="mcp-chev"
-                                        onClick={() => handleToggleExpand(server.name)}
+                                        onClick={() => controller.toggleExpand(server.name)}
                                         type="button"
                                         aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${server.name}`}
                                     >
@@ -1596,7 +1260,7 @@ export function McpServersPanel({
                                                 serverName={server.name}
                                                 flow={flow}
                                                 authStatus={server.authStatus}
-                                                onClick={() => handleAuthenticate(server.name)}
+                                                onClick={() => controller.authenticate(server.name)}
                                             />
                                         )}
                                     </div>
@@ -1613,23 +1277,24 @@ export function McpServersPanel({
                                 {isExpanded && (
                                     <ServerInspector
                                         server={server}
-                                        activeTab={inspectorTab}
-                                        onTabChange={setInspectorTab}
-                                        detail={detailCache[server.name] ?? null}
+                                        activeTab={controller.inspectorTab}
+                                        onTabChange={controller.setInspectorTab}
+                                        detail={controller.getDetail(server.name)}
                                         workspaceId={workspaceId}
-                                        onSaved={() => handleDetailSaved(server.name)}
-                                        onDeleted={handleServerDeleted}
+                                        updateServer={controller.updateServer}
+                                        migrateServer={controller.migrateServer}
+                                        deleteServer={controller.deleteServer}
                                         tools={{
                                             enabled: enabled && !isOverridden,
                                             result: discovery[server.name],
                                             discoveryState,
                                             discoveryError,
                                             allowEntry: toolsAllowList[server.name],
-                                            saving: toolsSaving,
-                                            onToggleTool: (toolName, on) => handleToolToggle(server.name, toolName, on),
-                                            onEnableAll: () => handleEnableAllTools(server.name),
-                                            onDisableAll: () => handleDisableAllTools(server.name),
-                                            onRefresh: () => void fetchTools(true),
+                                            saving: controller.toolsSaving,
+                                            onToggleTool: (toolName, on) => controller.toggleTool(server.name, toolName, on),
+                                            onEnableAll: () => controller.enableAllTools(server.name),
+                                            onDisableAll: () => controller.disableAllTools(server.name),
+                                            onRefresh: () => controller.refetchTools(true),
                                         }}
                                     />
                                 )}
@@ -1642,10 +1307,7 @@ export function McpServersPanel({
             {/* Add server card */}
             <AddServerCard
                 workspaceId={workspaceId}
-                onAdded={() => {
-                    onMutate?.();
-                    onRefresh?.();
-                }}
+                addServer={controller.addServer}
             />
 
             {/* Footer */}

--- a/packages/coc/src/server/spa/client/react/features/skills/SkillsConfigPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/skills/SkillsConfigPanel.tsx
@@ -1,30 +1,95 @@
 /**
  * SkillsConfigPanel — global skill configuration.
- * Shows disabled skills list and global skills directory.
+ *
+ * Sections (top → bottom):
+ *   1. Global Skills Directory   — read-only managed install location (`~/.coc/skills`).
+ *   2. Global Extra Skill Folders — configurable read-only skill sources (all workspaces).
+ *   3. Detected Skill Folders     — auto-detected OneDrive/CloudStorage folders + toggle.
+ *   4. Effective Search Order     — read-only diagnostic of what the agent will use.
+ *   5. Globally Disabled Skills   — skills disabled across all workspaces.
+ *
+ * The effective search order is fetched global-only (no active workspace on this
+ * global tab); repo-local and per-repo extra folders are configured in each
+ * repo's own settings and are intentionally NOT claimed to apply globally here.
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import type {
+    EffectiveSkillPath,
+    EffectiveSkillPathSource,
+    EffectiveSkillPathStatus,
+} from '@plusplusoneplusplus/coc-client';
 import { getSpaCocClient } from '../../api/cocClient';
+
+const SOURCE_BADGES: Record<EffectiveSkillPathSource, { label: string; className: string }> = {
+    'managed-global': { label: 'Managed', className: 'bg-[#0078d4]/15 text-[#0078d4]' },
+    'configured': { label: 'Configured', className: 'bg-[#8b5cf6]/15 text-[#8b5cf6]' },
+    'auto-detected': { label: 'Auto-detected', className: 'bg-[#0ca678]/15 text-[#0ca678]' },
+    'repo': { label: 'Repo', className: 'bg-[#d9822b]/15 text-[#d9822b]' },
+    'repo-extra': { label: 'Repo', className: 'bg-[#d9822b]/15 text-[#d9822b]' },
+    'bundled': { label: 'Bundled', className: 'bg-[#6b7280]/15 text-[#6b7280]' },
+};
+
+const STATUS_BADGES: Record<EffectiveSkillPathStatus, { label: string; className: string }> = {
+    'available': { label: 'Available', className: 'bg-[#2ea043]/15 text-[#2ea043]' },
+    'no-skills': { label: 'No skills', className: 'bg-[#6b7280]/15 text-[#6b7280]' },
+    'missing': { label: 'Missing', className: 'bg-[#f14c4c]/15 text-[#f14c4c]' },
+    'skipped': { label: 'Skipped', className: 'bg-[#d4a72c]/15 text-[#d4a72c]' },
+};
+
+function SourceBadge({ source }: { source: EffectiveSkillPathSource }) {
+    const badge = SOURCE_BADGES[source];
+    return (
+        <span className={`px-1.5 py-0.5 text-[10px] rounded font-medium whitespace-nowrap ${badge.className}`}>
+            {badge.label}
+        </span>
+    );
+}
+
+function StatusBadge({ status }: { status: EffectiveSkillPathStatus }) {
+    const badge = STATUS_BADGES[status];
+    return (
+        <span className={`px-1.5 py-0.5 text-[10px] rounded font-medium whitespace-nowrap ${badge.className}`}>
+            {badge.label}
+        </span>
+    );
+}
 
 export function SkillsConfigPanel() {
     const [disabledSkills, setDisabledSkills] = useState<string[]>([]);
     const [globalDir, setGlobalDir] = useState<string>('');
+    const [globalExtraFolders, setGlobalExtraFolders] = useState<string[]>([]);
+    const [autoDetect, setAutoDetect] = useState<boolean>(true);
+    const [effectivePaths, setEffectivePaths] = useState<EffectiveSkillPath[]>([]);
     const [loading, setLoading] = useState(true);
     const [newDisabledSkill, setNewDisabledSkill] = useState('');
+    const [newExtraFolder, setNewExtraFolder] = useState('');
+
+    const loadEffectivePaths = useCallback(() => {
+        // Global-only view: no workspace id, so the API returns global-scoped paths.
+        return getSpaCocClient().skills.getEffectivePaths()
+            .then(res => setEffectivePaths(Array.isArray(res?.paths) ? res.paths : []))
+            .catch(() => {});
+    }, []);
 
     const loadConfig = useCallback(() => {
         setLoading(true);
-        getSpaCocClient().skills.getGlobalConfig()
-            .then(data => {
-                setDisabledSkills(Array.isArray(data.globalDisabledSkills) ? data.globalDisabledSkills : []);
-                setGlobalDir(data.globalSkillsDir ?? '');
-            })
-            .catch(() => {})
-            .finally(() => setLoading(false));
-    }, []);
+        Promise.all([
+            getSpaCocClient().skills.getGlobalConfig()
+                .then(data => {
+                    setDisabledSkills(Array.isArray(data.globalDisabledSkills) ? data.globalDisabledSkills : []);
+                    setGlobalDir(data.globalSkillsDir ?? '');
+                    setGlobalExtraFolders(Array.isArray(data.globalExtraFolders) ? data.globalExtraFolders : []);
+                    setAutoDetect(data.autoDetectDefaultFolders !== false);
+                })
+                .catch(() => {}),
+            loadEffectivePaths(),
+        ]).finally(() => setLoading(false));
+    }, [loadEffectivePaths]);
 
     useEffect(() => { loadConfig(); }, [loadConfig]);
 
+    // ── Globally disabled skills ───────────────────────────────────────────
     const updateDisabledSkills = useCallback((updated: string[]) => {
         setDisabledSkills(updated);
         getSpaCocClient().skills.updateGlobalConfig({ globalDisabledSkills: updated }).catch(() => {});
@@ -41,13 +106,49 @@ export function SkillsConfigPanel() {
         updateDisabledSkills(disabledSkills.filter(s => s !== name));
     }, [disabledSkills, updateDisabledSkills]);
 
+    // ── Global extra skill folders ─────────────────────────────────────────
+    const persistExtraFolders = useCallback((updated: string[]) => {
+        setGlobalExtraFolders(updated);
+        // Send disabled list alongside so the required field stays intact; the
+        // server merges only the provided fields into the config file.
+        getSpaCocClient().skills
+            .updateGlobalConfig({ globalDisabledSkills: disabledSkills, globalExtraFolders: updated })
+            .then(() => loadEffectivePaths())
+            .catch(() => {});
+    }, [disabledSkills, loadEffectivePaths]);
+
+    const handleAddExtraFolder = useCallback(() => {
+        const folder = newExtraFolder.trim();
+        if (!folder || globalExtraFolders.includes(folder)) return;
+        persistExtraFolders([...globalExtraFolders, folder]);
+        setNewExtraFolder('');
+    }, [newExtraFolder, globalExtraFolders, persistExtraFolders]);
+
+    const handleRemoveExtraFolder = useCallback((folder: string) => {
+        persistExtraFolders(globalExtraFolders.filter(f => f !== folder));
+    }, [globalExtraFolders, persistExtraFolders]);
+
+    // ── Auto-detect toggle ─────────────────────────────────────────────────
+    const handleToggleAutoDetect = useCallback(() => {
+        const next = !autoDetect;
+        setAutoDetect(next);
+        getSpaCocClient().skills
+            .updateGlobalConfig({ globalDisabledSkills: disabledSkills, autoDetectDefaultFolders: next })
+            .then(() => loadEffectivePaths())
+            .catch(() => {});
+    }, [autoDetect, disabledSkills, loadEffectivePaths]);
+
     if (loading) {
         return <div className="p-4 text-sm text-[#848484]">Loading config…</div>;
     }
 
+    const detected = effectivePaths.filter(p => p.source === 'auto-detected');
+    const detectedVisible = detected.filter(p => p.status !== 'skipped');
+    const detectedSkipped = detected.filter(p => p.status === 'skipped');
+
     return (
-        <div className="p-4 flex flex-col gap-4 max-w-lg">
-            {/* Global skills directory */}
+        <div className="p-4 flex flex-col gap-5 max-w-2xl" data-testid="skills-config-panel">
+            {/* 1. Global skills directory (managed) */}
             <div>
                 <label className="block text-xs font-medium text-[#616161] dark:text-[#999] mb-1">
                     Global Skills Directory
@@ -55,9 +156,147 @@ export function SkillsConfigPanel() {
                 <div className="text-sm font-mono text-[#1e1e1e] dark:text-[#cccccc] bg-[#f3f3f3] dark:bg-[#333] px-3 py-2 rounded border border-[#e0e0e0] dark:border-[#3c3c3c]">
                     {globalDir || '~/.coc/skills/'}
                 </div>
+                <div className="text-xs text-[#848484] mt-1">
+                    CoC-managed install location. Skills installed on this page live here and apply to all repos.
+                </div>
             </div>
 
-            {/* Globally disabled skills */}
+            {/* 2. Global extra skill folders (configured, read-only sources) */}
+            <div data-testid="skills-global-extra-folders">
+                <label className="block text-xs font-medium text-[#616161] dark:text-[#999] mb-1">
+                    Global Extra Skill Folders
+                </label>
+                <div className="text-xs text-[#848484] mb-2">
+                    Read-only skill-source folders applied across all workspaces. CoC never installs or deletes
+                    skills in these folders. Use absolute paths or <code>~</code> for your home directory.
+                </div>
+                <div className="flex flex-wrap gap-1.5 mb-2">
+                    {globalExtraFolders.map(folder => (
+                        <span
+                            key={folder}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-[#0078d4]/10 text-[#0078d4] border border-[#0078d4]/30 font-mono"
+                        >
+                            {folder}
+                            <button
+                                onClick={() => handleRemoveExtraFolder(folder)}
+                                className="hover:text-[#005a9e] ml-0.5"
+                                title="Remove folder"
+                            >
+                                ✕
+                            </button>
+                        </span>
+                    ))}
+                    {globalExtraFolders.length === 0 && (
+                        <span className="text-xs text-[#848484]">No global extra folders configured.</span>
+                    )}
+                </div>
+                <div className="flex items-center gap-2">
+                    <input
+                        type="text"
+                        value={newExtraFolder}
+                        onChange={(e) => setNewExtraFolder(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && handleAddExtraFolder()}
+                        placeholder="Extra skill folder path…"
+                        className="flex-1 text-sm px-2 py-1.5 border border-[#e0e0e0] dark:border-[#3c3c3c] rounded bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] font-mono"
+                    />
+                    <button
+                        className="text-xs px-3 py-1.5 bg-[#0078d4] text-white rounded disabled:opacity-50"
+                        disabled={!newExtraFolder.trim()}
+                        onClick={handleAddExtraFolder}
+                    >
+                        Add
+                    </button>
+                </div>
+            </div>
+
+            {/* 3. Detected skill folders (auto-detected OneDrive/CloudStorage) */}
+            <div data-testid="skills-detected-folders">
+                <label className="block text-xs font-medium text-[#616161] dark:text-[#999] mb-1">
+                    Detected Skill Folders
+                </label>
+                <label className="flex items-center gap-2 text-xs text-[#616161] dark:text-[#cccccc] mb-2 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        checked={autoDetect}
+                        onChange={handleToggleAutoDetect}
+                        aria-label="Auto-detect default skill folders"
+                    />
+                    Auto-detect default skill folders (OneDrive / CloudStorage)
+                </label>
+                {!autoDetect ? (
+                    <div className="text-xs text-[#848484]">Auto-detection is disabled.</div>
+                ) : detectedVisible.length === 0 && detectedSkipped.length === 0 ? (
+                    <div className="text-xs text-[#848484]">No OneDrive skill folders detected.</div>
+                ) : (
+                    <div className="flex flex-col gap-1.5">
+                        {detectedVisible.map((p, i) => (
+                            <div
+                                key={`${p.path}-${i}`}
+                                className="flex items-center gap-2 text-xs bg-[#f3f3f3] dark:bg-[#2a2a2a] px-2 py-1.5 rounded border border-[#e0e0e0] dark:border-[#3c3c3c]"
+                            >
+                                <StatusBadge status={p.status} />
+                                <code className="flex-1 break-all text-[#1e1e1e] dark:text-[#cccccc]">{p.path}</code>
+                                {typeof p.skillCount === 'number' && (
+                                    <span className="text-[#848484] whitespace-nowrap">
+                                        {p.skillCount} skill{p.skillCount === 1 ? '' : 's'}
+                                    </span>
+                                )}
+                            </div>
+                        ))}
+                        {detectedSkipped.length > 0 && (
+                            <details className="text-xs text-[#848484]">
+                                <summary className="cursor-pointer">
+                                    Diagnostics ({detectedSkipped.length} skipped)
+                                </summary>
+                                <div className="flex flex-col gap-1 mt-1">
+                                    {detectedSkipped.map((p, i) => (
+                                        <div key={`${p.path}-${i}`} className="flex items-center gap-2">
+                                            <StatusBadge status={p.status} />
+                                            <code className="flex-1 break-all">{p.path}</code>
+                                            {p.note && <span className="italic">{p.note}</span>}
+                                        </div>
+                                    ))}
+                                </div>
+                            </details>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* 4. Effective search order (read-only diagnostic) */}
+            <div data-testid="skills-effective-search-order">
+                <label className="block text-xs font-medium text-[#616161] dark:text-[#999] mb-1">
+                    Effective Search Order
+                </label>
+                <div className="text-xs text-[#848484] mb-2">
+                    Read-only. The order the agent searches for skills. Showing global paths only — repo-local and
+                    per-repo extra folders are configured in each repo&apos;s settings and are not applied globally.
+                </div>
+                {effectivePaths.length === 0 ? (
+                    <div className="text-xs text-[#848484]">No effective skill paths.</div>
+                ) : (
+                    <ol className="flex flex-col gap-1.5">
+                        {effectivePaths.map((p, i) => (
+                            <li
+                                key={`${p.source}-${p.path}-${i}`}
+                                data-testid={`effective-path-${i}`}
+                                className="flex items-center gap-2 text-xs bg-[#f3f3f3] dark:bg-[#2a2a2a] px-2 py-1.5 rounded border border-[#e0e0e0] dark:border-[#3c3c3c]"
+                            >
+                                <SourceBadge source={p.source} />
+                                <StatusBadge status={p.status} />
+                                <code className="flex-1 break-all text-[#1e1e1e] dark:text-[#cccccc]">{p.path}</code>
+                                {typeof p.skillCount === 'number' && (
+                                    <span className="text-[#848484] whitespace-nowrap">
+                                        {p.skillCount} skill{p.skillCount === 1 ? '' : 's'}
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ol>
+                )}
+            </div>
+
+            {/* 5. Globally disabled skills */}
             <div>
                 <label className="block text-xs font-medium text-[#616161] dark:text-[#999] mb-1">
                     Globally Disabled Skills

--- a/packages/coc/src/server/spa/client/react/features/skills/mcp-server-list-model.ts
+++ b/packages/coc/src/server/spa/client/react/features/skills/mcp-server-list-model.ts
@@ -1,0 +1,268 @@
+/**
+ * Pure read model for the MCP servers panel.
+ *
+ * All list-level derivation — status dots, source pills, descriptions, per-row
+ * tool-count labels, the filter/search predicate, and the toolbar counts — lives
+ * here as framework-free functions so it can be unit-tested without rendering
+ * the panel. `buildMcpServerListModel` assembles the whole view model in one
+ * call from the raw config plus the controller's async caches.
+ *
+ * These helpers only ever read list-level fields (`McpServerEntry`). Detail-only
+ * metadata (env key names, raw JSON, args) is deliberately kept out so the list
+ * read model can never depend on the secrets-exposing detail response.
+ */
+
+import type {
+    McpServerAuthStatus,
+    McpServerToolsResult,
+} from '@plusplusoneplusplus/coc-client';
+import { isMcpToolEnabled, type EnabledMcpToolsMap } from './mcpToolsAllowList';
+
+export type DiscoveryState = 'idle' | 'loading' | 'loaded' | 'error';
+
+export type McpServerSource = 'global' | 'workspace';
+
+export type McpServerEntry = {
+    name: string;
+    type: string;
+    url?: string;
+    command?: string;
+    source?: McpServerSource;
+    effective?: boolean;
+    overriddenBy?: McpServerSource;
+    /** Derived status from the server response. */
+    status?: 'ok' | 'auth' | 'off' | 'err';
+    /** Auth state for remote servers (absent on stdio). */
+    authStatus?: McpServerAuthStatus;
+    /** Token expiry (epoch seconds), when known. */
+    authExpiresAt?: number;
+    /** User-provided description from config file. */
+    description?: string;
+};
+
+export type McpServerSourceSection = {
+    configPath: string;
+    fileExists: boolean;
+    success: boolean;
+    error?: string;
+    servers: McpServerEntry[];
+};
+
+export type McpServerSources = {
+    global: McpServerSourceSection;
+    workspace: McpServerSourceSection;
+};
+
+export type FilterTab = 'all' | 'active' | 'auth' | 'disabled';
+
+export type InspectorTab = 'overview' | 'tools' | 'configuration' | 'source' | 'activity';
+
+export type ServerStatus = 'ok' | 'auth' | 'off' | 'err';
+
+/**
+ * Local state for a server's OAuth flow. `starting` → `authorizing` → `completed`
+ * (or `failed`). Stored only in the panel — server-side state lives in the
+ * McpOauthManager and is fetched via `/api/mcp-oauth/pending/:id`.
+ */
+export type McpAuthFlowState =
+    | { phase: 'starting' }
+    | { phase: 'authorizing'; requestId: string; authorizationUrl?: string }
+    | { phase: 'completed'; requestId: string }
+    | { phase: 'failed'; requestId: string; error: string };
+
+/**
+ * Resolve the dot color for a row.
+ *
+ * Trust the server-derived `status` field when present — it already accounts
+ * for cached OAuth tokens. The legacy fallback (treat any HTTP/SSE server as
+ * "auth") is kept for older responses that pre-date authStatus.
+ */
+export function getServerStatus(server: McpServerEntry, isEnabled: boolean): ServerStatus {
+    if (!isEnabled) return 'off';
+    if (server.status) return server.status;
+    if (server.type === 'http' || server.type === 'sse') return 'auth';
+    return 'ok';
+}
+
+export function needsAuth(server: McpServerEntry): boolean {
+    if (server.type !== 'http' && server.type !== 'sse') return false;
+    if (!server.authStatus) return true; // legacy response — assume needs auth
+    return server.authStatus === 'required' || server.authStatus === 'expired';
+}
+
+export function isRemote(server: McpServerEntry): boolean {
+    return server.type === 'http' || server.type === 'sse';
+}
+
+export function getServerDescription(server: McpServerEntry, isEnabled: boolean): string {
+    const base = server.description || server.url || server.command || '';
+    if (!isEnabled) return `Disabled · ${base.toLowerCase()}`;
+    return base;
+}
+
+export function getTransportPillClass(type: string): string {
+    if (type === 'stdio') return 'accent';
+    if (type === 'http' || type === 'sse') return 'done';
+    return '';
+}
+
+export function getSourcePillInfo(server: McpServerEntry): { label: string; cls: string } {
+    if (server.overriddenBy === 'workspace' || server.source === 'workspace') {
+        return server.overriddenBy === 'workspace'
+            ? { label: 'user override', cls: 'warn' }
+            : { label: 'repo config', cls: 'muted' };
+    }
+    if (server.source === 'global') return { label: 'global', cls: 'muted' };
+    return { label: 'repo config', cls: 'muted' };
+}
+
+/** Whether a server's inline "Authenticate" pill should be shown. */
+export function shouldShowAuthButton(
+    server: McpServerEntry,
+    isEnabled: boolean,
+    flow: McpAuthFlowState | undefined,
+): boolean {
+    return isRemote(server) && isEnabled && (needsAuth(server) || (!!flow && flow.phase !== 'completed'));
+}
+
+/**
+ * Row-level tool count label, e.g. "12", "8/12", "…", "!", or "—".
+ *
+ * A disabled or overridden server shows "—". A discovered-but-unreached server
+ * shows "!" (with the error as a tooltip). Before discovery resolves the label
+ * is "…" while loading and "—" once discovery has settled without a result.
+ */
+export function getToolCountLabel(input: {
+    enabled: boolean;
+    effective: boolean;
+    result: McpServerToolsResult | undefined;
+    discoveryState: DiscoveryState;
+    allowEntry: string[] | undefined;
+}): { text: string; title?: string } {
+    const { enabled, effective, result, discoveryState, allowEntry } = input;
+    if (!enabled || !effective) return { text: '—' };
+    if (!result) {
+        return discoveryState === 'loading' || discoveryState === 'idle'
+            ? { text: '…' }
+            : { text: '—' };
+    }
+    if (result.status === 'error') return { text: '!', title: result.error };
+    const total = result.tools.length;
+    const enabledCount = result.tools.filter(t => isMcpToolEnabled(allowEntry, t.name)).length;
+    return {
+        text: enabledCount === total ? String(total) : `${enabledCount}/${total}`,
+        title: `${enabledCount} of ${total} tools enabled`,
+    };
+}
+
+export interface McpServerCounts {
+    all: number;
+    active: number;
+    auth: number;
+    disabled: number;
+}
+
+/** Toolbar filter counts, computed over the full (unfiltered) server list. */
+export function computeServerCounts(
+    servers: McpServerEntry[],
+    isEnabled: (name: string) => boolean,
+): McpServerCounts {
+    const active = servers.filter(s => isEnabled(s.name) && s.effective !== false && getServerStatus(s, true) === 'ok').length;
+    const auth = servers.filter(s => getServerStatus(s, isEnabled(s.name)) === 'auth').length;
+    const disabled = servers.filter(s => !isEnabled(s.name) || s.effective === false).length;
+    return { all: servers.length, active, auth, disabled };
+}
+
+/** Apply the active filter tab + search query to the server list. */
+export function filterServers(
+    servers: McpServerEntry[],
+    opts: { filterTab: FilterTab; searchQuery: string; isEnabled: (name: string) => boolean },
+): McpServerEntry[] {
+    const { filterTab, searchQuery, isEnabled } = opts;
+    let list = servers;
+
+    if (filterTab === 'active') {
+        list = list.filter(s => isEnabled(s.name) && s.effective !== false && getServerStatus(s, true) === 'ok');
+    } else if (filterTab === 'auth') {
+        list = list.filter(s => getServerStatus(s, isEnabled(s.name)) === 'auth');
+    } else if (filterTab === 'disabled') {
+        list = list.filter(s => !isEnabled(s.name) || s.effective === false);
+    }
+
+    const q = searchQuery.trim().toLowerCase();
+    if (q) {
+        list = list.filter(s =>
+            s.name.toLowerCase().includes(q) ||
+            (s.description ?? '').toLowerCase().includes(q),
+        );
+    }
+
+    return list;
+}
+
+/** Fully-derived display data for one server row. */
+export interface McpServerRowModel {
+    server: McpServerEntry;
+    enabled: boolean;
+    isOverridden: boolean;
+    status: ServerStatus;
+    description: string;
+    transportCls: string;
+    sourcePill: { label: string; cls: string };
+    toolCount: { text: string; title?: string };
+    flow: McpAuthFlowState | undefined;
+    showAuthBtn: boolean;
+}
+
+export interface McpServerListModelInput {
+    servers: McpServerEntry[];
+    isEnabled: (name: string) => boolean;
+    filterTab: FilterTab;
+    searchQuery: string;
+    discovery: Record<string, McpServerToolsResult>;
+    discoveryState: DiscoveryState;
+    toolsAllowList: EnabledMcpToolsMap;
+    authFlow: Record<string, McpAuthFlowState>;
+}
+
+export interface McpServerListModel {
+    counts: McpServerCounts;
+    rows: McpServerRowModel[];
+}
+
+/**
+ * Build the complete list view model: toolbar counts (over all servers) plus a
+ * fully-derived row for each server passing the current filter/search.
+ */
+export function buildMcpServerListModel(input: McpServerListModelInput): McpServerListModel {
+    const { servers, isEnabled, filterTab, searchQuery, discovery, discoveryState, toolsAllowList, authFlow } = input;
+
+    const counts = computeServerCounts(servers, isEnabled);
+    const filtered = filterServers(servers, { filterTab, searchQuery, isEnabled });
+
+    const rows: McpServerRowModel[] = filtered.map(server => {
+        const enabled = isEnabled(server.name);
+        const isOverridden = server.effective === false;
+        const flow = authFlow[server.name];
+        return {
+            server,
+            enabled,
+            isOverridden,
+            status: getServerStatus(server, enabled),
+            description: getServerDescription(server, enabled),
+            transportCls: getTransportPillClass(server.type),
+            sourcePill: getSourcePillInfo(server),
+            toolCount: getToolCountLabel({
+                enabled,
+                effective: server.effective !== false,
+                result: discovery[server.name],
+                discoveryState,
+                allowEntry: toolsAllowList[server.name],
+            }),
+            flow,
+            showAuthBtn: shouldShowAuthButton(server, enabled, flow),
+        };
+    });
+
+    return { counts, rows };
+}

--- a/packages/coc/src/server/spa/client/react/features/skills/mcpOAuthFlowController.ts
+++ b/packages/coc/src/server/spa/client/react/features/skills/mcpOAuthFlowController.ts
@@ -1,0 +1,128 @@
+/**
+ * OAuth polling lifecycle for the MCP servers panel.
+ *
+ * OAuth setup is security-sensitive and long-running: a flow can complete after
+ * the user has navigated to a different workspace. This registry owns the
+ * `setInterval` pollers so completion/failure/timeout handling, self-cleanup,
+ * and stale-guarding live in one framework-free place that can be unit-tested
+ * with fake timers and a mocked `fetch`.
+ *
+ * Each poller checks its `isStale` guard on every tick (and again after the
+ * network round-trip) so a result that arrives after a workspace switch is
+ * dropped and the poller stops itself instead of refreshing the wrong panel.
+ */
+
+export const AUTH_POLL_INTERVAL_MS = 2_000;
+export const AUTH_POLL_TIMEOUT_MS = 10 * 60 * 1_000;
+
+export interface McpOAuthPollHandlers {
+    /** Fired once when the server reports the flow completed (and not stale). */
+    onCompleted: () => void;
+    /** Fired once on server-reported failure or timeout (and not stale). */
+    onFailed: (error: string) => void;
+}
+
+export interface McpOAuthStartOptions {
+    /** Unique key for this poller (typically the server name). */
+    key: string;
+    /** OAuth request id returned by `POST /mcp-oauth/start`. */
+    requestId: string;
+    /** API base, e.g. the result of `getApiBase()`. */
+    apiBase: string;
+    intervalMs?: number;
+    timeoutMs?: number;
+    /**
+     * Returns true when the flow that started this poller is no longer current
+     * (e.g. the workspace changed). When it returns true the poller stops
+     * silently without firing either handler.
+     */
+    isStale?: () => boolean;
+}
+
+interface PendingEntry {
+    status?: string;
+    error?: string;
+}
+
+/**
+ * Manages the active OAuth pollers for a panel instance. One poller per key;
+ * starting a second poller for the same key replaces the first.
+ */
+export class McpOAuthFlowController {
+    private readonly pollers = new Map<string, ReturnType<typeof setInterval>>();
+
+    /** Begin polling `mcp-oauth/pending/:requestId` until it settles or times out. */
+    startPolling(options: McpOAuthStartOptions, handlers: McpOAuthPollHandlers): void {
+        const {
+            key,
+            requestId,
+            apiBase,
+            intervalMs = AUTH_POLL_INTERVAL_MS,
+            timeoutMs = AUTH_POLL_TIMEOUT_MS,
+            isStale,
+        } = options;
+
+        // Replace any existing poller for this key.
+        this.stop(key);
+
+        const url = `${apiBase}/mcp-oauth/pending/${encodeURIComponent(requestId)}`;
+        const startedAt = Date.now();
+
+        const tick = async (): Promise<void> => {
+            if (isStale?.()) { this.stop(key); return; }
+            try {
+                const r = await fetch(url);
+                // The workspace may have switched during the round-trip.
+                if (isStale?.()) { this.stop(key); return; }
+                if (r.ok) {
+                    const entry = await r.json() as PendingEntry;
+                    if (isStale?.()) { this.stop(key); return; }
+                    if (entry.status === 'completed') {
+                        this.stop(key);
+                        handlers.onCompleted();
+                        return;
+                    }
+                    if (entry.status === 'failed') {
+                        this.stop(key);
+                        handlers.onFailed(entry.error ?? 'Authorization failed');
+                        return;
+                    }
+                }
+            } catch {
+                // Transient network error — keep polling until timeout.
+            }
+            // Always check the timeout so a stuck/gone entry never polls forever.
+            if (Date.now() - startedAt > timeoutMs) {
+                this.stop(key);
+                handlers.onFailed('Authorization timed out');
+            }
+        };
+
+        this.pollers.set(key, setInterval(() => { void tick(); }, intervalMs));
+    }
+
+    /** Stop and forget the poller for `key`, if any. */
+    stop(key: string): void {
+        const existing = this.pollers.get(key);
+        if (existing !== undefined) {
+            clearInterval(existing);
+            this.pollers.delete(key);
+        }
+    }
+
+    /** Stop every poller — call on unmount and on workspace change. */
+    stopAll(): void {
+        for (const timer of this.pollers.values()) clearInterval(timer);
+        this.pollers.clear();
+    }
+
+    /** Whether a poller is currently active for `key`. */
+    isPolling(key: string): boolean {
+        return this.pollers.has(key);
+    }
+
+    /** Keys with an active poller (test/debug helper). */
+    activeKeys(): string[] {
+        return [...this.pollers.keys()];
+    }
+}

--- a/packages/coc/src/server/spa/client/react/features/skills/useMcpServerInspectorController.ts
+++ b/packages/coc/src/server/spa/client/react/features/skills/useMcpServerInspectorController.ts
@@ -1,0 +1,370 @@
+/**
+ * Workspace-scoped controller for the MCP servers panel.
+ *
+ * `McpServersPanel` is reused across workspace-scoped repo surfaces, so every
+ * cache (detail, discovery, allow-list, OAuth flow) and the expanded-row / tab
+ * UI state must belong to exactly one workspace. This hook owns all of that
+ * state and, on a `workspaceId` change, discards it and re-discovers tools for
+ * the new workspace.
+ *
+ * A monotonically-increasing generation token guards each async flow: a slow
+ * discovery, detail read, allow-list save, or OAuth poll that resolves after
+ * the workspace switched is dropped rather than written into the fresh state.
+ * This keeps same-named servers in different repos from ever sharing detail,
+ * tool counts, allow-list toggles, or OAuth results.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getSpaCocClient, getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { getApiBase } from '../../utils/config';
+import type {
+    McpServerDetail as ClientMcpServerDetail,
+    McpConfigScope,
+    McpServerToolsResult,
+    McpServerCreateRequest,
+    McpServerUpdateRequest,
+} from '@plusplusoneplusplus/coc-client';
+import {
+    applyMcpToolToggle,
+    enableAllMcpTools,
+    disableAllMcpTools,
+    normalizeEnabledMcpTools,
+    type EnabledMcpToolsMap,
+} from './mcpToolsAllowList';
+import { McpOAuthFlowController } from './mcpOAuthFlowController';
+import type { DiscoveryState, InspectorTab, McpAuthFlowState } from './mcp-server-list-model';
+
+export interface McpInspectorControllerOptions {
+    /**
+     * Raw enabled-server allow-list. Sent alongside per-tool toggles through the
+     * same `PUT /mcp-config` call so tool saves never clobber the server list.
+     */
+    enabledMcpServers?: string[] | null;
+    /** Per-repo enabled-tools allow-list (server → enabled tool names). */
+    enabledMcpTools?: Record<string, string[]> | null;
+    /** Called after an OAuth flow completes or a mutation lands. */
+    onRefresh?: () => void;
+    /** Called after a server is added or deleted so the parent can refresh. */
+    onMutate?: () => void;
+}
+
+export interface McpInspectorController {
+    // Inspector UI state
+    expandedServer: string | null;
+    inspectorTab: InspectorTab;
+    setInspectorTab: (tab: InspectorTab) => void;
+    toggleExpand: (name: string) => void;
+
+    // Detail cache
+    getDetail: (name: string) => ClientMcpServerDetail | null | 'loading';
+
+    // Live tool discovery
+    discovery: Record<string, McpServerToolsResult>;
+    discoveryState: DiscoveryState;
+    discoveryError: string | null;
+    refetchTools: (forceReload?: boolean) => void;
+
+    // Per-tool allow-list
+    toolsAllowList: EnabledMcpToolsMap;
+    toolsSaving: boolean;
+    toggleTool: (serverName: string, toolName: string, on: boolean) => void;
+    enableAllTools: (serverName: string) => void;
+    disableAllTools: (serverName: string) => void;
+
+    // OAuth flow
+    authFlow: Record<string, McpAuthFlowState>;
+    authenticate: (serverName: string) => void;
+
+    // Config mutations (preserve the existing REST payloads)
+    updateServer: (serverName: string, request: McpServerUpdateRequest) => Promise<void>;
+    migrateServer: (serverName: string, targetScope: McpConfigScope) => Promise<void>;
+    deleteServer: (serverName: string) => Promise<void>;
+    addServer: (request: McpServerCreateRequest) => Promise<void>;
+}
+
+type DetailCache = Record<string, ClientMcpServerDetail | null | 'loading'>;
+
+export function useMcpServerInspectorController(
+    workspaceId: string,
+    options: McpInspectorControllerOptions,
+): McpInspectorController {
+    const { enabledMcpServers, enabledMcpTools, onRefresh, onMutate } = options;
+
+    const [expandedServer, setExpandedServer] = useState<string | null>(null);
+    const [inspectorTab, setInspectorTab] = useState<InspectorTab>('overview');
+    const [detailCache, setDetailCache] = useState<DetailCache>({});
+
+    const [discovery, setDiscovery] = useState<Record<string, McpServerToolsResult>>({});
+    const [discoveryState, setDiscoveryState] = useState<DiscoveryState>('idle');
+    const [discoveryError, setDiscoveryError] = useState<string | null>(null);
+
+    const [toolsAllowList, setToolsAllowList] = useState<EnabledMcpToolsMap>(() => ({ ...(enabledMcpTools ?? {}) }));
+    const [toolsSaving, setToolsSaving] = useState(false);
+
+    const [authFlow, setAuthFlow] = useState<Record<string, McpAuthFlowState>>({});
+
+    // Generation token — bumped on every workspace change. Async flows capture
+    // it at start and drop their result when it no longer matches.
+    const genRef = useRef(0);
+    const oauthRef = useRef<McpOAuthFlowController | null>(null);
+    if (oauthRef.current === null) oauthRef.current = new McpOAuthFlowController();
+
+    // ── Live tool discovery ──────────────────────────────────────────────────
+    const fetchTools = useCallback(async (forceReload = false) => {
+        if (!workspaceId) return;
+        const gen = genRef.current;
+        setDiscoveryState('loading');
+        setDiscoveryError(null);
+        try {
+            const resp = await getSpaCocClient().workspaces.discoverMcpTools(
+                workspaceId,
+                forceReload ? { forceReload: true } : undefined,
+            );
+            if (genRef.current !== gen) return; // workspace switched mid-flight
+            setDiscovery(resp.servers ?? {});
+            setDiscoveryState('loaded');
+        } catch (e) {
+            if (genRef.current !== gen) return;
+            setDiscoveryError(getSpaCocClientErrorMessage(e, 'Failed to discover tools'));
+            setDiscoveryState('error');
+        }
+    }, [workspaceId]);
+
+    // On workspace change (and mount): discard all scoped state, stop pollers,
+    // then eagerly re-discover for the new workspace.
+    useEffect(() => {
+        genRef.current += 1;
+        oauthRef.current?.stopAll();
+        setDetailCache({});
+        setDiscovery({});
+        setDiscoveryState('idle');
+        setDiscoveryError(null);
+        setToolsSaving(false);
+        setAuthFlow({});
+        setExpandedServer(null);
+        setInspectorTab('overview');
+        void fetchTools();
+    }, [workspaceId, fetchTools]);
+
+    // Keep the local allow-list in sync with the parent config (and reset it on
+    // workspace change, which also changes `enabledMcpTools`).
+    useEffect(() => {
+        setToolsAllowList({ ...(enabledMcpTools ?? {}) });
+    }, [workspaceId, enabledMcpTools]);
+
+    // Tear down pollers on unmount.
+    useEffect(() => () => { oauthRef.current?.stopAll(); }, []);
+
+    const persistToolsAllowList = useCallback(async (nextMap: EnabledMcpToolsMap) => {
+        if (!workspaceId) return;
+        const gen = genRef.current;
+        let prev: EnabledMcpToolsMap = {};
+        setToolsAllowList(curr => { prev = curr; return nextMap; }); // optimistic
+        setToolsSaving(true);
+        try {
+            await getSpaCocClient().workspaces.updateMcpConfig(workspaceId, {
+                enabledMcpServers: enabledMcpServers ?? null,
+                enabledMcpTools: normalizeEnabledMcpTools(nextMap),
+            });
+        } catch (e) {
+            if (genRef.current === gen) {
+                setToolsAllowList(prev); // revert only within the same workspace
+                setDiscoveryError(getSpaCocClientErrorMessage(e, 'Failed to save tool settings'));
+            }
+        } finally {
+            setToolsSaving(false);
+        }
+    }, [workspaceId, enabledMcpServers]);
+
+    const discoveredToolNames = useCallback((serverName: string): string[] => {
+        const r = discovery[serverName];
+        return r && r.status === 'ok' ? r.tools.map(t => t.name) : [];
+    }, [discovery]);
+
+    const toggleTool = useCallback((serverName: string, toolName: string, on: boolean) => {
+        void persistToolsAllowList(
+            applyMcpToolToggle(toolsAllowList, serverName, discoveredToolNames(serverName), toolName, on),
+        );
+    }, [persistToolsAllowList, toolsAllowList, discoveredToolNames]);
+
+    const enableAllTools = useCallback((serverName: string) => {
+        void persistToolsAllowList(enableAllMcpTools(toolsAllowList, serverName));
+    }, [persistToolsAllowList, toolsAllowList]);
+
+    const disableAllTools = useCallback((serverName: string) => {
+        void persistToolsAllowList(disableAllMcpTools(toolsAllowList, serverName));
+    }, [persistToolsAllowList, toolsAllowList]);
+
+    // ── Detail cache ─────────────────────────────────────────────────────────
+    const fetchDetail = useCallback(async (name: string) => {
+        if (!workspaceId || detailCache[name] !== undefined) return; // already loading/cached
+        const gen = genRef.current;
+        setDetailCache(prev => ({ ...prev, [name]: 'loading' }));
+        try {
+            const detail = await getSpaCocClient().workspaces.getMcpServerDetail(workspaceId, name);
+            if (genRef.current !== gen) return; // workspace switched mid-flight
+            setDetailCache(prev => ({ ...prev, [name]: detail }));
+        } catch {
+            if (genRef.current !== gen) return;
+            setDetailCache(prev => ({ ...prev, [name]: null }));
+        }
+    }, [workspaceId, detailCache]);
+
+    const getDetail = useCallback(
+        (name: string): ClientMcpServerDetail | null | 'loading' => detailCache[name] ?? null,
+        [detailCache],
+    );
+
+    const invalidateDetail = useCallback((serverName: string) => {
+        setDetailCache(prev => {
+            if (!(serverName in prev)) return prev;
+            const next = { ...prev };
+            delete next[serverName];
+            return next;
+        });
+    }, []);
+
+    const toggleExpand = useCallback((name: string) => {
+        if (expandedServer === name) {
+            setExpandedServer(null);
+        } else {
+            setExpandedServer(name);
+            setInspectorTab('overview');
+            void fetchDetail(name);
+        }
+    }, [expandedServer, fetchDetail]);
+
+    const handleServerDeleted = useCallback(() => {
+        setExpandedServer(null);
+        onMutate?.();
+        onRefresh?.();
+    }, [onMutate, onRefresh]);
+
+    // ── OAuth flow ───────────────────────────────────────────────────────────
+    const setFlow = useCallback((serverName: string, next: McpAuthFlowState | null) => {
+        setAuthFlow(prev => {
+            if (next === null) {
+                if (!(serverName in prev)) return prev;
+                const copy = { ...prev };
+                delete copy[serverName];
+                return copy;
+            }
+            return { ...prev, [serverName]: next };
+        });
+    }, []);
+
+    const authenticate = useCallback(async (serverName: string) => {
+        const gen = genRef.current;
+        const startedWs = workspaceId;
+        setFlow(serverName, { phase: 'starting' });
+        try {
+            const r = await fetch(`${getApiBase()}/mcp-oauth/start`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ serverName, workspaceId: startedWs || undefined }),
+            });
+            if (!r.ok) {
+                const text = await r.text().catch(() => '');
+                throw new Error(text || `Failed to start OAuth flow (${r.status})`);
+            }
+            const result = await r.json() as {
+                requestId?: string;
+                authorizationUrl?: string;
+                alreadyAuthenticated?: boolean;
+            };
+            if (genRef.current !== gen) return; // workspace switched during start
+
+            if (result.alreadyAuthenticated) {
+                setFlow(serverName, { phase: 'completed', requestId: '' });
+                onRefresh?.();
+                return;
+            }
+            if (!result.requestId) {
+                throw new Error('Server did not return a request id');
+            }
+
+            if (result.authorizationUrl) {
+                window.open(result.authorizationUrl, '_blank', 'noopener,noreferrer');
+            }
+            const requestId = result.requestId;
+            setFlow(serverName, {
+                phase: 'authorizing',
+                requestId,
+                authorizationUrl: result.authorizationUrl,
+            });
+            oauthRef.current?.startPolling(
+                {
+                    key: serverName,
+                    requestId,
+                    apiBase: getApiBase(),
+                    isStale: () => genRef.current !== gen,
+                },
+                {
+                    onCompleted: () => {
+                        setFlow(serverName, { phase: 'completed', requestId });
+                        onRefresh?.();
+                    },
+                    onFailed: (error) => {
+                        setFlow(serverName, { phase: 'failed', requestId, error });
+                    },
+                },
+            );
+        } catch (err) {
+            if (genRef.current !== gen) return;
+            setFlow(serverName, {
+                phase: 'failed',
+                requestId: '',
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }, [workspaceId, onRefresh, setFlow]);
+
+    // ── Config mutations ─────────────────────────────────────────────────────
+    const updateServer = useCallback(async (serverName: string, request: McpServerUpdateRequest) => {
+        if (!workspaceId) return;
+        await getSpaCocClient().workspaces.updateMcpServer(workspaceId, serverName, request);
+        invalidateDetail(serverName);
+    }, [workspaceId, invalidateDetail]);
+
+    const migrateServer = useCallback(async (serverName: string, targetScope: McpConfigScope) => {
+        if (!workspaceId) return;
+        await getSpaCocClient().workspaces.migrateMcpServer(workspaceId, serverName, targetScope);
+        invalidateDetail(serverName);
+    }, [workspaceId, invalidateDetail]);
+
+    const deleteServer = useCallback(async (serverName: string) => {
+        if (!workspaceId) return;
+        await getSpaCocClient().workspaces.deleteMcpServer(workspaceId, serverName);
+        handleServerDeleted();
+    }, [workspaceId, handleServerDeleted]);
+
+    const addServer = useCallback(async (request: McpServerCreateRequest) => {
+        if (!workspaceId) return;
+        await getSpaCocClient().workspaces.addMcpServer(workspaceId, request);
+        onMutate?.();
+        onRefresh?.();
+    }, [workspaceId, onMutate, onRefresh]);
+
+    return {
+        expandedServer,
+        inspectorTab,
+        setInspectorTab,
+        toggleExpand,
+        getDetail,
+        discovery,
+        discoveryState,
+        discoveryError,
+        refetchTools: (forceReload = false) => { void fetchTools(forceReload); },
+        toolsAllowList,
+        toolsSaving,
+        toggleTool,
+        enableAllTools,
+        disableAllTools,
+        authFlow,
+        authenticate: (serverName: string) => { void authenticate(serverName); },
+        updateServer,
+        migrateServer,
+        deleteServer,
+        addServer,
+    };
+}

--- a/packages/coc/src/server/spa/client/react/layout/TopBar.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/TopBar.tsx
@@ -132,12 +132,12 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
     return (
         <>
         <header
-            className="h-10 md:h-12 px-3 flex items-center justify-between border-b border-[#e0e0e0] dark:border-[#3c3c3c] bg-[#f3f3f3] dark:bg-[#252526] text-[#1e1e1e] dark:text-[#cccccc]"
+            className="h-10 md:h-10 px-3 flex items-center justify-between border-b border-[#e0e0e0] dark:border-[#3c3c3c] bg-[#f3f3f3] dark:bg-[#252526] text-[#1e1e1e] dark:text-[#cccccc]"
             data-react
         >
             <div className="flex items-center gap-2 min-w-0 flex-1">
                 <button
-                    className="h-7 w-7 md:h-8 md:w-8 flex-shrink-0 rounded border border-transparent hover:border-[#c8c8c8] dark:hover:border-[#3c3c3c] hover:bg-black/[0.04] dark:hover:bg-white/[0.06] text-base leading-none touch-target"
+                    className="h-7 w-7 flex-shrink-0 rounded border border-transparent hover:border-[#c8c8c8] dark:hover:border-[#3c3c3c] hover:bg-black/[0.04] dark:hover:bg-white/[0.06] text-base leading-none touch-target"
                     id="hamburger-btn"
                     aria-label={isOnReposTab ? 'Manage repositories' : 'Go to repositories'}
                     aria-pressed={isOnReposTab ? popoverOpen : false}
@@ -156,7 +156,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                 <a
                     href="#"
                     data-tab="repos"
-                    className={`text-sm font-semibold whitespace-nowrap hidden md:inline-flex flex-shrink-0 px-2 h-8 transition-colors items-center ${isOnReposTab ? 'active border-b-2 border-[#0078d4] text-[#0078d4] dark:border-[#60b4ff] dark:text-[#60b4ff]' : 'hover:bg-black/[0.05] dark:hover:bg-white/[0.08]'}`}
+                    className={`text-sm font-semibold whitespace-nowrap hidden md:inline-flex flex-shrink-0 px-2 h-7 transition-colors items-center ${isOnReposTab ? 'active border-b-2 border-[#0078d4] text-[#0078d4] dark:border-[#60b4ff] dark:text-[#60b4ff]' : 'hover:bg-black/[0.05] dark:hover:bg-white/[0.08]'}`}
                     title={brandTooltip}
                     onClick={e => { e.preventDefault(); goToRepos(); }}
                 >{ brandLabel }</a>
@@ -164,7 +164,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                     <button
                         id="my-work-toggle"
                         className={
-                            `h-7 w-7 md:h-8 md:w-8 flex-shrink-0 inline-flex items-center justify-center rounded touch-target ` +
+                            `h-7 w-7 flex-shrink-0 inline-flex items-center justify-center rounded touch-target ` +
                             (isOnReposTab && state.selectedRepoId === MY_WORK_WORKSPACE_ID
                                 ? 'bg-[#0078d4] text-white'
                                 : 'hover:bg-black/[0.05] dark:hover:bg-white/[0.08]')
@@ -180,7 +180,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                     <button
                         id="my-life-toggle"
                         className={
-                            `h-7 w-7 md:h-8 md:w-8 flex-shrink-0 inline-flex items-center justify-center rounded touch-target ` +
+                            `h-7 w-7 flex-shrink-0 inline-flex items-center justify-center rounded touch-target ` +
                             (isOnReposTab && state.selectedRepoId === MY_LIFE_WORKSPACE_ID
                                 ? 'bg-[#0078d4] text-white'
                                 : 'hover:bg-black/[0.05] dark:hover:bg-white/[0.08]')
@@ -209,7 +209,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                             <button
                                 key={tab}
                                 className={
-                                    `h-8 px-3 rounded text-sm transition-colors ` +
+                                    `h-7 px-3 rounded text-sm transition-colors ` +
                                     (state.activeTab === tab
                                         ? 'active border-b-2 border-[#0078d4] text-[#0078d4] dark:border-[#60b4ff] dark:text-[#60b4ff]'
                                         : 'text-[#1e1e1e] dark:text-[#cccccc] hover:bg-black/[0.05] dark:hover:bg-white/[0.08]')
@@ -255,7 +255,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                     id="admin-toggle"
                     data-tab="admin"
                     className={
-                        `h-7 w-7 md:h-8 md:w-8 inline-flex items-center justify-center rounded touch-target text-base leading-none ` +
+                        `h-7 w-7 inline-flex items-center justify-center rounded touch-target text-base leading-none ` +
                         // The admin shell hosts both `admin` itself and the
                         // five embedded tool routes (skills/logs/stats/
                         // servers). Reflect "user is in the admin shell" in
@@ -276,7 +276,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                 </button>
                 <button
                     id="theme-toggle"
-                    className="h-7 w-7 md:h-8 md:w-8 inline-flex items-center justify-center rounded hover:bg-black/[0.05] dark:hover:bg-white/[0.08] touch-target text-base leading-none"
+                    className="h-7 w-7 inline-flex items-center justify-center rounded hover:bg-black/[0.05] dark:hover:bg-white/[0.08] touch-target text-base leading-none"
                     aria-label="Toggle theme"
                     onClick={toggleTheme}
                 >

--- a/packages/coc/src/server/spa/client/react/shared/MarkdownReviewEditor.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/MarkdownReviewEditor.tsx
@@ -22,14 +22,9 @@ import { InlineCommentPopup } from '../tasks/comments/InlineCommentPopup';
 import { CommentPopover } from '../tasks/comments/CommentPopover';
 import { ResponsiveSidebar } from '../ui/ResponsiveSidebar';
 import type { TaskComment, TaskCommentCategory, CommentSelection } from '../../comments/task-comments-types';
-import {
-    createAnchorData,
-    DEFAULT_ANCHOR_MATCH_CONFIG,
-} from '@plusplusoneplusplus/forge/editor/anchor';
 import { DASHBOARD_AI_COMMANDS } from './ai-commands';
 import { extractDocumentContext } from '../utils/document-context';
 import { useGlobalToast } from '../contexts/ToastContext';
-import { selectionToSourcePosition } from '../utils/selection-position';
 import { useBreakpoint } from '../hooks/ui/useBreakpoint';
 import { getLanguageFromFileName } from '../features/git/hooks/useSyntaxHighlight';
 import { useApp } from '../contexts/AppContext';
@@ -40,6 +35,17 @@ import { RichEditorCore } from '../features/notes/editor/RichEditorCore';
 import { markdownToHtml, htmlToMarkdown } from '../features/notes/editor/noteMarkdown';
 import type { Editor } from '@tiptap/core';
 import { getSpaCocClient, getSpaCocClientErrorMessage } from '../api/cocClient';
+import { createTasksNoteEditorIO } from '../tasks/TasksNoteEditorIO';
+import { createWorkspaceFileNoteEditorIO } from '../tasks/WorkspaceFileNoteEditorIO';
+import type { MarkdownDocumentIO } from './markdown-document/MarkdownDocumentIO';
+import {
+    useMarkdownDocumentKeyboardShortcuts,
+    useMarkdownDocumentSession,
+} from './markdown-document/useMarkdownDocumentSession';
+import {
+    buildMarkdownCommentAnchor,
+    resolveMarkdownReviewSelection,
+} from './markdown-document/markdownReviewSelection';
 
 const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdx']);
 
@@ -95,19 +101,21 @@ export interface MarkdownReviewEditorProps {
 /** Minimum selection length to trigger toolbar. */
 const MIN_SELECTION_LENGTH = 3;
 
-async function fetchTaskContent(wsId: string, filePath: string): Promise<string> {
-    const data = await getSpaCocClient().tasks.getContent(wsId, filePath);
-    if (typeof data === 'string') return data;
-    if (typeof data?.content === 'string') return data.content;
-    return '';
-}
+function createMarkdownReviewIO(fetchMode: 'tasks' | 'auto'): MarkdownDocumentIO {
+    const taskIo = createTasksNoteEditorIO();
+    if (fetchMode === 'tasks') return taskIo;
 
-async function fetchWorkspaceFileContent(wsId: string, filePath: string): Promise<string> {
-    const data = await getSpaCocClient().tasks.previewWorkspaceFile(wsId, filePath, { lines: 0 });
-    if (typeof data === 'string') return data;
-    if (typeof data?.content === 'string') return data.content;
-    if (Array.isArray(data?.lines)) return data.lines.join('\n');
-    return '';
+    const workspaceFileIo = createWorkspaceFileNoteEditorIO();
+    return {
+        ...taskIo,
+        async loadContent(workspaceId, path, root) {
+            try {
+                return await taskIo.loadContent(workspaceId, path, root);
+            } catch {
+                return workspaceFileIo.loadContent(workspaceId, path, root);
+            }
+        },
+    };
 }
 
 export function MarkdownReviewEditor({
@@ -138,15 +146,11 @@ export function MarkdownReviewEditor({
         return fp;
     }, [taskRootPath, workspaceRootPath]);
 
-    const [rawContent, setRawContent] = useState('');
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
     const previewRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const [viewMode, setViewModeRaw] = useState<ReviewViewMode>(initialViewMode);
     const [editedContent, setEditedContent] = useState('');
-    const [saving, setSaving] = useState(false);
-    const [refreshCounter, setRefreshCounter] = useState(0);
+    const [saveError, setSaveError] = useState<string | null>(null);
     const [aiDialogType, setAiDialogType] = useState<'update-document' | null>(null);
     const [resolveDialogState, setResolveDialogState] = useState<{
         open: boolean;
@@ -161,12 +165,41 @@ export function MarkdownReviewEditor({
     const [richEditor, setRichEditor] = useState<Editor | null>(null);
     const [richDirty, setRichDirty] = useState(false);
     const richContentRef = useRef<string>('');
+    const rawContentRef = useRef('');
+    const reviewIo = useMemo(() => createMarkdownReviewIO(fetchMode), [fetchMode]);
+    const documentSession = useMarkdownDocumentSession({
+        workspaceId: wsId,
+        documentPath: filePath,
+        io: reviewIo,
+        confirmBeforeLoadMessage: 'You have unsaved changes to the current file. Discard and load the new file?',
+        confirmRefreshMessage: 'You have unsaved changes. Discard and refresh?',
+        onDiscardDirty: () => {
+            setEditedContent(rawContentRef.current);
+            setRichDirty(false);
+            richContentRef.current = '';
+        },
+        onLoaded: (result) => {
+            setEditedContent(result.content);
+            setRichDirty(false);
+            richContentRef.current = '';
+            setSaveError(null);
+        },
+        onSaveError: (err) => {
+            setSaveError(getSpaCocClientErrorMessage(err, 'Failed to save'));
+        },
+    });
+    const rawContent = documentSession.content;
+    rawContentRef.current = rawContent;
+    const loading = documentSession.loading;
+    const error = documentSession.loadError ?? saveError;
+    const saving = documentSession.saveState === 'saving';
 
     const handleRichEditorReady = useCallback((ed: Editor) => { setRichEditor(ed); }, []);
     const handleRichChange = useCallback((ed: Editor) => {
         richContentRef.current = ed.getHTML();
         setRichDirty(true);
-    }, []);
+        documentSession.setDirty(true);
+    }, [documentSession]);
 
     const modeOptions = showRichMode ? RICH_MODE_OPTIONS : REVIEW_MODE_OPTIONS;
 
@@ -175,12 +208,12 @@ export function MarkdownReviewEditor({
         if (mode !== 'rich') onViewModeChange?.(mode as 'review' | 'source');
     }, [onViewModeChange]);
 
-    const isDirty = (viewMode === 'source' && editedContent !== rawContent) ||
-        (viewMode === 'rich' && richDirty);
+    const isDirty = documentSession.dirty;
 
-    // Ref mirror so the content-fetch useEffect can read dirty state without depending on it
-    const isDirtyRef = useRef(false);
-    isDirtyRef.current = isDirty;
+    const handleSourceChange = useCallback((content: string) => {
+        setEditedContent(content);
+        documentSession.setDirty(content !== rawContentRef.current);
+    }, [documentSession]);
 
     const { addToast } = useGlobalToast();
 
@@ -282,48 +315,6 @@ export function MarkdownReviewEditor({
 
     const showCommentListPanel = comments.length > 0;
 
-    useEffect(() => {
-        let cancelled = false;
-
-        // Guard: warn if switching files while dirty
-        if (isDirtyRef.current) {
-            if (!window.confirm('You have unsaved changes to the current file. Discard and load the new file?')) {
-                cancelled = true;
-                return;
-            }
-        }
-
-        setLoading(true);
-        setError(null);
-        setRawContent('');
-
-        const load = async () => {
-            try {
-                let content = '';
-                if (fetchMode === 'tasks') {
-                    content = await fetchTaskContent(wsId, filePath);
-                } else {
-                    try {
-                        content = await fetchTaskContent(wsId, filePath);
-                    } catch {
-                        content = await fetchWorkspaceFileContent(wsId, filePath);
-                    }
-                }
-
-                if (cancelled) return;
-                setRawContent(content);
-                setLoading(false);
-            } catch (err) {
-                if (cancelled) return;
-                setError(err instanceof Error ? err.message : 'Failed to load file');
-                setLoading(false);
-            }
-        };
-
-        void load();
-        return () => { cancelled = true; };
-    }, [wsId, filePath, fetchMode, refreshCounter]);
-
     // Restore scroll position after content finishes loading (for minimize/restore)
     useEffect(() => {
         if (!loading && initialScrollTop && scrollContainerRef.current) {
@@ -350,63 +341,28 @@ export function MarkdownReviewEditor({
 
     const saveContent = useCallback(async () => {
         if (!isDirty || saving) return;
-        setSaving(true);
         try {
             const contentToSave = viewMode === 'rich'
                 ? htmlToMarkdown(richContentRef.current)
                 : editedContent;
-            await getSpaCocClient().tasks.writeContent(wsId, { path: filePath, content: contentToSave });
-            setRawContent(contentToSave);
+            await documentSession.saveNow(contentToSave);
+            setEditedContent(contentToSave);
             if (viewMode === 'rich') setRichDirty(false);
             window.dispatchEvent(new CustomEvent('tasks-changed', { detail: { wsId } }));
         } catch (err) {
-            setError(getSpaCocClientErrorMessage(err, 'Failed to save'));
-        } finally {
-            setSaving(false);
+            setSaveError(getSpaCocClientErrorMessage(err, 'Failed to save'));
         }
-    }, [isDirty, saving, wsId, filePath, editedContent, viewMode]);
+    }, [isDirty, saving, editedContent, viewMode, documentSession, wsId]);
 
     const handleRefresh = useCallback(() => {
-        if (isDirty) {
-            if (!window.confirm('You have unsaved changes. Discard and refresh?')) return;
-            if (viewMode === 'source') setEditedContent(rawContent);
-            if (viewMode === 'rich') setRichDirty(false);
-        }
-        setRefreshCounter(c => c + 1);
-    }, [isDirty, rawContent, viewMode]);
+        documentSession.refresh();
+    }, [documentSession]);
 
-    // Ctrl/Cmd+Shift+R keyboard shortcut for refresh
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'R') {
-                e.preventDefault();
-                handleRefresh();
-            }
-        };
-        document.addEventListener('keydown', handler);
-        return () => document.removeEventListener('keydown', handler);
-    }, [handleRefresh]);
-
-    // Ctrl/Cmd+S keyboard shortcut for saving in source or rich mode
-    useEffect(() => {
-        if ((viewMode !== 'source' && viewMode !== 'rich') || !isDirty) return;
-        const handler = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 's') {
-                e.preventDefault();
-                saveContent();
-            }
-        };
-        document.addEventListener('keydown', handler);
-        return () => document.removeEventListener('keydown', handler);
-    }, [viewMode, isDirty, saveContent]);
-
-    // Warn before closing tab with unsaved changes
-    useEffect(() => {
-        if (!isDirty) return;
-        const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); };
-        window.addEventListener('beforeunload', handler);
-        return () => window.removeEventListener('beforeunload', handler);
-    }, [isDirty]);
+    useMarkdownDocumentKeyboardShortcuts({
+        onRefresh: handleRefresh,
+        onSave: saveContent,
+        saveEnabled: (viewMode === 'source' || viewMode === 'rich') && isDirty,
+    });
 
     // Save selection silently on mouseup
     useEffect(() => {
@@ -418,7 +374,7 @@ export function MarkdownReviewEditor({
                 previewRef.current?.contains(sel.anchorNode)
             ) {
                 const range = sel.getRangeAt(0);
-                const resolved = resolveSelectionPosition(rawContent, previewRef.current!, range, sel.toString().trim());
+                const resolved = resolveMarkdownReviewSelection(rawContent, previewRef.current!, range, sel.toString().trim());
                 setSavedSelection(resolved);
                 return;
             }
@@ -440,7 +396,7 @@ export function MarkdownReviewEditor({
                     previewRef.current?.contains(sel.anchorNode)
                 ) {
                     const range = sel.getRangeAt(0);
-                    const resolved = resolveSelectionPosition(rawContent, previewRef.current!, range, sel.toString().trim());
+                    const resolved = resolveMarkdownReviewSelection(rawContent, previewRef.current!, range, sel.toString().trim());
                     setSavedSelection(resolved);
                     if (resolved) {
                         const rect = range.getBoundingClientRect();
@@ -502,7 +458,7 @@ export function MarkdownReviewEditor({
             endColumn: pendingSelection.endColumn,
         };
 
-        const anchor = buildAnchor(
+        const anchor = buildMarkdownCommentAnchor(
             rawContent,
             pendingSelection.startLine,
             pendingSelection.endLine,
@@ -558,7 +514,7 @@ export function MarkdownReviewEditor({
             endColumn: savedSelection.endColumn,
         };
 
-        const anchor = buildAnchor(
+        const anchor = buildMarkdownCommentAnchor(
             rawContent,
             savedSelection.startLine,
             savedSelection.endLine,
@@ -599,7 +555,7 @@ export function MarkdownReviewEditor({
             endColumn: savedSelection.endColumn,
         };
 
-        const anchor = buildAnchor(
+        const anchor = buildMarkdownCommentAnchor(
             rawContent,
             savedSelection.startLine,
             savedSelection.endLine,
@@ -708,25 +664,28 @@ export function MarkdownReviewEditor({
             if (!window.confirm('You have unsaved changes. Discard and switch to Preview?')) return;
             if (viewMode === 'source') setEditedContent(rawContent);
             if (viewMode === 'rich') setRichDirty(false);
+            documentSession.setDirty(false);
         }
         setViewMode('review');
-    }, [isDirty, rawContent, setViewMode, viewMode]);
+    }, [isDirty, rawContent, setViewMode, viewMode, documentSession]);
 
     const handleSwitchToRich = useCallback(() => {
         if (viewMode === 'source' && isDirty) {
             if (!window.confirm('You have unsaved changes. Discard and switch to Rich?')) return;
             setEditedContent(rawContent);
+            documentSession.setDirty(false);
         }
         setViewMode('rich');
-    }, [viewMode, isDirty, rawContent, setViewMode]);
+    }, [viewMode, isDirty, rawContent, setViewMode, documentSession]);
 
     const handleSwitchToSource = useCallback(() => {
         if (viewMode === 'rich' && richDirty) {
             if (!window.confirm('You have unsaved changes. Discard and switch to Source?')) return;
             setRichDirty(false);
+            documentSession.setDirty(false);
         }
         setViewMode('source');
-    }, [viewMode, richDirty, setViewMode]);
+    }, [viewMode, richDirty, setViewMode, documentSession]);
 
     // Event delegation for build-time highlight click
     const handleHighlightClick = useCallback((e: React.MouseEvent) => {
@@ -737,7 +696,7 @@ export function MarkdownReviewEditor({
         if (comment) handleCommentClick(comment);
     }, [comments, handleCommentClick]);
 
-    if (loading && refreshCounter === 0) {
+    if (loading && !documentSession.hasLoaded && !rawContent) {
         return (
             <div className="flex items-center justify-center h-full">
                 <Spinner size="lg" />
@@ -856,7 +815,7 @@ export function MarkdownReviewEditor({
                         <div className="flex-1 overflow-y-auto min-h-0 min-w-0">
                             <SourceEditor
                                 content={editedContent}
-                                onChange={setEditedContent}
+                                onChange={handleSourceChange}
                             />
                         </div>
                     ) : viewMode === 'rich' ? (
@@ -1031,77 +990,4 @@ export function MarkdownReviewEditor({
             />
         </div>
     );
-}
-
-// ── Helpers (from legacy task-comments-ui.ts) ──
-
-/**
- * Attempt to create anchor data for a selection range, returning undefined if it fails.
- */
-function buildAnchor(
-    rawContent: string,
-    startLine: number,
-    endLine: number,
-    startColumn: number,
-    endColumn: number,
-) {
-    try {
-        return createAnchorData(rawContent, startLine, endLine, startColumn, endColumn, DEFAULT_ANCHOR_MATCH_CONFIG);
-    } catch {
-        return undefined;
-    }
-}
-
-/**
- * Resolve a browser selection range to source-file position coordinates.
- * Tries the DOM-aware `data-line` approach first; falls back to text-offset mapping.
- * Returns null if the selection cannot be resolved (e.g. container not found).
- */
-function resolveSelectionPosition(
-    rawContent: string,
-    previewEl: HTMLElement,
-    range: Range,
-    text: string,
-): { text: string; range: Range; startLine: number; startColumn: number; endLine: number; endColumn: number } | null {
-    const sourcePos = selectionToSourcePosition(rawContent, previewEl, range);
-    if (sourcePos) {
-        return { text, range: range.cloneRange(), ...sourcePos };
-    }
-
-    // Fallback for selections inside block elements (code blocks, tables)
-    console.warn('Selection is not inside an md-line element; using rendered-text fallback');
-    const previewText = previewEl.textContent || '';
-    const startOffset = getTextOffset(previewEl, range.startContainer, range.startOffset);
-    const endOffset = getTextOffset(previewEl, range.endContainer, range.endOffset);
-    const startPos = offsetToPosition(previewText, startOffset);
-    const endPos = offsetToPosition(previewText, endOffset);
-    return {
-        text,
-        range: range.cloneRange(),
-        startLine: startPos.line,
-        startColumn: startPos.column,
-        endLine: endPos.line,
-        endColumn: endPos.column,
-    };
-}
-
-function getTextOffset(container: Node, targetNode: Node, targetOffset: number): number {
-    let offset = 0;
-    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-    while (walker.nextNode()) {
-        if (walker.currentNode === targetNode) return offset + targetOffset;
-        offset += (walker.currentNode.textContent || '').length;
-    }
-    return offset + targetOffset;
-}
-
-/**
- * @deprecated Use `selectionToSourcePosition` from `../utils/selection-position` instead.
- * Kept as fallback for selections inside block elements without `data-line` ancestors.
- */
-function offsetToPosition(text: string, offset: number): { line: number; column: number } {
-    const clamped = Math.max(0, Math.min(offset, text.length));
-    const before = text.substring(0, clamped);
-    const lines = before.split('\n');
-    return { line: lines.length, column: (lines[lines.length - 1]?.length || 0) + 1 };
 }

--- a/packages/coc/src/server/spa/client/react/shared/SkillDetailPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/shared/SkillDetailPanel.tsx
@@ -13,7 +13,7 @@ export interface SkillInfo {
     references?: string[];
     scripts?: string[];
     relativePath?: string;
-    source?: 'global' | 'repo' | 'bundled' | 'linked-repo' | 'extra-folder';
+    source?: 'global' | 'repo' | 'bundled' | 'linked-repo' | 'extra-folder' | 'global-extra-folder';
     /** Workspace ID of the repo this skill was loaded from (only set when source = 'linked-repo'). */
     sourceRepoId?: string;
     /** Absolute path of the directory containing this skill. */

--- a/packages/coc/src/server/spa/client/react/shared/markdown-document/MarkdownDocumentIO.ts
+++ b/packages/coc/src/server/spa/client/react/shared/markdown-document/MarkdownDocumentIO.ts
@@ -1,0 +1,44 @@
+export interface MarkdownDocumentLoadResult {
+    content: string;
+    path: string;
+    mtime: number;
+}
+
+export interface MarkdownDocumentSaveResult {
+    path: string;
+    updated: boolean;
+    mtime: number;
+}
+
+/**
+ * Generic markdown-document I/O contract for editor surfaces.
+ *
+ * Notes, task files, workspace previews, and future markdown hosts should
+ * provide this adapter instead of wiring REST calls directly into editor state.
+ */
+export interface MarkdownDocumentIO {
+    loadContent(
+        workspaceId: string,
+        path: string,
+        root?: string,
+    ): Promise<MarkdownDocumentLoadResult>;
+
+    saveContent(
+        workspaceId: string,
+        path: string,
+        markdown: string,
+        expectedMtime?: number,
+        root?: string,
+    ): Promise<MarkdownDocumentSaveResult>;
+
+    uploadImage(
+        workspaceId: string,
+        fileName: string,
+        dataUrl: string,
+        root?: string,
+    ): Promise<{ path: string }>;
+
+    imageApiUrl(workspaceId: string, relativePath: string, root?: string): string;
+
+    localImageApiUrl(workspaceId: string, absolutePath: string): string;
+}

--- a/packages/coc/src/server/spa/client/react/shared/markdown-document/markdownReviewSelection.ts
+++ b/packages/coc/src/server/spa/client/react/shared/markdown-document/markdownReviewSelection.ts
@@ -1,0 +1,78 @@
+import {
+    createAnchorData,
+    DEFAULT_ANCHOR_MATCH_CONFIG,
+} from '@plusplusoneplusplus/forge/editor/anchor';
+import { selectionToSourcePosition } from '../../utils/selection-position';
+
+export interface MarkdownReviewSelection {
+    text: string;
+    range: Range;
+    startLine: number;
+    startColumn: number;
+    endLine: number;
+    endColumn: number;
+}
+
+export function buildMarkdownCommentAnchor(
+    rawContent: string,
+    startLine: number,
+    endLine: number,
+    startColumn: number,
+    endColumn: number,
+) {
+    try {
+        return createAnchorData(rawContent, startLine, endLine, startColumn, endColumn, DEFAULT_ANCHOR_MATCH_CONFIG);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Resolve a rendered markdown selection back to source coordinates.
+ *
+ * The primary path uses renderer-provided data-line metadata. The fallback is
+ * intentionally text-offset based so review hosts can still create comments in
+ * code blocks, tables, or other rendered blocks without line attributes.
+ */
+export function resolveMarkdownReviewSelection(
+    rawContent: string,
+    previewEl: HTMLElement,
+    range: Range,
+    text: string,
+): MarkdownReviewSelection | null {
+    const sourcePos = selectionToSourcePosition(rawContent, previewEl, range);
+    if (sourcePos) {
+        return { text, range: range.cloneRange(), ...sourcePos };
+    }
+
+    const previewText = previewEl.textContent || '';
+    const startOffset = getTextOffset(previewEl, range.startContainer, range.startOffset);
+    const endOffset = getTextOffset(previewEl, range.endContainer, range.endOffset);
+    const startPos = offsetToPosition(previewText, startOffset);
+    const endPos = offsetToPosition(previewText, endOffset);
+    return {
+        text,
+        range: range.cloneRange(),
+        startLine: startPos.line,
+        startColumn: startPos.column,
+        endLine: endPos.line,
+        endColumn: endPos.column,
+    };
+}
+
+function getTextOffset(container: Node, targetNode: Node, targetOffset: number): number {
+    let offset = 0;
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+        if (walker.currentNode === targetNode) return offset + targetOffset;
+        offset += (walker.currentNode.textContent || '').length;
+    }
+    return offset + targetOffset;
+}
+
+function offsetToPosition(text: string, offset: number): { line: number; column: number } {
+    const clamped = Math.max(0, Math.min(offset, text.length));
+    const before = text.substring(0, clamped);
+    const lines = before.split('\n');
+    return { line: lines.length, column: (lines[lines.length - 1]?.length || 0) + 1 };
+}

--- a/packages/coc/src/server/spa/client/react/shared/markdown-document/useMarkdownDocumentSession.ts
+++ b/packages/coc/src/server/spa/client/react/shared/markdown-document/useMarkdownDocumentSession.ts
@@ -1,0 +1,409 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import type {
+    MarkdownDocumentIO,
+    MarkdownDocumentLoadResult,
+    MarkdownDocumentSaveResult,
+} from './MarkdownDocumentIO';
+
+export type MarkdownDocumentSaveState = 'idle' | 'saving' | 'saved' | 'error' | 'conflict';
+
+export interface MarkdownDocumentSessionOptions {
+    workspaceId: string;
+    documentPath: string | null;
+    io: MarkdownDocumentIO;
+    root?: string;
+    enabled?: boolean;
+    autosaveDebounceMs?: number;
+    resetSavedAfterMs?: number;
+    loadRevision?: number;
+    confirmBeforeLoadMessage?: string;
+    confirmRefreshMessage?: string;
+    onBeforeLoad?: () => void;
+    onLoaded?: (result: MarkdownDocumentLoadResult) => void;
+    onLoadError?: (error: unknown) => boolean | void;
+    onSaved?: (content: string, result: MarkdownDocumentSaveResult) => void;
+    onSaveError?: (error: unknown, content: string) => void;
+    onConflict?: (error: unknown, content: string) => void;
+    onDiscardDirty?: () => void;
+    flushBeforeLoad?: boolean;
+}
+
+export interface SaveMarkdownDocumentOptions {
+    expectedMtime?: number | null;
+    markClean?: boolean;
+}
+
+export interface MarkdownDocumentSession {
+    content: string;
+    setContent: (content: string) => void;
+    loading: boolean;
+    loadError: string | null;
+    saveState: MarkdownDocumentSaveState;
+    setSaveState: Dispatch<SetStateAction<MarkdownDocumentSaveState>>;
+    dirty: boolean;
+    setDirty: Dispatch<SetStateAction<boolean>>;
+    conflictContent: string | null;
+    setConflictContent: Dispatch<SetStateAction<string | null>>;
+    hasLoaded: boolean;
+    mtimeRef: MutableRefObject<number | null>;
+    pendingContentRef: MutableRefObject<string | null>;
+    queueSave: (content: string) => void;
+    flushSave: (options?: SaveMarkdownDocumentOptions) => Promise<void>;
+    saveNow: (content: string, options?: SaveMarkdownDocumentOptions) => Promise<MarkdownDocumentSaveResult>;
+    discardPending: () => void;
+    refresh: () => boolean;
+}
+
+interface PendingSaveContext {
+    workspaceId: string;
+    documentPath: string;
+    root?: string;
+    expectedMtime: number | null;
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof Error && error.message) return error.message;
+    return fallback;
+}
+
+function extractConflictContent(error: unknown): string | null {
+    if (error && typeof error === 'object' && 'currentContent' in error) {
+        const currentContent = (error as { currentContent?: unknown }).currentContent;
+        return typeof currentContent === 'string' ? currentContent : null;
+    }
+    return null;
+}
+
+function isConflictError(error: unknown): boolean {
+    return !!error && typeof error === 'object' && (error as { status?: unknown }).status === 409;
+}
+
+export function useMarkdownDocumentSession(options: MarkdownDocumentSessionOptions): MarkdownDocumentSession {
+    const {
+        workspaceId,
+        documentPath,
+        io,
+        root,
+        enabled = true,
+        autosaveDebounceMs,
+        resetSavedAfterMs = 3000,
+        loadRevision = 0,
+        confirmBeforeLoadMessage,
+        confirmRefreshMessage = 'You have unsaved changes. Discard and refresh?',
+    } = options;
+
+    const [content, setContentState] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [saveState, setSaveState] = useState<MarkdownDocumentSaveState>('idle');
+    const [dirty, setDirtyState] = useState(false);
+    const [conflictContent, setConflictContent] = useState<string | null>(null);
+    const [refreshCounter, setRefreshCounter] = useState(0);
+    const [hasLoaded, setHasLoaded] = useState(false);
+
+    const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const savedResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pendingContentRef = useRef<string | null>(null);
+    const pendingSaveContextRef = useRef<PendingSaveContext | null>(null);
+    const mtimeRef = useRef<number | null>(null);
+    const dirtyRef = useRef(false);
+
+    const workspaceIdRef = useRef(workspaceId);
+    const documentPathRef = useRef(documentPath);
+    const ioRef = useRef(io);
+    const rootRef = useRef(root);
+    const callbacksRef = useRef(options);
+
+    workspaceIdRef.current = workspaceId;
+    documentPathRef.current = documentPath;
+    ioRef.current = io;
+    rootRef.current = root;
+    callbacksRef.current = options;
+    dirtyRef.current = dirty;
+
+    const clearSaveTimer = useCallback(() => {
+        if (saveTimerRef.current) {
+            clearTimeout(saveTimerRef.current);
+            saveTimerRef.current = null;
+        }
+    }, []);
+
+    const clearSavedResetTimer = useCallback(() => {
+        if (savedResetTimerRef.current) {
+            clearTimeout(savedResetTimerRef.current);
+            savedResetTimerRef.current = null;
+        }
+    }, []);
+
+    const setDirty = useCallback<Dispatch<SetStateAction<boolean>>>((value) => {
+        setDirtyState((previous) => {
+            const next = typeof value === 'function'
+                ? (value as (previous: boolean) => boolean)(previous)
+                : value;
+            dirtyRef.current = next;
+            return next;
+        });
+    }, []);
+
+    const setContent = useCallback((nextContent: string) => {
+        setContentState(nextContent);
+    }, []);
+
+    const discardPending = useCallback(() => {
+        clearSaveTimer();
+        pendingContentRef.current = null;
+        pendingSaveContextRef.current = null;
+        setDirty(false);
+        setConflictContent(null);
+        setSaveState('idle');
+    }, [clearSaveTimer, setDirty]);
+
+    const saveWithContext = useCallback(async (
+        markdown: string,
+        saveOptions: SaveMarkdownDocumentOptions = {},
+        context?: PendingSaveContext,
+    ): Promise<MarkdownDocumentSaveResult> => {
+        const path = context?.documentPath ?? documentPathRef.current;
+        if (path === null) {
+            throw new Error('No markdown document is selected');
+        }
+
+        clearSaveTimer();
+        clearSavedResetTimer();
+        setSaveState('saving');
+        try {
+            const expectedMtime = saveOptions.expectedMtime === null
+                ? undefined
+                : saveOptions.expectedMtime ?? context?.expectedMtime ?? mtimeRef.current ?? undefined;
+            const saveWorkspaceId = context?.workspaceId ?? workspaceIdRef.current;
+            const saveRoot = context?.root ?? rootRef.current;
+            const rawResult = await ioRef.current.saveContent(
+                saveWorkspaceId,
+                path,
+                markdown,
+                expectedMtime,
+                saveRoot,
+            );
+            const result = rawResult ?? {
+                path,
+                updated: true,
+                mtime: mtimeRef.current ?? 0,
+            };
+            pendingContentRef.current = null;
+            pendingSaveContextRef.current = null;
+            const isCurrentDocument =
+                saveWorkspaceId === workspaceIdRef.current &&
+                path === documentPathRef.current &&
+                saveRoot === rootRef.current;
+            if (isCurrentDocument) {
+                mtimeRef.current = result.mtime;
+                setContentState(markdown);
+            }
+            setConflictContent(null);
+            setSaveState('saved');
+            if (isCurrentDocument && saveOptions.markClean !== false) setDirty(false);
+            callbacksRef.current.onSaved?.(markdown, result);
+            savedResetTimerRef.current = setTimeout(() => {
+                setSaveState((state) => state === 'saved' ? 'idle' : state);
+            }, resetSavedAfterMs);
+            return result;
+        } catch (error) {
+            if (isConflictError(error)) {
+                setConflictContent(extractConflictContent(error));
+                setSaveState('conflict');
+                pendingContentRef.current = markdown;
+                pendingSaveContextRef.current = context ?? {
+                    workspaceId: saveWorkspaceId,
+                    documentPath: path,
+                    root: saveRoot,
+                    expectedMtime: mtimeRef.current,
+                };
+                callbacksRef.current.onConflict?.(error, markdown);
+            } else {
+                setSaveState('error');
+                callbacksRef.current.onSaveError?.(error, markdown);
+            }
+            throw error;
+        }
+    }, [clearSaveTimer, clearSavedResetTimer, resetSavedAfterMs, setDirty]);
+
+    const saveNow = useCallback(async (
+        markdown: string,
+        saveOptions: SaveMarkdownDocumentOptions = {},
+    ): Promise<MarkdownDocumentSaveResult> => saveWithContext(markdown, saveOptions), [saveWithContext]);
+
+    const flushSave = useCallback(async (saveOptions: SaveMarkdownDocumentOptions = {}) => {
+        const pending = pendingContentRef.current;
+        if (pending === null) return;
+        try {
+            await saveWithContext(pending, saveOptions, pendingSaveContextRef.current ?? undefined);
+        } catch {
+            // Autosave callers observe saveState/conflictContent; they should not
+            // receive unhandled promise rejections for background failures.
+        }
+    }, [saveWithContext]);
+
+    const queueSave = useCallback((nextContent: string) => {
+        pendingContentRef.current = nextContent;
+        const path = documentPathRef.current;
+        pendingSaveContextRef.current = path !== null
+            ? {
+                workspaceId: workspaceIdRef.current,
+                documentPath: path,
+                root: rootRef.current,
+                expectedMtime: mtimeRef.current,
+            }
+            : null;
+        setDirty(true);
+        if (autosaveDebounceMs === undefined) return;
+        clearSaveTimer();
+        saveTimerRef.current = setTimeout(() => {
+            void flushSave();
+        }, autosaveDebounceMs);
+    }, [autosaveDebounceMs, clearSaveTimer, flushSave, setDirty]);
+
+    const refresh = useCallback(() => {
+        if (dirtyRef.current) {
+            if (!window.confirm(confirmRefreshMessage)) return false;
+            discardPending();
+            callbacksRef.current.onDiscardDirty?.();
+        }
+        setRefreshCounter((counter) => counter + 1);
+        return true;
+    }, [confirmRefreshMessage, discardPending]);
+
+    useEffect(() => {
+        if (!enabled) {
+            setLoading(false);
+            setLoadError(null);
+            setContentState('');
+            setHasLoaded(false);
+            discardPending();
+            return;
+        }
+
+        if (dirtyRef.current && confirmBeforeLoadMessage) {
+            if (!window.confirm(confirmBeforeLoadMessage)) return;
+            discardPending();
+            callbacksRef.current.onDiscardDirty?.();
+        }
+
+        if (callbacksRef.current.flushBeforeLoad) void flushSave();
+        callbacksRef.current.onBeforeLoad?.();
+        discardPending();
+        setLoading(true);
+        setLoadError(null);
+        setSaveState('idle');
+        setConflictContent(null);
+        setHasLoaded(false);
+
+        if (documentPath === null) {
+            setContentState('');
+            mtimeRef.current = null;
+            setLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        io.loadContent(workspaceId, documentPath, root)
+            .then((result) => {
+                if (cancelled) return;
+                mtimeRef.current = result.mtime;
+                setContentState(result.content);
+                setDirty(false);
+                setHasLoaded(true);
+                callbacksRef.current.onLoaded?.(result);
+            })
+            .catch((error) => {
+                if (cancelled) return;
+                const handled = callbacksRef.current.onLoadError?.(error);
+                if (!handled) setLoadError(errorMessage(error, 'Failed to load markdown document'));
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        discardPending,
+        documentPath,
+        enabled,
+        loadRevision,
+        refreshCounter,
+        workspaceId,
+        root,
+        io,
+        confirmBeforeLoadMessage,
+        flushSave,
+    ]);
+
+    useEffect(() => {
+        if (!dirty) return;
+        const handler = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => window.removeEventListener('beforeunload', handler);
+    }, [dirty]);
+
+    useEffect(() => {
+        return () => {
+            clearSaveTimer();
+            clearSavedResetTimer();
+        };
+    }, [clearSaveTimer, clearSavedResetTimer]);
+
+    return {
+        content,
+        setContent,
+        loading,
+        loadError,
+        saveState,
+        setSaveState,
+        dirty,
+        setDirty,
+        conflictContent,
+        setConflictContent,
+        hasLoaded,
+        mtimeRef,
+        pendingContentRef,
+        queueSave,
+        flushSave,
+        saveNow,
+        discardPending,
+        refresh,
+    };
+}
+
+export function useMarkdownDocumentKeyboardShortcuts(options: {
+    onSave?: () => void | Promise<void>;
+    saveEnabled?: boolean;
+    onRefresh?: () => void;
+    refreshEnabled?: boolean;
+    onKeyDown?: (event: KeyboardEvent) => void;
+}) {
+    const optionsRef = useRef(options);
+    optionsRef.current = options;
+
+    useEffect(() => {
+        const handler = (event: KeyboardEvent) => {
+            const current = optionsRef.current;
+            if ((event.ctrlKey || event.metaKey) && event.key === 's' && current.saveEnabled !== false && current.onSave) {
+                event.preventDefault();
+                void current.onSave();
+                return;
+            }
+            if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === 'R' && current.refreshEnabled !== false && current.onRefresh) {
+                event.preventDefault();
+                current.onRefresh();
+                return;
+            }
+            current.onKeyDown?.(event);
+        };
+        document.addEventListener('keydown', handler);
+        return () => document.removeEventListener('keydown', handler);
+    }, []);
+}

--- a/packages/coc/src/server/spa/client/react/utils/chatUtils.ts
+++ b/packages/coc/src/server/spa/client/react/utils/chatUtils.ts
@@ -3,6 +3,8 @@ export interface QueuedMessage {
     id: string;           // server-assigned UUID — used as React key and identifier
     content: string;
     status: 'queued' | 'steering';
+    /** Base64 image data-URLs attached when the follow-up was queued (rendered as thumbnails). */
+    images?: string[];
 }
 
 export function buildMetadataProcess(task: any, processDetails: any, processId: string | null): any {

--- a/packages/coc/src/server/streaming/sse-handler.ts
+++ b/packages/coc/src/server/streaming/sse-handler.ts
@@ -48,6 +48,13 @@ export interface PendingMessageAddedPayload {
     content: string;
     mode?: string;
     createdAt: string;
+    /**
+     * Validated base64 image data-URLs attached to the queued follow-up. Broadcast
+     * so every connected client can render thumbnails in the QUEUED bubble in real
+     * time, without waiting for a page refresh. Omitted when the follow-up carries
+     * no images.
+     */
+    images?: string[];
 }
 
 /** Fired when a canvas linked to this process is created or updated by the AI. */
@@ -101,6 +108,7 @@ export function emitPendingMessageAdded(store: ProcessStore, processId: string, 
             content: payload.content,
             mode: payload.mode,
             createdAt: payload.createdAt,
+            ...(payload.images && payload.images.length > 0 ? { images: payload.images } : {}),
         },
     } as ProcessOutputEvent);
 }

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -1342,11 +1342,13 @@ timeout: 300
                   },
                   "showReportIntent": true,
                   "skills": {
+                    "autoDetectDefaultFolders": true,
                     "autoUpdate": false,
                     "defaultSkills": [
                       "rethink",
                       "terse-replies",
                     ],
+                    "globalExtraFolders": [],
                   },
                   "store": {
                     "backend": "file",

--- a/packages/coc/test/e2e/nested-spawn-tree.spec.ts
+++ b/packages/coc/test/e2e/nested-spawn-tree.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * Nested / Spawned Chat-Tree E2E Tests
+ *
+ * Covers the `SpawnedTreeRow` feature: when a chat spawns a child conversation
+ * (server-side `send_to_conversation` tool → `AIProcess.parentProcessId`), the
+ * child renders nested under its parent in the dashboard chat list, with
+ * descendant-count badges and per-node collapse.
+ *
+ * Two tiers:
+ *   - Tier A (this file): seed-driven rendering — deterministic, no executor.
+ *     Nesting is produced by seeding `parentProcessId` links directly via
+ *     `POST /api/processes` (completed status, so they surface through
+ *     `GET /api/workspaces/:id/history`). Owns tree depth, badges, collapse,
+ *     persistence, feature toggle, and orphan promotion.
+ *   - Tier B (nested-spawn-tree tier B tests): one real 1-level spawn through the
+ *     queue (`payload.context.spawnedFromProcessId`), hitting the identical
+ *     `process-lifecycle-runner` path.
+ *
+ * Data flow (Tier A): seed workspace + completed chat processes with
+ * `parentProcessId` links via REST → navigate to `#repos/<wsId>/activity` →
+ * assert the spawned tree renders in the Completed Tasks section.
+ *
+ * DOM contract (from SpawnedTreeRow.tsx):
+ *   Tree root:   [data-testid="spawned-tree-row"][data-root-id="<rootId>"]
+ *   Node:        [data-testid="spawned-tree-node"][data-node-id="<id>"][data-depth="N"]
+ *   Chevron:     [data-testid="spawned-tree-chevron"] (aria-expanded / aria-label)
+ *   Children:    [data-testid="spawned-tree-children"]
+ *   Badge:       [data-testid="spawned-tree-child-count"] (only when descendantCount > 0)
+ *
+ * A node's OWN chevron / badge live in its header (the node div's first <div>
+ * child); descendants live under a sibling `spawned-tree-children` div. The
+ * `> div > ...` direct-child combinator isolates a node's own controls from its
+ * descendants'.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { test, expect, safeRmSync } from './fixtures/server-fixture';
+import { seedProcess, seedWorkspace, request } from './fixtures/seed';
+import type { Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Provision a temporary workspace tied to a fresh temp directory. */
+async function makeWorkspace(
+    serverUrl: string,
+    idPrefix: string,
+): Promise<{ wsId: string; rootPath: string; cleanup: () => void }> {
+    const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), `e2e-spawn-${idPrefix}-`));
+    const wsId = `${idPrefix}-${Date.now().toString(36)}`;
+    await seedWorkspace(serverUrl, wsId, idPrefix, rootPath);
+    return { wsId, rootPath, cleanup: () => safeRmSync(rootPath) };
+}
+
+/** Seed a completed chat process scoped to a workspace, optionally spawned from a parent. */
+async function seedChat(
+    serverUrl: string,
+    wsId: string,
+    id: string,
+    parentProcessId?: string,
+): Promise<void> {
+    await seedProcess(serverUrl, id, {
+        type: 'chat',
+        status: 'completed',
+        workspaceId: wsId,
+        promptPreview: `Chat ${id}`,
+        ...(parentProcessId ? { parentProcessId } : {}),
+    });
+}
+
+/**
+ * Seed the canonical 3-node chain: root → child (parent=root) → gc (parent=child).
+ * Depths 0 / 1 / 2.
+ */
+async function seedCanonicalChain(serverUrl: string, wsId: string): Promise<void> {
+    await seedChat(serverUrl, wsId, 'root');
+    await seedChat(serverUrl, wsId, 'child', 'root');
+    await seedChat(serverUrl, wsId, 'gc', 'child');
+}
+
+/** Fetch the workspace history list (the array the SPA groups into the tree). */
+async function fetchHistory(serverUrl: string, wsId: string): Promise<Array<Record<string, any>>> {
+    const res = await request(
+        `${serverUrl}/api/workspaces/${encodeURIComponent(wsId)}/history?limit=100&offset=0`,
+    );
+    if (res.status !== 200) {
+        throw new Error(`history fetch failed: ${res.status} ${res.body}`);
+    }
+    const json = JSON.parse(res.body);
+    return (json.history ?? []) as Array<Record<string, any>>;
+}
+
+/** Navigate to the per-repo Activity sub-tab and wait for the split panel. */
+async function gotoActivity(page: Page, serverUrl: string, wsId: string): Promise<void> {
+    await page.goto(`${serverUrl}/#repos/${encodeURIComponent(wsId)}/activity`);
+    await expect(page.locator('[data-testid="activity-split-panel"]')).toBeVisible({ timeout: 10_000 });
+}
+
+// Locator builders --------------------------------------------------------
+
+const treeRow = (page: Page, rootId: string) =>
+    page.locator(`[data-testid="spawned-tree-row"][data-root-id="${rootId}"]`);
+
+const treeNode = (page: Page, nodeId: string) =>
+    page.locator(`[data-testid="spawned-tree-node"][data-node-id="${nodeId}"]`);
+
+/** A node's OWN chevron (its header, not a descendant's). */
+const nodeChevron = (page: Page, nodeId: string) =>
+    page.locator(
+        `[data-testid="spawned-tree-node"][data-node-id="${nodeId}"] > div > [data-testid="spawned-tree-chevron"]`,
+    );
+
+/** A node's OWN descendant-count badge (its header, not a descendant's). */
+const nodeBadge = (page: Page, nodeId: string) =>
+    page.locator(
+        `[data-testid="spawned-tree-node"][data-node-id="${nodeId}"] > div > [data-testid="spawned-tree-child-count"]`,
+    );
+
+// ---------------------------------------------------------------------------
+// Tier A — seed-driven rendering
+// ---------------------------------------------------------------------------
+
+test.describe('Nested spawn tree — Tier A (seed-driven)', () => {
+    // AC-01 — Spec scaffolding & workspace navigation + parentProcessId round-trip.
+    test('AC-01 seeded spawned chats round-trip and appear in the workspace list', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac01');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+
+            // Setup-time guard: parentProcessId links round-trip through the
+            // history API the SPA reads (Tier A assumption).
+            const history = await fetchHistory(serverUrl, wsId);
+            const byId = Object.fromEntries(history.map(h => [h.id, h]));
+            expect(byId['root']).toBeTruthy();
+            expect(byId['child']?.parentProcessId).toBe('root');
+            expect(byId['gc']?.parentProcessId).toBe('child');
+
+            await gotoActivity(page, serverUrl, wsId);
+
+            // Smoke: the root seeded chat row is visible for the workspace.
+            await expect(page.locator('[data-task-id="root"]')).toBeVisible({ timeout: 10_000 });
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-02 — 3-deep chain renders nested at depths 0/1/2, no duplicate flat rows.
+    test('AC-02 three-deep chain renders nested', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac02');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+            await gotoActivity(page, serverUrl, wsId);
+
+            const row = treeRow(page, 'root');
+            await expect(row).toBeVisible({ timeout: 10_000 });
+            // Exactly one spawned-tree-row (rooted at root).
+            await expect(page.locator('[data-testid="spawned-tree-row"]')).toHaveCount(1);
+
+            // Depths 0 / 1 / 2, each nested inside the row.
+            await expect(row.locator('[data-testid="spawned-tree-node"][data-node-id="root"]')).toHaveAttribute('data-depth', '0');
+            await expect(row.locator('[data-testid="spawned-tree-node"][data-node-id="child"]')).toHaveAttribute('data-depth', '1');
+            await expect(row.locator('[data-testid="spawned-tree-node"][data-node-id="gc"]')).toHaveAttribute('data-depth', '2');
+
+            // child + gc nest inside spawned-tree-children containers.
+            await expect(row.locator('[data-testid="spawned-tree-children"]')).toHaveCount(2);
+
+            // No duplicate flat rows: each chat's card renders exactly once
+            // (inside the tree); descendants are hidden from the flat list.
+            await expect(page.locator('[data-task-id="child"]')).toHaveCount(1);
+            await expect(page.locator('[data-task-id="gc"]')).toHaveCount(1);
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-03 — descendant-count badges: root=2, child=1, leaf none.
+    test('AC-03 descendant-count badges', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac03');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+            await gotoActivity(page, serverUrl, wsId);
+
+            await expect(treeRow(page, 'root')).toBeVisible({ timeout: 10_000 });
+
+            await expect(nodeBadge(page, 'root')).toHaveText('2');
+            await expect(nodeBadge(page, 'child')).toHaveText('1');
+            await expect(nodeBadge(page, 'gc')).toHaveCount(0);
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-04 — collapse / expand the root hides / restores all descendants.
+    test('AC-04 collapse and re-expand the root', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac04');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+            await gotoActivity(page, serverUrl, wsId);
+
+            await expect(treeRow(page, 'root')).toBeVisible({ timeout: 10_000 });
+            const chevron = nodeChevron(page, 'root');
+            await expect(chevron).toHaveAttribute('aria-expanded', 'true');
+            await expect(treeNode(page, 'child')).toBeVisible();
+            await expect(treeNode(page, 'gc')).toBeVisible();
+
+            // Collapse: descendants disappear, chevron reports collapsed.
+            await chevron.click();
+            await expect(chevron).toHaveAttribute('aria-expanded', 'false');
+            await expect(treeNode(page, 'child')).toHaveCount(0);
+            await expect(treeNode(page, 'gc')).toHaveCount(0);
+
+            // Re-expand: descendants return.
+            await chevron.click();
+            await expect(chevron).toHaveAttribute('aria-expanded', 'true');
+            await expect(treeNode(page, 'child')).toBeVisible();
+            await expect(treeNode(page, 'gc')).toBeVisible();
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-05 — collapse a middle node hides only its subtree.
+    test('AC-05 collapse a middle node hides only its subtree', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac05');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+            await gotoActivity(page, serverUrl, wsId);
+
+            await expect(treeRow(page, 'root')).toBeVisible({ timeout: 10_000 });
+            const childChevron = nodeChevron(page, 'child');
+            await expect(childChevron).toHaveAttribute('aria-expanded', 'true');
+
+            await childChevron.click();
+
+            // gc (child's subtree) hidden; root and child remain visible.
+            await expect(treeNode(page, 'gc')).toHaveCount(0);
+            await expect(treeNode(page, 'root')).toBeVisible();
+            await expect(treeNode(page, 'child')).toBeVisible();
+            await expect(childChevron).toHaveAttribute('aria-expanded', 'false');
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-06 — collapse state persists across reload (localStorage).
+    test('AC-06 collapse state persists across reload', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac06');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+            await gotoActivity(page, serverUrl, wsId);
+
+            await expect(treeRow(page, 'root')).toBeVisible({ timeout: 10_000 });
+            await nodeChevron(page, 'root').click();
+            await expect(treeNode(page, 'child')).toHaveCount(0);
+
+            // localStorage records the collapsed root id.
+            const collapsed = await page.evaluate(() => localStorage.getItem('coc-spawned-tree-collapsed'));
+            expect(collapsed).toBeTruthy();
+            expect(JSON.parse(collapsed as string)).toContain('root');
+
+            await page.reload();
+            await expect(page.locator('[data-testid="activity-split-panel"]')).toBeVisible({ timeout: 10_000 });
+
+            // Still collapsed after reload.
+            await expect(treeRow(page, 'root')).toBeVisible({ timeout: 10_000 });
+            await expect(nodeChevron(page, 'root')).toHaveAttribute('aria-expanded', 'false');
+            await expect(treeNode(page, 'child')).toHaveCount(0);
+            await expect(treeNode(page, 'gc')).toHaveCount(0);
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-07 — feature toggle off → flat rendering.
+    test('AC-07 feature toggle off renders flat rows', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac07');
+        try {
+            await seedCanonicalChain(serverUrl, wsId);
+
+            // Disable the spawned-tree view before the SPA loads.
+            await page.addInitScript(() => {
+                try { localStorage.setItem('coc-spawned-tree-enabled', 'false'); } catch { /* ignore */ }
+            });
+
+            await gotoActivity(page, serverUrl, wsId);
+
+            // No tree; all three chats render as flat sibling rows.
+            await expect(page.locator('[data-task-id="root"]')).toBeVisible({ timeout: 10_000 });
+            await expect(page.locator('[data-testid="spawned-tree-row"]')).toHaveCount(0);
+            await expect(page.locator('[data-task-id="root"]')).toHaveCount(1);
+            await expect(page.locator('[data-task-id="child"]')).toHaveCount(1);
+            await expect(page.locator('[data-task-id="gc"]')).toHaveCount(1);
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-08 — orphan child (parent not loaded) is promoted to its own root.
+    test('AC-08 orphan child becomes its own root', async ({ page, serverUrl }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac08');
+        try {
+            // Seed only child (parent=root) and gc (parent=child); root is absent.
+            await seedChat(serverUrl, wsId, 'child', 'root');
+            await seedChat(serverUrl, wsId, 'gc', 'child');
+
+            await gotoActivity(page, serverUrl, wsId);
+
+            // Tree rooted at the orphan `child`, with gc nested at depth 1.
+            const row = treeRow(page, 'child');
+            await expect(row).toBeVisible({ timeout: 10_000 });
+            await expect(row.locator('[data-testid="spawned-tree-node"][data-node-id="child"]')).toHaveAttribute('data-depth', '0');
+            await expect(row.locator('[data-testid="spawned-tree-node"][data-node-id="gc"]')).toHaveAttribute('data-depth', '1');
+
+            // No row / node references the absent root.
+            await expect(page.locator('[data-testid="spawned-tree-row"][data-root-id="root"]')).toHaveCount(0);
+            await expect(treeNode(page, 'root')).toHaveCount(0);
+        } finally {
+            cleanup();
+        }
+    });
+});

--- a/packages/coc/test/e2e/nested-spawn-tree.spec.ts
+++ b/packages/coc/test/e2e/nested-spawn-tree.spec.ts
@@ -37,7 +37,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { test, expect, safeRmSync } from './fixtures/server-fixture';
-import { seedProcess, seedWorkspace, request } from './fixtures/seed';
+import { seedProcess, seedWorkspace, seedQueueTask, request } from './fixtures/seed';
 import type { Page } from '@playwright/test';
 
 // ---------------------------------------------------------------------------
@@ -91,6 +91,59 @@ async function fetchHistory(serverUrl: string, wsId: string): Promise<Array<Reco
     }
     const json = JSON.parse(res.body);
     return (json.history ?? []) as Array<Record<string, any>>;
+}
+
+/** Poll GET /api/queue/:id until the task reaches one of `targetStatuses`. */
+async function waitForTaskStatus(
+    serverUrl: string,
+    taskId: string,
+    targetStatuses: string[],
+    timeoutMs = 15_000,
+    intervalMs = 200,
+): Promise<Record<string, any>> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const res = await request(`${serverUrl}/api/queue/${encodeURIComponent(taskId)}`);
+        if (res.status === 200) {
+            const json = JSON.parse(res.body);
+            const task = json.task ?? json;
+            if (targetStatuses.includes(task.status as string)) {
+                return task;
+            }
+        }
+        await new Promise(r => setTimeout(r, intervalMs));
+    }
+    throw new Error(`Task ${taskId} did not reach ${targetStatuses.join('|')} within ${timeoutMs}ms`);
+}
+
+/**
+ * Faithful reproduction of the `send_to_conversation` create-mode enqueue: POST
+ * a `type:'chat'` queue task carrying `payload.context.spawnedFromProcessId`, the
+ * identical shape the tool builds before `enqueueChat` (see
+ * send-to-conversation-tool.ts createNewConversation). The lifecycle runner reads
+ * `spawnedFromProcessId` and persists it on the child's top-level `parentProcessId`.
+ * Returns the queued task id and its derived process id (`queue_<taskId>`).
+ */
+async function spawnChatFromParent(
+    serverUrl: string,
+    wsId: string,
+    parentProcessId: string,
+    prompt: string,
+): Promise<{ taskId: string; childProcessId: string }> {
+    const task = await seedQueueTask(serverUrl, {
+        type: 'chat',
+        repoId: wsId,
+        payload: {
+            kind: 'chat',
+            mode: 'ask',
+            workspaceId: wsId,
+            provider: 'copilot',
+            prompt,
+            context: { spawnedFromProcessId: parentProcessId },
+        },
+    });
+    const taskId = task.id as string;
+    return { taskId, childProcessId: `queue_${taskId}` };
 }
 
 /** Navigate to the per-repo Activity sub-tab and wait for the split panel. */
@@ -317,6 +370,113 @@ test.describe('Nested spawn tree — Tier A (seed-driven)', () => {
             // No row / node references the absent root.
             await expect(page.locator('[data-testid="spawned-tree-row"][data-root-id="root"]')).toHaveCount(0);
             await expect(treeNode(page, 'root')).toHaveCount(0);
+        } finally {
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — real spawn plumbing through the queue
+//
+// Instead of seeding `parentProcessId` directly, Tier B drives the identical
+// server path a real `send_to_conversation` create-mode call takes: POST
+// /api/queue a `type:'chat'` task with `payload.context.spawnedFromProcessId`.
+// The mock-AI-backed executor runs the child to completion, and the
+// process-lifecycle-runner persists `parentProcessId = spawnedFromProcessId`
+// (process-lifecycle-runner.ts ~L519-532). The child then nests under its
+// parent in the same Completed Tasks tree the Tier A tests assert.
+// ---------------------------------------------------------------------------
+
+test.describe('Nested spawn tree — Tier B (real spawn via queue)', () => {
+    // AC-09 — real spawn plumbing: a queued chat carrying spawnedFromProcessId
+    // persists parentProcessId and renders nested under the parent.
+    test('AC-09 queued spawn persists parentProcessId and renders nested', async ({ page, serverUrl, mockAI }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac09');
+        try {
+            // Seed the completed parent chat the child will spawn from.
+            await seedChat(serverUrl, wsId, 'parent');
+
+            // The mock AI returns a short response for the spawned child's prompt.
+            mockAI.mockSendMessage.mockResolvedValueOnce({
+                success: true,
+                response: 'Spawned child reply',
+                sessionId: 'sess-ac09',
+            });
+
+            const { taskId, childProcessId } = await spawnChatFromParent(
+                serverUrl,
+                wsId,
+                'parent',
+                'Spawned from parent',
+            );
+
+            await waitForTaskStatus(serverUrl, taskId, ['completed', 'failed']);
+
+            // DoD (a): the history API reports the child's parentProcessId === 'parent'.
+            const history = await fetchHistory(serverUrl, wsId);
+            const byId = Object.fromEntries(history.map(h => [h.id, h]));
+            expect(byId[childProcessId]?.parentProcessId).toBe('parent');
+
+            // DoD (b): the DOM nests the child at depth 1 under the parent root.
+            await gotoActivity(page, serverUrl, wsId);
+            const row = treeRow(page, 'parent');
+            await expect(row).toBeVisible({ timeout: 10_000 });
+            await expect(
+                row.locator('[data-testid="spawned-tree-node"][data-node-id="parent"]'),
+            ).toHaveAttribute('data-depth', '0');
+            await expect(
+                row.locator(`[data-testid="spawned-tree-node"][data-node-id="${childProcessId}"]`),
+            ).toHaveAttribute('data-depth', '1');
+
+            // The child's own descendant badge is absent (leaf); the parent shows 1.
+            await expect(nodeBadge(page, 'parent')).toHaveText('1');
+            await expect(nodeBadge(page, childProcessId)).toHaveCount(0);
+        } finally {
+            cleanup();
+        }
+    });
+
+    // AC-10 — live nesting without reload: the spawned child appears nested in the
+    // already-open chat list. Running/queued WS broadcasts strip parentProcessId,
+    // so the child renders flat while running; the running→completed departure
+    // triggers RepoChatTab's automatic history refetch (history carries
+    // parentProcessId), converting the parent's flat row into a spawned tree.
+    test('AC-10 spawned child nests live without a page reload', async ({ page, serverUrl, mockAI }) => {
+        const { wsId, cleanup } = await makeWorkspace(serverUrl, 'ac10');
+        try {
+            await seedChat(serverUrl, wsId, 'parent');
+
+            // Open the activity view BEFORE spawning: a childless root renders as a
+            // flat row, not a tree.
+            await gotoActivity(page, serverUrl, wsId);
+            await expect(page.locator('[data-task-id="parent"]')).toBeVisible({ timeout: 10_000 });
+            await expect(page.locator('[data-testid="spawned-tree-row"]')).toHaveCount(0);
+
+            // Hold the child in a 'running' state briefly so the SPA observes it
+            // active before it completes — the departure on completion is what
+            // triggers the history refetch that carries parentProcessId.
+            mockAI.mockSendMessage.mockImplementationOnce(async () => {
+                await new Promise(r => setTimeout(r, 1500));
+                return { success: true, response: 'Live spawned reply', sessionId: 'sess-ac10' };
+            });
+
+            const { childProcessId } = await spawnChatFromParent(
+                serverUrl,
+                wsId,
+                'parent',
+                'Live spawn from parent',
+            );
+
+            // No page.reload(): auto-wait for the WS-driven refetch to nest the child
+            // at depth 1 under the parent root, converting the flat row into a tree.
+            const row = treeRow(page, 'parent');
+            await expect(row).toBeVisible({ timeout: 15_000 });
+            const childNode = row.locator(
+                `[data-testid="spawned-tree-node"][data-node-id="${childProcessId}"]`,
+            );
+            await expect(childNode).toBeVisible({ timeout: 15_000 });
+            await expect(childNode).toHaveAttribute('data-depth', '1');
         } finally {
             cleanup();
         }

--- a/packages/coc/test/server/executors/skill-config-resolver.test.ts
+++ b/packages/coc/test/server/executors/skill-config-resolver.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async (importOriginal) => {
     };
 });
 
-import { resolveSkillConfig, resolveDefaultOneDriveSkillDirs, expandHomePath } from '../../../src/server/executors/skill-config-resolver';
+import { resolveSkillConfig, resolveDefaultOneDriveSkillDirs, expandHomePath, resolveEffectiveSkillPaths } from '../../../src/server/executors/skill-config-resolver';
 import { getBundledSkillsPath } from '@plusplusoneplusplus/forge';
 import { createMockProcessStore } from '../helpers/mock-process-store';
 
@@ -439,5 +439,208 @@ describe('resolveSkillConfig', () => {
         it('leaves absolute paths untouched', () => {
             expect(expandHomePath('/opt/skills', '/home/alice')).toBe('/opt/skills');
         });
+    });
+});
+
+describe('resolveEffectiveSkillPaths', () => {
+    let tmpDir: string;
+    let fakeHome: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eff-paths-'));
+        // Empty fake home so no real OneDrive/CloudStorage folders are detected.
+        fakeHome = path.join(tmpDir, 'home');
+        fs.mkdirSync(fakeHome, { recursive: true });
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function makeSkill(dir: string, name: string): void {
+        const skillDir = path.join(dir, name);
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name}\nDesc`);
+    }
+
+    it('returns global-only entries when no workspace root is supplied', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });
+
+        const entries = await resolveEffectiveSkillPaths({ dataDir, homedir: fakeHome });
+
+        expect(entries.every(e => e.scope === 'global')).toBe(true);
+        expect(entries.some(e => e.source === 'repo')).toBe(false);
+        expect(entries.some(e => e.source === 'repo-extra')).toBe(false);
+        expect(entries.some(e => e.source === 'managed-global')).toBe(true);
+    });
+
+    it('marks a missing managed-global directory as missing', async () => {
+        const dataDir = path.join(tmpDir, 'data'); // no skills subdir created
+        const entries = await resolveEffectiveSkillPaths({ dataDir, homedir: fakeHome });
+        const managed = entries.find(e => e.source === 'managed-global')!;
+        expect(managed.status).toBe('missing');
+        expect(managed.skillCount).toBeUndefined();
+    });
+
+    it('marks an empty managed-global directory as no-skills', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });
+        const entries = await resolveEffectiveSkillPaths({ dataDir, homedir: fakeHome });
+        const managed = entries.find(e => e.source === 'managed-global')!;
+        expect(managed.status).toBe('no-skills');
+        expect(managed.skillCount).toBe(0);
+    });
+
+    it('counts skills in the managed-global directory', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        const skillsDir = path.join(dataDir, 'skills');
+        fs.mkdirSync(skillsDir, { recursive: true });
+        makeSkill(skillsDir, 'one');
+        makeSkill(skillsDir, 'two');
+        const entries = await resolveEffectiveSkillPaths({ dataDir, homedir: fakeHome });
+        const managed = entries.find(e => e.source === 'managed-global')!;
+        expect(managed.status).toBe('available');
+        expect(managed.skillCount).toBe(2);
+    });
+
+    it('includes a workspace-scoped repo path before managed-global when a workspace root is given', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });
+        const repoRoot = path.join(tmpDir, 'repo');
+        makeSkill(path.join(repoRoot, '.github', 'skills'), 'repo-one');
+
+        const entries = await resolveEffectiveSkillPaths({ dataDir, homedir: fakeHome, workspaceRootPath: repoRoot });
+
+        const repo = entries.find(e => e.source === 'repo')!;
+        expect(repo.scope).toBe('workspace');
+        expect(repo.status).toBe('available');
+        expect(repo.skillCount).toBe(1);
+        const repoIdx = entries.findIndex(e => e.source === 'repo');
+        const managedIdx = entries.findIndex(e => e.source === 'managed-global');
+        expect(repoIdx).toBeLessThan(managedIdx);
+    });
+
+    it('includes per-repo extra folders (workspace scope) after configured global folders', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });
+        const repoRoot = path.join(tmpDir, 'repo');
+        fs.mkdirSync(repoRoot, { recursive: true });
+        const globalExtra = path.join(tmpDir, 'global-extra');
+        fs.mkdirSync(globalExtra, { recursive: true });
+        const repoExtra = path.join(tmpDir, 'repo-extra');
+        fs.mkdirSync(repoExtra, { recursive: true });
+
+        const entries = await resolveEffectiveSkillPaths({
+            dataDir,
+            homedir: fakeHome,
+            workspaceRootPath: repoRoot,
+            extraSkillFolders: [repoExtra],
+            globalExtraFolders: [globalExtra],
+            autoDetectDefaultFolders: false,
+        });
+
+        const configuredIdx = entries.findIndex(e => e.source === 'configured');
+        const repoExtraIdx = entries.findIndex(e => e.source === 'repo-extra');
+        expect(configuredIdx).toBeGreaterThanOrEqual(0);
+        expect(repoExtraIdx).toBeGreaterThan(configuredIdx);
+        expect(entries[repoExtraIdx].scope).toBe('workspace');
+    });
+
+    it('classifies configured global extra folders as available, missing, or skipped', async () => {
+        const existing = path.join(tmpDir, 'existing-extra');
+        makeSkill(existing, 'x');
+        const missing = path.join(tmpDir, 'missing-extra');
+
+        const entries = await resolveEffectiveSkillPaths({
+            homedir: fakeHome,
+            globalExtraFolders: [existing, missing, 'relative/skills'],
+        });
+
+        const configured = entries.filter(e => e.source === 'configured');
+        expect(configured.find(e => e.path === existing)!.status).toBe('available');
+        expect(configured.find(e => e.path === missing)!.status).toBe('missing');
+        const rel = configured.find(e => e.path === 'relative/skills')!;
+        expect(rel.status).toBe('skipped');
+        expect(rel.note).toBeTruthy();
+    });
+
+    it('expands ~ in configured global extra folders', async () => {
+        const extra = path.join(fakeHome, 'team-skills');
+        makeSkill(extra, 'y');
+        const entries = await resolveEffectiveSkillPaths({
+            homedir: fakeHome,
+            globalExtraFolders: ['~/team-skills'],
+        });
+        const configured = entries.find(e => e.source === 'configured')!;
+        expect(configured.path).toBe(extra);
+        expect(configured.status).toBe('available');
+    });
+
+    it('skips auto-detected OneDrive folders when auto-detection is disabled', async () => {
+        const oneDrive = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        fs.mkdirSync(oneDrive, { recursive: true });
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome, autoDetectDefaultFolders: false });
+        expect(entries.some(e => e.source === 'auto-detected')).toBe(false);
+    });
+
+    it('surfaces an existing auto-detected OneDrive folder when detection is enabled', async () => {
+        const oneDrive = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        makeSkill(oneDrive, 'od-skill');
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome, autoDetectDefaultFolders: true });
+        const detected = entries.find(e => e.source === 'auto-detected');
+        expect(detected).toBeTruthy();
+        expect(detected!.path).toBe(oneDrive);
+        expect(detected!.scope).toBe('global');
+        expect(detected!.status).toBe('available');
+        expect(detected!.skillCount).toBe(1);
+    });
+
+    it('does not surface missing default OneDrive folders (concise diagnostics)', async () => {
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome });
+        expect(entries.some(e => e.source === 'auto-detected')).toBe(false);
+    });
+
+    it('includes the bundled skills directory last as a global source', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });
+        const entries = await resolveEffectiveSkillPaths({ dataDir, homedir: fakeHome });
+        const bundledDir = getBundledSkillsPath();
+        if (fs.existsSync(bundledDir)) {
+            const bundled = entries.find(e => e.source === 'bundled');
+            expect(bundled).toBeTruthy();
+            expect(bundled!.scope).toBe('global');
+            expect(entries[entries.length - 1].source).toBe('bundled');
+        }
+    });
+
+    it('preserves the full priority order: repo → managed → configured → repo-extra → bundled', async () => {
+        const dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });
+        const repoRoot = path.join(tmpDir, 'repo');
+        makeSkill(path.join(repoRoot, '.github', 'skills'), 'r');
+        const globalExtra = path.join(tmpDir, 'global-extra');
+        fs.mkdirSync(globalExtra, { recursive: true });
+        const repoExtra = path.join(tmpDir, 'repo-extra');
+        fs.mkdirSync(repoExtra, { recursive: true });
+
+        const entries = await resolveEffectiveSkillPaths({
+            dataDir,
+            homedir: fakeHome,
+            workspaceRootPath: repoRoot,
+            extraSkillFolders: [repoExtra],
+            globalExtraFolders: [globalExtra],
+            autoDetectDefaultFolders: false,
+        });
+
+        const order = entries.map(e => e.source);
+        const idx = (s: string) => order.indexOf(s);
+        expect(idx('repo')).toBeLessThan(idx('managed-global'));
+        expect(idx('managed-global')).toBeLessThan(idx('configured'));
+        expect(idx('configured')).toBeLessThan(idx('repo-extra'));
+        const bundledDir = getBundledSkillsPath();
+        if (fs.existsSync(bundledDir)) {
+            expect(idx('repo-extra')).toBeLessThan(idx('bundled'));
+        }
     });
 });

--- a/packages/coc/test/server/executors/skill-config-resolver.test.ts
+++ b/packages/coc/test/server/executors/skill-config-resolver.test.ts
@@ -427,6 +427,87 @@ describe('resolveSkillConfig', () => {
         });
     });
 
+    describe('multi-workspace isolation (AC #3)', () => {
+        // Two workspaces, each with its own per-repo extra skill folder. Runtime
+        // resolution must include only the *selected* workspace's extra folders,
+        // proving per-repo extraSkillFolders never leak between workspaces.
+        // dataDir is omitted so getEffectiveEnDevExtraSkillFolders returns the
+        // workspace's extraSkillFolders verbatim (no EnDev detection side effects).
+        function makeIsolationStore(wsAExtra: string, wsBExtra: string) {
+            return createMockProcessStore({
+                initialWorkspaces: [
+                    { id: 'ws-a', name: 'Repo A', rootPath: path.join(tmpDir, 'repo-a'), extraSkillFolders: [wsAExtra] },
+                    { id: 'ws-b', name: 'Repo B', rootPath: path.join(tmpDir, 'repo-b'), extraSkillFolders: [wsBExtra] },
+                ] as any,
+            });
+        }
+
+        // Empty fake home so no host OneDrive/CloudStorage folders enter results.
+        function useEmptyHome(): void {
+            const fakeHome = path.join(tmpDir, 'home');
+            fs.mkdirSync(fakeHome, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+        }
+
+        it("includes only the selected workspace's extra skill folders (no leak between workspaces)", async () => {
+            const wsAExtra = path.join(tmpDir, 'ws-a-extra');
+            const wsBExtra = path.join(tmpDir, 'ws-b-extra');
+            fs.mkdirSync(wsAExtra, { recursive: true });
+            fs.mkdirSync(wsBExtra, { recursive: true });
+            useEmptyHome();
+
+            const isoStore = makeIsolationStore(wsAExtra, wsBExtra);
+
+            // Resolving for workspace A includes A's extra folder but not B's.
+            const resultA = await resolveSkillConfig(isoStore, undefined, 'ws-a', undefined);
+            expect(resultA.skillDirectories ?? []).toContain(wsAExtra);
+            expect(resultA.skillDirectories ?? []).not.toContain(wsBExtra);
+
+            // Resolving for workspace B includes B's extra folder but not A's.
+            const resultB = await resolveSkillConfig(isoStore, undefined, 'ws-b', undefined);
+            expect(resultB.skillDirectories ?? []).toContain(wsBExtra);
+            expect(resultB.skillDirectories ?? []).not.toContain(wsAExtra);
+        });
+
+        it('applies configured global extra folders to every workspace while keeping per-repo extras scoped', async () => {
+            const globalExtra = path.join(tmpDir, 'global-extra');
+            const wsAExtra = path.join(tmpDir, 'ws-a-extra');
+            const wsBExtra = path.join(tmpDir, 'ws-b-extra');
+            [globalExtra, wsAExtra, wsBExtra].forEach(d => fs.mkdirSync(d, { recursive: true }));
+            useEmptyHome();
+
+            const isoStore = makeIsolationStore(wsAExtra, wsBExtra);
+            const options = { globalExtraFolders: [globalExtra], autoDetectDefaultFolders: false };
+
+            const resultA = await resolveSkillConfig(isoStore, undefined, 'ws-a', undefined, options);
+            expect(resultA.skillDirectories ?? []).toContain(globalExtra); // global applies to A
+            expect(resultA.skillDirectories ?? []).toContain(wsAExtra);     // A's own per-repo extra
+            expect(resultA.skillDirectories ?? []).not.toContain(wsBExtra); // B's extra must not leak into A
+
+            const resultB = await resolveSkillConfig(isoStore, undefined, 'ws-b', undefined, options);
+            expect(resultB.skillDirectories ?? []).toContain(globalExtra); // same global folder applies to B too
+            expect(resultB.skillDirectories ?? []).toContain(wsBExtra);
+            expect(resultB.skillDirectories ?? []).not.toContain(wsAExtra);
+        });
+
+        it("applies only the selected workspace's disabled skills", async () => {
+            const isoStore = createMockProcessStore({
+                initialWorkspaces: [
+                    { id: 'ws-a', name: 'Repo A', rootPath: path.join(tmpDir, 'repo-a'), disabledSkills: ['skill-a'] },
+                    { id: 'ws-b', name: 'Repo B', rootPath: path.join(tmpDir, 'repo-b'), disabledSkills: ['skill-b'] },
+                ] as any,
+            });
+
+            const resultA = await resolveSkillConfig(isoStore, undefined, 'ws-a', undefined);
+            expect(resultA.disabledSkills).toContain('skill-a');
+            expect(resultA.disabledSkills ?? []).not.toContain('skill-b');
+
+            const resultB = await resolveSkillConfig(isoStore, undefined, 'ws-b', undefined);
+            expect(resultB.disabledSkills).toContain('skill-b');
+            expect(resultB.disabledSkills ?? []).not.toContain('skill-a');
+        });
+    });
+
     describe('expandHomePath helper', () => {
         it('maps a bare ~ to the home directory', () => {
             expect(expandHomePath('~', '/home/alice')).toBe('/home/alice');

--- a/packages/coc/test/server/executors/skill-config-resolver.test.ts
+++ b/packages/coc/test/server/executors/skill-config-resolver.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async (importOriginal) => {
     };
 });
 
-import { resolveSkillConfig } from '../../../src/server/executors/skill-config-resolver';
+import { resolveSkillConfig, resolveDefaultOneDriveSkillDirs } from '../../../src/server/executors/skill-config-resolver';
 import { getBundledSkillsPath } from '@plusplusoneplusplus/forge';
 import { createMockProcessStore } from '../helpers/mock-process-store';
 
@@ -166,6 +166,128 @@ describe('resolveSkillConfig', () => {
                 expect(globalIdx).toBeLessThan(oneDriveIdx);
                 expect(oneDriveIdx).toBeLessThan(bundledIdx);
             }
+        });
+    });
+
+    describe('macOS CloudStorage OneDrive skill directories', () => {
+        it('includes a macOS CloudStorage OneDrive skill dir when it exists', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const cloudSkillsDir = path.join(
+                fakeHome, 'Library', 'CloudStorage', 'OneDrive-Personal', '.github', 'skills',
+            );
+            fs.mkdirSync(cloudSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(cloudSkillsDir);
+        });
+
+        it('includes multiple CloudStorage OneDrive roots when several exist', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const personalSkillsDir = path.join(
+                fakeHome, 'Library', 'CloudStorage', 'OneDrive-Personal', '.github', 'skills',
+            );
+            const bizSkillsDir = path.join(
+                fakeHome, 'Library', 'CloudStorage', 'OneDrive-Contoso', '.github', 'skills',
+            );
+            fs.mkdirSync(personalSkillsDir, { recursive: true });
+            fs.mkdirSync(bizSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(personalSkillsDir);
+            expect(result.skillDirectories).toContain(bizSkillsDir);
+        });
+
+        it('skips a CloudStorage OneDrive root that lacks .github/skills', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            // Root exists but no .github/skills beneath it (AC #7 diagnostics case).
+            const oneDriveRoot = path.join(fakeHome, 'Library', 'CloudStorage', 'OneDrive-Personal');
+            fs.mkdirSync(oneDriveRoot, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            const dirs = result.skillDirectories ?? [];
+            const expectedSkillsDir = path.join(oneDriveRoot, '.github', 'skills');
+            expect(dirs).not.toContain(expectedSkillsDir);
+        });
+
+        it('ignores non-OneDrive CloudStorage providers', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const googleSkillsDir = path.join(
+                fakeHome, 'Library', 'CloudStorage', 'GoogleDrive-user', '.github', 'skills',
+            );
+            fs.mkdirSync(googleSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            const dirs = result.skillDirectories ?? [];
+            expect(dirs).not.toContain(googleSkillsDir);
+        });
+
+        it('CloudStorage OneDrive dirs appear after global and before bundled', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const cloudSkillsDir = path.join(
+                fakeHome, 'Library', 'CloudStorage', 'OneDrive-Personal', '.github', 'skills',
+            );
+            fs.mkdirSync(cloudSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const dataDir = path.join(tmpDir, 'data');
+            const globalSkillsDir = path.join(dataDir, 'skills');
+            fs.mkdirSync(globalSkillsDir, { recursive: true });
+
+            const result = await resolveSkillConfig(store, dataDir, undefined, undefined);
+
+            const bundledDir = getBundledSkillsPath();
+            if (fs.existsSync(bundledDir)) {
+                const dirs = result.skillDirectories!;
+                const globalIdx = dirs.indexOf(globalSkillsDir);
+                const cloudIdx = dirs.indexOf(cloudSkillsDir);
+                const bundledIdx = dirs.indexOf(bundledDir);
+                expect(globalIdx).toBeLessThan(cloudIdx);
+                expect(cloudIdx).toBeLessThan(bundledIdx);
+            }
+        });
+    });
+
+    describe('resolveDefaultOneDriveSkillDirs helper', () => {
+        it('always returns the two Windows-style OneDrive candidates', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            fs.mkdirSync(fakeHome, { recursive: true });
+
+            const dirs = await resolveDefaultOneDriveSkillDirs(fakeHome);
+
+            expect(dirs).toContain(path.join(fakeHome, 'OneDrive', '.github', 'skills'));
+            expect(dirs).toContain(path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills'));
+        });
+
+        it('appends CloudStorage OneDrive candidates after the Windows-style ones', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const cloudRoot = path.join(fakeHome, 'Library', 'CloudStorage', 'OneDrive-Personal');
+            fs.mkdirSync(cloudRoot, { recursive: true });
+
+            const dirs = await resolveDefaultOneDriveSkillDirs(fakeHome);
+
+            const cloudSkillsDir = path.join(cloudRoot, '.github', 'skills');
+            expect(dirs).toContain(cloudSkillsDir);
+            const windowsIdx = dirs.indexOf(path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills'));
+            expect(dirs.indexOf(cloudSkillsDir)).toBeGreaterThan(windowsIdx);
+        });
+
+        it('returns only Windows-style candidates when no CloudStorage dir exists', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            fs.mkdirSync(fakeHome, { recursive: true });
+
+            const dirs = await resolveDefaultOneDriveSkillDirs(fakeHome);
+
+            expect(dirs).toHaveLength(2);
         });
     });
 });

--- a/packages/coc/test/server/executors/skill-config-resolver.test.ts
+++ b/packages/coc/test/server/executors/skill-config-resolver.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async (importOriginal) => {
     };
 });
 
-import { resolveSkillConfig, resolveDefaultOneDriveSkillDirs } from '../../../src/server/executors/skill-config-resolver';
+import { resolveSkillConfig, resolveDefaultOneDriveSkillDirs, expandHomePath } from '../../../src/server/executors/skill-config-resolver';
 import { getBundledSkillsPath } from '@plusplusoneplusplus/forge';
 import { createMockProcessStore } from '../helpers/mock-process-store';
 
@@ -288,6 +288,156 @@ describe('resolveSkillConfig', () => {
             const dirs = await resolveDefaultOneDriveSkillDirs(fakeHome);
 
             expect(dirs).toHaveLength(2);
+        });
+    });
+
+    describe('autoDetectDefaultFolders option', () => {
+        it('skips OneDrive detection when autoDetectDefaultFolders is false', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            fs.mkdirSync(oneDriveSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                autoDetectDefaultFolders: false,
+            });
+
+            const dirs = result.skillDirectories ?? [];
+            expect(dirs).not.toContain(oneDriveSkillsDir);
+        });
+
+        it('detects OneDrive folders when autoDetectDefaultFolders is true', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            fs.mkdirSync(oneDriveSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                autoDetectDefaultFolders: true,
+            });
+
+            expect(result.skillDirectories).toContain(oneDriveSkillsDir);
+        });
+
+        it('detects OneDrive folders when options are omitted (default on)', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+            fs.mkdirSync(oneDriveSkillsDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined);
+
+            expect(result.skillDirectories).toContain(oneDriveSkillsDir);
+        });
+    });
+
+    describe('globalExtraFolders option', () => {
+        it('includes a configured absolute global extra folder when it exists', async () => {
+            const extraDir = path.join(tmpDir, 'shared-skills');
+            fs.mkdirSync(extraDir, { recursive: true });
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                globalExtraFolders: [extraDir],
+            });
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(extraDir);
+        });
+
+        it('expands a ~-prefixed global extra folder against the home directory', async () => {
+            const fakeHome = path.join(tmpDir, 'home');
+            const extraDir = path.join(fakeHome, 'team-skills');
+            fs.mkdirSync(extraDir, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                globalExtraFolders: ['~/team-skills'],
+            });
+
+            expect(result.skillDirectories).toBeDefined();
+            expect(result.skillDirectories).toContain(extraDir);
+        });
+
+        it('skips a configured global extra folder that does not exist', async () => {
+            const missingDir = path.join(tmpDir, 'does-not-exist');
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                globalExtraFolders: [missingDir],
+            });
+
+            const dirs = result.skillDirectories ?? [];
+            expect(dirs).not.toContain(missingDir);
+        });
+
+        it('skips relative global extra folders (must be absolute)', async () => {
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                globalExtraFolders: ['relative/skills'],
+            });
+
+            const dirs = result.skillDirectories ?? [];
+            expect(dirs).not.toContain('relative/skills');
+        });
+
+        it('ignores empty and non-string entries without throwing', async () => {
+            const extraDir = path.join(tmpDir, 'shared-skills');
+            fs.mkdirSync(extraDir, { recursive: true });
+
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                // Invalid config shape: empty string, whitespace, and non-string entries.
+                globalExtraFolders: ['', '   ', 42 as unknown as string, extraDir],
+            });
+
+            expect(result.skillDirectories).toContain(extraDir);
+        });
+
+        it('tolerates a non-array globalExtraFolders payload', async () => {
+            const result = await resolveSkillConfig(store, undefined, undefined, undefined, {
+                globalExtraFolders: 'not-an-array' as unknown as string[],
+            });
+
+            // Should not throw; simply contributes no extra folders.
+            expect(result).toBeDefined();
+        });
+
+        it('orders configured global extra folders after global and before bundled', async () => {
+            const dataDir = path.join(tmpDir, 'data');
+            const globalSkillsDir = path.join(dataDir, 'skills');
+            fs.mkdirSync(globalSkillsDir, { recursive: true });
+
+            const extraDir = path.join(tmpDir, 'shared-skills');
+            fs.mkdirSync(extraDir, { recursive: true });
+
+            // Avoid picking up any real OneDrive folders on the host.
+            const fakeHome = path.join(tmpDir, 'home');
+            fs.mkdirSync(fakeHome, { recursive: true });
+            vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+            const result = await resolveSkillConfig(store, dataDir, undefined, undefined, {
+                globalExtraFolders: [extraDir],
+            });
+
+            const bundledDir = getBundledSkillsPath();
+            const dirs = result.skillDirectories!;
+            const globalIdx = dirs.indexOf(globalSkillsDir);
+            const extraIdx = dirs.indexOf(extraDir);
+            expect(globalIdx).toBeLessThan(extraIdx);
+            if (fs.existsSync(bundledDir)) {
+                expect(extraIdx).toBeLessThan(dirs.indexOf(bundledDir));
+            }
+        });
+    });
+
+    describe('expandHomePath helper', () => {
+        it('maps a bare ~ to the home directory', () => {
+            expect(expandHomePath('~', '/home/alice')).toBe('/home/alice');
+        });
+
+        it('joins ~/x beneath the home directory', () => {
+            expect(expandHomePath('~/skills', '/home/alice')).toBe(path.join('/home/alice', 'skills'));
+        });
+
+        it('leaves absolute paths untouched', () => {
+            expect(expandHomePath('/opt/skills', '/home/alice')).toBe('/opt/skills');
         });
     });
 });

--- a/packages/coc/test/server/executors/skill-config-resolver.test.ts
+++ b/packages/coc/test/server/executors/skill-config-resolver.test.ts
@@ -601,6 +601,51 @@ describe('resolveEffectiveSkillPaths', () => {
         expect(entries.some(e => e.source === 'auto-detected')).toBe(false);
     });
 
+    it('emits a skipped auto-detected entry when a OneDrive root exists but lacks .github/skills', async () => {
+        // Root present, but no .github/skills beneath it (AC #7 diagnostics case).
+        const oneDriveRoot = path.join(fakeHome, 'OneDrive');
+        fs.mkdirSync(oneDriveRoot, { recursive: true });
+
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome });
+
+        const autoDetected = entries.filter(e => e.source === 'auto-detected');
+        // Only the existing root is surfaced; the absent 'OneDrive - Microsoft'
+        // root stays silent — so exactly one skipped diagnostic.
+        expect(autoDetected).toHaveLength(1);
+        const skipped = autoDetected[0];
+        expect(skipped.status).toBe('skipped');
+        expect(skipped.path).toBe(path.join(oneDriveRoot, '.github', 'skills'));
+        expect(skipped.scope).toBe('global');
+        expect(skipped.note).toBeTruthy();
+        expect(skipped.skillCount).toBeUndefined();
+    });
+
+    it('emits a skipped auto-detected entry for a CloudStorage OneDrive root without .github/skills', async () => {
+        const cloudRoot = path.join(fakeHome, 'Library', 'CloudStorage', 'OneDrive-Personal');
+        fs.mkdirSync(cloudRoot, { recursive: true });
+
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome });
+
+        const skipped = entries.find(e => e.source === 'auto-detected' && e.status === 'skipped');
+        expect(skipped).toBeTruthy();
+        expect(skipped!.path).toBe(path.join(cloudRoot, '.github', 'skills'));
+        expect(skipped!.note).toBeTruthy();
+    });
+
+    it('stays silent for an absent OneDrive root (no auto-detected entry)', async () => {
+        // fakeHome is empty — no OneDrive root exists at all.
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome });
+        expect(entries.some(e => e.source === 'auto-detected')).toBe(false);
+    });
+
+    it('does not emit skipped auto-detected diagnostics when auto-detection is disabled', async () => {
+        const oneDriveRoot = path.join(fakeHome, 'OneDrive');
+        fs.mkdirSync(oneDriveRoot, { recursive: true });
+
+        const entries = await resolveEffectiveSkillPaths({ homedir: fakeHome, autoDetectDefaultFolders: false });
+        expect(entries.some(e => e.source === 'auto-detected')).toBe(false);
+    });
+
     it('includes the bundled skills directory last as a global source', async () => {
         const dataDir = path.join(tmpDir, 'data');
         fs.mkdirSync(path.join(dataDir, 'skills'), { recursive: true });

--- a/packages/coc/test/server/global-skill-handler.test.ts
+++ b/packages/coc/test/server/global-skill-handler.test.ts
@@ -64,15 +64,18 @@ async function dispatchRoute(
 ): Promise<{ statusCode: number; body: any }> {
     const { res, getStatusCode, getBody } = createMockResponse();
     const req = makeRequest(method, url, body);
+    // Real router matches on pathname (query stripped); mirror that here so the
+    // handler still sees the full url (with query) via req.url.
+    const pathname = url.split('?')[0];
 
     for (const route of routes) {
         const pattern = route.pattern;
         let match: RegExpMatchArray | null = null;
 
         if (typeof pattern === 'string') {
-            if (pattern === url) match = [url];
+            if (pattern === pathname) match = [pathname];
         } else {
-            match = url.match(pattern);
+            match = pathname.match(pattern);
         }
 
         if (match && route.method === method) {
@@ -382,6 +385,94 @@ describe('registerGlobalSkillRoutes', () => {
                 { globalDisabledSkills: [], autoDetectDefaultFolders: 'yes' }
             );
             expect(statusCode).toBe(400);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // GET /api/skills/effective-paths — structured effective search order
+    // -----------------------------------------------------------------------
+
+    describe('GET /api/skills/effective-paths', () => {
+        it('returns global-only paths when no workspace is given', async () => {
+            const { statusCode, body } = await dispatchRoute(routes, 'GET', '/api/skills/effective-paths');
+            expect(statusCode).toBe(200);
+            expect(body.workspaceId).toBeUndefined();
+            expect(Array.isArray(body.paths)).toBe(true);
+            // Managed global dir is present and every path is global-scoped.
+            const managed = body.paths.find((p: any) => p.source === 'managed-global');
+            expect(managed).toBeTruthy();
+            expect(managed.path).toBe(globalSkillsDir);
+            expect(body.paths.every((p: any) => p.scope === 'global')).toBe(true);
+            // No workspace-scoped repo path leaks into the global-only view.
+            expect(body.paths.some((p: any) => p.source === 'repo')).toBe(false);
+        });
+
+        it('reports managed-global status/skillCount from the filesystem', async () => {
+            const skillDir = path.join(globalSkillsDir, 'a-skill');
+            fs.mkdirSync(skillDir);
+            fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# a-skill\nDesc');
+
+            const { body } = await dispatchRoute(routes, 'GET', '/api/skills/effective-paths');
+            const managed = body.paths.find((p: any) => p.source === 'managed-global');
+            expect(managed.status).toBe('available');
+            expect(managed.skillCount).toBe(1);
+        });
+
+        it('includes workspace-scoped repo path when a valid workspace is given', async () => {
+            const repoSkillsDir = path.join(workspaceDir, '.github', 'skills', 'repo-skill');
+            fs.mkdirSync(repoSkillsDir, { recursive: true });
+            fs.writeFileSync(path.join(repoSkillsDir, 'SKILL.md'), '# repo-skill\nDesc');
+
+            const { statusCode, body } = await dispatchRoute(
+                routes, 'GET', `/api/skills/effective-paths?workspaceId=${workspaceId}`
+            );
+            expect(statusCode).toBe(200);
+            expect(body.workspaceId).toBe(workspaceId);
+            const repo = body.paths.find((p: any) => p.source === 'repo');
+            expect(repo).toBeTruthy();
+            expect(repo.scope).toBe('workspace');
+            expect(repo.status).toBe('available');
+            expect(repo.skillCount).toBe(1);
+            // Repo-local is ordered before managed-global.
+            const repoIdx = body.paths.findIndex((p: any) => p.source === 'repo');
+            const managedIdx = body.paths.findIndex((p: any) => p.source === 'managed-global');
+            expect(repoIdx).toBeLessThan(managedIdx);
+        });
+
+        it('falls back to global-only for an unknown workspace id', async () => {
+            const { statusCode, body } = await dispatchRoute(
+                routes, 'GET', '/api/skills/effective-paths?workspaceId=nonexistent'
+            );
+            expect(statusCode).toBe(200);
+            expect(body.workspaceId).toBeUndefined();
+            expect(body.paths.some((p: any) => p.source === 'repo')).toBe(false);
+        });
+
+        it('reflects configured globalExtraFolders with source/status from config', async () => {
+            const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-extra-'));
+            try {
+                writeConfigFile(configPath, {
+                    skills: { globalExtraFolders: [extraDir, '/does/not/exist'], autoDetectDefaultFolders: false },
+                } as any);
+
+                const { body } = await dispatchRoute(routes, 'GET', '/api/skills/effective-paths');
+                const configured = body.paths.filter((p: any) => p.source === 'configured');
+                expect(configured).toHaveLength(2);
+                expect(configured.find((p: any) => p.path === extraDir).status).toBe('no-skills');
+                expect(configured.find((p: any) => p.path === '/does/not/exist').status).toBe('missing');
+                // auto-detect disabled → no auto-detected entries surface.
+                expect(body.paths.some((p: any) => p.source === 'auto-detected')).toBe(false);
+            } finally {
+                fs.rmSync(extraDir, { recursive: true, force: true });
+            }
+        });
+
+        it('is not swallowed by the /skills/:name catch-all route', async () => {
+            // Ensure a global skill literally named would-be-detail does not shadow the diagnostic.
+            const { statusCode, body } = await dispatchRoute(routes, 'GET', '/api/skills/effective-paths');
+            expect(statusCode).toBe(200);
+            expect(body).toHaveProperty('paths');
+            expect(body).not.toHaveProperty('skill');
         });
     });
 

--- a/packages/coc/test/server/global-skill-handler.test.ts
+++ b/packages/coc/test/server/global-skill-handler.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { registerGlobalSkillRoutes } from '../../src/server/skills/global-skill-handler';
+import { loadConfigFile, writeConfigFile } from '../../src/config';
 import { createMockProcessStore } from './helpers/mock-process-store';
 import type { Route } from '../../src/server/types';
 import { getRepoDataPath, type WorkspaceInfo } from '@plusplusoneplusplus/forge';
@@ -92,6 +93,7 @@ describe('registerGlobalSkillRoutes', () => {
     let store: ReturnType<typeof createMockProcessStore>;
     let dataDir: string;
     let globalSkillsDir: string;
+    let configPath: string;
     const workspaceId = 'ws-test-global';
     let workspaceDir: string;
 
@@ -101,6 +103,8 @@ describe('registerGlobalSkillRoutes', () => {
         globalSkillsDir = path.join(dataDir, 'skills');
         fs.mkdirSync(globalSkillsDir, { recursive: true });
         workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-skill-ws-'));
+        // Point config-file reads/writes at a hermetic temp path (not ~/.coc/config.yaml).
+        configPath = path.join(dataDir, 'config.yaml');
         store = createMockProcessStore({
             initialWorkspaces: [{
                 id: workspaceId,
@@ -113,7 +117,11 @@ describe('registerGlobalSkillRoutes', () => {
             name: 'Test Workspace',
             rootPath: workspaceDir,
         } as WorkspaceInfo]);
-        registerGlobalSkillRoutes(routes, store, dataDir);
+        registerGlobalSkillRoutes(routes, store, dataDir, {
+            loadConfigFile,
+            writeConfigFile,
+            getConfigFilePath: () => configPath,
+        });
     });
 
     afterEach(() => {
@@ -243,6 +251,33 @@ describe('registerGlobalSkillRoutes', () => {
             expect(statusCode).toBe(200);
             expect(body.globalDisabledSkills).toEqual(['skill-a', 'skill-b']);
         });
+
+        it('defaults folder-source fields when no config file exists', async () => {
+            const { statusCode, body } = await dispatchRoute(routes, 'GET', '/api/skills/config');
+            expect(statusCode).toBe(200);
+            expect(body.globalExtraFolders).toEqual([]);
+            expect(body.autoDetectDefaultFolders).toBe(true);
+        });
+
+        it('returns configured globalExtraFolders and autoDetectDefaultFolders from the config file', async () => {
+            writeConfigFile(configPath, {
+                skills: { globalExtraFolders: ['/team/skills', '~/my-skills'], autoDetectDefaultFolders: false },
+            } as any);
+
+            const { statusCode, body } = await dispatchRoute(routes, 'GET', '/api/skills/config');
+            expect(statusCode).toBe(200);
+            expect(body.globalExtraFolders).toEqual(['/team/skills', '~/my-skills']);
+            expect(body.autoDetectDefaultFolders).toBe(false);
+        });
+
+        it('falls back to safe defaults when the config file is malformed', async () => {
+            fs.writeFileSync(configPath, ':\n  not: [valid: yaml');
+
+            const { statusCode, body } = await dispatchRoute(routes, 'GET', '/api/skills/config');
+            expect(statusCode).toBe(200);
+            expect(body.globalExtraFolders).toEqual([]);
+            expect(body.autoDetectDefaultFolders).toBe(true);
+        });
     });
 
     // -----------------------------------------------------------------------
@@ -275,6 +310,76 @@ describe('registerGlobalSkillRoutes', () => {
             const { statusCode } = await dispatchRoute(
                 routes, 'PUT', '/api/skills/config',
                 { something: 'else' }
+            );
+            expect(statusCode).toBe(400);
+        });
+
+        it('persists globalExtraFolders to the config file and echoes them back', async () => {
+            const { statusCode, body } = await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: [], globalExtraFolders: ['/team/skills', '~/extra'] }
+            );
+            expect(statusCode).toBe(200);
+            expect(body.globalExtraFolders).toEqual(['/team/skills', '~/extra']);
+
+            // Verify it round-trips through the config file.
+            const written = loadConfigFile(configPath);
+            expect(written?.skills?.globalExtraFolders).toEqual(['/team/skills', '~/extra']);
+        });
+
+        it('persists autoDetectDefaultFolders toggle to the config file', async () => {
+            const { statusCode, body } = await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: [], autoDetectDefaultFolders: false }
+            );
+            expect(statusCode).toBe(200);
+            expect(body.autoDetectDefaultFolders).toBe(false);
+            expect(loadConfigFile(configPath)?.skills?.autoDetectDefaultFolders).toBe(false);
+        });
+
+        it('preserves unrelated config fields when updating folder sources', async () => {
+            writeConfigFile(configPath, {
+                skills: { autoUpdate: false, globalExtraFolders: ['/old'] },
+            } as any);
+
+            await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: [], globalExtraFolders: ['/new'] }
+            );
+
+            const written = loadConfigFile(configPath);
+            expect(written?.skills?.autoUpdate).toBe(false);
+            expect(written?.skills?.globalExtraFolders).toEqual(['/new']);
+        });
+
+        it('does not write the config file when no folder fields are provided', async () => {
+            await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: ['skill-x'] }
+            );
+            expect(fs.existsSync(configPath)).toBe(false);
+        });
+
+        it('rejects non-array globalExtraFolders', async () => {
+            const { statusCode } = await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: [], globalExtraFolders: '/single' }
+            );
+            expect(statusCode).toBe(400);
+        });
+
+        it('rejects globalExtraFolders with non-string items', async () => {
+            const { statusCode } = await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: [], globalExtraFolders: ['/ok', 42] }
+            );
+            expect(statusCode).toBe(400);
+        });
+
+        it('rejects non-boolean autoDetectDefaultFolders', async () => {
+            const { statusCode } = await dispatchRoute(
+                routes, 'PUT', '/api/skills/config',
+                { globalDisabledSkills: [], autoDetectDefaultFolders: 'yes' }
             );
             expect(statusCode).toBe(400);
         });

--- a/packages/coc/test/server/global-skill-handler.test.ts
+++ b/packages/coc/test/server/global-skill-handler.test.ts
@@ -450,16 +450,19 @@ describe('registerGlobalSkillRoutes', () => {
 
         it('reflects configured globalExtraFolders with source/status from config', async () => {
             const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-extra-'));
+            // A non-existent but absolute host path on the current platform, so it
+            // resolves to `missing` rather than being skipped as unresolvable.
+            const missingDir = path.join(os.tmpdir(), `global-extra-missing-${Date.now()}`);
             try {
                 writeConfigFile(configPath, {
-                    skills: { globalExtraFolders: [extraDir, '/does/not/exist'], autoDetectDefaultFolders: false },
+                    skills: { globalExtraFolders: [extraDir, missingDir], autoDetectDefaultFolders: false },
                 } as any);
 
                 const { body } = await dispatchRoute(routes, 'GET', '/api/skills/effective-paths');
                 const configured = body.paths.filter((p: any) => p.source === 'configured');
                 expect(configured).toHaveLength(2);
                 expect(configured.find((p: any) => p.path === extraDir).status).toBe('no-skills');
-                expect(configured.find((p: any) => p.path === '/does/not/exist').status).toBe('missing');
+                expect(configured.find((p: any) => p.path === missingDir).status).toBe('missing');
                 // auto-detect disabled → no auto-detected entries surface.
                 expect(body.paths.some((p: any) => p.source === 'auto-detected')).toBe(false);
             } finally {

--- a/packages/coc/test/server/skill-handler.test.ts
+++ b/packages/coc/test/server/skill-handler.test.ts
@@ -7,7 +7,7 @@ import * as http from 'http';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { registerSkillRoutes, sortSkillsByUsage, skillCache, SKILL_CACHE_TTL_MS } from '../../src/server/skills/skill-handler';
+import { registerSkillRoutes, sortSkillsByUsage, skillCache, SKILL_CACHE_TTL_MS, loadSkillsForWorkspace, readConfiguredGlobalExtraFolders } from '../../src/server/skills/skill-handler';
 import { createMockProcessStore } from './helpers/mock-process-store';
 import type { Route } from '../../src/server/types';
 import { getRepoDataPath, type WorkspaceInfo } from '@plusplusoneplusplus/forge';
@@ -114,7 +114,9 @@ describe('registerSkillRoutes', () => {
             name: 'Test Workspace',
             rootPath: workspaceDir,
         } as WorkspaceInfo]);
-        registerSkillRoutes(routes, store);
+        // Inject an empty global-extra-folder reader so these tests stay hermetic
+        // and never pick up the host's ~/.coc/config.yaml.
+        registerSkillRoutes(routes, store, undefined, () => []);
     });
 
     describe('EnDev xDPU wrapper visibility', () => {
@@ -142,7 +144,7 @@ describe('registerSkillRoutes', () => {
         beforeEach(() => {
             dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-endev-data-'));
             routesWithDataDir = [];
-            registerSkillRoutes(routesWithDataDir, store, dataDir);
+            registerSkillRoutes(routesWithDataDir, store, dataDir, () => []);
         });
 
         afterEach(() => {
@@ -545,7 +547,7 @@ describe('registerSkillRoutes', () => {
 
         // Re-register routes with dataDir
         const sortedRoutes: Route[] = [];
-        registerSkillRoutes(sortedRoutes, store, dataDir);
+        registerSkillRoutes(sortedRoutes, store, dataDir, () => []);
 
         const { statusCode, body } = await dispatchRoute(
             sortedRoutes, 'GET', `/api/workspaces/${workspaceId}/skills`
@@ -715,7 +717,7 @@ describe('registerSkillRoutes', () => {
         fs.writeFileSync(path.join(globalSkillsDir, 'global-skill', 'SKILL.md'), '---\ndescription: A global skill\n---');
 
         const globalRoutes: Route[] = [];
-        registerSkillRoutes(globalRoutes, store, dataDir);
+        registerSkillRoutes(globalRoutes, store, dataDir, () => []);
 
         const { statusCode, body } = await dispatchRoute(
             globalRoutes, 'GET', `/api/workspaces/${workspaceId}/skills`
@@ -743,7 +745,7 @@ describe('registerSkillRoutes', () => {
         fs.writeFileSync(path.join(globalSkillsDir, 'shared-skill', 'SKILL.md'), '---\ndescription: global version\n---');
 
         const globalRoutes: Route[] = [];
-        registerSkillRoutes(globalRoutes, store, dataDir);
+        registerSkillRoutes(globalRoutes, store, dataDir, () => []);
 
         const { statusCode, body } = await dispatchRoute(
             globalRoutes, 'GET', `/api/workspaces/${workspaceId}/skills`
@@ -957,5 +959,206 @@ describe('sortSkillsByUsage', () => {
         const copy = [...skills];
         sortSkillsByUsage(skills, {});
         expect(skills).toEqual(copy);
+    });
+});
+
+// ============================================================================
+// AC #2 — configured global extra skill folders
+// ============================================================================
+
+describe('loadSkillsForWorkspace — configured global extra folders (AC #2)', () => {
+    let store: ReturnType<typeof createMockProcessStore>;
+    let repoDir: string;
+    let tmpDirs: string[];
+    const wsId = 'ws-ge-1';
+
+    function mkSkill(root: string, name: string, frontmatter = ''): void {
+        const dir = path.join(root, name);
+        fs.mkdirSync(dir, { recursive: true });
+        const body = frontmatter ? `---\n${frontmatter}\n---\n# ${name}` : `# ${name}`;
+        fs.writeFileSync(path.join(dir, 'SKILL.md'), body);
+    }
+
+    function mkTmp(prefix: string): string {
+        const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+        tmpDirs.push(d);
+        return d;
+    }
+
+    function ws(extraSkillFolders?: string[]): WorkspaceInfo {
+        return { id: wsId, name: 'GE WS', rootPath: repoDir, extraSkillFolders } as WorkspaceInfo;
+    }
+
+    beforeEach(() => {
+        skillCache.clear();
+        tmpDirs = [];
+        repoDir = mkTmp('ge-repo-');
+        store = createMockProcessStore({ initialWorkspaces: [ws()] });
+        store.getWorkspaces = vi.fn(async () => [ws()]);
+    });
+
+    afterEach(() => {
+        for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+    });
+
+    it('surfaces skills from a configured global extra folder with source=global-extra-folder', async () => {
+        const geDir = mkTmp('ge-folder-');
+        mkSkill(geDir, 'ge-skill', 'description: A global extra skill');
+
+        const skills = await loadSkillsForWorkspace(ws(), undefined, store, { globalExtraFolders: [geDir] });
+        const s = skills.find(x => x.name === 'ge-skill');
+        expect(s).toBeDefined();
+        expect(s!.source).toBe('global-extra-folder');
+        expect(s!.folderPath).toBe(geDir);
+        expect(s!.description).toBe('A global extra skill');
+    });
+
+    it('skips a configured global extra folder that does not exist', async () => {
+        const missing = path.join(os.tmpdir(), 'ge-does-not-exist-9f8a7b');
+        const skills = await loadSkillsForWorkspace(ws(), undefined, store, { globalExtraFolders: [missing] });
+        expect(skills).toEqual([]);
+    });
+
+    it('local repo skill takes precedence over a global extra folder skill of the same name', async () => {
+        mkSkill(path.join(repoDir, '.github', 'skills'), 'dup', 'description: local version');
+        const geDir = mkTmp('ge-folder-');
+        mkSkill(geDir, 'dup', 'description: global-extra version');
+
+        const skills = await loadSkillsForWorkspace(ws(), undefined, store, { globalExtraFolders: [geDir] });
+        const dups = skills.filter(x => x.name === 'dup');
+        expect(dups).toHaveLength(1);
+        expect(dups[0].source).toBe('repo');
+        expect(dups[0].description).toBe('local version');
+    });
+
+    it('managed global skill takes precedence over a global extra folder skill of the same name', async () => {
+        const dataDir = mkTmp('ge-data-');
+        mkSkill(path.join(dataDir, 'skills'), 'dup', 'description: managed global');
+        const geDir = mkTmp('ge-folder-');
+        mkSkill(geDir, 'dup', 'description: global-extra');
+
+        const skills = await loadSkillsForWorkspace(ws(), dataDir, store, { globalExtraFolders: [geDir] });
+        const dups = skills.filter(x => x.name === 'dup');
+        expect(dups).toHaveLength(1);
+        expect(dups[0].source).toBe('global');
+        expect(dups[0].description).toBe('managed global');
+    });
+
+    it('when two global extra folders share a skill name, the first folder wins', async () => {
+        const first = mkTmp('ge-first-');
+        const second = mkTmp('ge-second-');
+        mkSkill(first, 'shared', 'description: from first');
+        mkSkill(second, 'shared', 'description: from second');
+
+        const skills = await loadSkillsForWorkspace(ws(), undefined, store, { globalExtraFolders: [first, second] });
+        const shared = skills.filter(x => x.name === 'shared');
+        expect(shared).toHaveLength(1);
+        expect(shared[0].folderPath).toBe(first);
+        expect(shared[0].description).toBe('from first');
+    });
+
+    it('per-workspace extra folder is suppressed when a global extra folder provides the same skill name', async () => {
+        const geDir = mkTmp('ge-folder-');
+        mkSkill(geDir, 'shared', 'description: from global-extra');
+        const perRepo = mkTmp('ge-perrepo-');
+        mkSkill(perRepo, 'shared', 'description: from per-repo');
+
+        const wsWithExtra = ws([perRepo]);
+        store.getWorkspaces = vi.fn(async () => [wsWithExtra]);
+
+        const skills = await loadSkillsForWorkspace(wsWithExtra, undefined, store, { globalExtraFolders: [geDir] });
+        const shared = skills.filter(x => x.name === 'shared');
+        expect(shared).toHaveLength(1);
+        expect(shared[0].source).toBe('global-extra-folder');
+        expect(shared[0].description).toBe('from global-extra');
+    });
+
+    it('ignores invalid global extra folder entries (empty, whitespace, relative, non-string) without throwing', async () => {
+        const geDir = mkTmp('ge-folder-');
+        mkSkill(geDir, 'valid', 'description: valid');
+
+        const skills = await loadSkillsForWorkspace(ws(), undefined, store, {
+            globalExtraFolders: ['', '   ', 'relative/path', 42 as any, null as any, undefined as any, geDir],
+        });
+        expect(skills.map(s => s.name)).toEqual(['valid']);
+        expect(skills[0].source).toBe('global-extra-folder');
+    });
+
+    it('treats an omitted globalExtraFolders option as no global extra folders', async () => {
+        mkSkill(path.join(repoDir, '.github', 'skills'), 'only-local');
+        const skills = await loadSkillsForWorkspace(ws(), undefined, store);
+        expect(skills.map(s => s.name)).toEqual(['only-local']);
+    });
+
+    it('expands ~ in a configured global extra folder path', async () => {
+        const home = mkTmp('ge-home-');
+        mkSkill(path.join(home, 'my-skills'), 'tilde-skill', 'description: via tilde');
+        const prevHome = process.env.HOME;
+        const prevUserProfile = process.env.USERPROFILE;
+        // os.homedir() reads $HOME on POSIX and %USERPROFILE% on Windows.
+        process.env.HOME = home;
+        process.env.USERPROFILE = home;
+        try {
+            const skills = await loadSkillsForWorkspace(ws(), undefined, store, { globalExtraFolders: ['~/my-skills'] });
+            const s = skills.find(x => x.name === 'tilde-skill');
+            expect(s).toBeDefined();
+            expect(s!.source).toBe('global-extra-folder');
+        } finally {
+            if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+            if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+        }
+    });
+});
+
+describe('readConfiguredGlobalExtraFolders (AC #2 config shapes)', () => {
+    it('returns the configured string folders', () => {
+        expect(readConfiguredGlobalExtraFolders(() => ({ skills: { globalExtraFolders: ['/a', '/b'] } }))).toEqual(['/a', '/b']);
+    });
+
+    it('drops non-string entries', () => {
+        expect(readConfiguredGlobalExtraFolders(() => ({ skills: { globalExtraFolders: ['/a', 3, null, '/b'] } }))).toEqual(['/a', '/b']);
+    });
+
+    it('returns [] when globalExtraFolders is not an array', () => {
+        expect(readConfiguredGlobalExtraFolders(() => ({ skills: { globalExtraFolders: 'nope' } }))).toEqual([]);
+    });
+
+    it('returns [] when the skills namespace is absent', () => {
+        expect(readConfiguredGlobalExtraFolders(() => ({}))).toEqual([]);
+    });
+
+    it('returns [] when config is undefined', () => {
+        expect(readConfiguredGlobalExtraFolders(() => undefined)).toEqual([]);
+    });
+
+    it('never throws when the loader throws', () => {
+        expect(readConfiguredGlobalExtraFolders(() => { throw new Error('bad config'); })).toEqual([]);
+    });
+});
+
+describe('GET /api/workspaces/:id/skills — configured global extra folders (AC #2 wiring)', () => {
+    it('includes global-extra-folder skills from the injected config reader', async () => {
+        const geDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ge-route-'));
+        const skillDir = path.join(geDir, 'route-ge-skill');
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# route-ge-skill');
+
+        const wsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ge-route-ws-'));
+        const id = 'ws-ge-route';
+        const store = createMockProcessStore({ initialWorkspaces: [{ id, name: 'W', rootPath: wsDir } as WorkspaceInfo] });
+        store.getWorkspaces = vi.fn(async () => [{ id, name: 'W', rootPath: wsDir } as WorkspaceInfo]);
+        skillCache.clear();
+
+        const routes: Route[] = [];
+        registerSkillRoutes(routes, store, undefined, () => [geDir]);
+
+        const { statusCode, body } = await dispatchRoute(routes, 'GET', `/api/workspaces/${id}/skills`);
+        expect(statusCode).toBe(200);
+        const s = body.skills.find((x: any) => x.name === 'route-ge-skill');
+        expect(s).toBeDefined();
+        expect(s.source).toBe('global-extra-folder');
+
+        fs.rmSync(geDir, { recursive: true, force: true });
+        fs.rmSync(wsDir, { recursive: true, force: true });
     });
 });

--- a/packages/coc/test/server/skills-config-api.test.ts
+++ b/packages/coc/test/server/skills-config-api.test.ts
@@ -248,4 +248,59 @@ describe('Skills Config API endpoints', () => {
             expect(res.status).toBe(400);
         });
     });
+
+    // ========================================================================
+    // Multi-workspace isolation (AC #3)
+    //
+    // With two workspaces registered, the per-repo skills-config endpoint must
+    // return (and update) only the requested workspace's config, proving
+    // extraSkillFolders / disabledSkills never leak between workspaces.
+    // ========================================================================
+
+    describe('multi-workspace isolation (AC #3)', () => {
+        const WS_A = 'ws-iso-a';
+        const WS_B = 'ws-iso-b';
+
+        beforeEach(() => {
+            // Override the single-workspace default set by the outer beforeEach.
+            (mockStore.getWorkspaces as any).mockResolvedValue([
+                { id: WS_A, name: 'Repo A', rootPath: '/projects/a', extraSkillFolders: ['/a/skills'], disabledSkills: ['skill-a'] },
+                { id: WS_B, name: 'Repo B', rootPath: '/projects/b', extraSkillFolders: ['/b/skills'], disabledSkills: ['skill-b'] },
+            ]);
+        });
+
+        it('GET returns only workspace A config, without workspace B folders leaking', async () => {
+            const res = await request(`${base()}/api/workspaces/${WS_A}/skills-config`);
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.extraSkillFolders).toEqual(['/a/skills']);
+            expect(data.disabledSkills).toEqual(['skill-a']);
+            expect(data.extraSkillFolders).not.toContain('/b/skills');
+            expect(data.disabledSkills).not.toContain('skill-b');
+        });
+
+        it('GET returns only workspace B config, without workspace A folders leaking', async () => {
+            const res = await request(`${base()}/api/workspaces/${WS_B}/skills-config`);
+            expect(res.status).toBe(200);
+            const data = res.json();
+            expect(data.extraSkillFolders).toEqual(['/b/skills']);
+            expect(data.disabledSkills).toEqual(['skill-b']);
+            expect(data.extraSkillFolders).not.toContain('/a/skills');
+            expect(data.disabledSkills).not.toContain('skill-a');
+        });
+
+        it('PUT updates only the targeted workspace and never the other one', async () => {
+            const res = await request(`${base()}/api/workspaces/${WS_A}/skills-config`, {
+                method: 'PUT',
+                body: JSON.stringify({ disabledSkills: [], extraSkillFolders: ['/a/new'] }),
+            });
+            expect(res.status).toBe(200);
+            expect(mockStore.updateWorkspace).toHaveBeenCalledWith(WS_A, {
+                disabledSkills: [],
+                extraSkillFolders: ['/a/new'],
+            });
+            // Workspace B is never mutated by an update targeting workspace A.
+            expect(mockStore.updateWorkspace).not.toHaveBeenCalledWith(WS_B, expect.anything());
+        });
+    });
 });

--- a/packages/coc/test/server/spa/client/spawned-tree-grouping.test.ts
+++ b/packages/coc/test/server/spa/client/spawned-tree-grouping.test.ts
@@ -7,6 +7,7 @@ import {
     collectSpawnedDescendantIds,
     collectSpawnedEntryTasks,
     buildSpawnedTreeChatView,
+    partitionSpawnedTreesByArchived,
     type SpawnedTreeEntry,
 } from '../../../../src/server/spa/client/react/features/chat/spawned-tree-grouping';
 
@@ -198,5 +199,181 @@ describe('buildSpawnedTreeChatView', () => {
         ];
         const view = buildSpawnedTreeChatView(items, { enabled: true, excludeIds: new Set(['proc-1']) });
         expect(view.groups).toHaveLength(0);
+    });
+});
+
+/** Build the spawned-tree groups from a flat chat list, the way ChatListPane does. */
+function groupsOf(items: any[], unseen?: Set<string>): SpawnedTreeEntry[] {
+    return groupBySpawnedTree(items, unseen).filter(isSpawnedTreeEntry);
+}
+
+describe('partitionSpawnedTreesByArchived', () => {
+    it('passes groups through untouched when nothing is archived (same reference)', () => {
+        const groups = groupsOf([chat('root'), chat('child', { parentProcessId: 'root' })]);
+        const part = partitionSpawnedTreesByArchived(groups, new Set());
+        expect(part.activeGroups).toBe(groups);
+        expect(part.activeTasks).toEqual([]);
+        expect(part.archivedGroups).toEqual([]);
+        expect(part.archivedTasks).toEqual([]);
+        expect(part.effectiveArchivedIds.size).toBe(0);
+    });
+
+    it('treats a null/undefined archived set as no-op', () => {
+        const groups = groupsOf([chat('root'), chat('child', { parentProcessId: 'root' })]);
+        expect(partitionSpawnedTreesByArchived(groups, null).activeGroups).toBe(groups);
+        expect(partitionSpawnedTreesByArchived(groups, undefined).activeGroups).toBe(groups);
+    });
+
+    it('AC-01/AC-02: archiving the ROOT moves the whole subtree out of active into archived', () => {
+        const groups = groupsOf([
+            chat('root'),
+            chat('child', { parentProcessId: 'root' }),
+            chat('grand', { parentProcessId: 'child' }),
+        ]);
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['root']));
+
+        expect(part.activeGroups).toHaveLength(0);
+        expect(part.activeTasks).toHaveLength(0);
+        expect(part.archivedGroups).toHaveLength(1);
+        expect(part.archivedGroups[0].rootProcessId).toBe('root');
+        expect(part.archivedGroups[0].descendantCount).toBe(2);
+        // root + every descendant is effectively archived
+        expect([...part.effectiveArchivedIds].sort()).toEqual(['child', 'grand', 'root']);
+    });
+
+    it('AC-01: an archived MIDDLE node splits off; the active root keeps its non-archived branch', () => {
+        const groups = groupsOf([
+            chat('root', { lastActivityAt: 1_000 }),
+            chat('childA', { parentProcessId: 'root', lastActivityAt: 2_000 }),
+            chat('grandA', { parentProcessId: 'childA', lastActivityAt: 3_000 }),
+            chat('childB', { parentProcessId: 'root', lastActivityAt: 8_000 }),
+            chat('grandB', { parentProcessId: 'childB', lastActivityAt: 9_000 }),
+        ]);
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['childB']));
+
+        // Active root keeps only the childA branch, re-finalized.
+        expect(part.activeGroups).toHaveLength(1);
+        const activeRoot = part.activeGroups[0];
+        expect(activeRoot.rootProcessId).toBe('root');
+        expect(activeRoot.root.children.map(c => c.task.id)).toEqual(['childA']);
+        expect(activeRoot.descendantCount).toBe(2); // childA + grandA
+        // The archived childB branch carried the latest activity; pruning it drops
+        // the active root's subtree-latest back to grandA's 3_000.
+        expect(activeRoot.latestTimestamp).toBe(3_000);
+
+        // Archived subtree is rooted at childB (the shallowest archived node).
+        expect(part.archivedGroups).toHaveLength(1);
+        expect(part.archivedGroups[0].rootProcessId).toBe('childB');
+        expect(part.archivedGroups[0].descendantCount).toBe(1); // grandB
+        expect([...part.effectiveArchivedIds].sort()).toEqual(['childB', 'grandB']);
+    });
+
+    it('AC-02: an archived LEAF (no descendants) becomes a flat archived task', () => {
+        const groups = groupsOf([
+            chat('root'),
+            chat('childA', { parentProcessId: 'root' }),
+            chat('childB', { parentProcessId: 'root' }),
+        ]);
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['childB']));
+
+        expect(part.activeGroups).toHaveLength(1);
+        expect(part.activeGroups[0].root.children.map(c => c.task.id)).toEqual(['childA']);
+        // childB has no descendants → flat archived task, not a tree.
+        expect(part.archivedGroups).toHaveLength(0);
+        expect(part.archivedTasks.map(t => t.id)).toEqual(['childB']);
+        expect([...part.effectiveArchivedIds]).toEqual(['childB']);
+    });
+
+    it('demotes an active root to a flat task when ALL its children are archived', () => {
+        const groups = groupsOf([
+            chat('root'),
+            chat('childA', { parentProcessId: 'root' }),
+            chat('childB', { parentProcessId: 'root' }),
+        ]);
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['childA', 'childB']));
+
+        // Root survives (not archived) but is childless → flat active task.
+        expect(part.activeGroups).toHaveLength(0);
+        expect(part.activeTasks.map(t => t.id)).toEqual(['root']);
+        expect(part.archivedTasks.map(t => t.id).sort()).toEqual(['childA', 'childB']);
+    });
+
+    it('AC-03: a deeper archived node inside an archived subtree does NOT re-root', () => {
+        const groups = groupsOf([
+            chat('root'),
+            chat('mid', { parentProcessId: 'root' }),
+            chat('grand', { parentProcessId: 'mid' }),
+        ]);
+        // Both mid and grand are explicitly archived; mid is the shallowest.
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['mid', 'grand']));
+
+        expect(part.archivedGroups).toHaveLength(1);
+        expect(part.archivedGroups[0].rootProcessId).toBe('mid');
+        expect(part.archivedGroups[0].descendantCount).toBe(1); // grand travels with mid
+        expect(part.activeGroups).toHaveLength(0); // root left childless
+        expect(part.activeTasks.map(t => t.id)).toEqual(['root']);
+    });
+
+    it('AC-03: unarchiving the ancestor re-roots the independently-archived descendant (recompute)', () => {
+        const items = [
+            chat('root'),
+            chat('mid', { parentProcessId: 'root' }),
+            chat('grand', { parentProcessId: 'mid' }),
+        ];
+        // While both archived, mid owns the subtree (grand does not re-root)…
+        const bothArchived = partitionSpawnedTreesByArchived(groupsOf(items), new Set(['mid', 'grand']));
+        expect(bothArchived.archivedGroups[0].rootProcessId).toBe('mid');
+
+        // …after unarchiving mid, grand becomes the shallowest archived node and
+        // re-roots as its own archived sub-tree; root+mid stay active.
+        const afterUnarchiveMid = partitionSpawnedTreesByArchived(groupsOf(items), new Set(['grand']));
+        expect(afterUnarchiveMid.activeGroups).toHaveLength(1);
+        expect(afterUnarchiveMid.activeGroups[0].rootProcessId).toBe('root');
+        expect(afterUnarchiveMid.activeGroups[0].root.children.map(c => c.task.id)).toEqual(['mid']);
+        expect(afterUnarchiveMid.archivedTasks.map(t => t.id)).toEqual(['grand']);
+    });
+
+    it('recomputes hasUnseen for both sides after the split', () => {
+        const unseen = new Set(['grandB']);
+        const groups = groupsOf([
+            chat('root'),
+            chat('childA', { parentProcessId: 'root' }),
+            chat('childB', { parentProcessId: 'root' }),
+            chat('grandB', { parentProcessId: 'childB' }),
+        ], unseen);
+        // Whole tree is unseen because grandB is unseen.
+        expect(groups[0].hasUnseen).toBe(true);
+
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['childB']), unseen);
+        // Active side (root + childA) no longer contains the unseen node.
+        expect(part.activeGroups[0].hasUnseen).toBe(false);
+        // Archived side (childB → grandB) carries the unseen flag.
+        expect(part.archivedGroups[0].hasUnseen).toBe(true);
+    });
+
+    it('resolves archived state by id OR processId', () => {
+        const groups = groupsOf([
+            { id: 'task-root', processId: 'proc-root', lastActivityAt: 1_000 },
+            { id: 'task-child', processId: 'proc-child', parentProcessId: 'proc-root', lastActivityAt: 2_000 },
+        ]);
+        // Archive keyed on the child's processId (not its id).
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['proc-child']));
+        expect(part.archivedTasks.map(t => t.id)).toEqual(['task-child']);
+        expect(part.effectiveArchivedIds.has('task-child')).toBe(true);
+        expect(part.effectiveArchivedIds.has('proc-child')).toBe(true);
+    });
+
+    it('partitions several trees independently in one call', () => {
+        const groups = groupsOf([
+            chat('r1', { lastActivityAt: 5_000 }),
+            chat('r1c', { parentProcessId: 'r1', lastActivityAt: 6_000 }),
+            chat('r2', { lastActivityAt: 1_000 }),
+            chat('r2c', { parentProcessId: 'r2', lastActivityAt: 2_000 }),
+        ]);
+        // Archive the whole r2 tree; leave r1 active.
+        const part = partitionSpawnedTreesByArchived(groups, new Set(['r2']));
+        expect(part.activeGroups.map(g => g.rootProcessId)).toEqual(['r1']);
+        expect(part.archivedGroups.map(g => g.rootProcessId)).toEqual(['r2']);
+        expect([...part.effectiveArchivedIds].sort()).toEqual(['r2', 'r2c']);
     });
 });

--- a/packages/coc/test/server/sse-pending-message-events.test.ts
+++ b/packages/coc/test/server/sse-pending-message-events.test.ts
@@ -67,4 +67,39 @@ describe('emitPendingMessageAdded', () => {
             expect.objectContaining({ type: 'pending-message-added' }),
         );
     });
+
+    it('includes images in the emitted payload when present', () => {
+        const store = createMockStore();
+        const images = ['data:image/png;base64,AAA', 'data:image/jpeg;base64,BBB'];
+        emitPendingMessageAdded(store as any, 'proc-img', {
+            id: 'msg-img',
+            content: 'look at this',
+            createdAt: '2026-04-10T03:00:00.000Z',
+            images,
+        });
+
+        expect(store.emitProcessEvent).toHaveBeenCalledWith('proc-img', {
+            type: 'pending-message-added',
+            pendingMessage: {
+                id: 'msg-img',
+                content: 'look at this',
+                mode: undefined,
+                createdAt: '2026-04-10T03:00:00.000Z',
+                images,
+            },
+        });
+    });
+
+    it('omits images from the emitted payload when absent or empty', () => {
+        const store = createMockStore();
+        emitPendingMessageAdded(store as any, 'proc-noimg', {
+            id: 'msg-noimg',
+            content: 'text only',
+            createdAt: '2026-04-10T04:00:00.000Z',
+            images: [],
+        });
+
+        const emitted = (store.emitProcessEvent as any).mock.calls[0][1];
+        expect(emitted.pendingMessage).not.toHaveProperty('images');
+    });
 });

--- a/packages/coc/test/spa/react/QueuedFollowUps-redesign.test.tsx
+++ b/packages/coc/test/spa/react/QueuedFollowUps-redesign.test.tsx
@@ -152,6 +152,50 @@ describe('QueuedFollowUps — redesign', () => {
     });
 });
 
+describe('QueuedFollowUps — queued image attachments', () => {
+    const IMG_A = 'data:image/png;base64,AAA';
+    const IMG_B = 'data:image/jpeg;base64,BBB';
+
+    it('renders an ImageGallery of thumbnails when the queued message has images', () => {
+        const { getByTestId, getAllByTestId } = render(
+            <QueuedFollowUps queue={[makeMsg({ images: [IMG_A, IMG_B] })]} />,
+        );
+        expect(getByTestId('image-gallery')).toBeTruthy();
+        const items = getAllByTestId('image-gallery-item');
+        expect(items.length).toBe(2);
+        const imgs = getByTestId('queued-item').querySelectorAll('img');
+        expect(imgs[0].getAttribute('src')).toBe(IMG_A);
+        expect(imgs[1].getAttribute('src')).toBe(IMG_B);
+    });
+
+    it('renders no gallery when the queued message has no images', () => {
+        const { container } = render(<QueuedFollowUps queue={[makeMsg()]} />);
+        expect(container.querySelector('[data-testid="image-gallery"]')).toBeNull();
+    });
+
+    it('renders no gallery when images is an empty array (no layout shift)', () => {
+        const { container } = render(<QueuedFollowUps queue={[makeMsg({ images: [] })]} />);
+        expect(container.querySelector('[data-testid="image-gallery"]')).toBeNull();
+    });
+
+    it('lays the item out as a column so the gallery sits below the text/✕ row', () => {
+        const { getByTestId } = render(<QueuedFollowUps queue={[makeMsg({ images: [IMG_A] })]} />);
+        const item = getByTestId('queued-item');
+        expect(item.className).toContain('flex-col');
+    });
+
+    it('keeps the ✕ cancel working when images are present', () => {
+        const onCancel = vi.fn();
+        const { container } = render(
+            <QueuedFollowUps queue={[makeMsg({ id: 'img-msg', images: [IMG_A] })]} onCancel={onCancel} />,
+        );
+        const btn = container.querySelector<HTMLButtonElement>('[data-testid="queued-item-cancel"]');
+        expect(btn).not.toBeNull();
+        fireEvent.click(btn!);
+        expect(onCancel).toHaveBeenCalledWith('img-msg');
+    });
+});
+
 describe('QueuedBubble — deprecated wrapper', () => {
     it('still renders a single queued item with no clock emoji', () => {
         const { container } = render(<QueuedBubble msg={makeMsg({ content: 'legacy single' })} />);

--- a/packages/coc/test/spa/react/features/skills/SkillsConfigPanel.test.tsx
+++ b/packages/coc/test/spa/react/features/skills/SkillsConfigPanel.test.tsx
@@ -1,16 +1,19 @@
 /**
  * Tests for SkillsConfigPanel component.
  *
- * Covers: initial load, global directory display, disabled-skills badges,
- * add/remove disabled skill, duplicate prevention, Enter-key support,
- * empty state, and error handling.
+ * Covers: initial load, global directory display + fallback, disabled-skills
+ * badges, add/remove disabled skill, duplicate prevention, Enter-key support,
+ * empty state, error handling, global extra skill folders (add/remove/dup),
+ * auto-detect toggle, detected-folder concise display + diagnostics, and the
+ * read-only effective search order with source/status badges.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { SkillsConfigPanel } from '../../../../../src/server/spa/client/react/features/skills/SkillsConfigPanel';
 
 const mockFetchApi = vi.hoisted(() => vi.fn());
+const mockGetEffectivePaths = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
     getSpaCocClient: () => ({
@@ -20,9 +23,16 @@ vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
                 method: 'PUT',
                 body: JSON.stringify(body),
             }),
+            getEffectivePaths: (workspaceId?: string) => mockGetEffectivePaths(workspaceId),
         },
     }),
 }));
+
+beforeEach(() => {
+    // Default: global-only effective view with no paths. Individual tests override
+    // with mockResolvedValueOnce for specific path shapes.
+    mockGetEffectivePaths.mockResolvedValue({ paths: [] });
+});
 
 afterEach(() => {
     vi.clearAllMocks();
@@ -31,6 +41,8 @@ afterEach(() => {
 const makeConfig = (overrides: Record<string, any> = {}) => ({
     globalDisabledSkills: [],
     globalSkillsDir: '',
+    globalExtraFolders: [],
+    autoDetectDefaultFolders: true,
     ...overrides,
 });
 
@@ -55,6 +67,15 @@ describe('SkillsConfigPanel', () => {
 
     it('shows default directory when API returns empty string', async () => {
         mockFetchApi.mockResolvedValueOnce(makeConfig({ globalSkillsDir: '' }));
+        render(<SkillsConfigPanel />);
+        await waitFor(() => {
+            expect(screen.getByText('~/.coc/skills/')).toBeTruthy();
+        });
+    });
+
+    it('falls back to ~/.coc/skills/ when server omits globalSkillsDir (AC #1)', async () => {
+        // Config payload with no globalSkillsDir key at all.
+        mockFetchApi.mockResolvedValueOnce({ globalDisabledSkills: [], globalExtraFolders: [] });
         render(<SkillsConfigPanel />);
         await waitFor(() => {
             expect(screen.getByText('~/.coc/skills/')).toBeTruthy();
@@ -321,6 +342,273 @@ describe('SkillsConfigPanel', () => {
                     body: JSON.stringify({ globalDisabledSkills: ['first', 'second'] }),
                 }),
             );
+        });
+    });
+
+    // ── Global extra skill folders (AC #2 / #5) ────────────────────────
+
+    it('renders configured global extra folders as chips', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig({
+            globalExtraFolders: ['/opt/shared/skills', '~/team/skills'],
+        }));
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-global-extra-folders');
+        await waitFor(() => {
+            expect(within(section).getByText('/opt/shared/skills')).toBeTruthy();
+            expect(within(section).getByText('~/team/skills')).toBeTruthy();
+        });
+    });
+
+    it('shows empty state when no global extra folders configured', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig({ globalExtraFolders: [] }));
+        render(<SkillsConfigPanel />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No global extra folders configured.')).toBeTruthy();
+        });
+    });
+
+    it('adds a global extra folder via the Add button', async () => {
+        mockFetchApi
+            .mockResolvedValueOnce(makeConfig())       // GET
+            .mockResolvedValueOnce(undefined);          // PUT
+        render(<SkillsConfigPanel />);
+
+        const input = await screen.findByPlaceholderText('Extra skill folder path…');
+        fireEvent.change(input, { target: { value: '/opt/skills' } });
+        fireEvent.click(screen.getByText('Add'));
+
+        await waitFor(() => {
+            expect(mockFetchApi).toHaveBeenCalledWith(
+                '/skills/config',
+                expect.objectContaining({
+                    method: 'PUT',
+                    body: JSON.stringify({ globalDisabledSkills: [], globalExtraFolders: ['/opt/skills'] }),
+                }),
+            );
+        });
+        const section = screen.getByTestId('skills-global-extra-folders');
+        expect(within(section).getByText('/opt/skills')).toBeTruthy();
+    });
+
+    it('adds a global extra folder when Enter is pressed', async () => {
+        mockFetchApi
+            .mockResolvedValueOnce(makeConfig())
+            .mockResolvedValueOnce(undefined);
+        render(<SkillsConfigPanel />);
+
+        const input = await screen.findByPlaceholderText('Extra skill folder path…');
+        fireEvent.change(input, { target: { value: '~/my/skills' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        await waitFor(() => {
+            expect(mockFetchApi).toHaveBeenCalledWith(
+                '/skills/config',
+                expect.objectContaining({
+                    method: 'PUT',
+                    body: JSON.stringify({ globalDisabledSkills: [], globalExtraFolders: ['~/my/skills'] }),
+                }),
+            );
+        });
+    });
+
+    it('removes a global extra folder', async () => {
+        mockFetchApi
+            .mockResolvedValueOnce(makeConfig({ globalExtraFolders: ['/keep', '/drop'] }))
+            .mockResolvedValueOnce(undefined);
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-global-extra-folders');
+        await waitFor(() => {
+            expect(within(section).getByText('/keep')).toBeTruthy();
+            expect(within(section).getByText('/drop')).toBeTruthy();
+        });
+
+        const removeBtns = within(section).getAllByTitle('Remove folder');
+        fireEvent.click(removeBtns[1]); // remove "/drop"
+
+        await waitFor(() => {
+            expect(mockFetchApi).toHaveBeenCalledWith(
+                '/skills/config',
+                expect.objectContaining({
+                    body: JSON.stringify({ globalDisabledSkills: [], globalExtraFolders: ['/keep'] }),
+                }),
+            );
+        });
+        expect(within(section).queryByText('/drop')).toBeNull();
+    });
+
+    it('does not add a duplicate global extra folder', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig({ globalExtraFolders: ['/opt/skills'] }));
+        render(<SkillsConfigPanel />);
+
+        const input = await screen.findByPlaceholderText('Extra skill folder path…');
+        fireEvent.change(input, { target: { value: '/opt/skills' } });
+        fireEvent.click(screen.getByText('Add'));
+
+        // Only the initial GET should have been called (no PUT for the dup)
+        expect(mockFetchApi).toHaveBeenCalledTimes(1);
+    });
+
+    // ── Auto-detect toggle (AC #4 / #5) ────────────────────────────────
+
+    it('renders the auto-detect checkbox checked by default', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig({ autoDetectDefaultFolders: true }));
+        render(<SkillsConfigPanel />);
+
+        const checkbox = await screen.findByLabelText('Auto-detect default skill folders') as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
+    });
+
+    it('renders the auto-detect checkbox unchecked when disabled', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig({ autoDetectDefaultFolders: false }));
+        render(<SkillsConfigPanel />);
+
+        const checkbox = await screen.findByLabelText('Auto-detect default skill folders') as HTMLInputElement;
+        expect(checkbox.checked).toBe(false);
+        expect(screen.getByText('Auto-detection is disabled.')).toBeTruthy();
+    });
+
+    it('persists autoDetectDefaultFolders when toggled off', async () => {
+        mockFetchApi
+            .mockResolvedValueOnce(makeConfig({ autoDetectDefaultFolders: true }))
+            .mockResolvedValueOnce(undefined);
+        render(<SkillsConfigPanel />);
+
+        const checkbox = await screen.findByLabelText('Auto-detect default skill folders');
+        fireEvent.click(checkbox);
+
+        await waitFor(() => {
+            expect(mockFetchApi).toHaveBeenCalledWith(
+                '/skills/config',
+                expect.objectContaining({
+                    method: 'PUT',
+                    body: JSON.stringify({ globalDisabledSkills: [], autoDetectDefaultFolders: false }),
+                }),
+            );
+        });
+    });
+
+    // ── Detected skill folders (AC #5 / #7) ────────────────────────────
+
+    it('shows "No OneDrive skill folders detected." when none are auto-detected', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig());
+        mockGetEffectivePaths.mockResolvedValueOnce({
+            paths: [
+                { source: 'managed-global', scope: 'global', status: 'available', path: '/home/u/.coc/skills', skillCount: 2 },
+            ],
+        });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-detected-folders');
+        await waitFor(() => {
+            expect(within(section).getByText('No OneDrive skill folders detected.')).toBeTruthy();
+        });
+    });
+
+    it('renders a detected auto-detected folder with skill count', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig());
+        mockGetEffectivePaths.mockResolvedValueOnce({
+            paths: [
+                { source: 'auto-detected', scope: 'global', status: 'available', path: '/home/u/OneDrive/.github/skills', skillCount: 3 },
+            ],
+        });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-detected-folders');
+        await waitFor(() => {
+            expect(within(section).getByText('/home/u/OneDrive/.github/skills')).toBeTruthy();
+            expect(within(section).getByText('3 skills')).toBeTruthy();
+        });
+        // No loud "not detected" message when a folder is present.
+        expect(within(section).queryByText('No OneDrive skill folders detected.')).toBeNull();
+    });
+
+    it('shows skipped OneDrive roots only in collapsed diagnostics (AC #7)', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig());
+        mockGetEffectivePaths.mockResolvedValueOnce({
+            paths: [
+                {
+                    source: 'auto-detected',
+                    scope: 'global',
+                    status: 'skipped',
+                    path: '/home/u/OneDrive',
+                    note: 'OneDrive root exists but has no .github/skills folder',
+                },
+            ],
+        });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-detected-folders');
+        await waitFor(() => {
+            expect(within(section).getByText('Diagnostics (1 skipped)')).toBeTruthy();
+        });
+        expect(within(section).getByText('OneDrive root exists but has no .github/skills folder')).toBeTruthy();
+        // A skipped root is not surfaced as "no folders detected".
+        expect(within(section).queryByText('No OneDrive skill folders detected.')).toBeNull();
+    });
+
+    it('shows "Auto-detection is disabled." and no detected list when off', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig({ autoDetectDefaultFolders: false }));
+        mockGetEffectivePaths.mockResolvedValueOnce({ paths: [] });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-detected-folders');
+        await waitFor(() => {
+            expect(within(section).getByText('Auto-detection is disabled.')).toBeTruthy();
+        });
+        expect(within(section).queryByText('No OneDrive skill folders detected.')).toBeNull();
+    });
+
+    // ── Effective search order (AC #6) ─────────────────────────────────
+
+    it('renders the effective search order with source and status badges', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig());
+        mockGetEffectivePaths.mockResolvedValueOnce({
+            paths: [
+                { source: 'managed-global', scope: 'global', status: 'available', path: '/home/u/.coc/skills', skillCount: 4 },
+                { source: 'configured', scope: 'global', status: 'missing', path: '/opt/team/skills' },
+                { source: 'bundled', scope: 'global', status: 'no-skills', path: '/app/bundled/skills', skillCount: 0 },
+            ],
+        });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-effective-search-order');
+        await waitFor(() => {
+            expect(within(section).getByText('/home/u/.coc/skills')).toBeTruthy();
+        });
+        // Source badges
+        expect(within(section).getByText('Managed')).toBeTruthy();
+        expect(within(section).getByText('Configured')).toBeTruthy();
+        expect(within(section).getByText('Bundled')).toBeTruthy();
+        // Status badges
+        expect(within(section).getByText('Available')).toBeTruthy();
+        expect(within(section).getByText('Missing')).toBeTruthy();
+        expect(within(section).getByText('No skills')).toBeTruthy();
+        // Skill count
+        expect(within(section).getByText('4 skills')).toBeTruthy();
+    });
+
+    it('shows a global-only note in the effective search order', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig());
+        mockGetEffectivePaths.mockResolvedValueOnce({ paths: [] });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-effective-search-order');
+        await waitFor(() => {
+            expect(within(section).getByText(/Showing global paths only/i)).toBeTruthy();
+        });
+    });
+
+    it('shows "No effective skill paths." when the list is empty', async () => {
+        mockFetchApi.mockResolvedValueOnce(makeConfig());
+        mockGetEffectivePaths.mockResolvedValueOnce({ paths: [] });
+        render(<SkillsConfigPanel />);
+
+        const section = await screen.findByTestId('skills-effective-search-order');
+        await waitFor(() => {
+            expect(within(section).getByText('No effective skill paths.')).toBeTruthy();
         });
     });
 });

--- a/packages/coc/test/spa/react/features/skills/mcp-server-list-model.test.ts
+++ b/packages/coc/test/spa/react/features/skills/mcp-server-list-model.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for the pure MCP server list read model — status/source/description
+ * derivation, tool-count labels, counts, filtering, and the assembled view model.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { McpServerToolsResult } from '@plusplusoneplusplus/coc-client';
+import {
+    getServerStatus,
+    needsAuth,
+    isRemote,
+    getServerDescription,
+    getTransportPillClass,
+    getSourcePillInfo,
+    shouldShowAuthButton,
+    getToolCountLabel,
+    computeServerCounts,
+    filterServers,
+    buildMcpServerListModel,
+    type McpServerEntry,
+} from '../../../../../src/server/spa/client/react/features/skills/mcp-server-list-model';
+
+const stdio: McpServerEntry = { name: 'local', type: 'stdio' };
+const http: McpServerEntry = { name: 'remote', type: 'http', url: 'https://api.example.com' };
+
+describe('getServerStatus', () => {
+    it('is off when disabled regardless of transport', () => {
+        expect(getServerStatus(http, false)).toBe('off');
+        expect(getServerStatus(stdio, false)).toBe('off');
+    });
+
+    it('trusts the server-derived status field when present', () => {
+        expect(getServerStatus({ ...http, status: 'ok' }, true)).toBe('ok');
+        expect(getServerStatus({ ...http, status: 'err' }, true)).toBe('err');
+    });
+
+    it('falls back to auth for remote servers without a status', () => {
+        expect(getServerStatus(http, true)).toBe('auth');
+        expect(getServerStatus({ name: 's', type: 'sse' }, true)).toBe('auth');
+    });
+
+    it('falls back to ok for stdio servers without a status', () => {
+        expect(getServerStatus(stdio, true)).toBe('ok');
+    });
+});
+
+describe('needsAuth', () => {
+    it('is false for stdio servers', () => {
+        expect(needsAuth(stdio)).toBe(false);
+    });
+
+    it('assumes auth is needed for a remote server with no authStatus (legacy)', () => {
+        expect(needsAuth(http)).toBe(true);
+    });
+
+    it('needs auth only when required or expired', () => {
+        expect(needsAuth({ ...http, authStatus: 'required' })).toBe(true);
+        expect(needsAuth({ ...http, authStatus: 'expired' })).toBe(true);
+        expect(needsAuth({ ...http, authStatus: 'authenticated' })).toBe(false);
+        expect(needsAuth({ ...http, authStatus: 'not-required' })).toBe(false);
+    });
+});
+
+describe('isRemote', () => {
+    it('is true only for http/sse', () => {
+        expect(isRemote(http)).toBe(true);
+        expect(isRemote({ name: 's', type: 'sse' })).toBe(true);
+        expect(isRemote(stdio)).toBe(false);
+    });
+});
+
+describe('getServerDescription', () => {
+    it('uses description then url then command when enabled', () => {
+        expect(getServerDescription({ ...stdio, description: 'Local docs' }, true)).toBe('Local docs');
+        expect(getServerDescription(http, true)).toBe('https://api.example.com');
+        expect(getServerDescription({ name: 'c', type: 'stdio', command: 'npx foo' }, true)).toBe('npx foo');
+    });
+
+    it('prefixes and lowercases the base when disabled', () => {
+        expect(getServerDescription({ ...stdio, description: 'Local Docs' }, false)).toBe('Disabled · local docs');
+    });
+});
+
+describe('getTransportPillClass', () => {
+    it('maps transports to pill classes', () => {
+        expect(getTransportPillClass('stdio')).toBe('accent');
+        expect(getTransportPillClass('http')).toBe('done');
+        expect(getTransportPillClass('sse')).toBe('done');
+        expect(getTransportPillClass('other')).toBe('');
+    });
+});
+
+describe('getSourcePillInfo', () => {
+    it('marks a user override', () => {
+        expect(getSourcePillInfo({ ...stdio, overriddenBy: 'workspace' })).toEqual({ label: 'user override', cls: 'warn' });
+    });
+
+    it('labels workspace-sourced servers as repo config', () => {
+        expect(getSourcePillInfo({ ...stdio, source: 'workspace' })).toEqual({ label: 'repo config', cls: 'muted' });
+    });
+
+    it('labels global-sourced servers as global', () => {
+        expect(getSourcePillInfo({ ...stdio, source: 'global' })).toEqual({ label: 'global', cls: 'muted' });
+    });
+
+    it('defaults to repo config', () => {
+        expect(getSourcePillInfo(stdio)).toEqual({ label: 'repo config', cls: 'muted' });
+    });
+});
+
+describe('shouldShowAuthButton', () => {
+    it('shows for an enabled remote server that needs auth', () => {
+        expect(shouldShowAuthButton(http, true, undefined)).toBe(true);
+    });
+
+    it('hides for a disabled server', () => {
+        expect(shouldShowAuthButton(http, false, undefined)).toBe(false);
+    });
+
+    it('hides for a stdio server', () => {
+        expect(shouldShowAuthButton(stdio, true, undefined)).toBe(false);
+    });
+
+    it('keeps showing while a non-completed flow is in progress', () => {
+        const authed: McpServerEntry = { ...http, authStatus: 'authenticated' };
+        expect(shouldShowAuthButton(authed, true, undefined)).toBe(false);
+        expect(shouldShowAuthButton(authed, true, { phase: 'authorizing', requestId: 'r' })).toBe(true);
+        expect(shouldShowAuthButton(authed, true, { phase: 'completed', requestId: 'r' })).toBe(false);
+    });
+});
+
+const okResult = (names: string[]): McpServerToolsResult => ({
+    status: 'ok',
+    tools: names.map(name => ({ name })),
+});
+
+describe('getToolCountLabel', () => {
+    const base = { discoveryState: 'loaded' as const, allowEntry: undefined, result: okResult(['a', 'b']) };
+
+    it('is a dash for a disabled or overridden server', () => {
+        expect(getToolCountLabel({ ...base, enabled: false, effective: true }).text).toBe('—');
+        expect(getToolCountLabel({ ...base, enabled: true, effective: false }).text).toBe('—');
+    });
+
+    it('is an ellipsis while discovery is loading and a dash once settled empty', () => {
+        expect(getToolCountLabel({ enabled: true, effective: true, result: undefined, discoveryState: 'loading', allowEntry: undefined }).text).toBe('…');
+        expect(getToolCountLabel({ enabled: true, effective: true, result: undefined, discoveryState: 'idle', allowEntry: undefined }).text).toBe('…');
+        expect(getToolCountLabel({ enabled: true, effective: true, result: undefined, discoveryState: 'loaded', allowEntry: undefined }).text).toBe('—');
+    });
+
+    it('is a bang with the error as tooltip for an unreachable server', () => {
+        const label = getToolCountLabel({ enabled: true, effective: true, result: { status: 'error', tools: [], error: 'ECONNREFUSED' }, discoveryState: 'loaded', allowEntry: undefined });
+        expect(label.text).toBe('!');
+        expect(label.title).toBe('ECONNREFUSED');
+    });
+
+    it('shows the total when all tools are enabled', () => {
+        expect(getToolCountLabel({ ...base, enabled: true, effective: true }).text).toBe('2');
+    });
+
+    it('shows enabled/total when an allow-list restricts tools', () => {
+        const label = getToolCountLabel({ enabled: true, effective: true, result: okResult(['a', 'b']), discoveryState: 'loaded', allowEntry: ['a'] });
+        expect(label.text).toBe('1/2');
+        expect(label.title).toBe('1 of 2 tools enabled');
+    });
+});
+
+const servers: McpServerEntry[] = [
+    { name: 'active-stdio', type: 'stdio', status: 'ok' },
+    { name: 'needs-auth', type: 'http' },
+    { name: 'disabled-one', type: 'stdio' },
+    { name: 'overridden', type: 'stdio', effective: false },
+];
+const isEnabled = (name: string) => name !== 'disabled-one';
+
+describe('computeServerCounts', () => {
+    it('counts all/active/auth/disabled independently', () => {
+        // disabled-one is off; overridden is disabled (effective false); needs-auth is remote → auth.
+        expect(computeServerCounts(servers, isEnabled)).toEqual({ all: 4, active: 1, auth: 1, disabled: 2 });
+    });
+});
+
+describe('filterServers', () => {
+    it('returns everything for the all tab', () => {
+        expect(filterServers(servers, { filterTab: 'all', searchQuery: '', isEnabled }).map(s => s.name))
+            .toEqual(['active-stdio', 'needs-auth', 'disabled-one', 'overridden']);
+    });
+
+    it('keeps only healthy enabled servers for the active tab', () => {
+        expect(filterServers(servers, { filterTab: 'active', searchQuery: '', isEnabled }).map(s => s.name)).toEqual(['active-stdio']);
+    });
+
+    it('keeps only auth-status servers for the auth tab', () => {
+        expect(filterServers(servers, { filterTab: 'auth', searchQuery: '', isEnabled }).map(s => s.name)).toEqual(['needs-auth']);
+    });
+
+    it('keeps disabled and overridden servers for the disabled tab', () => {
+        expect(filterServers(servers, { filterTab: 'disabled', searchQuery: '', isEnabled }).map(s => s.name)).toEqual(['disabled-one', 'overridden']);
+    });
+
+    it('applies the search query by name and description', () => {
+        const withDesc: McpServerEntry[] = [
+            { name: 'github', type: 'stdio', description: 'source control' },
+            { name: 'postgres', type: 'stdio', description: 'database' },
+        ];
+        expect(filterServers(withDesc, { filterTab: 'all', searchQuery: 'data', isEnabled: () => true }).map(s => s.name)).toEqual(['postgres']);
+        expect(filterServers(withDesc, { filterTab: 'all', searchQuery: 'GIT', isEnabled: () => true }).map(s => s.name)).toEqual(['github']);
+    });
+});
+
+describe('buildMcpServerListModel', () => {
+    it('assembles counts over all servers and rows over the filtered set', () => {
+        const model = buildMcpServerListModel({
+            servers,
+            isEnabled,
+            filterTab: 'active',
+            searchQuery: '',
+            discovery: { 'active-stdio': okResult(['x', 'y', 'z']) },
+            discoveryState: 'loaded',
+            toolsAllowList: { 'active-stdio': ['x'] },
+            authFlow: {},
+        });
+
+        expect(model.counts).toEqual({ all: 4, active: 1, auth: 1, disabled: 2 });
+        expect(model.rows).toHaveLength(1);
+        const row = model.rows[0];
+        expect(row.server.name).toBe('active-stdio');
+        expect(row.status).toBe('ok');
+        expect(row.transportCls).toBe('accent');
+        expect(row.toolCount.text).toBe('1/3');
+        expect(row.showAuthBtn).toBe(false);
+    });
+
+    it('flags the auth button and carries the flow for a remote server', () => {
+        const model = buildMcpServerListModel({
+            servers,
+            isEnabled,
+            filterTab: 'auth',
+            searchQuery: '',
+            discovery: {},
+            discoveryState: 'idle',
+            toolsAllowList: {},
+            authFlow: { 'needs-auth': { phase: 'authorizing', requestId: 'r1' } },
+        });
+        expect(model.rows).toHaveLength(1);
+        expect(model.rows[0].showAuthBtn).toBe(true);
+        expect(model.rows[0].flow).toEqual({ phase: 'authorizing', requestId: 'r1' });
+    });
+});

--- a/packages/coc/test/spa/react/features/skills/mcpOAuthFlowController.test.ts
+++ b/packages/coc/test/spa/react/features/skills/mcpOAuthFlowController.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the MCP OAuth poller registry — completion, failure, timeout,
+ * transient-error resilience, the stale guard, replacement, and stopAll.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { McpOAuthFlowController } from '../../../../../src/server/spa/client/react/features/skills/mcpOAuthFlowController';
+
+const API_BASE = 'http://localhost/api';
+const INTERVAL = 100;
+const TIMEOUT = 1_000;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function pendingResponse(body: unknown) {
+    return { ok: true, json: async () => body };
+}
+
+function start(
+    controller: McpOAuthFlowController,
+    handlers: { onCompleted?: () => void; onFailed?: (e: string) => void } = {},
+    opts: { isStale?: () => boolean } = {},
+) {
+    controller.startPolling(
+        { key: 'srv', requestId: 'req-1', apiBase: API_BASE, intervalMs: INTERVAL, timeoutMs: TIMEOUT, isStale: opts.isStale },
+        { onCompleted: handlers.onCompleted ?? (() => {}), onFailed: handlers.onFailed ?? (() => {}) },
+    );
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+describe('McpOAuthFlowController', () => {
+    it('fires onCompleted once and stops when the server reports completed', async () => {
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'completed' }));
+        const controller = new McpOAuthFlowController();
+        const onCompleted = vi.fn();
+        start(controller, { onCompleted });
+
+        expect(controller.isPolling('srv')).toBe(true);
+        await vi.advanceTimersByTimeAsync(INTERVAL);
+        expect(onCompleted).toHaveBeenCalledTimes(1);
+        expect(controller.isPolling('srv')).toBe(false);
+
+        // No further ticks after completion.
+        await vi.advanceTimersByTimeAsync(INTERVAL * 5);
+        expect(onCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onFailed with the server error and stops', async () => {
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'failed', error: 'user denied' }));
+        const controller = new McpOAuthFlowController();
+        const onFailed = vi.fn();
+        start(controller, { onFailed });
+
+        await vi.advanceTimersByTimeAsync(INTERVAL);
+        expect(onFailed).toHaveBeenCalledWith('user denied');
+        expect(controller.isPolling('srv')).toBe(false);
+    });
+
+    it('times out when the flow never settles', async () => {
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'pending' }));
+        const controller = new McpOAuthFlowController();
+        const onFailed = vi.fn();
+        start(controller, { onFailed });
+
+        await vi.advanceTimersByTimeAsync(TIMEOUT + INTERVAL);
+        expect(onFailed).toHaveBeenCalledWith('Authorization timed out');
+        expect(controller.isPolling('srv')).toBe(false);
+    });
+
+    it('keeps polling through a transient network error', async () => {
+        fetchMock
+            .mockRejectedValueOnce(new Error('network'))
+            .mockResolvedValue(pendingResponse({ status: 'completed' }));
+        const controller = new McpOAuthFlowController();
+        const onCompleted = vi.fn();
+        start(controller, { onCompleted });
+
+        await vi.advanceTimersByTimeAsync(INTERVAL); // transient error tick
+        expect(onCompleted).not.toHaveBeenCalled();
+        expect(controller.isPolling('srv')).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(INTERVAL); // success tick
+        expect(onCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops the poll and stops silently when the flow is stale', async () => {
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'completed' }));
+        const controller = new McpOAuthFlowController();
+        const onCompleted = vi.fn();
+        const onFailed = vi.fn();
+        start(controller, { onCompleted, onFailed }, { isStale: () => true });
+
+        await vi.advanceTimersByTimeAsync(INTERVAL);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(onCompleted).not.toHaveBeenCalled();
+        expect(onFailed).not.toHaveBeenCalled();
+        expect(controller.isPolling('srv')).toBe(false);
+    });
+
+    it('replaces an existing poller for the same key', async () => {
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'pending' }));
+        const controller = new McpOAuthFlowController();
+        const firstCompleted = vi.fn();
+        const secondCompleted = vi.fn();
+        start(controller, { onCompleted: firstCompleted });
+        start(controller, { onCompleted: secondCompleted });
+
+        expect(controller.activeKeys()).toEqual(['srv']);
+
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'completed' }));
+        await vi.advanceTimersByTimeAsync(INTERVAL);
+        expect(firstCompleted).not.toHaveBeenCalled();
+        expect(secondCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('stopAll cancels every active poller', async () => {
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'pending' }));
+        const controller = new McpOAuthFlowController();
+        const onCompleted = vi.fn();
+        controller.startPolling(
+            { key: 'a', requestId: 'r-a', apiBase: API_BASE, intervalMs: INTERVAL, timeoutMs: TIMEOUT },
+            { onCompleted, onFailed: () => {} },
+        );
+        controller.startPolling(
+            { key: 'b', requestId: 'r-b', apiBase: API_BASE, intervalMs: INTERVAL, timeoutMs: TIMEOUT },
+            { onCompleted, onFailed: () => {} },
+        );
+        expect(controller.activeKeys().sort()).toEqual(['a', 'b']);
+
+        controller.stopAll();
+        expect(controller.activeKeys()).toEqual([]);
+
+        fetchMock.mockResolvedValue(pendingResponse({ status: 'completed' }));
+        await vi.advanceTimersByTimeAsync(INTERVAL * 3);
+        expect(onCompleted).not.toHaveBeenCalled();
+    });
+});

--- a/packages/coc/test/spa/react/features/skills/useMcpServerInspectorController.test.tsx
+++ b/packages/coc/test/spa/react/features/skills/useMcpServerInspectorController.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for the workspace-scoped MCP inspector controller hook.
+ *
+ * Focus: switching workspaces never reuses another repo's detail, discovery,
+ * allow-list, or OAuth state; async results that resolve after a switch are
+ * dropped; mutations hit the REST client with the expected payloads.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import type { McpServerToolsResult } from '@plusplusoneplusplus/coc-client';
+import { useMcpServerInspectorController } from '../../../../../src/server/spa/client/react/features/skills/useMcpServerInspectorController';
+import { McpOAuthFlowController } from '../../../../../src/server/spa/client/react/features/skills/mcpOAuthFlowController';
+
+const discoverMcpTools = vi.hoisted(() => vi.fn());
+const updateMcpConfig = vi.hoisted(() => vi.fn());
+const getMcpServerDetail = vi.hoisted(() => vi.fn());
+const addMcpServer = vi.hoisted(() => vi.fn());
+const deleteMcpServer = vi.hoisted(() => vi.fn());
+const migrateMcpServer = vi.hoisted(() => vi.fn());
+const updateMcpServer = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        workspaces: {
+            discoverMcpTools: (...a: unknown[]) => discoverMcpTools(...a),
+            updateMcpConfig: (...a: unknown[]) => updateMcpConfig(...a),
+            getMcpServerDetail: (...a: unknown[]) => getMcpServerDetail(...a),
+            addMcpServer: (...a: unknown[]) => addMcpServer(...a),
+            deleteMcpServer: (...a: unknown[]) => deleteMcpServer(...a),
+            migrateMcpServer: (...a: unknown[]) => migrateMcpServer(...a),
+            updateMcpServer: (...a: unknown[]) => updateMcpServer(...a),
+        },
+    }),
+    getSpaCocClientErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+const okResult: McpServerToolsResult = { status: 'ok', tools: [{ name: 'a' }, { name: 'b' }] };
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    discoverMcpTools.mockResolvedValue({ servers: {} });
+    updateMcpConfig.mockResolvedValue({ workspace: {} });
+    getMcpServerDetail.mockResolvedValue({ description: 'd', envKeys: [], args: [], toolScope: 'all', source: 'workspace', rawJson: {} });
+    addMcpServer.mockResolvedValue({ name: 'x', scope: 'workspace' });
+    deleteMcpServer.mockResolvedValue({ name: 'x', deleted: true });
+    migrateMcpServer.mockResolvedValue({ name: 'x', scope: 'global' });
+    updateMcpServer.mockResolvedValue({ name: 'x', updated: true });
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(window, 'open').mockReturnValue(null);
+    // Stub the real interval-based poller so no background timer survives the
+    // test. Poll completion/failure/timeout is covered by the controller's own
+    // unit test (mcpOAuthFlowController.test.ts).
+    vi.spyOn(McpOAuthFlowController.prototype, 'startPolling').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    cleanup(); // unmount hooks so the controller tears down any OAuth pollers
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('useMcpServerInspectorController — discovery', () => {
+    it('eagerly discovers tools for the workspace on mount', async () => {
+        discoverMcpTools.mockResolvedValue({ servers: { github: okResult } });
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', {}));
+        await waitFor(() => expect(result.current.discovery.github?.status).toBe('ok'));
+        expect(discoverMcpTools).toHaveBeenCalledWith('ws-1', undefined);
+        expect(result.current.discoveryState).toBe('loaded');
+    });
+
+    it('does not call the client without a workspace id', async () => {
+        renderHook(() => useMcpServerInspectorController('', {}));
+        await act(async () => { await Promise.resolve(); });
+        expect(discoverMcpTools).not.toHaveBeenCalled();
+    });
+});
+
+describe('useMcpServerInspectorController — workspace isolation', () => {
+    it('resets detail, discovery, allow-list and expanded row on workspace switch', async () => {
+        discoverMcpTools.mockImplementation((ws: string) =>
+            Promise.resolve({ servers: ws === 'ws-1' ? { github: okResult } : {} }));
+        getMcpServerDetail.mockImplementation((ws: string, name: string) =>
+            Promise.resolve({ description: `${ws}:${name}`, envKeys: [], args: [], toolScope: 'all', source: 'workspace', rawJson: {} }));
+
+        const { result, rerender } = renderHook(
+            ({ ws, tools }) => useMcpServerInspectorController(ws, { enabledMcpTools: tools }),
+            { initialProps: { ws: 'ws-1', tools: { github: ['a'] } as Record<string, string[]> } },
+        );
+
+        await waitFor(() => expect(result.current.discovery.github?.status).toBe('ok'));
+        expect(result.current.toolsAllowList).toEqual({ github: ['a'] });
+
+        // Load ws-1 detail for a server named "github".
+        act(() => { result.current.toggleExpand('github'); });
+        await waitFor(() => expect(result.current.getDetail('github')).toMatchObject({ description: 'ws-1:github' }));
+        expect(result.current.expandedServer).toBe('github');
+
+        // Switch to ws-2, which also has a server named "github" but different config.
+        rerender({ ws: 'ws-2', tools: {} });
+
+        // Prior workspace state is discarded synchronously on switch.
+        expect(result.current.getDetail('github')).toBeNull();
+        expect(result.current.expandedServer).toBeNull();
+        expect(result.current.toolsAllowList).toEqual({});
+
+        await waitFor(() => expect(result.current.discoveryState).toBe('loaded'));
+        // ws-2 has no github discovery — the ws-1 result is never reused.
+        expect(result.current.discovery.github).toBeUndefined();
+        expect(discoverMcpTools).toHaveBeenCalledWith('ws-2', undefined);
+    });
+
+    it('drops a discovery result that resolves after the workspace switched', async () => {
+        let resolveWs1: (v: unknown) => void = () => {};
+        discoverMcpTools.mockImplementation((ws: string) => {
+            if (ws === 'ws-1') return new Promise(res => { resolveWs1 = res; });
+            return Promise.resolve({ servers: {} });
+        });
+
+        const { result, rerender } = renderHook(
+            ({ ws }) => useMcpServerInspectorController(ws, {}),
+            { initialProps: { ws: 'ws-1' } },
+        );
+
+        rerender({ ws: 'ws-2' });
+        await waitFor(() => expect(result.current.discoveryState).toBe('loaded'));
+
+        // The slow ws-1 discovery lands now — it must be ignored.
+        await act(async () => { resolveWs1({ servers: { stale: okResult } }); await Promise.resolve(); });
+        expect(result.current.discovery.stale).toBeUndefined();
+    });
+
+    it('clears the OAuth flow state on workspace switch', async () => {
+        fetchMock.mockResolvedValue({ ok: true, json: async () => ({ requestId: 'r1', authorizationUrl: 'https://auth' }) });
+        const { result, rerender } = renderHook(
+            ({ ws }) => useMcpServerInspectorController(ws, {}),
+            { initialProps: { ws: 'ws-1' } },
+        );
+        await act(async () => { result.current.authenticate('srv'); await new Promise(r => setTimeout(r, 0)); });
+        expect(result.current.authFlow.srv?.phase).toBe('authorizing');
+
+        rerender({ ws: 'ws-2' });
+        expect(result.current.authFlow).toEqual({});
+    });
+});
+
+describe('useMcpServerInspectorController — OAuth', () => {
+    it('starts a flow, opens the auth url and enters the authorizing phase', async () => {
+        fetchMock.mockResolvedValue({ ok: true, json: async () => ({ requestId: 'r1', authorizationUrl: 'https://auth.example' }) });
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', {}));
+
+        await act(async () => { result.current.authenticate('srv'); await new Promise(r => setTimeout(r, 0)); });
+
+        expect(result.current.authFlow.srv?.phase).toBe('authorizing');
+        expect(window.open).toHaveBeenCalledWith('https://auth.example', '_blank', 'noopener,noreferrer');
+        const startCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/mcp-oauth/start'));
+        expect(startCall).toBeTruthy();
+        expect(JSON.parse((startCall![1] as { body: string }).body)).toEqual({ serverName: 'srv', workspaceId: 'ws-1' });
+    });
+
+    it('marks the flow completed immediately when already authenticated', async () => {
+        fetchMock.mockResolvedValue({ ok: true, json: async () => ({ alreadyAuthenticated: true }) });
+        const onRefresh = vi.fn();
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', { onRefresh }));
+        await act(async () => { result.current.authenticate('srv'); await new Promise(r => setTimeout(r, 0)); });
+        expect(result.current.authFlow.srv?.phase).toBe('completed');
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the flow failed when the start request is rejected', async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => 'server error' });
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', {}));
+        await act(async () => { result.current.authenticate('srv'); await new Promise(r => setTimeout(r, 0)); });
+        expect(result.current.authFlow.srv?.phase).toBe('failed');
+    });
+});
+
+describe('useMcpServerInspectorController — mutations', () => {
+    it('addServer calls the client and refreshes the parent', async () => {
+        const onMutate = vi.fn();
+        const onRefresh = vi.fn();
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', { onMutate, onRefresh }));
+        await act(async () => { await result.current.addServer({ name: 'x', type: 'stdio', scope: 'workspace' }); });
+        expect(addMcpServer).toHaveBeenCalledWith('ws-1', { name: 'x', type: 'stdio', scope: 'workspace' });
+        expect(onMutate).toHaveBeenCalledTimes(1);
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('deleteServer removes the server, collapses the row and refreshes', async () => {
+        getMcpServerDetail.mockResolvedValue({ description: 'd', envKeys: [], args: [], toolScope: 'all', source: 'workspace', rawJson: {} });
+        const onMutate = vi.fn();
+        const onRefresh = vi.fn();
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', { onMutate, onRefresh }));
+        act(() => { result.current.toggleExpand('srv'); });
+        await waitFor(() => expect(result.current.expandedServer).toBe('srv'));
+
+        await act(async () => { await result.current.deleteServer('srv'); });
+        expect(deleteMcpServer).toHaveBeenCalledWith('ws-1', 'srv');
+        expect(result.current.expandedServer).toBeNull();
+        expect(onMutate).toHaveBeenCalledTimes(1);
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('updateServer and migrateServer invalidate the cached detail', async () => {
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', {}));
+        act(() => { result.current.toggleExpand('srv'); });
+        await waitFor(() => expect(result.current.getDetail('srv')).toMatchObject({ description: 'd' }));
+
+        await act(async () => { await result.current.updateServer('srv', { args: ['--flag'] }); });
+        expect(updateMcpServer).toHaveBeenCalledWith('ws-1', 'srv', { args: ['--flag'] });
+        expect(result.current.getDetail('srv')).toBeNull(); // invalidated
+
+        act(() => { result.current.toggleExpand('srv'); }); // collapse
+        act(() => { result.current.toggleExpand('srv'); }); // re-open → re-fetch
+        await waitFor(() => expect(result.current.getDetail('srv')).toMatchObject({ description: 'd' }));
+
+        await act(async () => { await result.current.migrateServer('srv', 'global'); });
+        expect(migrateMcpServer).toHaveBeenCalledWith('ws-1', 'srv', 'global');
+        expect(result.current.getDetail('srv')).toBeNull();
+    });
+});
+
+describe('useMcpServerInspectorController — allow-list', () => {
+    it('persists a tool toggle-off through updateMcpConfig, preserving enabledMcpServers', async () => {
+        discoverMcpTools.mockResolvedValue({ servers: { github: okResult } });
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', { enabledMcpServers: ['github'] }));
+        await waitFor(() => expect(result.current.discovery.github?.status).toBe('ok'));
+
+        await act(async () => { result.current.toggleTool('github', 'a', false); await new Promise(r => setTimeout(r, 0)); });
+        expect(updateMcpConfig).toHaveBeenCalledWith('ws-1', {
+            enabledMcpServers: ['github'],
+            enabledMcpTools: { github: ['b'] },
+        });
+    });
+
+    it('reverts the optimistic allow-list when the save fails', async () => {
+        discoverMcpTools.mockResolvedValue({ servers: { github: okResult } });
+        updateMcpConfig.mockImplementationOnce(async () => { throw new Error('boom'); });
+        // Omit enabledMcpTools (a stable `undefined`) so the allow-list sync effect
+        // is not re-triggered by a fresh object identity on every render.
+        const { result } = renderHook(() => useMcpServerInspectorController('ws-1', {}));
+        await waitFor(() => expect(result.current.discovery.github?.status).toBe('ok'));
+
+        act(() => { result.current.toggleTool('github', 'a', false); });
+        await waitFor(() => expect(result.current.toolsAllowList).toEqual({ github: ['b'] })); // optimistic
+        await waitFor(() => expect(result.current.toolsAllowList).toEqual({})); // reverted after failure
+    });
+});

--- a/packages/coc/test/spa/react/hooks/useChatSSE.test.ts
+++ b/packages/coc/test/spa/react/hooks/useChatSSE.test.ts
@@ -607,6 +607,34 @@ describe('useChatSSE', () => {
             expect(result[0]).toEqual({ id: 'pm-1', content: 'queued msg', status: 'queued' });
         });
 
+        it('SSE3b: pending-message-added carries images into the queue entry', () => {
+            const setPendingQueue = vi.fn();
+            renderHook(() => useChatSSE(makeOptions({ setPendingQueue })));
+            const images = ['data:image/png;base64,AAA'];
+            act(() => {
+                MockEventSource.last._emit('pending-message-added', {
+                    pendingMessage: { id: 'pm-img', content: 'with image', createdAt: '2024-01-01', images },
+                });
+            });
+            const updater = setPendingQueue.mock.calls[0][0];
+            const result = updater([]);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({ id: 'pm-img', content: 'with image', status: 'queued', images });
+        });
+
+        it('SSE3c: pending-message-added omits images when none are present', () => {
+            const setPendingQueue = vi.fn();
+            renderHook(() => useChatSSE(makeOptions({ setPendingQueue })));
+            act(() => {
+                MockEventSource.last._emit('pending-message-added', {
+                    pendingMessage: { id: 'pm-noimg', content: 'no image', createdAt: '2024-01-01' },
+                });
+            });
+            const updater = setPendingQueue.mock.calls[0][0];
+            const result = updater([]);
+            expect(result[0]).not.toHaveProperty('images');
+        });
+
         it('SSE4: pending-message-added deduplicates by id', () => {
             const setPendingQueue = vi.fn();
             renderHook(() => useChatSSE(makeOptions({ setPendingQueue })));

--- a/packages/coc/test/spa/react/layout/TopBar.test.tsx
+++ b/packages/coc/test/spa/react/layout/TopBar.test.tsx
@@ -252,3 +252,60 @@ describe('TopBar — My Work icon button', () => {
         expect(btn.textContent).toContain('💼');
     });
 });
+
+// ── Compact header row (see "Compact Header Rows" spec) ─────────────────
+// Row 1 shrinks on desktop (md:h-12 → md:h-10) while mobile stays h-10, and
+// the icon buttons drop their md: up-size (md:h-8 → h-7) so the whole bar is a
+// uniform 28px-control row inside a 40px chrome.
+describe('TopBar compact header row', () => {
+    let viewportCleanup: (() => void) | undefined;
+
+    afterEach(() => {
+        viewportCleanup?.();
+        viewportCleanup = undefined;
+    });
+
+    it('header is 40px on desktop (md:h-10) and no longer md:h-12', () => {
+        viewportCleanup = mockViewport(1024);
+        render(<TopBar />);
+        const header = document.querySelector('header')!;
+        expect(header.className).toContain('md:h-10');
+        expect(header.className).not.toContain('md:h-12');
+    });
+
+    it('keeps mobile header height at h-10 (mobile layout unchanged)', () => {
+        viewportCleanup = mockViewport(375);
+        render(<TopBar />);
+        const header = document.querySelector('header')!;
+        expect(header.className).toContain('h-10');
+    });
+
+    it('icon buttons are a uniform h-7 w-7 without the md: up-size', () => {
+        mockMyWorkEnabled = true;
+        mockMyLifeEnabled = true;
+        viewportCleanup = mockViewport(1024);
+        render(<TopBar />);
+        for (const id of ['hamburger-btn', 'admin-toggle', 'theme-toggle', 'my-work-toggle', 'my-life-toggle']) {
+            const btn = document.getElementById(id)!;
+            expect(btn.className, `${id} should be h-7 w-7`).toContain('h-7 w-7');
+            expect(btn.className, `${id} should drop md:h-8`).not.toContain('md:h-8');
+            expect(btn.className, `${id} should drop md:w-8`).not.toContain('md:w-8');
+        }
+    });
+
+    it('interactive icon buttons keep their touch-target class after shrinking', () => {
+        viewportCleanup = mockViewport(375);
+        render(<TopBar />);
+        for (const id of ['hamburger-btn', 'admin-toggle', 'theme-toggle']) {
+            expect(document.getElementById(id)!.className).toContain('touch-target');
+        }
+    });
+
+    it('desktop brand link shrinks to h-7 (no h-8)', () => {
+        viewportCleanup = mockViewport(1024);
+        render(<TopBar />);
+        const brand = document.querySelector('[data-tab="repos"]')!;
+        expect(brand.className).toContain('h-7');
+        expect(brand.className).not.toContain('h-8');
+    });
+});

--- a/packages/coc/test/spa/react/layout/compact-header-chrome.test.ts
+++ b/packages/coc/test/spa/react/layout/compact-header-chrome.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Compact header rows — locks the two-row chrome dimensions defined by the
+ * "Compact Header Rows" spec.
+ *
+ * These are source-mirror assertions (like RepoDetail-mobile.test.ts): the
+ * classic-mode header lives deep inside RepoDetail and is expensive to render,
+ * and the combined-chrome budget spans two files, so we assert the height
+ * tokens directly at the source and compute the invariant from them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const reactDir = path.join(__dirname, '..', '..', '..', '..', 'src', 'server', 'spa', 'client', 'react');
+const read = (...p: string[]) => fs.readFileSync(path.join(reactDir, ...p), 'utf-8');
+
+const TOPBAR_SOURCE = read('layout', 'TopBar.tsx');
+const REMOTE_SUB_BAR_SOURCE = read('features', 'remote-shell', 'RemoteSubBar.tsx');
+const REPO_DETAIL_SOURCE = read('features', 'repo-detail', 'RepoDetail.tsx');
+
+// Tailwind `h-10` = 2.5rem = 40px. The desktop header collapses md:h-12 → md:h-10.
+const HEADER_DESKTOP_PX = 40;
+
+describe('compact header rows: TopBar (row 1)', () => {
+    it('desktop header is md:h-10 and no longer md:h-12', () => {
+        expect(TOPBAR_SOURCE).toContain('h-10 md:h-10');
+        expect(TOPBAR_SOURCE).not.toContain('md:h-12');
+    });
+
+    it('icon buttons drop the md: up-size (no md:h-8 md:w-8 left)', () => {
+        expect(TOPBAR_SOURCE).not.toContain('md:h-8 md:w-8');
+        expect(TOPBAR_SOURCE).toContain('h-7 w-7');
+    });
+});
+
+describe('compact header rows: RemoteSubBar (row 2)', () => {
+    it('container shrinks to 32px', () => {
+        expect(REMOTE_SUB_BAR_SOURCE).toContain('gap-0.5 h-[32px] flex-shrink-0');
+        expect(REMOTE_SUB_BAR_SOURCE).not.toContain('h-[42px]');
+    });
+
+    it('tabs / clone-switch / overflow are 26px (old 30px gone)', () => {
+        expect(REMOTE_SUB_BAR_SOURCE).toContain('h-[26px]');
+        expect(REMOTE_SUB_BAR_SOURCE).not.toContain('h-[30px]');
+    });
+
+    it('Ask / Queue actions are 24px (old 28px gone)', () => {
+        expect(REMOTE_SUB_BAR_SOURCE).toContain('h-[24px]');
+        expect(REMOTE_SUB_BAR_SOURCE).not.toContain('h-[28px]');
+    });
+
+    it('scope divider scales down to 18px', () => {
+        expect(REMOTE_SUB_BAR_SOURCE).toContain('h-[18px]');
+        expect(REMOTE_SUB_BAR_SOURCE).not.toContain('h-[22px]');
+    });
+});
+
+describe('compact header rows: classic-mode header (RepoDetail)', () => {
+    it('header container shrinks to 32px to match RemoteSubBar', () => {
+        expect(REPO_DETAIL_SOURCE).toContain('minHeight: 32');
+        expect(REPO_DETAIL_SOURCE).not.toContain('minHeight: 44');
+    });
+
+    it('sub-tabs shrink to min-h-[26px]', () => {
+        expect(REPO_DETAIL_SOURCE).toContain('min-h-[26px]');
+        expect(REPO_DETAIL_SOURCE).not.toContain('min-h-[32px]');
+    });
+
+    it('action buttons + overflow toggle shrink to 26px (old 30px gone)', () => {
+        expect(REPO_DETAIL_SOURCE).toContain('!h-[26px]');
+        expect(REPO_DETAIL_SOURCE).toContain('h-[26px] w-[31px]');
+        expect(REPO_DETAIL_SOURCE).not.toContain('!h-[30px]');
+        expect(REPO_DETAIL_SOURCE).not.toContain('h-[30px] w-[31px]');
+    });
+
+    it('active-tab underline offset moves in so it stays inside the shorter bar', () => {
+        expect(REPO_DETAIL_SOURCE).toContain('-bottom-[2px]');
+        expect(REPO_DETAIL_SOURCE).not.toContain('-bottom-[5px]');
+    });
+});
+
+describe('compact header rows: combined chrome budget', () => {
+    it('desktop header + sub-bar is ≤ 72px', () => {
+        const m = REMOTE_SUB_BAR_SOURCE.match(/gap-0\.5 h-\[(\d+)px\] flex-shrink-0/);
+        expect(m).not.toBeNull();
+        const subBarPx = Number(m![1]);
+        expect(HEADER_DESKTOP_PX + subBarPx).toBeLessThanOrEqual(72);
+    });
+});

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -577,3 +577,33 @@ describe('RemoteSubBar', () => {
         expect(remoteRow.textContent?.toLowerCase()).not.toContain('local');
     });
 });
+
+// ── Compact sub-bar (see "Compact Header Rows" spec) ───────────────────
+// Row 2 shrinks 42px → 32px; tabs/clone-switch/overflow 30px → 26px; the
+// Ask/Queue actions 28px → 24px. The hidden measure mirror must track the tab
+// height (26px) or the overflow width calc drifts.
+describe('RemoteSubBar compact sizing', () => {
+    it('sub-bar container is 32px tall', () => {
+        renderBar();
+        expect(screen.getByTestId('remote-sub-bar').className).toContain('h-[32px]');
+    });
+
+    it('clone tabs and clone-switch are 26px tall', () => {
+        renderBar();
+        expect(screen.getAllByTestId('clone-scope-tab')[0].className).toContain('h-[26px]');
+        expect(screen.getByTestId('clone-switch').className).toContain('h-[26px]');
+    });
+
+    it('Ask and Queue actions are 24px tall (fit inside the shorter bar)', () => {
+        renderBar();
+        expect(screen.getByTestId('subbar-ask').className).toContain('h-[24px]');
+        expect(screen.getByTestId('subbar-queue').className).toContain('h-[24px]');
+    });
+
+    it('hidden measure mirror matches the 26px tab height (keeps overflow calc correct)', () => {
+        renderBar();
+        const mirror = document.querySelector('[data-measure-key]');
+        expect(mirror).not.toBeNull();
+        expect(mirror!.className).toContain('h-[26px]');
+    });
+});

--- a/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane.test.tsx
@@ -3024,4 +3024,158 @@ describe('ChatListPane spawned-conversation tree (AC-03)', () => {
         expect(document.querySelector('[data-task-id="child"]')).toBeTruthy();
         expect(document.querySelector('[data-task-id="grand"]')).toBeTruthy();
     });
+
+    // ════════════════════════════════════════════════════════════════════
+    // AC-01 / AC-02: archived spawned subtrees leave COMPLETED and render as
+    // nested trees under ARCHIVED (fixes the leak where an archived tree node
+    // stayed rendered under COMPLETED).
+    // ════════════════════════════════════════════════════════════════════
+
+    /** root → childA (leaf) and root → childB → grand — a two-branch tree. */
+    function spawnTreeTwoBranch(now: number) {
+        const stamp = (offsetMs: number) => ({
+            completedAt: new Date(now - offsetMs).toISOString(),
+            lastActivityAt: now - offsetMs,
+            startTime: now - offsetMs,
+        });
+        return [
+            makeHistoryTask({ id: 'root', displayName: 'Root Chat', ...stamp(4000) }),
+            makeHistoryTask({ id: 'childA', displayName: 'Child A', parentProcessId: 'root', ...stamp(3000) }),
+            makeHistoryTask({ id: 'childB', displayName: 'Child B', parentProcessId: 'root', ...stamp(2000) }),
+            makeHistoryTask({ id: 'grand', displayName: 'Grandchild', parentProcessId: 'childB', ...stamp(1000) }),
+        ];
+    }
+
+    it('AC-01/AC-02: archiving the root moves the whole subtree out of COMPLETED and into ARCHIVED as a nested tree', () => {
+        mockArchivedChatIds = new Set(['root']);
+        const now = Date.now();
+        renderPane({ activeTab: 'chats', now, history: spawnTreeHistory(now) });
+
+        // The archived tree is gone from COMPLETED entirely (archived section is
+        // collapsed by default, so its subtree is not rendered anywhere yet).
+        expect(document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]')).toBeNull();
+        expect(document.querySelector('[data-task-id="child"]')).toBeNull();
+        expect(document.querySelector('[data-task-id="grand"]')).toBeNull();
+
+        // The unrelated chat stays a normal flat row under COMPLETED.
+        expect(document.querySelector('[data-task-id="lonely"]')).toBeTruthy();
+
+        // The archived toggle reports the moved subtree as one archived tree.
+        const toggle = screen.getByTestId('chat-archived-toggle');
+        expect(toggle.textContent).toContain('1');
+
+        // Expanding ARCHIVED reveals the same tree, nested, with its full sub-job
+        // count (child + grandchild = 2).
+        fireEvent.click(toggle);
+        const archivedTree = document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]') as HTMLElement;
+        expect(archivedTree).toBeTruthy();
+        expect(archivedTree.querySelector('[data-testid="spawned-tree-child-count"]')?.textContent).toBe('2');
+        expect(archivedTree.querySelector('[data-testid="spawned-tree-children"] [data-task-id="child"]')).toBeTruthy();
+        expect(archivedTree.querySelector('[data-task-id="grand"]')).toBeTruthy();
+    });
+
+    it('AC-01: archiving a middle node splits it off — the active root keeps its other branch in COMPLETED, the archived branch nests under ARCHIVED', () => {
+        mockArchivedChatIds = new Set(['childB']);
+        const now = Date.now();
+        renderPane({ activeTab: 'chats', now, history: spawnTreeTwoBranch(now) });
+
+        // The active root stays in COMPLETED with only its non-archived branch
+        // (childA). Sub-job count drops to 1 (childB + grand peeled off).
+        const activeTree = document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]') as HTMLElement;
+        expect(activeTree).toBeTruthy();
+        expect(activeTree.querySelector('[data-testid="spawned-tree-child-count"]')?.textContent).toBe('1');
+        expect(activeTree.querySelector('[data-task-id="childA"]')).toBeTruthy();
+        // The archived branch is absent from COMPLETED (archived + collapsed).
+        expect(document.querySelector('[data-task-id="childB"]')).toBeNull();
+        expect(document.querySelector('[data-task-id="grand"]')).toBeNull();
+
+        // Expanding ARCHIVED reveals the split-off branch rooted at childB.
+        fireEvent.click(screen.getByTestId('chat-archived-toggle'));
+        const archivedTree = document.querySelector('[data-testid="spawned-tree-row"][data-root-id="childB"]') as HTMLElement;
+        expect(archivedTree).toBeTruthy();
+        expect(archivedTree.querySelector('[data-testid="spawned-tree-child-count"]')?.textContent).toBe('1');
+        expect(archivedTree.querySelector('[data-task-id="grand"]')).toBeTruthy();
+        // The active root did NOT follow the archived branch out of COMPLETED.
+        expect(document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]')).toBeTruthy();
+    });
+
+    it('AC-01: archiving a leaf keeps the parent tree in COMPLETED and demotes the leaf to a flat row under ARCHIVED', () => {
+        mockArchivedChatIds = new Set(['grand']);
+        const now = Date.now();
+        renderPane({ activeTab: 'chats', now, history: spawnTreeHistory(now) });
+
+        // Parent tree stays in COMPLETED; only the archived leaf is pruned, so the
+        // sub-job count drops to 1 (child only).
+        const activeTree = document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]') as HTMLElement;
+        expect(activeTree).toBeTruthy();
+        expect(activeTree.querySelector('[data-testid="spawned-tree-child-count"]')?.textContent).toBe('1');
+        expect(activeTree.querySelector('[data-task-id="child"]')).toBeTruthy();
+        expect(document.querySelector('[data-task-id="grand"]')).toBeNull();
+
+        // The archived leaf has no descendants, so it renders as a flat archived
+        // row (not a tree).
+        fireEvent.click(screen.getByTestId('chat-archived-toggle'));
+        const grand = document.querySelector('[data-task-id="grand"]');
+        expect(grand).toBeTruthy();
+        expect(grand!.closest('[data-testid="spawned-tree-row"]')).toBeNull();
+    });
+
+    it('AC-01: archiving the only leaf of a two-node tree demotes both roots to flat rows (COMPLETED parent, ARCHIVED leaf)', () => {
+        mockArchivedChatIds = new Set(['child']);
+        const now = Date.now();
+        const stamp = (offsetMs: number) => ({
+            completedAt: new Date(now - offsetMs).toISOString(),
+            lastActivityAt: now - offsetMs,
+            startTime: now - offsetMs,
+        });
+        renderPane({
+            activeTab: 'chats',
+            now,
+            history: [
+                makeHistoryTask({ id: 'root', displayName: 'Root Chat', ...stamp(2000) }),
+                makeHistoryTask({ id: 'child', displayName: 'Child Chat', parentProcessId: 'root', ...stamp(1000) }),
+            ],
+        });
+
+        // The root lost its only child, so there is no tree left — the root
+        // demotes to a plain COMPLETED row.
+        expect(document.querySelector('[data-testid="spawned-tree-row"]')).toBeNull();
+        const root = document.querySelector('[data-task-id="root"]');
+        expect(root).toBeTruthy();
+        expect(root!.closest('[data-testid="spawned-tree-row"]')).toBeNull();
+        expect(document.querySelector('[data-task-id="child"]')).toBeNull();
+
+        // The archived leaf surfaces as a flat row under ARCHIVED.
+        fireEvent.click(screen.getByTestId('chat-archived-toggle'));
+        expect(document.querySelector('[data-task-id="child"]')).toBeTruthy();
+    });
+
+    it('AC-03: with no archived ids the whole tree stays in COMPLETED and ARCHIVED is empty (display-only, reversible)', () => {
+        mockArchivedChatIds = new Set();
+        const now = Date.now();
+        renderPane({ activeTab: 'chats', now, history: spawnTreeHistory(now) });
+
+        // Full tree in COMPLETED, no archived section at all.
+        const tree = document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]') as HTMLElement;
+        expect(tree).toBeTruthy();
+        expect(tree.querySelector('[data-testid="spawned-tree-child-count"]')?.textContent).toBe('2');
+        expect(screen.queryByTestId('chat-archived-toggle')).toBeNull();
+    });
+
+    it('AC-02: the Activity-tab ARCHIVED section also renders the archived subtree as a nested tree', () => {
+        mockArchivedChatIds = new Set(['root']);
+        const now = Date.now();
+        // No activeTab → the Activity branch (Completed Tasks / 📦 Archived).
+        renderPane({ now, history: spawnTreeHistory(now) });
+
+        // Not in COMPLETED (archived + collapsed archived section).
+        expect(document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]')).toBeNull();
+
+        // Expand the Activity-tab archived toggle → nested tree appears.
+        fireEvent.click(screen.getByTestId('archived-chats-section-toggle'));
+        const archivedTree = document.querySelector('[data-testid="spawned-tree-row"][data-root-id="root"]') as HTMLElement;
+        expect(archivedTree).toBeTruthy();
+        expect(archivedTree.querySelector('[data-testid="spawned-tree-child-count"]')?.textContent).toBe('2');
+        expect(archivedTree.querySelector('[data-testid="spawned-tree-children"] [data-task-id="child"]')).toBeTruthy();
+    });
 });

--- a/packages/coc/test/spa/react/repos/McpServersPanel.controller.test.tsx
+++ b/packages/coc/test/spa/react/repos/McpServersPanel.controller.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Integration tests for McpServersPanel ↔ controller wiring: workspace switching
+ * resets the inspector and re-discovers, and the Add-server form routes through
+ * the controller's REST action.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { McpServersPanel } from '../../../../src/server/spa/client/react/features/skills/McpServersPanel';
+import type { McpServerEntry } from '../../../../src/server/spa/client/react/features/skills/McpServersPanel';
+
+const discoverMcpTools = vi.hoisted(() => vi.fn());
+const getMcpServerDetail = vi.hoisted(() => vi.fn());
+const addMcpServer = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        workspaces: {
+            discoverMcpTools: (...a: unknown[]) => discoverMcpTools(...a),
+            getMcpServerDetail: (...a: unknown[]) => getMcpServerDetail(...a),
+            addMcpServer: (...a: unknown[]) => addMcpServer(...a),
+        },
+    }),
+    getSpaCocClientErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+const servers: McpServerEntry[] = [{ name: 'github', type: 'stdio' }];
+
+beforeEach(() => {
+    discoverMcpTools.mockImplementation((ws: string) =>
+        Promise.resolve({ servers: ws === 'ws-1' ? { github: { status: 'ok', tools: [{ name: 't1' }] } } : {} }));
+    getMcpServerDetail.mockImplementation((ws: string, name: string) =>
+        Promise.resolve({ description: `${ws}:${name}`, envKeys: [], args: [], toolScope: 'all', source: 'workspace', rawJson: {} }));
+    addMcpServer.mockResolvedValue({ name: 'my-server', scope: 'workspace' });
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('McpServersPanel — workspace switch resets inspector state', () => {
+    it('collapses the open inspector and re-discovers tools for the new workspace', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <McpServersPanel
+                workspaceId="ws-1"
+                loading={false}
+                error={null}
+                saving={false}
+                availableServers={servers}
+                isEnabled={() => true}
+                onToggle={vi.fn()}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId('mcp-tools-count-github').textContent).toBe('1'));
+
+        // Open the inspector for the ws-1 "github" server.
+        await user.click(screen.getByRole('button', { name: 'Expand github' }));
+        expect(await screen.findByRole('button', { name: 'Overview' })).toBeTruthy();
+        await waitFor(() => expect(getMcpServerDetail).toHaveBeenCalledWith('ws-1', 'github'));
+
+        // Switch to ws-2 (a different repo that also happens to have "github").
+        rerender(
+            <McpServersPanel
+                workspaceId="ws-2"
+                loading={false}
+                error={null}
+                saving={false}
+                availableServers={servers}
+                isEnabled={() => true}
+                onToggle={vi.fn()}
+            />,
+        );
+
+        // The inspector from ws-1 must be gone (expanded row was reset).
+        await waitFor(() => expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull());
+        // Tools were re-discovered for the new workspace; ws-2 has no github tools.
+        expect(discoverMcpTools).toHaveBeenCalledWith('ws-1', undefined);
+        expect(discoverMcpTools).toHaveBeenCalledWith('ws-2', undefined);
+        await waitFor(() => expect(screen.getByTestId('mcp-tools-count-github').textContent).toBe('—'));
+    });
+});
+
+describe('McpServersPanel — add server routes through the controller', () => {
+    it('submits the add form via the client and refreshes the parent', async () => {
+        const user = userEvent.setup();
+        const onMutate = vi.fn();
+        const onRefresh = vi.fn();
+        render(
+            <McpServersPanel
+                workspaceId="ws-1"
+                loading={false}
+                error={null}
+                saving={false}
+                availableServers={[]}
+                isEnabled={() => false}
+                onToggle={vi.fn()}
+                onMutate={onMutate}
+                onRefresh={onRefresh}
+            />,
+        );
+
+        await user.type(screen.getByPlaceholderText('e.g. github, postgres, internal-docs'), 'my-server');
+        await user.click(screen.getByRole('button', { name: 'Add server' }));
+
+        await waitFor(() => expect(addMcpServer).toHaveBeenCalledTimes(1));
+        expect(addMcpServer).toHaveBeenCalledWith('ws-1', expect.objectContaining({
+            name: 'my-server',
+            type: 'stdio',
+            command: 'npx',
+            scope: 'workspace',
+        }));
+        expect(onMutate).toHaveBeenCalledTimes(1);
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/coc/test/spa/react/repos/SideBySideDiffViewerComments.test.tsx
+++ b/packages/coc/test/spa/react/repos/SideBySideDiffViewerComments.test.tsx
@@ -74,6 +74,7 @@ function mockSelection(opts: {
         rangeCount: opts.collapsed ? 0 : 1,
         getRangeAt: (_: number) => mockRange,
         toString: () => opts.text ?? 'selected text',
+        removeAllRanges: vi.fn(),
     };
     vi.spyOn(window, 'getSelection').mockReturnValue(mockSel as unknown as Selection);
     return { mockSel, mockRange };

--- a/packages/coc/test/spa/react/repos/groupSkillsByFolder.test.ts
+++ b/packages/coc/test/spa/react/repos/groupSkillsByFolder.test.ts
@@ -108,4 +108,40 @@ describe('groupSkillsByFolder', () => {
         expect(groups).toHaveLength(1);
         expect(groups[0].skills).toHaveLength(2);
     });
+
+    // ----- configured global extra folders (AC #2) -----
+
+    it('groups global-extra-folder skills into a non-removable group by folderPath', () => {
+        const skills: Skill[] = [
+            { name: 'ge-a', source: 'global-extra-folder', folderPath: '/opt/shared-skills' },
+            { name: 'ge-b', source: 'global-extra-folder', folderPath: '/opt/shared-skills' },
+        ];
+        const groups = groupSkillsByFolder(skills, emptyRepos);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].source).toBe('global-extra-folder');
+        expect(groups[0].label).toBe('🌐 /opt/shared-skills');
+        expect(groups[0].isRemovable).toBe(false);
+        expect(groups[0].skills).toHaveLength(2);
+    });
+
+    it('orders global-extra groups after global/repo and before per-repo extra folders', () => {
+        const skills: Skill[] = [
+            { name: 'extra', source: 'extra-folder', folderPath: '/custom/path' },
+            { name: 'ge', source: 'global-extra-folder', folderPath: '/opt/shared' },
+            { name: 'local', source: 'repo', folderPath: '/repo/.github/skills' },
+            { name: 'global-one', source: 'global', folderPath: '/data/skills' },
+        ];
+        const groups = groupSkillsByFolder(skills, emptyRepos);
+        expect(groups.map(g => g.source)).toEqual(['global', 'repo', 'global-extra-folder', 'extra-folder']);
+    });
+
+    it('multiple global-extra folders create separate groups', () => {
+        const skills: Skill[] = [
+            { name: 'a', source: 'global-extra-folder', folderPath: '/opt/one' },
+            { name: 'b', source: 'global-extra-folder', folderPath: '/opt/two' },
+        ];
+        const groups = groupSkillsByFolder(skills, emptyRepos);
+        expect(groups).toHaveLength(2);
+        expect(groups.map(g => g.folderPath).sort()).toEqual(['/opt/one', '/opt/two']);
+    });
 });

--- a/packages/coc/test/spa/react/repos/pull-requests/PrAiPanels.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PrAiPanels.test.tsx
@@ -217,7 +217,7 @@ describe('PrChecksTable + PrMergeReadiness', () => {
 });
 
 describe('PrFilesPanel', () => {
-    const realDiff = parseDiffFileList([
+    const rawFilesDiff = [
         'diff --git a/src/foo.ts b/src/foo.ts',
         '--- a/src/foo.ts',
         '+++ b/src/foo.ts',
@@ -237,7 +237,8 @@ describe('PrFilesPanel', () => {
         '@@ -0,0 +1,1 @@',
         '+ok',
         '',
-    ].join('\n'));
+    ].join('\n');
+    const realDiff = parseDiffFileList(rawFilesDiff);
 
     it('renders a row per parsed file', () => {
         render(<PrFilesPanel files={realDiff} />);
@@ -266,15 +267,41 @@ describe('PrFilesPanel', () => {
 
     it('renders an empty placeholder when there are no files', () => {
         render(<PrFilesPanel files={[]} />);
-        expect(screen.getByText(/No file changes/i)).toBeTruthy();
+        // Split layout: both the file list and the diff panel report the empty state.
+        expect(screen.getAllByText(/No file changes/i).length).toBeGreaterThan(0);
     });
 
-    it('calls onFileClick when a file row is clicked', () => {
-        const onFileClick = vi.fn();
-        render(<PrFilesPanel files={realDiff} onFileClick={onFileClick} />);
+    it('selects a file inline on row click without triggering the pop-out', () => {
+        const onPopOut = vi.fn();
+        render(<PrFilesPanel files={realDiff} onPopOut={onPopOut} />);
         const rows = screen.getAllByTestId('pr-file-row');
         fireEvent.click(rows[0]);
-        expect(onFileClick).toHaveBeenCalledWith(rows[0].getAttribute('data-file-path'));
+        expect(onPopOut).not.toHaveBeenCalled();
+    });
+
+    it('calls onPopOut with the active file from the explicit pop-out button', () => {
+        const onPopOut = vi.fn();
+        render(<PrFilesPanel files={realDiff} diffText={rawFilesDiff} onPopOut={onPopOut} />);
+        const target = screen.getAllByTestId('pr-file-row')
+            .find(row => row.getAttribute('data-file-path') === 'test/worker.ts');
+        fireEvent.click(target!);
+        fireEvent.click(screen.getByTestId('pr-diff-popout'));
+        expect(onPopOut).toHaveBeenCalledWith('test/worker.ts');
+    });
+
+    it('renders the selected file diff inline and swaps to another file lazily', () => {
+        render(<PrFilesPanel files={realDiff} diffText={rawFilesDiff} />);
+        // Default selection (src/foo.ts) renders inline; other files are not rendered.
+        const fooDiff = screen.getByTestId('pr-inline-diff');
+        expect(fooDiff.textContent).toContain('added');
+        expect(fooDiff.textContent).not.toContain('old');
+
+        const readmeRow = screen.getAllByTestId('pr-file-row')
+            .find(row => row.getAttribute('data-file-path') === 'docs/readme.md');
+        fireEvent.click(readmeRow!);
+        const readmeDiff = screen.getByTestId('pr-inline-diff');
+        expect(readmeDiff.textContent).toContain('old');
+        expect(readmeDiff.textContent).toContain('new');
     });
 
     it('shows file rows by basename (not full path) inside their parent folder', () => {

--- a/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/pull-requests/PullRequestDetail.test.tsx
@@ -433,14 +433,19 @@ describe('tabs', () => {
         expect(screen.getByTestId('tab-files').textContent).toContain('2');
     });
 
-    it('opens PR review pop-out URLs with the resolved origin ID', async () => {
+    it('opens PR review pop-out URLs with the resolved origin ID from the explicit pop-out action', async () => {
         const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
         mockFetchDetail(makePr(), [], SAMPLE_DIFF);
         await act(async () => { await renderDetail(); });
         await waitFor(() => expect(screen.getByTestId('tab-files')).toBeInTheDocument());
         fireEvent.click(screen.getByTestId('tab-files'));
-        fireEvent.click(screen.getAllByTestId('pr-file-row')[0]);
 
+        // Clicking a file row selects it inline and must NOT open the pop-out window.
+        fireEvent.click(screen.getAllByTestId('pr-file-row')[0]);
+        expect(openSpy).not.toHaveBeenCalled();
+
+        // The pop-out remains reachable via its explicit button.
+        fireEvent.click(screen.getByTestId('pr-diff-popout'));
         expect(openSpy).toHaveBeenCalledWith(
             '/?workspace=repo-1&repo=repo-1&origin=gh_octo_repo#popout/git-review/pr/142',
             'coc-git-review-pr-142',
@@ -449,7 +454,7 @@ describe('tabs', () => {
         openSpy.mockRestore();
     });
 
-    it('renders the minimal file list without inline diff in the Files tab', async () => {
+    it('renders a split layout with the changed-files list and an inline diff panel in the Files tab', async () => {
         mockFetchDetail(makePr(), makeThreads([{
             id: 'thread-actual',
             threadContext: { filePath: '/src/foo.ts', line: 2, side: 'right' },
@@ -465,10 +470,38 @@ describe('tabs', () => {
         await waitFor(() => expect(screen.getByTestId('tab-files')).toBeInTheDocument());
         fireEvent.click(screen.getByTestId('tab-files'));
 
-        // Minimal file list renders file rows but no inline diff
+        // Left rail: changed-files list. Right rail: inline diff panel.
         expect(screen.getAllByTestId('pr-file-row').length).toBeGreaterThan(0);
+        expect(screen.getByTestId('pr-diff-panel')).toBeInTheDocument();
+        // The first file (src/foo.ts) is selected by default and its diff renders inline.
+        expect(screen.getByTestId('pr-inline-diff')).toBeInTheDocument();
+        // Legacy inline-comment / diff-card surfaces are not part of this panel.
         expect(screen.queryByTestId('pr-file-inline-comments')).not.toBeInTheDocument();
         expect(screen.queryByTestId('pr-file-diff-card')).not.toBeInTheDocument();
+    });
+
+    it('renders the selected file diff inline and swaps it (and only it) when another file is selected', async () => {
+        mockFetchDetail(makePr(), [], SAMPLE_DIFF);
+        await act(async () => { await renderDetail(); });
+        await waitFor(() => expect(screen.getByTestId('tab-files')).toBeInTheDocument());
+        fireEvent.click(screen.getByTestId('tab-files'));
+
+        // Default selection is the first file (src/foo.ts): its added lines show,
+        // and the OTHER file's removed line is not rendered (lazy per-file slice).
+        const fooDiff = screen.getByTestId('pr-inline-diff');
+        expect(fooDiff.textContent).toContain('added one');
+        expect(fooDiff.textContent).toContain('added two');
+        expect(fooDiff.textContent).not.toContain('removed one');
+
+        // Select the second file → the panel swaps to that file's diff only.
+        const barRow = screen.getAllByTestId('pr-file-row')
+            .find(r => r.getAttribute('data-file-path') === 'src/bar.ts');
+        expect(barRow).toBeDefined();
+        fireEvent.click(barRow!);
+
+        const barDiff = screen.getByTestId('pr-inline-diff');
+        expect(barDiff.textContent).toContain('removed one');
+        expect(barDiff.textContent).not.toContain('added one');
     });
 
     it('switches to the Commits tab and renders real commits from the /commits endpoint', async () => {

--- a/packages/coc/test/spa/react/shared/useMarkdownDocumentSession.test.tsx
+++ b/packages/coc/test/spa/react/shared/useMarkdownDocumentSession.test.tsx
@@ -1,0 +1,149 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MarkdownDocumentIO } from '../../../../src/server/spa/client/react/shared/markdown-document/MarkdownDocumentIO';
+import { useMarkdownDocumentSession } from '../../../../src/server/spa/client/react/shared/markdown-document/useMarkdownDocumentSession';
+import { resolveMarkdownReviewSelection } from '../../../../src/server/spa/client/react/shared/markdown-document/markdownReviewSelection';
+
+function createIo(content = '# Initial', mtime = 7): MarkdownDocumentIO {
+    return {
+        loadContent: vi.fn(async (_workspaceId: string, path: string) => ({ content, path, mtime })),
+        saveContent: vi.fn(async (_workspaceId: string, path: string, _markdown: string) => ({
+            path,
+            updated: true,
+            mtime: mtime + 1,
+        })),
+        uploadImage: vi.fn(async () => ({ path: '.attachments/image.png' })),
+        imageApiUrl: vi.fn(() => '/image'),
+        localImageApiUrl: vi.fn(() => '/local-image'),
+    };
+}
+
+function Harness({
+    io,
+    autosaveDebounceMs,
+}: {
+    io: MarkdownDocumentIO;
+    autosaveDebounceMs?: number;
+}) {
+    const session = useMarkdownDocumentSession({
+        workspaceId: 'ws1',
+        documentPath: 'doc.md',
+        io,
+        autosaveDebounceMs,
+        confirmRefreshMessage: 'Discard edits?',
+    });
+
+    return (
+        <div>
+            <div data-testid="content">{session.content}</div>
+            <div data-testid="save-state">{session.saveState}</div>
+            <div data-testid="dirty">{String(session.dirty)}</div>
+            <div data-testid="conflict">{session.conflictContent ?? ''}</div>
+            <button onClick={() => session.queueSave('# Queued')}>Queue</button>
+            <button onClick={() => session.flushSave()}>Flush</button>
+            <button onClick={() => session.saveNow('# Manual')}>Save now</button>
+            <button onClick={() => session.refresh()}>Refresh</button>
+        </div>
+    );
+}
+
+describe('useMarkdownDocumentSession', () => {
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('loads and manually saves through injected markdown document I/O', async () => {
+        const io = createIo();
+        render(<Harness io={io} />);
+
+        await screen.findByText('# Initial');
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Save now'));
+        });
+
+        expect(io.saveContent).toHaveBeenCalledWith('ws1', 'doc.md', '# Manual', 7, undefined);
+        expect(screen.getByTestId('content').textContent).toBe('# Manual');
+        expect(screen.getByTestId('dirty').textContent).toBe('false');
+    });
+
+    it('autosaves queued content with the loaded mtime for future markdown surfaces', async () => {
+        const io = createIo('# Initial', 11);
+        render(<Harness io={io} autosaveDebounceMs={0} />);
+
+        await screen.findByText('# Initial');
+
+        act(() => {
+            fireEvent.click(screen.getByText('Queue'));
+        });
+        expect(screen.getByTestId('dirty').textContent).toBe('true');
+
+        await waitFor(() => {
+            expect(io.saveContent).toHaveBeenCalledWith('ws1', 'doc.md', '# Queued', 11, undefined);
+        });
+        expect(screen.getByTestId('dirty').textContent).toBe('false');
+    });
+
+    it('guards refresh while dirty and reloads only after confirmation', async () => {
+        const io = createIo('# Initial', 1);
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+        render(<Harness io={io} />);
+
+        await screen.findByText('# Initial');
+        fireEvent.click(screen.getByText('Queue'));
+        fireEvent.click(screen.getByText('Refresh'));
+
+        expect(confirmSpy).toHaveBeenCalledWith('Discard edits?');
+        expect(io.loadContent).toHaveBeenCalledTimes(1);
+
+        confirmSpy.mockReturnValue(true);
+        fireEvent.click(screen.getByText('Refresh'));
+
+        await waitFor(() => expect(io.loadContent).toHaveBeenCalledTimes(2));
+    });
+
+    it('captures conflict content for queued saves without leaking a rejection', async () => {
+        const io = createIo('# Initial', 1);
+        vi.mocked(io.saveContent).mockRejectedValueOnce(
+            Object.assign(new Error('mtime_mismatch'), {
+                status: 409,
+                currentContent: '# Disk',
+            }),
+        );
+        render(<Harness io={io} autosaveDebounceMs={0} />);
+
+        await screen.findByText('# Initial');
+        fireEvent.click(screen.getByText('Queue'));
+
+        await waitFor(() => expect(screen.getByTestId('save-state').textContent).toBe('conflict'));
+        expect(screen.getByTestId('conflict').textContent).toBe('# Disk');
+    });
+});
+
+describe('markdown review selection helpers', () => {
+    it('maps rendered text selections to fallback source coordinates', () => {
+        const container = document.createElement('div');
+        container.textContent = 'alpha\nbeta';
+        document.body.appendChild(container);
+
+        const textNode = container.firstChild;
+        expect(textNode).toBeTruthy();
+        const range = document.createRange();
+        range.setStart(textNode!, 6);
+        range.setEnd(textNode!, 10);
+
+        const selection = resolveMarkdownReviewSelection('alpha\nbeta', container, range, 'beta');
+
+        expect(selection).toMatchObject({
+            text: 'beta',
+            startLine: 2,
+            startColumn: 1,
+            endLine: 2,
+            endColumn: 5,
+        });
+    });
+});

--- a/packages/forge/src/process-store.ts
+++ b/packages/forge/src/process-store.ts
@@ -151,7 +151,7 @@ export interface ProcessOutputEvent {
     /** Whether the session is waiting for background tasks to drain (for 'background-tasks' events). */
     backgroundWaitingForDrain?: boolean;
     /** The pending message that was added (for 'pending-message-added' events). */
-    pendingMessage?: { id: string; content: string; mode?: string; createdAt: string };
+    pendingMessage?: { id: string; content: string; mode?: string; createdAt: string; images?: string[] };
     /** Note file edit event data (for 'note-file-edit' events). */
     noteFileEdit?: {
         toolCallId: string;


### PR DESCRIPTION
- **test(coc): add Tier A e2e coverage for nested spawn-conversation tree**
- **test(coc): add Tier B real-spawn e2e coverage for nested spawn tree (AC-09/AC-10)**
- **feat(coc): render attached images in queued follow-up bubbles**
- **feat(coc): add pure partitionSpawnedTreesByArchived helper for archived spawn trees**
- **fix(coc): move archived spawn subtrees out of COMPLETED into ARCHIVED tree**
- **feat(coc): inline side-by-side diff panel on PR Files changed tab**
- **feat(coc): detect macOS CloudStorage OneDrive skill folders**
- **feat(coc): add skills.globalExtraFolders + autoDetectDefaultFolders config**
- **feat(coc): expose global extra skill folders + auto-detect toggle via /api/skills/config**
- **feat(coc): structured effective skill search-order API (GET /api/skills/effective-paths)**
- **feat(coc): Skills Config UI — global extra folders, detected folders, effective search order**
- **feat(coc): emit skipped diagnostic for OneDrive root without .github/skills**
- **feat(coc): surface configured global-extra-folder skills in workspace listing**
- **test(coc): multi-workspace skill-folder isolation (AC #3)**
- **docs(coc): document skills folder sources, effective-paths API, and Config panel**
- **feat(coc): compact the dashboard's two header rows**
- **refactor(coc): extract workspace-scoped MCP inspector controller + read model**
- **Extract markdown document editor session kernel**
