### PR TITLE
Refactor shared task group chat UI

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -63,12 +63,33 @@ by Ralph), `features/chat/task-group-descriptors.ts` registers per-type
 presentation/behavior descriptors (label, badge, accent, pin type,
 `matchesTask`, `groupable` — Dreams is `groupable: false` so its internals
 stay ungrouped), and `features/chat/TaskGroupRunRow.tsx` is the shared
-parent-row chrome that `ForEachRunRow`/`MapReduceRunRow` configure as thin
-wrappers. The per-feature grouping modules (`for-each-run-grouping.ts`,
-`map-reduce-run-grouping.ts`, `ralph-session-grouping.ts`) are adapters over
-the engine that keep their legacy matching (feature contexts,
-`generationProcessId`) in addition to the generic tag, so historical chats
-group without data migration.
+parent-row chrome that `ForEachRunRow`/`MapReduceRunRow`/`RalphSessionRow`
+configure as thin wrappers (Ralph supplies its phase dot, `R` badge,
+clarifying/iteration sub-label, and session-context drag payload through the
+row's optional display/behavior hooks). The per-feature grouping modules
+(`for-each-run-grouping.ts`, `map-reduce-run-grouping.ts`,
+`ralph-session-grouping.ts`) are adapters over the engine that keep their
+legacy matching (feature contexts, `generationProcessId`) in addition to the
+generic tag, so historical chats group without data migration.
+
+The task-group UI family shares the same wrapper-over-generic pattern beyond
+rows: `features/chat/TaskGroupRunPane.tsx` is the shared run-detail pane
+(load/refresh/busy-action state, header with run metadata and Start/Continue,
+Cancel remaining, Refresh actions, original-request/shared-instructions
+sections, items table with per-item Retry/Skip and child-chat links) that
+`ForEachRunPane`/`MapReduceRunPane` configure per kind — Map Reduce adds its
+reduce-step section and header metadata through config render slots.
+`features/chat/TaskGroupPlanReviewCard.tsx` is the shared plan-review card
+(transcript-vs-persisted scan merge, structured item editor, Advanced JSON
+editor, validation footer, approve flow) that
+`ForEachPlanReviewCard`/`MapReducePlanReviewCard` configure with per-kind
+scan/build/format/parse/validate adapters and an `approve` submission; Map
+Reduce contributes its max-parallel input, reduce-instructions editor, and
+header pill via render slots. `features/chat/task-group-expansion.ts` holds
+the workspace-scoped expand/collapse state for all group kinds behind
+`useTaskGroupExpansion` (pure, unit-tested helpers; state resets on workspace
+switch), and `features/chat/task-group-copy-info.ts` holds the pure "Copy
+run/session info" context-menu text builders.
 
 `features/chat/ChatListPane.tsx` keeps grouped chat-history expansion state
 local to the mounted view. Ralph session groups, For Each run groups, Map

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -119,7 +119,14 @@ all have their own `references/*.md`.
   `src/server/spa/client/react/features/chat/task-group-descriptors.ts`.
   Group statuses are normalized (`draft|running|completed|failed|cancelled`)
   with feature detail in `extra.detailStatus`; registry writes are best-effort
-  and must never break orchestration.
+  and must never break orchestration. On the SPA side, reuse the shared
+  task-group UI family instead of forking components: `TaskGroupRunRow`
+  (chat-list parent row; For Each/Map Reduce/Ralph rows are thin config
+  wrappers), `TaskGroupRunPane` (run-detail pane), `TaskGroupPlanReviewCard`
+  (plan review/approve card), `useTaskGroupExpansion`
+  (workspace-scoped expand/collapse for all group kinds), and
+  `task-group-copy-info.ts` (context-menu copy text) under
+  `src/server/spa/client/react/features/chat/`.
 - **Chat canvas** (`canvas.enabled`, default off) persists markdown, code, or
   extension artifacts (descriptor `type` + normalized `language`) under
   `~/.coc/repos/<wsId>/canvases/<canvasId>/` through

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -32,6 +32,8 @@ import { RalphSessionRow } from './RalphSessionRow';
 import { groupByForEachRun, getForEachEntryTimestamp, getForEachRunId, type ForEachRunGroup, type ForEachRunHistoryEntry } from './for-each-run-grouping';
 import { ForEachRunRow } from './ForEachRunRow';
 import { groupByMapReduceRun, getMapReduceEntryTimestamp, getMapReduceRunId, type MapReduceRunGroup, type MapReduceRunHistoryEntry } from './map-reduce-run-grouping';
+import { useTaskGroupExpansion } from './task-group-expansion';
+import { buildForEachRunCopyInfo, buildMapReduceRunCopyInfo, buildRalphSessionCopyInfo } from './task-group-copy-info';
 import { MapReduceRunRow } from './MapReduceRunRow';
 import { buildSpawnedTreeChatView, collectSpawnedEntryTasks, getSpawnedEntryTimestamp, isSpawnedTreeEntry, partitionSpawnedTreesByArchived, type SpawnedTreeEntry } from './spawned-tree-grouping';
 import { SpawnedTreeRow } from './SpawnedTreeRow';
@@ -1588,66 +1590,16 @@ export function ChatListPane({
         [chatGroups, applyRalphGrouping],
     );
 
-    const [expandedRalphSessionState, setExpandedRalphSessionState] = useState<{ workspaceId?: string; sessions: Set<string> }>({
-        workspaceId,
-        sessions: new Set(),
-    });
-    const [expandedForEachRunState, setExpandedForEachRunState] = useState<{ workspaceId?: string; runs: Set<string> }>({
-        workspaceId,
-        runs: new Set(),
-    });
-    const [expandedMapReduceRunState, setExpandedMapReduceRunState] = useState<{ workspaceId?: string; runs: Set<string> }>({
-        workspaceId,
-        runs: new Set(),
-    });
-    const expandedRalphSessionIds = useMemo(
-        () => expandedRalphSessionState.workspaceId === workspaceId ? expandedRalphSessionState.sessions : new Set<string>(),
-        [expandedRalphSessionState, workspaceId],
-    );
-    const expandedForEachRunIds = useMemo(
-        () => expandedForEachRunState.workspaceId === workspaceId ? expandedForEachRunState.runs : new Set<string>(),
-        [expandedForEachRunState, workspaceId],
-    );
-    const expandedMapReduceRunIds = useMemo(
-        () => expandedMapReduceRunState.workspaceId === workspaceId ? expandedMapReduceRunState.runs : new Set<string>(),
-        [expandedMapReduceRunState, workspaceId],
-    );
-    const toggleRalphSession = useCallback((sessionId: string) => {
-        setExpandedRalphSessionState(prev => {
-            const sessions = new Set(prev.workspaceId === workspaceId ? prev.sessions : []);
-            sessions.has(sessionId) ? sessions.delete(sessionId) : sessions.add(sessionId);
-            return { workspaceId, sessions };
-        });
-    }, [workspaceId]);
-    const toggleForEachRun = useCallback((runId: string) => {
-        setExpandedForEachRunState(prev => {
-            const runs = new Set(prev.workspaceId === workspaceId ? prev.runs : []);
-            runs.has(runId) ? runs.delete(runId) : runs.add(runId);
-            return { workspaceId, runs };
-        });
-    }, [workspaceId]);
-    const toggleMapReduceRun = useCallback((runId: string) => {
-        setExpandedMapReduceRunState(prev => {
-            const runs = new Set(prev.workspaceId === workspaceId ? prev.runs : []);
-            runs.has(runId) ? runs.delete(runId) : runs.add(runId);
-            return { workspaceId, runs };
-        });
-    }, [workspaceId]);
-
-    useEffect(() => {
-        setExpandedRalphSessionState(prev => {
-            if (prev.workspaceId === workspaceId && prev.sessions.size === 0) return prev;
-            return { workspaceId, sessions: new Set() };
-        });
-        setExpandedForEachRunState(prev => {
-            if (prev.workspaceId === workspaceId && prev.runs.size === 0) return prev;
-            return { workspaceId, runs: new Set() };
-        });
-        setExpandedMapReduceRunState(prev => {
-            if (prev.workspaceId === workspaceId && prev.runs.size === 0) return prev;
-            return { workspaceId, runs: new Set() };
-        });
-    }, [workspaceId]);
+    // Workspace-scoped expand/collapse for all task-group kinds (Ralph
+    // sessions, For Each runs, Map Reduce runs) lives in one keyed state.
+    const taskGroupExpansion = useTaskGroupExpansion(workspaceId);
+    const expandedRalphSessionIds = taskGroupExpansion.expandedIds('ralph');
+    const expandedForEachRunIds = taskGroupExpansion.expandedIds('for-each');
+    const expandedMapReduceRunIds = taskGroupExpansion.expandedIds('map-reduce');
+    const toggleTaskGroup = taskGroupExpansion.toggle;
+    const toggleRalphSession = useCallback((sessionId: string) => toggleTaskGroup('ralph', sessionId), [toggleTaskGroup]);
+    const toggleForEachRun = useCallback((runId: string) => toggleTaskGroup('for-each', runId), [toggleTaskGroup]);
+    const toggleMapReduceRun = useCallback((runId: string) => toggleTaskGroup('map-reduce', runId), [toggleTaskGroup]);
 
     // Per-root collapse state for spawned-conversation trees (AC-03). Seeded
     // from localStorage so a collapsed root survives reload; default expanded
@@ -2036,16 +1988,7 @@ export function ChatListPane({
                     label: 'Copy run info',
                     icon: '📎',
                     onClick: () => {
-                        const group = contextMenu.forEachRun!;
-                        const lines = [
-                            `For Each run ${group.runId}`,
-                            `Status: ${group.run.status}`,
-                            `Items: ${group.run.itemCount}`,
-                            `Updated: ${group.run.updatedAt ?? group.run.completedAt ?? group.run.createdAt}`,
-                            'Processes:',
-                            ...ids.map(id => `  - ${id}`),
-                        ];
-                        void copyToClipboard(lines.join('\n'));
+                        void copyToClipboard(buildForEachRunCopyInfo(contextMenu.forEachRun!, ids));
                         closeContextMenu();
                     },
                 }] : []),
@@ -2053,17 +1996,7 @@ export function ChatListPane({
                     label: 'Copy run info',
                     icon: '📎',
                     onClick: () => {
-                        const group = contextMenu.mapReduceRun!;
-                        const lines = [
-                            `Map Reduce run ${group.runId}`,
-                            `Status: ${group.run.status}`,
-                            `Map items: ${group.run.itemCount}`,
-                            `Reduce: ${group.run.reduceStatus}`,
-                            `Updated: ${group.run.updatedAt ?? group.run.completedAt ?? group.run.createdAt}`,
-                            'Processes:',
-                            ...ids.map(id => `  - ${id}`),
-                        ];
-                        void copyToClipboard(lines.join('\n'));
+                        void copyToClipboard(buildMapReduceRunCopyInfo(contextMenu.mapReduceRun!, ids));
                         closeContextMenu();
                     },
                 }] : []),
@@ -2071,16 +2004,7 @@ export function ChatListPane({
                     label: 'Copy session info',
                     icon: '📎',
                     onClick: () => {
-                        const rs = contextMenu.ralphSession!;
-                        const lines = [
-                            `Ralph session ${rs.sessionId}`,
-                            `Phase: ${rs.phase}`,
-                            `Iterations: ${rs.iterations.length}`,
-                            `Updated: ${rs.latestTimestamp ? new Date(rs.latestTimestamp).toISOString() : 'unknown'}`,
-                            'Processes:',
-                            ...ids.map(id => `  - ${id}`),
-                        ];
-                        void copyToClipboard(lines.join('\n'));
+                        void copyToClipboard(buildRalphSessionCopyInfo(contextMenu.ralphSession!, ids));
                         closeContextMenu();
                     },
                 }] : []),

--- a/packages/coc/src/server/spa/client/react/features/chat/ForEachPlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ForEachPlanReviewCard.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
 import type {
     ForEachChildMode,
     ForEachItem,
     ForEachPlanArtifact,
     ForEachPlanScanResult,
-    ForEachRun,
 } from '@plusplusoneplusplus/coc-client';
 import {
     normalizeForEachPlanItems,
@@ -13,9 +11,11 @@ import {
     scanForEachPlanArtifacts,
 } from '@plusplusoneplusplus/coc-client';
 import type { ClientConversationTurn } from '../../types/dashboard';
-import { getSpaCocClientErrorMessage } from '../../api/cocClient';
-import { useCocClient } from '../../repos/cloneRouting';
-import { cn } from '../../ui/cn';
+import {
+    TaskGroupPlanReviewCard,
+    type TaskGroupPlanApproveArgs,
+    type TaskGroupPlanReviewConfig,
+} from './TaskGroupPlanReviewCard';
 
 export interface ForEachGenerationMetadata {
     kind: 'generation';
@@ -90,43 +90,10 @@ function parseDraftJson(text: string): DraftPlan {
     return { childMode, sharedInstructions, items: validation.items };
 }
 
-function itemDependencyText(item: ForEachItem): string {
-    return (item.dependsOn ?? []).join(', ');
-}
-
-function parseDependencies(value: string): string[] | undefined {
-    const deps = value.split(',').map(part => part.trim()).filter(Boolean);
-    return deps.length > 0 ? deps : undefined;
-}
-
-function makeNewItem(existing: ForEachItem[]): ForEachItem {
-    const used = new Set(existing.map(item => item.id));
-    let index = existing.length + 1;
-    let id = `item-${index}`;
-    while (used.has(id)) {
-        index += 1;
-        id = `item-${index}`;
-    }
-    return {
-        id,
-        title: `Item ${index}`,
-        prompt: '',
-        status: 'pending',
-    };
-}
-
 function isForEachGenerationMetadata(value: unknown): value is ForEachGenerationMetadata {
     return !!value
         && typeof value === 'object'
         && (value as { kind?: unknown }).kind === 'generation';
-}
-
-function planJson(plan: Pick<DraftPlan, 'childMode' | 'sharedInstructions' | 'items'>): string {
-    return JSON.stringify({
-        childMode: plan.childMode,
-        sharedInstructions: plan.sharedInstructions || undefined,
-        items: plan.items,
-    }, null, 2);
 }
 
 function getPersistedPlanState(forEach: ForEachGenerationMetadata): ForEachPlanScanResult {
@@ -149,7 +116,7 @@ function getPersistedPlanState(forEach: ForEachGenerationMetadata): ForEachPlanS
                 items,
                 rawJson: typeof latestPlan.rawJson === 'string'
                     ? latestPlan.rawJson
-                    : planJson({
+                    : formatDraftJson({
                         childMode: latestPlan.childMode,
                         sharedInstructions: sharedInstructions ?? '',
                         items,
@@ -175,339 +142,105 @@ function getPersistedPlanState(forEach: ForEachGenerationMetadata): ForEachPlanS
     return { plan, error };
 }
 
-function latestScanTurn(scan: ForEachPlanScanResult): number {
-    return Math.max(scan.plan?.turnIndex ?? -1, scan.error?.turnIndex ?? -1);
-}
-
-export function ForEachPlanReviewCard({
+async function approve({
+    client,
     workspaceId,
     processId,
+    meta: forEach,
     metadataProcess,
-    forEach,
-    turns,
+    draft,
+    scanPlanTurnIndex,
     provider,
     model,
     reasoningEffort,
-    onApprovedRun,
-}: ForEachPlanReviewCardProps) {
-    // AC-07: plan create/update/approve route to the selected clone's server.
-    const cloneClient = useCocClient(workspaceId);
-    const transcriptScan = useMemo(() => scanForEachPlans(turns), [turns]);
-    const persistedScan = useMemo(() => getPersistedPlanState(forEach), [forEach]);
-    const scan = latestScanTurn(transcriptScan) > latestScanTurn(persistedScan)
-        ? transcriptScan
-        : persistedScan.plan || persistedScan.error
-            ? persistedScan
-            : transcriptScan;
-    const generatedKey = scan.plan ? `${scan.plan.turnIndex}:${scan.plan.rawJson}` : 'none';
-    const [loadedKey, setLoadedKey] = useState('');
-    const [baselineJson, setBaselineJson] = useState('');
-    const [draft, setDraft] = useState<DraftPlan | null>(null);
-    const [jsonOpen, setJsonOpen] = useState(false);
-    const [jsonText, setJsonText] = useState('');
-    const [jsonError, setJsonError] = useState<string | null>(null);
-    const [busy, setBusy] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [approvedRun, setApprovedRun] = useState<ForEachRun | null>(null);
-
-    useEffect(() => {
-        if (!scan.plan || generatedKey === loadedKey) return;
-        const nextDraft: DraftPlan = {
-            childMode: scan.plan.childMode ?? forEach.childMode ?? 'ask',
-            sharedInstructions: scan.plan.sharedInstructions ?? '',
-            items: scan.plan.items,
-        };
-        const formatted = formatDraftJson(nextDraft);
-        setDraft(nextDraft);
-        setBaselineJson(formatted);
-        setJsonText(formatted);
-        setJsonError(null);
-        setLoadedKey(generatedKey);
-        setError(null);
-    }, [forEach.childMode, generatedKey, loadedKey, scan.plan]);
-
-    if (!scan.plan && !scan.error) return null;
-
-    const validation = draft ? validateForEachDraftPlan(draft.items) : { items: null, error: 'No valid For Each item plan is available yet.' };
-    const currentJson = draft ? formatDraftJson(draft) : '';
-    const dirty = draft ? currentJson !== baselineJson : false;
-    const approvalBlocked = busy || !!jsonError || !!validation.error || !draft || !workspaceId || !processId || forEach.status === 'approved' || !!approvedRun;
-    const linkedRunId = approvedRun?.runId ?? forEach.runId;
-
-    function applyDraft(next: DraftPlan) {
-        setDraft(next);
-        setJsonText(formatDraftJson(next));
-        setJsonError(null);
-        setError(null);
-    }
-
-    function updateItem(index: number, patch: Partial<ForEachItem>) {
-        if (!draft) return;
-        applyDraft({
-            ...draft,
-            items: draft.items.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item),
+}: TaskGroupPlanApproveArgs<DraftPlan, ForEachGenerationMetadata>) {
+    const run = forEach.runId
+        ? await client.forEach.updatePlan(workspaceId, forEach.runId, {
+            items: draft.items,
+            sharedInstructions: draft.sharedInstructions,
+            childMode: draft.childMode,
+        })
+        : await client.forEach.create(workspaceId, {
+            originalRequest: forEach.originalRequest,
+            items: draft.items,
+            sharedInstructions: draft.sharedInstructions,
+            childMode: draft.childMode,
+            provider,
+            config: model || reasoningEffort ? { ...(model ? { model } : {}), ...(reasoningEffort ? { reasoningEffort } : {}) } : undefined,
+            generationProcessId: processId,
+            generationId: forEach.generationId,
         });
-    }
+    const approved = run.status === 'approved'
+        ? run
+        : await client.forEach.approve(workspaceId, run.runId);
 
-    function moveItem(index: number, direction: -1 | 1) {
-        if (!draft) return;
-        const target = index + direction;
-        if (target < 0 || target >= draft.items.length) return;
-        const items = [...draft.items];
-        const [item] = items.splice(index, 1);
-        items.splice(target, 0, item);
-        applyDraft({ ...draft, items });
-    }
+    const currentMetadata = (metadataProcess?.metadata ?? {}) as Record<string, unknown>;
+    const currentForEach = isForEachGenerationMetadata(currentMetadata.forEach) ? currentMetadata.forEach : forEach;
+    const nextForEach: ForEachGenerationMetadata = {
+        ...currentForEach,
+        status: 'approved',
+        runId: approved.runId,
+        latestItemCount: approved.items.length,
+        latestPlanTurnIndex: scanPlanTurnIndex,
+        latestPlan: {
+            turnIndex: scanPlanTurnIndex ?? currentForEach.latestPlan?.turnIndex ?? 0,
+            childMode: draft.childMode,
+            sharedInstructions: draft.sharedInstructions || undefined,
+            items: draft.items,
+            rawJson: formatDraftJson(draft),
+            updatedAt: new Date().toISOString(),
+        },
+    };
+    delete nextForEach.lastPlanError;
+    delete nextForEach.lastPlanErrorTurnIndex;
+    await client.processes.patchMetadata(processId, {
+        set: { forEach: nextForEach },
+    }, { workspace: workspaceId });
+    return approved;
+}
 
-    function removeItem(index: number) {
-        if (!draft) return;
-        applyDraft({ ...draft, items: draft.items.filter((_, itemIndex) => itemIndex !== index) });
-    }
-
-    function handleJsonChange(value: string) {
-        setJsonText(value);
-        setError(null);
-        try {
-            const parsed = parseDraftJson(value);
-            setDraft(parsed);
-            setJsonError(null);
-        } catch (err) {
-            setJsonError(err instanceof Error ? err.message : String(err));
-        }
-    }
-
-    async function approveRun() {
-        if (!draft || !workspaceId || !processId) return;
+const FOR_EACH_PLAN_CONFIG: TaskGroupPlanReviewConfig<DraftPlan, ForEachGenerationMetadata> = {
+    testIdPrefix: 'for-each',
+    heading: 'Proposed For Each item plan',
+    itemNoun: 'item',
+    addItemLabel: 'Add item',
+    description: 'Review and approve only. Child chats start later from the For Each run pane.',
+    scanErrorNoun: 'item plan',
+    noPlanText: 'No valid For Each item plan is available yet.',
+    approveErrorFallback: 'Failed to approve For Each item plan',
+    topGridClassName: 'md:grid-cols-[minmax(0,1fr)_auto]',
+    accent: {
+        card: 'border-sky-200 bg-sky-50/70 dark:border-sky-900/60 dark:bg-sky-950/20',
+        headingText: 'text-sky-900 dark:text-sky-100',
+        pill: 'bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-100',
+        subText: 'text-sky-800/80 dark:text-sky-200/80',
+        openRunButton: 'border-sky-300 text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-100 dark:hover:bg-sky-900/60',
+        editorBorder: 'border-sky-200 dark:border-sky-900',
+        childModeActive: 'bg-sky-100 text-sky-800 dark:bg-sky-900/60 dark:text-sky-100',
+        hairlineBorder: 'border-sky-100 dark:border-sky-900/70',
+        addItemButton: 'border-sky-300 text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-100',
+        jsonSummaryText: 'text-sky-800 dark:text-sky-100',
+        approveButton: 'bg-sky-600 hover:bg-sky-700 disabled:bg-sky-300 dark:disabled:bg-sky-900',
+    },
+    scanTranscript: scanForEachPlans,
+    getPersistedPlanState,
+    buildDraft: (plan: ForEachPlanArtifact, forEach) => ({
+        childMode: plan.childMode ?? forEach.childMode ?? 'ask',
+        sharedInstructions: plan.sharedInstructions ?? '',
+        items: plan.items,
+    }),
+    formatDraftJson,
+    parseDraftJson,
+    validate: draft => {
         const checked = validateForEachDraftPlan(draft.items);
         if (checked.error || !checked.items) {
-            setError(checked.error ?? 'Invalid For Each item plan');
-            return;
+            return { draft: null, error: checked.error ?? 'Invalid For Each item plan' };
         }
-        setBusy(true);
-        setError(null);
-        try {
-            const client = cloneClient;
-            const run = forEach.runId
-                ? await client.forEach.updatePlan(workspaceId, forEach.runId, {
-                    items: checked.items,
-                    sharedInstructions: draft.sharedInstructions,
-                    childMode: draft.childMode,
-                })
-                : await client.forEach.create(workspaceId, {
-                    originalRequest: forEach.originalRequest,
-                    items: checked.items,
-                    sharedInstructions: draft.sharedInstructions,
-                    childMode: draft.childMode,
-                    provider,
-                    config: model || reasoningEffort ? { ...(model ? { model } : {}), ...(reasoningEffort ? { reasoningEffort } : {}) } : undefined,
-                    generationProcessId: processId,
-                    generationId: forEach.generationId,
-                });
-            const approved = run.status === 'approved'
-                ? run
-                : await client.forEach.approve(workspaceId, run.runId);
-            setApprovedRun(approved);
+        return { draft: { ...draft, items: checked.items }, error: null };
+    },
+    approve,
+};
 
-            const currentMetadata = (metadataProcess?.metadata ?? {}) as Record<string, unknown>;
-            const currentForEach = isForEachGenerationMetadata(currentMetadata.forEach) ? currentMetadata.forEach : forEach;
-            const nextForEach: ForEachGenerationMetadata = {
-                ...currentForEach,
-                status: 'approved',
-                runId: approved.runId,
-                latestItemCount: approved.items.length,
-                latestPlanTurnIndex: scan.plan?.turnIndex,
-                latestPlan: {
-                    turnIndex: scan.plan?.turnIndex ?? currentForEach.latestPlan?.turnIndex ?? 0,
-                    childMode: draft.childMode,
-                    sharedInstructions: draft.sharedInstructions || undefined,
-                    items: checked.items,
-                    rawJson: formatDraftJson({ ...draft, items: checked.items }),
-                    updatedAt: new Date().toISOString(),
-                },
-            };
-            delete nextForEach.lastPlanError;
-            delete nextForEach.lastPlanErrorTurnIndex;
-            await client.processes.patchMetadata(processId, {
-                set: { forEach: nextForEach },
-            }, { workspace: workspaceId });
-            onApprovedRun?.(approved.runId);
-        } catch (err) {
-            setError(getSpaCocClientErrorMessage(err, 'Failed to approve For Each item plan'));
-        } finally {
-            setBusy(false);
-        }
-    }
-
-    return (
-        <section
-            className="mx-4 mb-3 rounded-lg border border-sky-200 bg-sky-50/70 p-3 text-xs shadow-sm dark:border-sky-900/60 dark:bg-sky-950/20"
-            data-testid="for-each-plan-review-card"
-        >
-            <div className="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                    <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-sky-900 dark:text-sky-100">Proposed For Each item plan</h3>
-                        <span className="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-sky-700 dark:bg-sky-900/60 dark:text-sky-100">
-                            {draft?.items.length ?? 0} item{draft?.items.length === 1 ? '' : 's'}
-                        </span>
-                        {dirty && <span className="text-[10px] font-medium text-amber-700 dark:text-amber-300" data-testid="for-each-plan-dirty">Edited</span>}
-                    </div>
-                    <p className="mt-0.5 text-[11px] text-sky-800/80 dark:text-sky-200/80">
-                        Review and approve only. Child chats start later from the For Each run pane.
-                    </p>
-                </div>
-                {linkedRunId && (
-                    <button
-                        type="button"
-                        className="rounded border border-sky-300 bg-white px-2 py-1 text-[11px] font-medium text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-100 dark:hover:bg-sky-900/60"
-                        onClick={() => onApprovedRun?.(linkedRunId)}
-                        data-testid="for-each-open-run-btn"
-                    >
-                        Open run
-                    </button>
-                )}
-            </div>
-
-            {scan.error && (
-                <div className="mt-3 rounded border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200" data-testid="for-each-plan-scan-error">
-                    Latest assistant output did not contain a valid item plan: {scan.error.message}. Keeping the previous valid plan.
-                </div>
-            )}
-
-            {draft && (
-                <div className="mt-3 space-y-3">
-                    <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
-                        <label className="block">
-                            <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-sky-900 dark:text-sky-100">Shared instructions</span>
-                            <textarea
-                                value={draft.sharedInstructions}
-                                onChange={(e) => applyDraft({ ...draft, sharedInstructions: e.target.value })}
-                                rows={2}
-                                className="w-full resize-y rounded border border-sky-200 bg-white p-2 text-xs text-zinc-900 dark:border-sky-900 dark:bg-zinc-950 dark:text-zinc-100"
-                                data-testid="for-each-shared-instructions-editor"
-                            />
-                        </label>
-                        <div>
-                            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-sky-900 dark:text-sky-100">Child mode</div>
-                            <div className="inline-flex rounded border border-sky-200 bg-white p-0.5 dark:border-sky-900 dark:bg-zinc-950" data-testid="for-each-plan-child-mode">
-                                {(['ask', 'autopilot'] as const).map(mode => (
-                                    <button
-                                        key={mode}
-                                        type="button"
-                                        onClick={() => applyDraft({ ...draft, childMode: mode })}
-                                        className={cn(
-                                            'rounded px-2 py-1 text-[11px] font-medium',
-                                            draft.childMode === mode
-                                                ? 'bg-sky-100 text-sky-800 dark:bg-sky-900/60 dark:text-sky-100'
-                                                : 'text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900',
-                                        )}
-                                        data-testid={`for-each-plan-child-mode-${mode}`}
-                                    >
-                                        {mode === 'ask' ? 'Ask' : 'Autopilot'}
-                                    </button>
-                                ))}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="space-y-2" data-testid="for-each-plan-items">
-                        {draft.items.map((item, index) => (
-                            <div key={`${item.id}:${index}`} className="rounded border border-sky-100 bg-white p-2 dark:border-sky-900/70 dark:bg-zinc-950" data-testid={`for-each-plan-item-${item.id}`}>
-                                <div className="grid gap-2 md:grid-cols-[10rem_minmax(0,1fr)_auto]">
-                                    <label className="block">
-                                        <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">ID</span>
-                                        <input
-                                            value={item.id}
-                                            onChange={(e) => updateItem(index, { id: e.target.value })}
-                                            className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                            data-testid={`for-each-plan-item-id-${index}`}
-                                        />
-                                    </label>
-                                    <label className="block">
-                                        <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Title</span>
-                                        <input
-                                            value={item.title}
-                                            onChange={(e) => updateItem(index, { title: e.target.value })}
-                                            className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                            data-testid={`for-each-plan-item-title-${index}`}
-                                        />
-                                    </label>
-                                    <div className="flex items-end gap-1">
-                                        <button type="button" onClick={() => moveItem(index, -1)} disabled={index === 0} className="rounded border border-zinc-200 px-2 py-1 text-[11px] disabled:opacity-40 dark:border-zinc-800" data-testid={`for-each-plan-item-up-${index}`}>Up</button>
-                                        <button type="button" onClick={() => moveItem(index, 1)} disabled={index === draft.items.length - 1} className="rounded border border-zinc-200 px-2 py-1 text-[11px] disabled:opacity-40 dark:border-zinc-800" data-testid={`for-each-plan-item-down-${index}`}>Down</button>
-                                        <button type="button" onClick={() => removeItem(index)} className="rounded border border-red-200 px-2 py-1 text-[11px] text-red-700 dark:border-red-900 dark:text-red-200" data-testid={`for-each-plan-item-remove-${index}`}>Remove</button>
-                                    </div>
-                                </div>
-                                <label className="mt-2 block">
-                                    <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Prompt</span>
-                                    <textarea
-                                        value={item.prompt}
-                                        onChange={(e) => updateItem(index, { prompt: e.target.value })}
-                                        rows={3}
-                                        className="w-full resize-y rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                        data-testid={`for-each-plan-item-prompt-${index}`}
-                                    />
-                                </label>
-                                <label className="mt-2 block">
-                                    <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Dependencies</span>
-                                    <input
-                                        value={itemDependencyText(item)}
-                                        onChange={(e) => updateItem(index, { dependsOn: parseDependencies(e.target.value) })}
-                                        placeholder="item-1, item-2"
-                                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                        data-testid={`for-each-plan-item-deps-${index}`}
-                                    />
-                                </label>
-                            </div>
-                        ))}
-                    </div>
-
-                    <button
-                        type="button"
-                        onClick={() => applyDraft({ ...draft, items: [...draft.items, makeNewItem(draft.items)] })}
-                        className="rounded border border-sky-300 bg-white px-2 py-1 text-[11px] font-medium text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-100"
-                        data-testid="for-each-plan-add-item"
-                    >
-                        Add item
-                    </button>
-
-                    <details open={jsonOpen} onToggle={(event) => setJsonOpen(event.currentTarget.open)} className="rounded border border-sky-100 bg-white p-2 dark:border-sky-900/70 dark:bg-zinc-950">
-                        <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-sky-800 dark:text-sky-100" data-testid="for-each-plan-json-toggle">
-                            Advanced JSON
-                        </summary>
-                        <textarea
-                            value={jsonText}
-                            onChange={(e) => handleJsonChange(e.target.value)}
-                            rows={10}
-                            className="mt-2 w-full resize-y rounded border border-zinc-200 bg-white p-2 font-mono text-xs text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
-                            data-testid="for-each-plan-json"
-                        />
-                        {jsonError && (
-                            <p className="mt-1 text-[11px] text-red-600 dark:text-red-300" data-testid="for-each-plan-json-error">{jsonError}</p>
-                        )}
-                    </details>
-
-                    <div className="flex flex-wrap items-center justify-between gap-2 border-t border-sky-100 pt-2 dark:border-sky-900/70">
-                        <div>
-                            {validation.error ? (
-                                <p className="text-[11px] text-red-600 dark:text-red-300" data-testid="for-each-plan-validation-error">{validation.error}</p>
-                            ) : (
-                                <p className="text-[11px] text-emerald-700 dark:text-emerald-300" data-testid="for-each-plan-validation-ok">Plan is valid and ready for approval.</p>
-                            )}
-                            {error && <p className="mt-1 text-[11px] text-red-600 dark:text-red-300" data-testid="for-each-plan-approve-error">{error}</p>}
-                        </div>
-                        <button
-                            type="button"
-                            onClick={() => void approveRun()}
-                            disabled={approvalBlocked}
-                            className="rounded bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-sky-700 disabled:cursor-not-allowed disabled:bg-sky-300 dark:disabled:bg-sky-900"
-                            data-testid="for-each-plan-approve-btn"
-                        >
-                            {busy ? 'Approving...' : forEach.status === 'approved' || approvedRun ? 'Approved' : 'Approve run'}
-                        </button>
-                    </div>
-                </div>
-            )}
-        </section>
-    );
+export function ForEachPlanReviewCard({ forEach, ...rest }: ForEachPlanReviewCardProps) {
+    return <TaskGroupPlanReviewCard {...rest} meta={forEach} config={FOR_EACH_PLAN_CONFIG} />;
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/ForEachRunPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ForEachRunPane.tsx
@@ -1,9 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import type { ForEachItem, ForEachItemStatus, ForEachRun, ForEachRunStatus } from '@plusplusoneplusplus/coc-client';
-import { cn } from '../../ui/cn';
-import { getSpaCocClientErrorMessage } from '../../api/cocClient';
-import { useCocClient } from '../../repos/cloneRouting';
-import { formatRelativeTime } from '../../utils/format';
+import type { ForEachItemStatus, ForEachRun, ForEachRunStatus } from '@plusplusoneplusplus/coc-client';
+import { TaskGroupRunPane, type TaskGroupRunPaneConfig } from './TaskGroupRunPane';
 
 export interface ForEachRunPaneProps {
     workspaceId: string;
@@ -30,299 +26,39 @@ const ITEM_STATUS_CLASS: Record<ForEachItemStatus, string> = {
     skipped: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-100',
 };
 
-function singleLine(text: string, max = 120): string {
-    const flat = text.replace(/\s+/g, ' ').trim();
-    return flat.length > max ? flat.slice(0, max - 3) + '...' : flat;
-}
-
-function countItems(run: ForEachRun): string {
-    const counts = new Map<ForEachItemStatus, number>();
-    for (const item of run.items) counts.set(item.status, (counts.get(item.status) ?? 0) + 1);
-    return Array.from(counts.entries()).map(([status, count]) => `${count} ${status}`).join(' - ');
-}
-
-function hasRunningItem(run: ForEachRun): boolean {
-    return run.items.some(item => item.status === 'running');
-}
-
-function hasFailedItem(run: ForEachRun): boolean {
-    return run.items.some(item => item.status === 'failed');
-}
-
-function hasPendingItem(run: ForEachRun): boolean {
-    return run.items.some(item => item.status === 'pending');
-}
-
 function canCancel(run: ForEachRun): boolean {
     return run.status === 'draft' || run.status === 'approved' || run.status === 'running' || run.status === 'failed';
 }
 
 function canContinue(run: ForEachRun): boolean {
     if (run.status !== 'approved' && run.status !== 'running') return false;
-    return !hasRunningItem(run) && !hasFailedItem(run) && hasPendingItem(run);
+    return !run.items.some(item => item.status === 'running')
+        && !run.items.some(item => item.status === 'failed')
+        && run.items.some(item => item.status === 'pending');
 }
 
-function promptPreview(item: ForEachItem): string {
-    return singleLine(item.prompt, 220);
-}
+const FOR_EACH_PANE_CONFIG: TaskGroupRunPaneConfig<ForEachRun> = {
+    testIdPrefix: 'for-each',
+    label: 'For Each',
+    itemColumnHeader: 'Item',
+    childChatLabel: 'Open child chat',
+    generationButtonClassName: 'border-sky-300 text-sky-700 hover:bg-sky-50 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-100 dark:hover:bg-sky-900/60',
+    primaryButtonClassName: 'border-sky-500 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-400 dark:bg-sky-900/30 dark:text-sky-100',
+    childLinkClassName: 'border-sky-300 text-sky-700 hover:bg-sky-50 dark:border-sky-700 dark:text-sky-200 dark:hover:bg-sky-950/40',
+    runStatusClassName: status => RUN_STATUS_CLASS[status],
+    itemStatusClassName: status => ITEM_STATUS_CLASS[status as ForEachItemStatus],
+    canCancel,
+    canStartOrContinue: canContinue,
+    api: {
+        get: (client, workspaceId, runId) => client.forEach.get(workspaceId, runId),
+        start: (client, workspaceId, runId) => client.forEach.start(workspaceId, runId),
+        continue: (client, workspaceId, runId) => client.forEach.continue(workspaceId, runId),
+        cancel: (client, workspaceId, runId) => client.forEach.cancel(workspaceId, runId),
+        retryItem: (client, workspaceId, runId, itemId) => client.forEach.retryItem(workspaceId, runId, itemId),
+        skipItem: (client, workspaceId, runId, itemId) => client.forEach.skipItem(workspaceId, runId, itemId),
+    },
+};
 
-export function ForEachRunPane({ workspaceId, runId, onClose, onSelectGenerationProcess, onSelectChildProcess }: ForEachRunPaneProps) {
-    // AC-07: For Each run data + actions target the selected clone's server.
-    const cloneClient = useCocClient(workspaceId);
-    const [run, setRun] = useState<ForEachRun | null | undefined>(undefined);
-    const [busyAction, setBusyAction] = useState<string | null>(null);
-    const [error, setError] = useState<string | null>(null);
-
-    const refresh = useCallback(async () => {
-        try {
-            const nextRun = await cloneClient.forEach.get(workspaceId, runId);
-            setRun(nextRun);
-            setError(null);
-        } catch (err) {
-            setRun(null);
-            setError(getSpaCocClientErrorMessage(err, 'Failed to load For Each run'));
-        }
-    }, [workspaceId, runId, cloneClient]);
-
-    useEffect(() => {
-        setRun(undefined);
-        void refresh();
-    }, [refresh]);
-
-    async function runAction(actionId: string, action: () => Promise<ForEachRun>) {
-        setBusyAction(actionId);
-        setError(null);
-        try {
-            const nextRun = await action();
-            setRun(nextRun);
-        } catch (err) {
-            setError(getSpaCocClientErrorMessage(err, 'For Each action failed'));
-        } finally {
-            setBusyAction(null);
-        }
-    }
-
-    if (run === undefined) {
-        return (
-            <div className="flex h-full items-center justify-center text-sm text-zinc-500 dark:text-zinc-400" data-testid="for-each-run-pane-loading">
-                Loading For Each run...
-            </div>
-        );
-    }
-
-    if (run === null) {
-        return (
-            <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400" data-testid="for-each-run-pane-empty">
-                <p>For Each run not found.</p>
-                <p className="text-xs">Run id: <code className="font-mono">{runId}</code></p>
-                {error && <p className="text-xs text-red-600 dark:text-red-300">{error}</p>}
-            </div>
-        );
-    }
-
-    const continueEnabled = canContinue(run);
-    const cancelEnabled = canCancel(run);
-    const startOrContinue = () => {
-        if (run.status === 'approved') {
-            return cloneClient.forEach.start(workspaceId, run.runId);
-        }
-        return cloneClient.forEach.continue(workspaceId, run.runId);
-    };
-    const generationProcessId = run.generationProcessId;
-
-    return (
-        <div className="flex h-full flex-col overflow-hidden bg-white dark:bg-zinc-950" data-testid="for-each-run-pane">
-            <div className="flex flex-wrap items-start gap-2 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
-                <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                        <h2 className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                            For Each: {singleLine(run.originalRequest, 90)}
-                        </h2>
-                        <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', RUN_STATUS_CLASS[run.status])} data-testid="for-each-run-status">
-                            {run.status}
-                        </span>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
-                        <span data-testid="for-each-run-counts">{countItems(run)}</span>
-                        <span>Child mode: {run.childMode === 'ask' ? 'Ask' : 'Autopilot'}</span>
-                        <span>Updated {formatRelativeTime(run.updatedAt)}</span>
-                        {run.provider && <span>Provider: {run.provider}</span>}
-                    </div>
-                </div>
-                <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
-                    {generationProcessId && onSelectGenerationProcess && (
-                        <button
-                            type="button"
-                            onClick={() => onSelectGenerationProcess(generationProcessId)}
-                            data-testid="for-each-generation-link-btn"
-                            className="rounded border border-sky-300 bg-white px-2 py-1 text-xs font-medium text-sky-700 hover:bg-sky-50 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-100 dark:hover:bg-sky-900/60"
-                        >
-                            Open generation chat
-                        </button>
-                    )}
-                    <button
-                        type="button"
-                        onClick={() => runAction('continue', startOrContinue)}
-                        disabled={!continueEnabled || busyAction !== null}
-                        data-testid="for-each-continue-btn"
-                        className="rounded border border-sky-500 bg-sky-50 px-2 py-1 text-xs text-sky-700 hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-sky-400 dark:bg-sky-900/30 dark:text-sky-100"
-                    >
-                        {run.status === 'approved' ? 'Start' : 'Continue'}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => runAction('cancel', () => cloneClient.forEach.cancel(workspaceId, run.runId))}
-                        disabled={!cancelEnabled || busyAction !== null}
-                        data-testid="for-each-cancel-btn"
-                        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    >
-                        Cancel remaining
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => void refresh()}
-                        disabled={busyAction !== null}
-                        data-testid="for-each-refresh-btn"
-                        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    >
-                        Refresh
-                    </button>
-                    {onClose && (
-                        <button
-                            type="button"
-                            onClick={onClose}
-                            data-testid="for-each-close-btn"
-                            className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                        >
-                            Close
-                        </button>
-                    )}
-                </div>
-            </div>
-
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-                {error && (
-                    <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200" data-testid="for-each-run-error">
-                        {error}
-                    </div>
-                )}
-
-                <section className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/40" data-testid="for-each-original-request">
-                    <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Original request</h3>
-                    <p className="whitespace-pre-wrap text-xs text-zinc-700 dark:text-zinc-200">{run.originalRequest}</p>
-                </section>
-
-                {run.sharedInstructions?.trim() && (
-                    <section className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/40" data-testid="for-each-shared-instructions-preview">
-                        <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Shared instructions</h3>
-                        <p className="whitespace-pre-wrap text-xs text-zinc-700 dark:text-zinc-200">{run.sharedInstructions}</p>
-                    </section>
-                )}
-
-                <div className="overflow-hidden rounded border border-zinc-200 dark:border-zinc-800">
-                    <table className="w-full table-fixed text-left text-xs" data-testid="for-each-items-table">
-                        <thead className="bg-zinc-50 text-[11px] uppercase tracking-wide text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
-                            <tr>
-                                <th className="w-32 px-2 py-2">Status</th>
-                                <th className="w-56 px-2 py-2">Item</th>
-                                <th className="px-2 py-2">Prompt preview</th>
-                                <th className="w-44 px-2 py-2">Child chat</th>
-                                <th className="w-40 px-2 py-2">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                            {run.items.map(item => (
-                                <ForEachItemRow
-                                    key={item.id}
-                                    item={item}
-                                    busyAction={busyAction}
-                                    onSelectChildProcess={onSelectChildProcess}
-                                    onRetry={() => runAction(`retry:${item.id}`, () => cloneClient.forEach.retryItem(workspaceId, run.runId, item.id))}
-                                    onSkip={() => runAction(`skip:${item.id}`, () => cloneClient.forEach.skipItem(workspaceId, run.runId, item.id))}
-                                />
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    );
-}
-
-interface ForEachItemRowProps {
-    item: ForEachItem;
-    busyAction: string | null;
-    onSelectChildProcess?: (processId: string) => void;
-    onRetry: () => void;
-    onSkip: () => void;
-}
-
-function ForEachItemRow({ item, busyAction, onSelectChildProcess, onRetry, onSkip }: ForEachItemRowProps) {
-    const canRetry = item.status === 'failed';
-    const canSkip = item.status === 'failed' || item.status === 'pending';
-
-    return (
-        <tr data-testid={`for-each-item-${item.id}`} className="align-top text-zinc-800 dark:text-zinc-100">
-            <td className="px-2 py-2">
-                <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', ITEM_STATUS_CLASS[item.status])}>
-                    {item.status}
-                </span>
-                {item.error && (
-                    <p className="mt-1 line-clamp-3 text-[11px] text-red-600 dark:text-red-300" title={item.error}>
-                        {item.error}
-                    </p>
-                )}
-            </td>
-            <td className="px-2 py-2">
-                <div className="font-medium">{item.title}</div>
-                <div className="mt-1 font-mono text-[10px] text-zinc-500 dark:text-zinc-400">{item.id}</div>
-                {item.dependsOn && item.dependsOn.length > 0 && (
-                    <div className="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
-                        Depends on {item.dependsOn.join(', ')}
-                    </div>
-                )}
-            </td>
-            <td className="px-2 py-2">
-                <p className="line-clamp-4 text-zinc-700 dark:text-zinc-200" title={item.prompt} data-testid={`for-each-item-prompt-${item.id}`}>
-                    {promptPreview(item)}
-                </p>
-            </td>
-            <td className="px-2 py-2">
-                {item.childProcessId ? (
-                    <button
-                        type="button"
-                        onClick={() => onSelectChildProcess?.(item.childProcessId!)}
-                        className="rounded border border-sky-300 px-2 py-1 text-[11px] text-sky-700 hover:bg-sky-50 dark:border-sky-700 dark:text-sky-200 dark:hover:bg-sky-950/40"
-                        data-testid={`for-each-child-link-${item.id}`}
-                    >
-                        Open child chat
-                    </button>
-                ) : (
-                    <span className="text-[11px] text-zinc-400">Not started</span>
-                )}
-            </td>
-            <td className="px-2 py-2">
-                <div className="flex flex-wrap gap-1">
-                    <button
-                        type="button"
-                        onClick={onRetry}
-                        disabled={!canRetry || busyAction !== null}
-                        data-testid={`for-each-retry-${item.id}`}
-                        className="rounded border border-red-300 px-2 py-1 text-[11px] text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-950/40"
-                    >
-                        Retry
-                    </button>
-                    <button
-                        type="button"
-                        onClick={onSkip}
-                        disabled={!canSkip || busyAction !== null}
-                        data-testid={`for-each-skip-${item.id}`}
-                        className="rounded border border-amber-300 px-2 py-1 text-[11px] text-amber-700 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-950/40"
-                    >
-                        Skip
-                    </button>
-                </div>
-            </td>
-        </tr>
-    );
+export function ForEachRunPane(props: ForEachRunPaneProps) {
+    return <TaskGroupRunPane {...props} config={FOR_EACH_PANE_CONFIG} />;
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/MapReducePlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/MapReducePlanReviewCard.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
 import type {
     MapReduceChildMode,
     MapReduceItem,
     MapReducePlanArtifact,
     MapReducePlanScanResult,
-    MapReduceRun,
 } from '@plusplusoneplusplus/coc-client';
 import {
     DEFAULT_MAP_REDUCE_MAX_PARALLEL,
@@ -16,9 +14,12 @@ import {
     validateMapReduceDraftPlan,
 } from '@plusplusoneplusplus/coc-client';
 import type { ClientConversationTurn } from '../../types/dashboard';
-import { getSpaCocClientErrorMessage } from '../../api/cocClient';
-import { useCocClient } from '../../repos/cloneRouting';
 import { cn } from '../../ui/cn';
+import {
+    TaskGroupPlanReviewCard,
+    type TaskGroupPlanApproveArgs,
+    type TaskGroupPlanReviewConfig,
+} from './TaskGroupPlanReviewCard';
 
 export interface MapReduceGenerationMetadata {
     kind: 'generation';
@@ -105,45 +106,10 @@ function parseDraftJson(text: string): DraftPlan {
     };
 }
 
-function itemDependencyText(item: MapReduceItem): string {
-    return (item.dependsOn ?? []).join(', ');
-}
-
-function parseDependencies(value: string): string[] | undefined {
-    const deps = value.split(',').map(part => part.trim()).filter(Boolean);
-    return deps.length > 0 ? deps : undefined;
-}
-
-function makeNewItem(existing: MapReduceItem[]): MapReduceItem {
-    const used = new Set(existing.map(item => item.id));
-    let index = existing.length + 1;
-    let id = `item-${index}`;
-    while (used.has(id)) {
-        index += 1;
-        id = `item-${index}`;
-    }
-    return {
-        id,
-        title: `Item ${index}`,
-        prompt: '',
-        status: 'pending',
-    };
-}
-
 function isMapReduceGenerationMetadata(value: unknown): value is MapReduceGenerationMetadata {
     return !!value
         && typeof value === 'object'
         && (value as { kind?: unknown }).kind === 'generation';
-}
-
-function planJson(plan: Pick<DraftPlan, 'childMode' | 'sharedInstructions' | 'maxParallel' | 'reduceInstructions' | 'items'>): string {
-    return JSON.stringify({
-        childMode: plan.childMode,
-        sharedInstructions: plan.sharedInstructions || undefined,
-        maxParallel: plan.maxParallel,
-        reduceInstructions: plan.reduceInstructions,
-        items: plan.items,
-    }, null, 2);
 }
 
 function getPersistedPlanState(mapReduce: MapReduceGenerationMetadata): MapReducePlanScanResult {
@@ -170,7 +136,7 @@ function getPersistedPlanState(mapReduce: MapReduceGenerationMetadata): MapReduc
                 maxParallel,
                 rawJson: typeof latestPlan.rawJson === 'string'
                     ? latestPlan.rawJson
-                    : planJson({
+                    : formatDraftJson({
                         childMode: latestPlan.childMode,
                         sharedInstructions: sharedInstructions ?? '',
                         maxParallel,
@@ -198,390 +164,159 @@ function getPersistedPlanState(mapReduce: MapReduceGenerationMetadata): MapReduc
     return { plan, error };
 }
 
-function latestScanTurn(scan: MapReducePlanScanResult): number {
-    return Math.max(scan.plan?.turnIndex ?? -1, scan.error?.turnIndex ?? -1);
-}
-
-export function MapReducePlanReviewCard({
+async function approve({
+    client,
     workspaceId,
     processId,
+    meta: mapReduce,
     metadataProcess,
-    mapReduce,
-    turns,
+    draft,
+    scanPlanTurnIndex,
     provider,
     model,
     reasoningEffort,
-    onApprovedRun,
-}: MapReducePlanReviewCardProps) {
-    // AC-07: plan create/update/approve route to the selected clone's server.
-    const cloneClient = useCocClient(workspaceId);
-    const transcriptScan = useMemo(() => scanMapReducePlans(turns), [turns]);
-    const persistedScan = useMemo(() => getPersistedPlanState(mapReduce), [mapReduce]);
-    const scan = latestScanTurn(transcriptScan) > latestScanTurn(persistedScan)
-        ? transcriptScan
-        : persistedScan.plan || persistedScan.error
-            ? persistedScan
-            : transcriptScan;
-    const generatedKey = scan.plan ? `${scan.plan.turnIndex}:${scan.plan.rawJson}` : 'none';
-    const [loadedKey, setLoadedKey] = useState('');
-    const [baselineJson, setBaselineJson] = useState('');
-    const [draft, setDraft] = useState<DraftPlan | null>(null);
-    const [jsonOpen, setJsonOpen] = useState(false);
-    const [jsonText, setJsonText] = useState('');
-    const [jsonError, setJsonError] = useState<string | null>(null);
-    const [busy, setBusy] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [approvedRun, setApprovedRun] = useState<MapReduceRun | null>(null);
-
-    useEffect(() => {
-        if (!scan.plan || generatedKey === loadedKey) return;
-        const nextDraft: DraftPlan = {
-            childMode: scan.plan.childMode ?? mapReduce.childMode ?? 'ask',
-            sharedInstructions: scan.plan.sharedInstructions ?? '',
-            reduceInstructions: scan.plan.reduceInstructions,
-            maxParallel: scan.plan.maxParallel ?? DEFAULT_MAP_REDUCE_MAX_PARALLEL,
-            items: scan.plan.items,
-        };
-        const formatted = formatDraftJson(nextDraft);
-        setDraft(nextDraft);
-        setBaselineJson(formatted);
-        setJsonText(formatted);
-        setJsonError(null);
-        setLoadedKey(generatedKey);
-        setError(null);
-    }, [generatedKey, loadedKey, mapReduce.childMode, scan.plan]);
-
-    if (!scan.plan && !scan.error) return null;
-
-    const validation = draft
-        ? validateMapReduceDraftPlan({
+}: TaskGroupPlanApproveArgs<DraftPlan, MapReduceGenerationMetadata>) {
+    const run = mapReduce.runId
+        ? await client.mapReduce.updatePlan(workspaceId, mapReduce.runId, {
             items: draft.items,
+            sharedInstructions: draft.sharedInstructions,
             reduceInstructions: draft.reduceInstructions,
             maxParallel: draft.maxParallel,
+            childMode: draft.childMode,
         })
-        : { plan: null, error: 'No valid Map Reduce plan is available yet.' };
-    const currentJson = draft ? formatDraftJson(draft) : '';
-    const dirty = draft ? currentJson !== baselineJson : false;
-    const approvalBlocked = busy || !!jsonError || !!validation.error || !draft || !workspaceId || !processId || mapReduce.status === 'approved' || !!approvedRun;
-    const linkedRunId = approvedRun?.runId ?? mapReduce.runId;
-
-    function applyDraft(next: DraftPlan) {
-        setDraft(next);
-        setJsonText(formatDraftJson(next));
-        setJsonError(null);
-        setError(null);
-    }
-
-    function updateItem(index: number, patch: Partial<MapReduceItem>) {
-        if (!draft) return;
-        applyDraft({
-            ...draft,
-            items: draft.items.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item),
+        : await client.mapReduce.create(workspaceId, {
+            originalRequest: mapReduce.originalRequest,
+            items: draft.items,
+            sharedInstructions: draft.sharedInstructions,
+            reduceInstructions: draft.reduceInstructions,
+            maxParallel: draft.maxParallel,
+            childMode: draft.childMode,
+            provider,
+            config: model || reasoningEffort ? { ...(model ? { model } : {}), ...(reasoningEffort ? { reasoningEffort } : {}) } : undefined,
+            generationProcessId: processId,
+            generationId: mapReduce.generationId,
         });
-    }
+    const approved = run.status === 'approved'
+        ? run
+        : await client.mapReduce.approve(workspaceId, run.runId);
 
-    function moveItem(index: number, direction: -1 | 1) {
-        if (!draft) return;
-        const target = index + direction;
-        if (target < 0 || target >= draft.items.length) return;
-        const items = [...draft.items];
-        const [item] = items.splice(index, 1);
-        items.splice(target, 0, item);
-        applyDraft({ ...draft, items });
-    }
+    const currentMetadata = (metadataProcess?.metadata ?? {}) as Record<string, unknown>;
+    const currentMapReduce = isMapReduceGenerationMetadata(currentMetadata.mapReduce) ? currentMetadata.mapReduce : mapReduce;
+    const nextMapReduce: MapReduceGenerationMetadata = {
+        ...currentMapReduce,
+        status: 'approved',
+        runId: approved.runId,
+        latestItemCount: approved.items.length,
+        latestPlanTurnIndex: scanPlanTurnIndex,
+        latestPlan: {
+            turnIndex: scanPlanTurnIndex ?? currentMapReduce.latestPlan?.turnIndex ?? 0,
+            childMode: draft.childMode,
+            sharedInstructions: draft.sharedInstructions || undefined,
+            reduceInstructions: draft.reduceInstructions,
+            maxParallel: draft.maxParallel,
+            items: draft.items,
+            rawJson: formatDraftJson(draft),
+            updatedAt: new Date().toISOString(),
+        },
+    };
+    delete nextMapReduce.lastPlanError;
+    delete nextMapReduce.lastPlanErrorTurnIndex;
+    await client.processes.patchMetadata(processId, {
+        set: { mapReduce: nextMapReduce },
+    }, { workspace: workspaceId });
+    return approved;
+}
 
-    function removeItem(index: number) {
-        if (!draft) return;
-        applyDraft({ ...draft, items: draft.items.filter((_, itemIndex) => itemIndex !== index) });
-    }
-
-    function handleJsonChange(value: string) {
-        setJsonText(value);
-        setError(null);
-        try {
-            const parsed = parseDraftJson(value);
-            setDraft(parsed);
-            setJsonError(null);
-        } catch (err) {
-            setJsonError(err instanceof Error ? err.message : String(err));
-        }
-    }
-
-    async function approveRun() {
-        if (!draft || !workspaceId || !processId) return;
+const MAP_REDUCE_PLAN_CONFIG: TaskGroupPlanReviewConfig<DraftPlan, MapReduceGenerationMetadata> = {
+    testIdPrefix: 'map-reduce',
+    heading: 'Proposed Map Reduce plan',
+    itemNoun: 'map item',
+    addItemLabel: 'Add map item',
+    description: 'Review and approve only. Map and reduce child chats start later from the Map Reduce run pane.',
+    scanErrorNoun: 'Map Reduce plan',
+    noPlanText: 'No valid Map Reduce plan is available yet.',
+    approveErrorFallback: 'Failed to approve Map Reduce plan',
+    topGridClassName: 'md:grid-cols-[minmax(0,1fr)_9rem_auto]',
+    accent: {
+        card: 'border-indigo-200 bg-indigo-50/70 dark:border-indigo-900/60 dark:bg-indigo-950/20',
+        headingText: 'text-indigo-900 dark:text-indigo-100',
+        pill: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-100',
+        subText: 'text-indigo-800/80 dark:text-indigo-200/80',
+        openRunButton: 'border-indigo-300 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-100 dark:hover:bg-indigo-900/60',
+        editorBorder: 'border-indigo-200 dark:border-indigo-900',
+        childModeActive: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/60 dark:text-indigo-100',
+        hairlineBorder: 'border-indigo-100 dark:border-indigo-900/70',
+        addItemButton: 'border-indigo-300 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-100',
+        jsonSummaryText: 'text-indigo-800 dark:text-indigo-100',
+        approveButton: 'bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-300 dark:disabled:bg-indigo-900',
+    },
+    scanTranscript: scanMapReducePlans,
+    getPersistedPlanState,
+    buildDraft: (plan: MapReducePlanArtifact, mapReduce) => ({
+        childMode: plan.childMode ?? mapReduce.childMode ?? 'ask',
+        sharedInstructions: plan.sharedInstructions ?? '',
+        reduceInstructions: plan.reduceInstructions,
+        maxParallel: plan.maxParallel ?? DEFAULT_MAP_REDUCE_MAX_PARALLEL,
+        items: plan.items,
+    }),
+    formatDraftJson,
+    parseDraftJson,
+    validate: draft => {
         const checked = validateMapReduceDraftPlan({
             items: draft.items,
             reduceInstructions: draft.reduceInstructions,
             maxParallel: draft.maxParallel,
         });
         if (checked.error || !checked.plan) {
-            setError(checked.error ?? 'Invalid Map Reduce plan');
-            return;
+            return { draft: null, error: checked.error ?? 'Invalid Map Reduce plan' };
         }
-        setBusy(true);
-        setError(null);
-        try {
-            const client = cloneClient;
-            const run = mapReduce.runId
-                ? await client.mapReduce.updatePlan(workspaceId, mapReduce.runId, {
-                    items: checked.plan.items,
-                    sharedInstructions: draft.sharedInstructions,
-                    reduceInstructions: checked.plan.reduceInstructions,
-                    maxParallel: checked.plan.maxParallel,
-                    childMode: draft.childMode,
-                })
-                : await client.mapReduce.create(workspaceId, {
-                    originalRequest: mapReduce.originalRequest,
-                    items: checked.plan.items,
-                    sharedInstructions: draft.sharedInstructions,
-                    reduceInstructions: checked.plan.reduceInstructions,
-                    maxParallel: checked.plan.maxParallel,
-                    childMode: draft.childMode,
-                    provider,
-                    config: model || reasoningEffort ? { ...(model ? { model } : {}), ...(reasoningEffort ? { reasoningEffort } : {}) } : undefined,
-                    generationProcessId: processId,
-                    generationId: mapReduce.generationId,
-                });
-            const approved = run.status === 'approved'
-                ? run
-                : await client.mapReduce.approve(workspaceId, run.runId);
-            setApprovedRun(approved);
-
-            const currentMetadata = (metadataProcess?.metadata ?? {}) as Record<string, unknown>;
-            const currentMapReduce = isMapReduceGenerationMetadata(currentMetadata.mapReduce) ? currentMetadata.mapReduce : mapReduce;
-            const nextMapReduce: MapReduceGenerationMetadata = {
-                ...currentMapReduce,
-                status: 'approved',
-                runId: approved.runId,
-                latestItemCount: approved.items.length,
-                latestPlanTurnIndex: scan.plan?.turnIndex,
-                latestPlan: {
-                    turnIndex: scan.plan?.turnIndex ?? currentMapReduce.latestPlan?.turnIndex ?? 0,
-                    childMode: draft.childMode,
-                    sharedInstructions: draft.sharedInstructions || undefined,
-                    reduceInstructions: checked.plan.reduceInstructions,
-                    maxParallel: checked.plan.maxParallel,
-                    items: checked.plan.items,
-                    rawJson: formatDraftJson({
-                        ...draft,
-                        items: checked.plan.items,
-                        reduceInstructions: checked.plan.reduceInstructions,
-                        maxParallel: checked.plan.maxParallel,
-                    }),
-                    updatedAt: new Date().toISOString(),
-                },
-            };
-            delete nextMapReduce.lastPlanError;
-            delete nextMapReduce.lastPlanErrorTurnIndex;
-            await client.processes.patchMetadata(processId, {
-                set: { mapReduce: nextMapReduce },
-            }, { workspace: workspaceId });
-            onApprovedRun?.(approved.runId);
-        } catch (err) {
-            setError(getSpaCocClientErrorMessage(err, 'Failed to approve Map Reduce plan'));
-        } finally {
-            setBusy(false);
-        }
-    }
-
-    return (
-        <section
-            className="mx-4 mb-3 rounded-lg border border-indigo-200 bg-indigo-50/70 p-3 text-xs shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/20"
-            data-testid="map-reduce-plan-review-card"
+        return {
+            draft: {
+                ...draft,
+                items: checked.plan.items,
+                reduceInstructions: checked.plan.reduceInstructions,
+                maxParallel: checked.plan.maxParallel,
+            },
+            error: null,
+        };
+    },
+    approve,
+    renderHeaderPills: draft => (
+        <span
+            className={cn('rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide', 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-100')}
+            data-testid="map-reduce-plan-max-parallel-pill"
         >
-            <div className="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                    <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-indigo-900 dark:text-indigo-100">Proposed Map Reduce plan</h3>
-                        <span className="rounded bg-indigo-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-100">
-                            {draft?.items.length ?? 0} map item{draft?.items.length === 1 ? '' : 's'}
-                        </span>
-                        {draft && (
-                            <span className="rounded bg-indigo-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-100" data-testid="map-reduce-plan-max-parallel-pill">
-                                max {draft.maxParallel} parallel
-                            </span>
-                        )}
-                        {dirty && <span className="text-[10px] font-medium text-amber-700 dark:text-amber-300" data-testid="map-reduce-plan-dirty">Edited</span>}
-                    </div>
-                    <p className="mt-0.5 text-[11px] text-indigo-800/80 dark:text-indigo-200/80">
-                        Review and approve only. Map and reduce child chats start later from the Map Reduce run pane.
-                    </p>
-                </div>
-                {linkedRunId && (
-                    <button
-                        type="button"
-                        className="rounded border border-indigo-300 bg-white px-2 py-1 text-[11px] font-medium text-indigo-700 hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-100 dark:hover:bg-indigo-900/60"
-                        onClick={() => onApprovedRun?.(linkedRunId)}
-                        data-testid="map-reduce-open-run-btn"
-                    >
-                        Open run
-                    </button>
-                )}
-            </div>
+            max {draft.maxParallel} parallel
+        </span>
+    ),
+    renderExtraTopFields: (draft, applyDraft) => (
+        <label className="block">
+            <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Max parallel</span>
+            <input
+                type="number"
+                min={1}
+                step={1}
+                value={draft.maxParallel}
+                onChange={(e) => applyDraft({ ...draft, maxParallel: Number(e.target.value) })}
+                className="w-full rounded border border-indigo-200 bg-white px-2 py-1 text-xs dark:border-indigo-900 dark:bg-zinc-950"
+                data-testid="map-reduce-max-parallel-editor"
+            />
+        </label>
+    ),
+    renderExtraSections: (draft, applyDraft) => (
+        <label className="block">
+            <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Reduce instructions</span>
+            <textarea
+                value={draft.reduceInstructions}
+                onChange={(e) => applyDraft({ ...draft, reduceInstructions: e.target.value })}
+                rows={3}
+                className="w-full resize-y rounded border border-indigo-200 bg-white p-2 text-xs text-zinc-900 dark:border-indigo-900 dark:bg-zinc-950 dark:text-zinc-100"
+                data-testid="map-reduce-reduce-instructions-editor"
+            />
+        </label>
+    ),
+};
 
-            {scan.error && (
-                <div className="mt-3 rounded border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200" data-testid="map-reduce-plan-scan-error">
-                    Latest assistant output did not contain a valid Map Reduce plan: {scan.error.message}. Keeping the previous valid plan.
-                </div>
-            )}
-
-            {draft && (
-                <div className="mt-3 space-y-3">
-                    <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_9rem_auto]">
-                        <label className="block">
-                            <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Shared instructions</span>
-                            <textarea
-                                value={draft.sharedInstructions}
-                                onChange={(e) => applyDraft({ ...draft, sharedInstructions: e.target.value })}
-                                rows={2}
-                                className="w-full resize-y rounded border border-indigo-200 bg-white p-2 text-xs text-zinc-900 dark:border-indigo-900 dark:bg-zinc-950 dark:text-zinc-100"
-                                data-testid="map-reduce-shared-instructions-editor"
-                            />
-                        </label>
-                        <label className="block">
-                            <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Max parallel</span>
-                            <input
-                                type="number"
-                                min={1}
-                                step={1}
-                                value={draft.maxParallel}
-                                onChange={(e) => applyDraft({ ...draft, maxParallel: Number(e.target.value) })}
-                                className="w-full rounded border border-indigo-200 bg-white px-2 py-1 text-xs dark:border-indigo-900 dark:bg-zinc-950"
-                                data-testid="map-reduce-max-parallel-editor"
-                            />
-                        </label>
-                        <div>
-                            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Child mode</div>
-                            <div className="inline-flex rounded border border-indigo-200 bg-white p-0.5 dark:border-indigo-900 dark:bg-zinc-950" data-testid="map-reduce-plan-child-mode">
-                                {(['ask', 'autopilot'] as const).map(mode => (
-                                    <button
-                                        key={mode}
-                                        type="button"
-                                        onClick={() => applyDraft({ ...draft, childMode: mode })}
-                                        className={cn(
-                                            'rounded px-2 py-1 text-[11px] font-medium',
-                                            draft.childMode === mode
-                                                ? 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/60 dark:text-indigo-100'
-                                                : 'text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900',
-                                        )}
-                                        data-testid={`map-reduce-plan-child-mode-${mode}`}
-                                    >
-                                        {mode === 'ask' ? 'Ask' : 'Autopilot'}
-                                    </button>
-                                ))}
-                            </div>
-                        </div>
-                    </div>
-
-                    <label className="block">
-                        <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Reduce instructions</span>
-                        <textarea
-                            value={draft.reduceInstructions}
-                            onChange={(e) => applyDraft({ ...draft, reduceInstructions: e.target.value })}
-                            rows={3}
-                            className="w-full resize-y rounded border border-indigo-200 bg-white p-2 text-xs text-zinc-900 dark:border-indigo-900 dark:bg-zinc-950 dark:text-zinc-100"
-                            data-testid="map-reduce-reduce-instructions-editor"
-                        />
-                    </label>
-
-                    <div className="space-y-2" data-testid="map-reduce-plan-items">
-                        {draft.items.map((item, index) => (
-                            <div key={`${item.id}:${index}`} className="rounded border border-indigo-100 bg-white p-2 dark:border-indigo-900/70 dark:bg-zinc-950" data-testid={`map-reduce-plan-item-${item.id}`}>
-                                <div className="grid gap-2 md:grid-cols-[10rem_minmax(0,1fr)_auto]">
-                                    <label className="block">
-                                        <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">ID</span>
-                                        <input
-                                            value={item.id}
-                                            onChange={(e) => updateItem(index, { id: e.target.value })}
-                                            className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                            data-testid={`map-reduce-plan-item-id-${index}`}
-                                        />
-                                    </label>
-                                    <label className="block">
-                                        <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Title</span>
-                                        <input
-                                            value={item.title}
-                                            onChange={(e) => updateItem(index, { title: e.target.value })}
-                                            className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                            data-testid={`map-reduce-plan-item-title-${index}`}
-                                        />
-                                    </label>
-                                    <div className="flex items-end gap-1">
-                                        <button type="button" onClick={() => moveItem(index, -1)} disabled={index === 0} className="rounded border border-zinc-200 px-2 py-1 text-[11px] disabled:opacity-40 dark:border-zinc-800" data-testid={`map-reduce-plan-item-up-${index}`}>Up</button>
-                                        <button type="button" onClick={() => moveItem(index, 1)} disabled={index === draft.items.length - 1} className="rounded border border-zinc-200 px-2 py-1 text-[11px] disabled:opacity-40 dark:border-zinc-800" data-testid={`map-reduce-plan-item-down-${index}`}>Down</button>
-                                        <button type="button" onClick={() => removeItem(index)} className="rounded border border-red-200 px-2 py-1 text-[11px] text-red-700 dark:border-red-900 dark:text-red-200" data-testid={`map-reduce-plan-item-remove-${index}`}>Remove</button>
-                                    </div>
-                                </div>
-                                <label className="mt-2 block">
-                                    <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Prompt</span>
-                                    <textarea
-                                        value={item.prompt}
-                                        onChange={(e) => updateItem(index, { prompt: e.target.value })}
-                                        rows={3}
-                                        className="w-full resize-y rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                        data-testid={`map-reduce-plan-item-prompt-${index}`}
-                                    />
-                                </label>
-                                <label className="mt-2 block">
-                                    <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Dependencies</span>
-                                    <input
-                                        value={itemDependencyText(item)}
-                                        onChange={(e) => updateItem(index, { dependsOn: parseDependencies(e.target.value) })}
-                                        placeholder="item-1, item-2"
-                                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                                        data-testid={`map-reduce-plan-item-deps-${index}`}
-                                    />
-                                </label>
-                            </div>
-                        ))}
-                    </div>
-
-                    <button
-                        type="button"
-                        onClick={() => applyDraft({ ...draft, items: [...draft.items, makeNewItem(draft.items)] })}
-                        className="rounded border border-indigo-300 bg-white px-2 py-1 text-[11px] font-medium text-indigo-700 hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-100"
-                        data-testid="map-reduce-plan-add-item"
-                    >
-                        Add map item
-                    </button>
-
-                    <details open={jsonOpen} onToggle={(event) => setJsonOpen(event.currentTarget.open)} className="rounded border border-indigo-100 bg-white p-2 dark:border-indigo-900/70 dark:bg-zinc-950">
-                        <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-indigo-800 dark:text-indigo-100" data-testid="map-reduce-plan-json-toggle">
-                            Advanced JSON
-                        </summary>
-                        <textarea
-                            value={jsonText}
-                            onChange={(e) => handleJsonChange(e.target.value)}
-                            rows={10}
-                            className="mt-2 w-full resize-y rounded border border-zinc-200 bg-white p-2 font-mono text-xs text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
-                            data-testid="map-reduce-plan-json"
-                        />
-                        {jsonError && (
-                            <p className="mt-1 text-[11px] text-red-600 dark:text-red-300" data-testid="map-reduce-plan-json-error">{jsonError}</p>
-                        )}
-                    </details>
-
-                    <div className="flex flex-wrap items-center justify-between gap-2 border-t border-indigo-100 pt-2 dark:border-indigo-900/70">
-                        <div>
-                            {validation.error ? (
-                                <p className="text-[11px] text-red-600 dark:text-red-300" data-testid="map-reduce-plan-validation-error">{validation.error}</p>
-                            ) : (
-                                <p className="text-[11px] text-emerald-700 dark:text-emerald-300" data-testid="map-reduce-plan-validation-ok">Plan is valid and ready for approval.</p>
-                            )}
-                            {error && <p className="mt-1 text-[11px] text-red-600 dark:text-red-300" data-testid="map-reduce-plan-approve-error">{error}</p>}
-                        </div>
-                        <button
-                            type="button"
-                            onClick={() => void approveRun()}
-                            disabled={approvalBlocked}
-                            className="rounded bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-300 dark:disabled:bg-indigo-900"
-                            data-testid="map-reduce-plan-approve-btn"
-                        >
-                            {busy ? 'Approving...' : mapReduce.status === 'approved' || approvedRun ? 'Approved' : 'Approve run'}
-                        </button>
-                    </div>
-                </div>
-            )}
-        </section>
-    );
+export function MapReducePlanReviewCard({ mapReduce, ...rest }: MapReducePlanReviewCardProps) {
+    return <TaskGroupPlanReviewCard {...rest} meta={mapReduce} config={MAP_REDUCE_PLAN_CONFIG} />;
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/MapReduceRunPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/MapReduceRunPane.tsx
@@ -1,6 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
 import type {
-    MapReduceItem,
     MapReduceItemStatus,
     MapReduceReduceStep,
     MapReduceReduceStepStatus,
@@ -8,9 +6,11 @@ import type {
     MapReduceRunStatus,
 } from '@plusplusoneplusplus/coc-client';
 import { cn } from '../../ui/cn';
-import { getSpaCocClientErrorMessage } from '../../api/cocClient';
-import { useCocClient } from '../../repos/cloneRouting';
-import { formatRelativeTime } from '../../utils/format';
+import {
+    TaskGroupRunPane,
+    type TaskGroupRunPaneActionContext,
+    type TaskGroupRunPaneConfig,
+} from './TaskGroupRunPane';
 
 export interface MapReduceRunPaneProps {
     workspaceId: string;
@@ -46,29 +46,6 @@ const REDUCE_STATUS_CLASS: Record<MapReduceReduceStepStatus, string> = {
     cancelled: 'bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-100',
 };
 
-function singleLine(text: string, max = 120): string {
-    const flat = text.replace(/\s+/g, ' ').trim();
-    return flat.length > max ? flat.slice(0, max - 3) + '...' : flat;
-}
-
-function countItems(run: MapReduceRun): string {
-    const counts = new Map<MapReduceItemStatus, number>();
-    for (const item of run.items) counts.set(item.status, (counts.get(item.status) ?? 0) + 1);
-    return Array.from(counts.entries()).map(([status, count]) => `${count} ${status}`).join(' - ');
-}
-
-function hasRunningItem(run: MapReduceRun): boolean {
-    return run.items.some(item => item.status === 'running');
-}
-
-function hasFailedItem(run: MapReduceRun): boolean {
-    return run.items.some(item => item.status === 'failed');
-}
-
-function hasPendingItem(run: MapReduceRun): boolean {
-    return run.items.some(item => item.status === 'pending');
-}
-
 function canCancel(run: MapReduceRun): boolean {
     return run.status === 'draft' || run.status === 'approved' || run.status === 'running' || run.status === 'reducing' || run.status === 'failed';
 }
@@ -76,7 +53,9 @@ function canCancel(run: MapReduceRun): boolean {
 function canStartOrContinue(run: MapReduceRun): boolean {
     if (run.status === 'approved') return true;
     if (run.status === 'running') {
-        return !hasRunningItem(run) && !hasFailedItem(run) && hasPendingItem(run);
+        return !run.items.some(item => item.status === 'running')
+            && !run.items.some(item => item.status === 'failed')
+            && run.items.some(item => item.status === 'pending');
     }
     if (run.status === 'reducing') {
         return run.reduceStep.status === 'pending';
@@ -84,210 +63,63 @@ function canStartOrContinue(run: MapReduceRun): boolean {
     return false;
 }
 
-function promptPreview(item: MapReduceItem): string {
-    return singleLine(item.prompt, 220);
+const MAP_REDUCE_PANE_CONFIG: TaskGroupRunPaneConfig<MapReduceRun> = {
+    testIdPrefix: 'map-reduce',
+    label: 'Map Reduce',
+    itemColumnHeader: 'Map item',
+    childChatLabel: 'Open map chat',
+    generationButtonClassName: 'border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-100 dark:hover:bg-indigo-900/60',
+    primaryButtonClassName: 'border-indigo-500 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-400 dark:bg-indigo-900/30 dark:text-indigo-100',
+    childLinkClassName: 'border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-200 dark:hover:bg-indigo-950/40',
+    runStatusClassName: status => RUN_STATUS_CLASS[status],
+    itemStatusClassName: status => ITEM_STATUS_CLASS[status as MapReduceItemStatus],
+    canCancel,
+    canStartOrContinue,
+    api: {
+        get: (client, workspaceId, runId) => client.mapReduce.get(workspaceId, runId),
+        start: (client, workspaceId, runId) => client.mapReduce.start(workspaceId, runId),
+        continue: (client, workspaceId, runId) => client.mapReduce.continue(workspaceId, runId),
+        cancel: (client, workspaceId, runId) => client.mapReduce.cancel(workspaceId, runId),
+        retryItem: (client, workspaceId, runId, itemId) => client.mapReduce.retryItem(workspaceId, runId, itemId),
+        skipItem: (client, workspaceId, runId, itemId) => client.mapReduce.skipItem(workspaceId, runId, itemId),
+    },
+    renderHeaderMeta: run => (
+        <>
+            <span>Reduce: {run.reduceStep.status}</span>
+            <span>Max parallel: {run.maxParallel}</span>
+        </>
+    ),
+    renderExtraSections: (run, ctx) => <ReduceStepSection run={run} ctx={ctx} />,
+};
+
+export function MapReduceRunPane(props: MapReduceRunPaneProps) {
+    return <TaskGroupRunPane {...props} config={MAP_REDUCE_PANE_CONFIG} />;
 }
 
-export function MapReduceRunPane({ workspaceId, runId, onClose, onSelectGenerationProcess, onSelectChildProcess }: MapReduceRunPaneProps) {
-    // AC-07: Map Reduce run data + actions target the selected clone's server.
-    const cloneClient = useCocClient(workspaceId);
-    const [run, setRun] = useState<MapReduceRun | null | undefined>(undefined);
-    const [busyAction, setBusyAction] = useState<string | null>(null);
-    const [error, setError] = useState<string | null>(null);
+interface ReduceStepSectionProps {
+    run: MapReduceRun;
+    ctx: TaskGroupRunPaneActionContext;
+}
 
-    const refresh = useCallback(async () => {
-        try {
-            const nextRun = await cloneClient.mapReduce.get(workspaceId, runId);
-            setRun(nextRun);
-            setError(null);
-        } catch (err) {
-            setRun(null);
-            setError(getSpaCocClientErrorMessage(err, 'Failed to load Map Reduce run'));
-        }
-    }, [workspaceId, runId, cloneClient]);
-
-    useEffect(() => {
-        setRun(undefined);
-        void refresh();
-    }, [refresh]);
-
-    async function runAction(actionId: string, action: () => Promise<MapReduceRun>) {
-        setBusyAction(actionId);
-        setError(null);
-        try {
-            const nextRun = await action();
-            setRun(nextRun);
-        } catch (err) {
-            setError(getSpaCocClientErrorMessage(err, 'Map Reduce action failed'));
-        } finally {
-            setBusyAction(null);
-        }
-    }
-
-    if (run === undefined) {
-        return (
-            <div className="flex h-full items-center justify-center text-sm text-zinc-500 dark:text-zinc-400" data-testid="map-reduce-run-pane-loading">
-                Loading Map Reduce run...
-            </div>
-        );
-    }
-
-    if (run === null) {
-        return (
-            <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400" data-testid="map-reduce-run-pane-empty">
-                <p>Map Reduce run not found.</p>
-                <p className="text-xs">Run id: <code className="font-mono">{runId}</code></p>
-                {error && <p className="text-xs text-red-600 dark:text-red-300">{error}</p>}
-            </div>
-        );
-    }
-
-    const startContinueEnabled = canStartOrContinue(run);
-    const cancelEnabled = canCancel(run);
-    const startOrContinue = () => {
-        if (run.status === 'approved') {
-            return cloneClient.mapReduce.start(workspaceId, run.runId);
-        }
-        return cloneClient.mapReduce.continue(workspaceId, run.runId);
-    };
-    const generationProcessId = run.generationProcessId;
-
+function ReduceStepSection({ run, ctx }: ReduceStepSectionProps) {
     return (
-        <div className="flex h-full flex-col overflow-hidden bg-white dark:bg-zinc-950" data-testid="map-reduce-run-pane">
-            <div className="flex flex-wrap items-start gap-2 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
-                <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                        <h2 className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                            Map Reduce: {singleLine(run.originalRequest, 90)}
-                        </h2>
-                        <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', RUN_STATUS_CLASS[run.status])} data-testid="map-reduce-run-status">
-                            {run.status}
-                        </span>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
-                        <span data-testid="map-reduce-run-counts">{countItems(run)}</span>
-                        <span>Reduce: {run.reduceStep.status}</span>
-                        <span>Max parallel: {run.maxParallel}</span>
-                        <span>Child mode: {run.childMode === 'ask' ? 'Ask' : 'Autopilot'}</span>
-                        <span>Updated {formatRelativeTime(run.updatedAt)}</span>
-                        {run.provider && <span>Provider: {run.provider}</span>}
-                    </div>
+        <section className="mb-3 rounded border border-indigo-200 bg-indigo-50/60 p-3 dark:border-indigo-900/60 dark:bg-indigo-950/20" data-testid="map-reduce-reduce-step">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Reduce step</h3>
+                    <p className="mt-1 whitespace-pre-wrap text-xs text-indigo-900/80 dark:text-indigo-100/80">{run.reduceInstructions}</p>
                 </div>
-                <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
-                    {generationProcessId && onSelectGenerationProcess && (
-                        <button
-                            type="button"
-                            onClick={() => onSelectGenerationProcess(generationProcessId)}
-                            data-testid="map-reduce-generation-link-btn"
-                            className="rounded border border-indigo-300 bg-white px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-50 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-100 dark:hover:bg-indigo-900/60"
-                        >
-                            Open generation chat
-                        </button>
-                    )}
-                    <button
-                        type="button"
-                        onClick={() => runAction('continue', startOrContinue)}
-                        disabled={!startContinueEnabled || busyAction !== null}
-                        data-testid="map-reduce-continue-btn"
-                        className="rounded border border-indigo-500 bg-indigo-50 px-2 py-1 text-xs text-indigo-700 hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-indigo-400 dark:bg-indigo-900/30 dark:text-indigo-100"
-                    >
-                        {run.status === 'approved' ? 'Start' : 'Continue'}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => runAction('cancel', () => cloneClient.mapReduce.cancel(workspaceId, run.runId))}
-                        disabled={!cancelEnabled || busyAction !== null}
-                        data-testid="map-reduce-cancel-btn"
-                        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    >
-                        Cancel remaining
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => void refresh()}
-                        disabled={busyAction !== null}
-                        data-testid="map-reduce-refresh-btn"
-                        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    >
-                        Refresh
-                    </button>
-                    {onClose && (
-                        <button
-                            type="button"
-                            onClick={onClose}
-                            data-testid="map-reduce-close-btn"
-                            className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                        >
-                            Close
-                        </button>
-                    )}
-                </div>
+                <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', REDUCE_STATUS_CLASS[run.reduceStep.status])} data-testid="map-reduce-reduce-status">
+                    {run.reduceStep.status}
+                </span>
             </div>
-
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-                {error && (
-                    <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200" data-testid="map-reduce-run-error">
-                        {error}
-                    </div>
-                )}
-
-                <section className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/40" data-testid="map-reduce-original-request">
-                    <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Original request</h3>
-                    <p className="whitespace-pre-wrap text-xs text-zinc-700 dark:text-zinc-200">{run.originalRequest}</p>
-                </section>
-
-                {run.sharedInstructions?.trim() && (
-                    <section className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/40" data-testid="map-reduce-shared-instructions-preview">
-                        <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Shared instructions</h3>
-                        <p className="whitespace-pre-wrap text-xs text-zinc-700 dark:text-zinc-200">{run.sharedInstructions}</p>
-                    </section>
-                )}
-
-                <section className="mb-3 rounded border border-indigo-200 bg-indigo-50/60 p-3 dark:border-indigo-900/60 dark:bg-indigo-950/20" data-testid="map-reduce-reduce-step">
-                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                        <div>
-                            <h3 className="text-xs font-semibold uppercase tracking-wide text-indigo-900 dark:text-indigo-100">Reduce step</h3>
-                            <p className="mt-1 whitespace-pre-wrap text-xs text-indigo-900/80 dark:text-indigo-100/80">{run.reduceInstructions}</p>
-                        </div>
-                        <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', REDUCE_STATUS_CLASS[run.reduceStep.status])} data-testid="map-reduce-reduce-status">
-                            {run.reduceStep.status}
-                        </span>
-                    </div>
-                    <ReduceStepActions
-                        reduceStep={run.reduceStep}
-                        busyAction={busyAction}
-                        onSelectChildProcess={onSelectChildProcess}
-                        onRetry={() => runAction('retry-reduce', () => cloneClient.mapReduce.retryReduce(workspaceId, run.runId))}
-                    />
-                </section>
-
-                <div className="overflow-hidden rounded border border-zinc-200 dark:border-zinc-800">
-                    <table className="w-full table-fixed text-left text-xs" data-testid="map-reduce-items-table">
-                        <thead className="bg-zinc-50 text-[11px] uppercase tracking-wide text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
-                            <tr>
-                                <th className="w-32 px-2 py-2">Status</th>
-                                <th className="w-56 px-2 py-2">Map item</th>
-                                <th className="px-2 py-2">Prompt preview</th>
-                                <th className="w-44 px-2 py-2">Child chat</th>
-                                <th className="w-40 px-2 py-2">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                            {run.items.map(item => (
-                                <MapReduceItemRow
-                                    key={item.id}
-                                    item={item}
-                                    busyAction={busyAction}
-                                    onSelectChildProcess={onSelectChildProcess}
-                                    onRetry={() => runAction(`retry:${item.id}`, () => cloneClient.mapReduce.retryItem(workspaceId, run.runId, item.id))}
-                                    onSkip={() => runAction(`skip:${item.id}`, () => cloneClient.mapReduce.skipItem(workspaceId, run.runId, item.id))}
-                                />
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
+            <ReduceStepActions
+                reduceStep={run.reduceStep}
+                busyAction={ctx.busyAction}
+                onSelectChildProcess={ctx.onSelectChildProcess}
+                onRetry={() => void ctx.runAction('retry-reduce', () => ctx.client.mapReduce.retryReduce(ctx.workspaceId, run.runId))}
+            />
+        </section>
     );
 }
 
@@ -329,83 +161,5 @@ function ReduceStepActions({ reduceStep, busyAction, onSelectChildProcess, onRet
                 Retry reduce
             </button>
         </div>
-    );
-}
-
-interface MapReduceItemRowProps {
-    item: MapReduceItem;
-    busyAction: string | null;
-    onSelectChildProcess?: (processId: string) => void;
-    onRetry: () => void;
-    onSkip: () => void;
-}
-
-function MapReduceItemRow({ item, busyAction, onSelectChildProcess, onRetry, onSkip }: MapReduceItemRowProps) {
-    const canRetry = item.status === 'failed';
-    const canSkip = item.status === 'failed' || item.status === 'pending';
-
-    return (
-        <tr data-testid={`map-reduce-item-${item.id}`} className="align-top text-zinc-800 dark:text-zinc-100">
-            <td className="px-2 py-2">
-                <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', ITEM_STATUS_CLASS[item.status])}>
-                    {item.status}
-                </span>
-                {item.error && (
-                    <p className="mt-1 line-clamp-3 text-[11px] text-red-600 dark:text-red-300" title={item.error}>
-                        {item.error}
-                    </p>
-                )}
-            </td>
-            <td className="px-2 py-2">
-                <div className="font-medium">{item.title}</div>
-                <div className="mt-1 font-mono text-[10px] text-zinc-500 dark:text-zinc-400">{item.id}</div>
-                {item.dependsOn && item.dependsOn.length > 0 && (
-                    <div className="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
-                        Depends on {item.dependsOn.join(', ')}
-                    </div>
-                )}
-            </td>
-            <td className="px-2 py-2">
-                <p className="line-clamp-4 text-zinc-700 dark:text-zinc-200" title={item.prompt} data-testid={`map-reduce-item-prompt-${item.id}`}>
-                    {promptPreview(item)}
-                </p>
-            </td>
-            <td className="px-2 py-2">
-                {item.childProcessId ? (
-                    <button
-                        type="button"
-                        onClick={() => onSelectChildProcess?.(item.childProcessId!)}
-                        className="rounded border border-indigo-300 px-2 py-1 text-[11px] text-indigo-700 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-200 dark:hover:bg-indigo-950/40"
-                        data-testid={`map-reduce-child-link-${item.id}`}
-                    >
-                        Open map chat
-                    </button>
-                ) : (
-                    <span className="text-[11px] text-zinc-400">Not started</span>
-                )}
-            </td>
-            <td className="px-2 py-2">
-                <div className="flex flex-wrap gap-1">
-                    <button
-                        type="button"
-                        onClick={onRetry}
-                        disabled={!canRetry || busyAction !== null}
-                        data-testid={`map-reduce-retry-${item.id}`}
-                        className="rounded border border-red-300 px-2 py-1 text-[11px] text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-950/40"
-                    >
-                        Retry
-                    </button>
-                    <button
-                        type="button"
-                        onClick={onSkip}
-                        disabled={!canSkip || busyAction !== null}
-                        data-testid={`map-reduce-skip-${item.id}`}
-                        className="rounded border border-amber-300 px-2 py-1 text-[11px] text-amber-700 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-950/40"
-                    >
-                        Skip
-                    </button>
-                </div>
-            </td>
-        </tr>
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/RalphSessionRow.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/RalphSessionRow.tsx
@@ -1,21 +1,19 @@
 /**
  * RalphSessionRow — collapsible group row for a Ralph session.
  *
- * Visually mirrors `HistoryGroupHeader` (plan-file groups): a compact one-line
- * row in the same `[10px_30px_minmax(0,1fr)_auto]` grid with a status dot,
- * compact `R` mode pill, chevron toggle, title, child-count badge, and relative
- * time. Phase is signaled entirely via the status-dot color (no separate
- * phase badge). Children are rendered inline (no decorative wrapper) by
- * delegating to the caller's `renderTaskCard` with `{ isGroupChild: true }`.
+ * Thin wrapper over the shared `TaskGroupRunRow` chrome: it derives the
+ * Ralph-specific display (phase status dot, `R` badge, clarifying/iteration
+ * sub-label, session-context drag support) and delegates layout, expansion,
+ * pin/more affordances, and child rendering to the shared row. Children are
+ * rendered by delegating to the caller's `renderTaskCard` with
+ * `{ isGroupChild: true }`.
  */
 
 import type React from 'react';
-import { useState } from 'react';
-import { cn } from '../../ui/cn';
-import { formatRelativeTime } from '../../utils/format';
 import type { RalphSession } from './ralph-session-grouping';
 import { RALPH_MULTI_LOOP } from '../../featureFlags';
 import { type RalphSessionContextDragPayload, writeRalphSessionContextDragData } from './sessionContextDrag';
+import { TaskGroupRunRow } from './TaskGroupRunRow';
 
 interface RalphSessionRowProps {
     session: RalphSession;
@@ -77,9 +75,9 @@ export function RalphSessionRow({
     selectedTaskId: _selectedTaskId,
     selectedSessionId,
     isRangeSelected,
-    expanded: controlledExpanded,
+    expanded,
     onToggleExpanded,
-    now: _now,
+    now,
     unseenProcessIds: _unseenProcessIds,
     onSelectTask: _onSelectTask,
     onSelectSession,
@@ -93,12 +91,7 @@ export function RalphSessionRow({
     sessionContextPayload,
     renderTaskCard,
 }: RalphSessionRowProps) {
-    const [internalExpanded, setInternalExpanded] = useState(false);
-    const expanded = controlledExpanded ?? internalExpanded;
-    const isSelected = selectedSessionId === session.sessionId || !!isRangeSelected;
-
     const iterCount = session.iterations.length;
-    const subCount = (session.grillingProcess ? 1 : 0) + iterCount;
 
     // Short muted suffix that fits inside the truncating title cell.
     // When multi-loop is enabled and there are multiple loops, prefix with the loop count.
@@ -111,182 +104,62 @@ export function RalphSessionRow({
         subLabel = `${iterCount} iter`;
     }
 
-    const timestamp = session.latestTimestamp
-        ? formatRelativeTime(new Date(session.latestTimestamp).toISOString())
-        : '';
-
-    const dotClasses = PHASE_DOT_CLASSES[session.phase];
-
-    // RALPH mode pill — purple variant, same shape as HistoryGroupHeader's
-    // `modeBadgeClasses`, mirroring the ralph color from ChatListPane.
-    const modeBadgeClasses = cn(
-        'inline-flex items-center justify-center rounded-[3px] border font-mono font-bold uppercase select-none',
-        'text-[9.5px] leading-none tracking-[0.06em] py-[4px] w-full',
-        'text-purple-600 dark:text-purple-400',
-        'border-purple-500/70 dark:border-purple-500/60',
-        'bg-purple-50/60 dark:bg-purple-500/10',
-    );
-
-    const toggle = () => {
-        if (onToggleExpanded) {
-            onToggleExpanded();
-            return;
-        }
-        setInternalExpanded(e => !e);
-    };
+    const children = [
+        ...(session.grillingProcess ? [session.grillingProcess] : []),
+        ...session.iterations,
+    ];
 
     return (
-        <div
-            data-testid="ralph-session-row"
-            data-session-id={session.sessionId}
-            data-selected={isSelected ? 'true' : 'false'}
-            className={cn(
-                expanded && 'bg-[#f7f7f8] dark:bg-[#1f1f20]/80',
-                isSelected && 'ring-1 ring-[#0078d4]/40',
-            )}
-            data-pinned={isPinned ? 'true' : undefined}
-        >
-            <div
-                className={cn(
-                    'chat-row group relative cursor-pointer leading-none transition-colors',
-                    'grid items-center gap-2 px-3 py-1',
-                    'grid-cols-[10px_30px_minmax(0,1fr)_auto]',
-                    'text-[12.5px] h-[26px]',
-                    'border-b border-[#e0e0e0]/60 dark:border-[#3c3c3c]/60',
-                    'hover:bg-[#f5f5f5] dark:hover:bg-[#2a2a2b]',
-                    isPinned && 'border-l-2 border-l-amber-400 dark:border-l-amber-500',
-                )}
-                onClick={e => {
-                    if (onSelectSession) onSelectSession(session.sessionId, e);
-                    else toggle();
-                }}
-                onContextMenu={onContextMenu}
-                onTouchStart={onTouchStart}
-                onTouchEnd={onTouchEnd}
-                onTouchMove={onTouchMove}
-                draggable={!!sessionContextPayload}
-                onDragStart={sessionContextPayload ? (e) => writeRalphSessionContextDragData(e.dataTransfer, sessionContextPayload) : undefined}
-                data-testid="ralph-session-body"
-                data-session-phase={session.phase}
-                data-pinned={isPinned ? 'true' : undefined}
-                data-session-context-source={sessionContextPayload ? 'true' : undefined}
-                data-session-context-kind={sessionContextPayload ? 'ralph-session' : undefined}
-                data-session-context-status={sessionContextPayload?.status}
-                data-expanded={expanded ? 'true' : 'false'}
-                title={sessionContextPayload ? `${sessionContextPayload.displayLabel} - drag to attach as Ralph session context` : undefined}
-                aria-expanded={expanded}
-            >
-                <span
-                    className={cn('w-2 h-2 rounded-full justify-self-center transition-shadow', dotClasses)}
-                    aria-label={`phase: ${PHASE_DOT_LABEL[session.phase]}`}
-                />
-                <span className={modeBadgeClasses} title="Ralph · iterative goal-driven session">
-                    R
-                </span>
-                <span className="min-w-0 flex items-center gap-1 overflow-hidden">
-                    <button
-                        type="button"
-                        className={cn(
-                            'shrink-0 inline-flex items-center justify-center w-4 h-4 -ml-1 rounded',
-                            'text-[#848484] dark:text-[#a0a0a0] hover:bg-black/[0.06] dark:hover:bg-white/[0.08]',
-                            'transition-transform',
-                            expanded && 'rotate-90',
-                        )}
-                        onClick={e => { e.stopPropagation(); toggle(); }}
-                        data-testid="ralph-session-chevron"
-                        aria-label={expanded ? 'Collapse session' : 'Expand session'}
-                        aria-expanded={expanded}
-                    >
-                        <span className="text-[12px] leading-none" aria-hidden="true">›</span>
-                    </button>
-                    {session.hasUnseen && (
-                        <span
-                            className="shrink-0 w-1.5 h-1.5 rounded-full bg-[#0078d4] dark:bg-[#3794ff]"
-                            data-testid="ralph-session-unseen-dot"
-                            aria-label="Unseen activity"
-                        />
-                    )}
-                    <span
-                        className={cn(
-                            'chat-title truncate text-[#1e1e1e] dark:text-[#cccccc]',
-                            session.hasUnseen && 'font-semibold',
-                        )}
-                        title={`${session.title} · ${subLabel}`}
-                        aria-label={`Ralph session: ${session.title} · ${subLabel}`}
-                        data-testid="ralph-session-title"
-                    >
-                        {session.title}
-                        <span className="ml-1.5 font-normal text-[#848484] dark:text-[#9d9d9d]">
-                            {subLabel}
-                        </span>
-                    </span>
-                    {subCount > 0 && (
-                        <span
-                            className="shrink-0 text-[10px] font-mono tabular-nums text-[#848484] dark:text-[#9d9d9d]"
-                            data-testid="ralph-session-child-count"
-                        >
-                            {subCount}
-                        </span>
-                    )}
-                </span>
-                <span className="flex items-center gap-1 text-[#848484] dark:text-[#999]">
-                    <span className="chat-row-when text-[10.5px] font-mono tabular-nums whitespace-nowrap group-hover:hidden">
-                        {timestamp}
-                    </span>
-                    {(onTogglePin || onMoreActions) && (
-                        <span className="chat-row-actions hidden group-hover:flex items-center gap-0">
-                            {onTogglePin && (
-                                <button
-                                    type="button"
-                                    className="h-5 w-5 grid place-items-center rounded text-[#848484] hover:text-[#1e1e1e] dark:hover:text-[#cccccc] hover:bg-[#ececec] dark:hover:bg-[#2f2f30]"
-                                    title={isPinned ? 'Unpin' : 'Pin'}
-                                    aria-label={isPinned ? 'Unpin Ralph session group' : 'Pin Ralph session group'}
-                                    data-testid="ralph-session-pin"
-                                    onClick={e => { e.stopPropagation(); onTogglePin(); }}
-                                >
-                                    <svg width="12" height="12" viewBox="0 0 14 14" fill={isPinned ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" aria-hidden="true">
-                                        <path d="M9 1.5l3.5 3.5-2 1-1.5 4-2-2-3 3-.5-.5 3-3-2-2 4-1.5 1-1z"/>
-                                    </svg>
-                                </button>
-                            )}
-                            {onMoreActions && (
-                                <button
-                                    type="button"
-                                    className="h-5 w-5 grid place-items-center rounded text-[#848484] hover:text-[#1e1e1e] dark:hover:text-[#cccccc] hover:bg-[#ececec] dark:hover:bg-[#2f2f30]"
-                                    title="More"
-                                    aria-label="More Ralph session group actions"
-                                    data-testid="ralph-session-more"
-                                    onClick={e => { e.stopPropagation(); onMoreActions(e); }}
-                                >
-                                    <svg width="12" height="12" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
-                                        <circle cx="3.5" cy="7" r="1"/>
-                                        <circle cx="7" cy="7" r="1"/>
-                                        <circle cx="10.5" cy="7" r="1"/>
-                                    </svg>
-                                </button>
-                            )}
-                        </span>
-                    )}
-                </span>
-            </div>
-
-            {expanded && (
-                <div
-                    className="flex flex-col ml-3 pl-2 border-l border-[#e0e0e0] dark:border-[#3c3c3c]"
-                    data-testid="ralph-session-children"
-                >
-                    {session.grillingProcess && (
-                        <div key={session.grillingProcess.id ?? 'grilling'}>
-                            {renderTaskCard(session.grillingProcess, { isGroupChild: true })}
-                        </div>
-                    )}
-                    {session.iterations.map((iter, idx) => (
-                        <div key={iter.id ?? idx}>
-                            {renderTaskCard(iter, { isGroupChild: true })}
-                        </div>
-                    ))}
-                </div>
-            )}
-        </div>
+        <TaskGroupRunRow
+            group={{
+                runId: session.sessionId,
+                children,
+                latestTimestamp: session.latestTimestamp,
+                hasUnseen: session.hasUnseen,
+            }}
+            display={{
+                testIdPrefix: 'ralph-session',
+                label: session.title,
+                title: subLabel,
+                badge: 'R',
+                badgeTitle: 'Ralph · iterative goal-driven session',
+                groupNoun: 'Ralph session',
+                badgeClassName: 'text-purple-600 dark:text-purple-400 border-purple-500/70 dark:border-purple-500/60 bg-purple-50/60 dark:bg-purple-500/10',
+                selectedRingClassName: 'ring-[#0078d4]/40',
+                statusDotClassName: PHASE_DOT_CLASSES[session.phase],
+                statusLabel: session.phase,
+                statusAriaLabel: `phase: ${PHASE_DOT_LABEL[session.phase]}`,
+                status: session.phase,
+                statusAttributeName: 'data-session-phase',
+                groupIdAttributeName: 'data-session-id',
+                titleTestId: 'ralph-session-title',
+                titleTooltip: `${session.title} · ${subLabel}`,
+                titleAriaLabel: `Ralph session: ${session.title} · ${subLabel}`,
+                collapseAriaLabel: 'Collapse session',
+                expandAriaLabel: 'Expand session',
+            }}
+            selectedRunId={selectedSessionId}
+            isRangeSelected={isRangeSelected}
+            expanded={expanded}
+            onToggleExpanded={onToggleExpanded}
+            now={now}
+            onSelectRun={onSelectSession ? (sessionId, event) => onSelectSession(sessionId, event) : undefined}
+            onContextMenu={onContextMenu}
+            onTouchStart={onTouchStart}
+            onTouchEnd={onTouchEnd}
+            onTouchMove={onTouchMove}
+            isPinned={isPinned}
+            onTogglePin={onTogglePin}
+            onMoreActions={onMoreActions}
+            draggable={sessionContextPayload ? true : undefined}
+            onDragStart={sessionContextPayload ? (e) => writeRalphSessionContextDragData(e.dataTransfer, sessionContextPayload) : undefined}
+            bodyDataAttributes={{
+                'data-session-context-source': sessionContextPayload ? 'true' : undefined,
+                'data-session-context-kind': sessionContextPayload ? 'ralph-session' : undefined,
+                'data-session-context-status': sessionContextPayload?.status,
+            }}
+            bodyTitle={sessionContextPayload ? `${sessionContextPayload.displayLabel} - drag to attach as Ralph session context` : undefined}
+            renderTaskCard={(task) => renderTaskCard(task, { isGroupChild: true })}
+        />
     );
 }

--- a/packages/coc/src/server/spa/client/react/features/chat/TaskGroupPlanReviewCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/TaskGroupPlanReviewCard.tsx
@@ -1,0 +1,471 @@
+import { useEffect, useMemo, useState } from 'react';
+import type React from 'react';
+import type { ClientConversationTurn } from '../../types/dashboard';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
+import { cn } from '../../ui/cn';
+
+/**
+ * TaskGroupPlanReviewCard — shared plan-review card for item-based task
+ * groups (For Each runs, Map Reduce runs, future group types).
+ *
+ * The scan merge (transcript vs persisted metadata), draft/JSON editor
+ * state machinery, item list editor, and approval flow live here once.
+ * Feature cards stay as thin wrappers that supply a
+ * {@link TaskGroupPlanReviewConfig} (labels, accent, scan/validate/format
+ * adapters, the approve submission, and kind-specific extra fields).
+ */
+
+export interface TaskGroupPlanDraftItem {
+    id: string;
+    title: string;
+    prompt: string;
+    status?: string;
+    dependsOn?: string[];
+}
+
+export interface TaskGroupPlanDraftBase {
+    /** Feature item type (ForEachItem, MapReduceItem, …); the editor only touches the shared fields. */
+    items: any[];
+    sharedInstructions: string;
+    childMode: 'ask' | 'autopilot';
+}
+
+export interface TaskGroupPlanScan {
+    plan: { turnIndex: number; rawJson?: string } | null;
+    error: { turnIndex: number; message: string } | null;
+}
+
+export interface TaskGroupPlanMetadataBase {
+    status: 'draft' | 'approved';
+    runId?: string;
+}
+
+export interface TaskGroupPlanAccent {
+    /** Card container border/background. */
+    card: string;
+    /** Heading + field label text. */
+    headingText: string;
+    /** Count pill (and other header pills). */
+    pill: string;
+    /** Muted description text under the heading. */
+    subText: string;
+    /** "Open run" button. */
+    openRunButton: string;
+    /** Borders for the shared-instructions/child-mode editors. */
+    editorBorder: string;
+    /** Active child-mode toggle. */
+    childModeActive: string;
+    /** Item card / details / footer hairline border. */
+    hairlineBorder: string;
+    /** "Add item" button. */
+    addItemButton: string;
+    /** Advanced JSON summary text. */
+    jsonSummaryText: string;
+    /** Approve button. */
+    approveButton: string;
+}
+
+export interface TaskGroupPlanApproveArgs<TDraft extends TaskGroupPlanDraftBase, TMeta extends TaskGroupPlanMetadataBase> {
+    client: ReturnType<typeof useCocClient>;
+    workspaceId: string;
+    processId: string;
+    meta: TMeta;
+    metadataProcess: any;
+    /** Draft with validated/normalized fields applied. */
+    draft: TDraft;
+    scanPlanTurnIndex?: number;
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
+    model?: string;
+    reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
+}
+
+export interface TaskGroupPlanReviewConfig<TDraft extends TaskGroupPlanDraftBase, TMeta extends TaskGroupPlanMetadataBase> {
+    /** DOM test-id prefix (e.g. 'for-each' → 'for-each-plan-review-card', 'for-each-plan-item-…'). */
+    testIdPrefix: string;
+    /** Card heading (e.g. 'Proposed For Each item plan'). */
+    heading: string;
+    /** Noun used in the count pill ('item' | 'map item'). */
+    itemNoun: string;
+    /** 'Add item' button label. */
+    addItemLabel: string;
+    /** Muted description under the heading. */
+    description: string;
+    /** Noun in the scan-error banner ('item plan' | 'Map Reduce plan'). */
+    scanErrorNoun: string;
+    /** Validation message when no plan is available yet. */
+    noPlanText: string;
+    /** Fallback error for a failed approval. */
+    approveErrorFallback: string;
+    /** Tailwind classes for the accent family. */
+    accent: TaskGroupPlanAccent;
+    /** Grid template for the top row (shared instructions … child mode). */
+    topGridClassName: string;
+    scanTranscript: (turns: ClientConversationTurn[]) => TaskGroupPlanScan;
+    getPersistedPlanState: (meta: TMeta) => TaskGroupPlanScan;
+    /** Build the initial draft from the winning scan's plan artifact (the feature's plan artifact type). */
+    buildDraft: (plan: any, meta: TMeta) => TDraft;
+    formatDraftJson: (draft: TDraft) => string;
+    /** Parse the advanced-JSON editor text; throws with a user-facing message. */
+    parseDraftJson: (text: string) => TDraft;
+    /** Validate the draft; returns the draft with normalized fields applied, or an error. */
+    validate: (draft: TDraft) => { draft: TDraft | null; error: string | null };
+    /** Create/update + approve the run and patch generation metadata. Returns the approved run. */
+    approve: (args: TaskGroupPlanApproveArgs<TDraft, TMeta>) => Promise<{ runId: string }>;
+    /** Extra header pills after the count pill (e.g. max parallel). */
+    renderHeaderPills?: (draft: TDraft) => React.ReactNode;
+    /** Extra fields inside the top grid, between shared instructions and child mode. */
+    renderExtraTopFields?: (draft: TDraft, applyDraft: (next: TDraft) => void) => React.ReactNode;
+    /** Extra sections between the top grid and the item list (e.g. reduce instructions). */
+    renderExtraSections?: (draft: TDraft, applyDraft: (next: TDraft) => void) => React.ReactNode;
+}
+
+export interface TaskGroupPlanReviewCardProps<TDraft extends TaskGroupPlanDraftBase, TMeta extends TaskGroupPlanMetadataBase> {
+    workspaceId?: string;
+    processId?: string | null;
+    metadataProcess: any;
+    meta: TMeta;
+    turns: ClientConversationTurn[];
+    config: TaskGroupPlanReviewConfig<TDraft, TMeta>;
+    provider?: 'copilot' | 'codex' | 'claude' | 'opencode';
+    model?: string;
+    reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
+    onApprovedRun?: (runId: string) => void;
+}
+
+function itemDependencyText(item: TaskGroupPlanDraftItem): string {
+    return (item.dependsOn ?? []).join(', ');
+}
+
+function parseDependencies(value: string): string[] | undefined {
+    const deps = value.split(',').map(part => part.trim()).filter(Boolean);
+    return deps.length > 0 ? deps : undefined;
+}
+
+function makeNewItem(existing: TaskGroupPlanDraftItem[]): any {
+    const used = new Set(existing.map(item => item.id));
+    let index = existing.length + 1;
+    let id = `item-${index}`;
+    while (used.has(id)) {
+        index += 1;
+        id = `item-${index}`;
+    }
+    return {
+        id,
+        title: `Item ${index}`,
+        prompt: '',
+        status: 'pending',
+    };
+}
+
+function latestScanTurn(scan: TaskGroupPlanScan): number {
+    return Math.max(scan.plan?.turnIndex ?? -1, scan.error?.turnIndex ?? -1);
+}
+
+export function TaskGroupPlanReviewCard<TDraft extends TaskGroupPlanDraftBase, TMeta extends TaskGroupPlanMetadataBase>({
+    workspaceId,
+    processId,
+    metadataProcess,
+    meta,
+    turns,
+    config,
+    provider,
+    model,
+    reasoningEffort,
+    onApprovedRun,
+}: TaskGroupPlanReviewCardProps<TDraft, TMeta>) {
+    // AC-07: plan create/update/approve route to the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
+    const prefix = config.testIdPrefix;
+    const accent = config.accent;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const transcriptScan = useMemo(() => config.scanTranscript(turns), [turns]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const persistedScan = useMemo(() => config.getPersistedPlanState(meta), [meta]);
+    const scan = latestScanTurn(transcriptScan) > latestScanTurn(persistedScan)
+        ? transcriptScan
+        : persistedScan.plan || persistedScan.error
+            ? persistedScan
+            : transcriptScan;
+    const generatedKey = scan.plan ? `${scan.plan.turnIndex}:${scan.plan.rawJson}` : 'none';
+    const [loadedKey, setLoadedKey] = useState('');
+    const [baselineJson, setBaselineJson] = useState('');
+    const [draft, setDraft] = useState<TDraft | null>(null);
+    const [jsonOpen, setJsonOpen] = useState(false);
+    const [jsonText, setJsonText] = useState('');
+    const [jsonError, setJsonError] = useState<string | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [approvedRun, setApprovedRun] = useState<{ runId: string } | null>(null);
+
+    useEffect(() => {
+        if (!scan.plan || generatedKey === loadedKey) return;
+        const nextDraft = config.buildDraft(scan.plan, meta);
+        const formatted = config.formatDraftJson(nextDraft);
+        setDraft(nextDraft);
+        setBaselineJson(formatted);
+        setJsonText(formatted);
+        setJsonError(null);
+        setLoadedKey(generatedKey);
+        setError(null);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [meta, generatedKey, loadedKey, scan.plan]);
+
+    if (!scan.plan && !scan.error) return null;
+
+    const validation = draft ? config.validate(draft) : { draft: null, error: config.noPlanText };
+    const currentJson = draft ? config.formatDraftJson(draft) : '';
+    const dirty = draft ? currentJson !== baselineJson : false;
+    const approvalBlocked = busy || !!jsonError || !!validation.error || !draft || !workspaceId || !processId || meta.status === 'approved' || !!approvedRun;
+    const linkedRunId = approvedRun?.runId ?? meta.runId;
+
+    function applyDraft(next: TDraft) {
+        setDraft(next);
+        setJsonText(config.formatDraftJson(next));
+        setJsonError(null);
+        setError(null);
+    }
+
+    function updateItem(index: number, patch: Partial<TaskGroupPlanDraftItem>) {
+        if (!draft) return;
+        applyDraft({
+            ...draft,
+            items: draft.items.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item),
+        } as TDraft);
+    }
+
+    function moveItem(index: number, direction: -1 | 1) {
+        if (!draft) return;
+        const target = index + direction;
+        if (target < 0 || target >= draft.items.length) return;
+        const items = [...draft.items];
+        const [item] = items.splice(index, 1);
+        items.splice(target, 0, item);
+        applyDraft({ ...draft, items } as TDraft);
+    }
+
+    function removeItem(index: number) {
+        if (!draft) return;
+        applyDraft({ ...draft, items: draft.items.filter((_, itemIndex) => itemIndex !== index) } as TDraft);
+    }
+
+    function handleJsonChange(value: string) {
+        setJsonText(value);
+        setError(null);
+        try {
+            const parsed = config.parseDraftJson(value);
+            setDraft(parsed);
+            setJsonError(null);
+        } catch (err) {
+            setJsonError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    async function approveRun() {
+        if (!draft || !workspaceId || !processId) return;
+        const checked = config.validate(draft);
+        if (checked.error || !checked.draft) {
+            setError(checked.error ?? config.approveErrorFallback);
+            return;
+        }
+        setBusy(true);
+        setError(null);
+        try {
+            const approved = await config.approve({
+                client: cloneClient,
+                workspaceId,
+                processId,
+                meta,
+                metadataProcess,
+                draft: checked.draft,
+                scanPlanTurnIndex: scan.plan?.turnIndex,
+                provider,
+                model,
+                reasoningEffort,
+            });
+            setApprovedRun(approved);
+            onApprovedRun?.(approved.runId);
+        } catch (err) {
+            setError(getSpaCocClientErrorMessage(err, config.approveErrorFallback));
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <section
+            className={cn('mx-4 mb-3 rounded-lg border p-3 text-xs shadow-sm', accent.card)}
+            data-testid={`${prefix}-plan-review-card`}
+        >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                    <div className="flex items-center gap-2">
+                        <h3 className={cn('text-sm font-semibold', accent.headingText)}>{config.heading}</h3>
+                        <span className={cn('rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide', accent.pill)}>
+                            {draft?.items.length ?? 0} {config.itemNoun}{draft?.items.length === 1 ? '' : 's'}
+                        </span>
+                        {draft && config.renderHeaderPills?.(draft)}
+                        {dirty && <span className="text-[10px] font-medium text-amber-700 dark:text-amber-300" data-testid={`${prefix}-plan-dirty`}>Edited</span>}
+                    </div>
+                    <p className={cn('mt-0.5 text-[11px]', accent.subText)}>
+                        {config.description}
+                    </p>
+                </div>
+                {linkedRunId && (
+                    <button
+                        type="button"
+                        className={cn('rounded border bg-white px-2 py-1 text-[11px] font-medium', accent.openRunButton)}
+                        onClick={() => onApprovedRun?.(linkedRunId)}
+                        data-testid={`${prefix}-open-run-btn`}
+                    >
+                        Open run
+                    </button>
+                )}
+            </div>
+
+            {scan.error && (
+                <div className="mt-3 rounded border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200" data-testid={`${prefix}-plan-scan-error`}>
+                    Latest assistant output did not contain a valid {config.scanErrorNoun}: {scan.error.message}. Keeping the previous valid plan.
+                </div>
+            )}
+
+            {draft && (
+                <div className="mt-3 space-y-3">
+                    <div className={cn('grid gap-2', config.topGridClassName)}>
+                        <label className="block">
+                            <span className={cn('mb-1 block text-[11px] font-medium uppercase tracking-wide', accent.headingText)}>Shared instructions</span>
+                            <textarea
+                                value={draft.sharedInstructions}
+                                onChange={(e) => applyDraft({ ...draft, sharedInstructions: e.target.value } as TDraft)}
+                                rows={2}
+                                className={cn('w-full resize-y rounded border bg-white p-2 text-xs text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100', accent.editorBorder)}
+                                data-testid={`${prefix}-shared-instructions-editor`}
+                            />
+                        </label>
+                        {config.renderExtraTopFields?.(draft, applyDraft)}
+                        <div>
+                            <div className={cn('mb-1 text-[11px] font-medium uppercase tracking-wide', accent.headingText)}>Child mode</div>
+                            <div className={cn('inline-flex rounded border bg-white p-0.5 dark:bg-zinc-950', accent.editorBorder)} data-testid={`${prefix}-plan-child-mode`}>
+                                {(['ask', 'autopilot'] as const).map(mode => (
+                                    <button
+                                        key={mode}
+                                        type="button"
+                                        onClick={() => applyDraft({ ...draft, childMode: mode } as TDraft)}
+                                        className={cn(
+                                            'rounded px-2 py-1 text-[11px] font-medium',
+                                            draft.childMode === mode
+                                                ? accent.childModeActive
+                                                : 'text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900',
+                                        )}
+                                        data-testid={`${prefix}-plan-child-mode-${mode}`}
+                                    >
+                                        {mode === 'ask' ? 'Ask' : 'Autopilot'}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+
+                    {config.renderExtraSections?.(draft, applyDraft)}
+
+                    <div className="space-y-2" data-testid={`${prefix}-plan-items`}>
+                        {draft.items.map((item, index) => (
+                            <div key={`${item.id}:${index}`} className={cn('rounded border bg-white p-2 dark:bg-zinc-950', accent.hairlineBorder)} data-testid={`${prefix}-plan-item-${item.id}`}>
+                                <div className="grid gap-2 md:grid-cols-[10rem_minmax(0,1fr)_auto]">
+                                    <label className="block">
+                                        <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">ID</span>
+                                        <input
+                                            value={item.id}
+                                            onChange={(e) => updateItem(index, { id: e.target.value })}
+                                            className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+                                            data-testid={`${prefix}-plan-item-id-${index}`}
+                                        />
+                                    </label>
+                                    <label className="block">
+                                        <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Title</span>
+                                        <input
+                                            value={item.title}
+                                            onChange={(e) => updateItem(index, { title: e.target.value })}
+                                            className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+                                            data-testid={`${prefix}-plan-item-title-${index}`}
+                                        />
+                                    </label>
+                                    <div className="flex items-end gap-1">
+                                        <button type="button" onClick={() => moveItem(index, -1)} disabled={index === 0} className="rounded border border-zinc-200 px-2 py-1 text-[11px] disabled:opacity-40 dark:border-zinc-800" data-testid={`${prefix}-plan-item-up-${index}`}>Up</button>
+                                        <button type="button" onClick={() => moveItem(index, 1)} disabled={index === draft.items.length - 1} className="rounded border border-zinc-200 px-2 py-1 text-[11px] disabled:opacity-40 dark:border-zinc-800" data-testid={`${prefix}-plan-item-down-${index}`}>Down</button>
+                                        <button type="button" onClick={() => removeItem(index)} className="rounded border border-red-200 px-2 py-1 text-[11px] text-red-700 dark:border-red-900 dark:text-red-200" data-testid={`${prefix}-plan-item-remove-${index}`}>Remove</button>
+                                    </div>
+                                </div>
+                                <label className="mt-2 block">
+                                    <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Prompt</span>
+                                    <textarea
+                                        value={item.prompt}
+                                        onChange={(e) => updateItem(index, { prompt: e.target.value })}
+                                        rows={3}
+                                        className="w-full resize-y rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+                                        data-testid={`${prefix}-plan-item-prompt-${index}`}
+                                    />
+                                </label>
+                                <label className="mt-2 block">
+                                    <span className="mb-1 block text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Dependencies</span>
+                                    <input
+                                        value={itemDependencyText(item)}
+                                        onChange={(e) => updateItem(index, { dependsOn: parseDependencies(e.target.value) })}
+                                        placeholder="item-1, item-2"
+                                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+                                        data-testid={`${prefix}-plan-item-deps-${index}`}
+                                    />
+                                </label>
+                            </div>
+                        ))}
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={() => applyDraft({ ...draft, items: [...draft.items, makeNewItem(draft.items)] } as TDraft)}
+                        className={cn('rounded border bg-white px-2 py-1 text-[11px] font-medium', accent.addItemButton)}
+                        data-testid={`${prefix}-plan-add-item`}
+                    >
+                        {config.addItemLabel}
+                    </button>
+
+                    <details open={jsonOpen} onToggle={(event) => setJsonOpen(event.currentTarget.open)} className={cn('rounded border bg-white p-2 dark:bg-zinc-950', accent.hairlineBorder)}>
+                        <summary className={cn('cursor-pointer text-[11px] font-semibold uppercase tracking-wide', accent.jsonSummaryText)} data-testid={`${prefix}-plan-json-toggle`}>
+                            Advanced JSON
+                        </summary>
+                        <textarea
+                            value={jsonText}
+                            onChange={(e) => handleJsonChange(e.target.value)}
+                            rows={10}
+                            className="mt-2 w-full resize-y rounded border border-zinc-200 bg-white p-2 font-mono text-xs text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
+                            data-testid={`${prefix}-plan-json`}
+                        />
+                        {jsonError && (
+                            <p className="mt-1 text-[11px] text-red-600 dark:text-red-300" data-testid={`${prefix}-plan-json-error`}>{jsonError}</p>
+                        )}
+                    </details>
+
+                    <div className={cn('flex flex-wrap items-center justify-between gap-2 border-t pt-2', accent.hairlineBorder)}>
+                        <div>
+                            {validation.error ? (
+                                <p className="text-[11px] text-red-600 dark:text-red-300" data-testid={`${prefix}-plan-validation-error`}>{validation.error}</p>
+                            ) : (
+                                <p className="text-[11px] text-emerald-700 dark:text-emerald-300" data-testid={`${prefix}-plan-validation-ok`}>Plan is valid and ready for approval.</p>
+                            )}
+                            {error && <p className="mt-1 text-[11px] text-red-600 dark:text-red-300" data-testid={`${prefix}-plan-approve-error`}>{error}</p>}
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => void approveRun()}
+                            disabled={approvalBlocked}
+                            className={cn('rounded px-3 py-1.5 text-xs font-semibold text-white disabled:cursor-not-allowed', accent.approveButton)}
+                            data-testid={`${prefix}-plan-approve-btn`}
+                        >
+                            {busy ? 'Approving...' : meta.status === 'approved' || approvedRun ? 'Approved' : 'Approve run'}
+                        </button>
+                    </div>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/TaskGroupRunPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/TaskGroupRunPane.tsx
@@ -1,0 +1,382 @@
+import { useCallback, useEffect, useState } from 'react';
+import type React from 'react';
+import { cn } from '../../ui/cn';
+import { getSpaCocClientErrorMessage } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
+import { formatRelativeTime } from '../../utils/format';
+
+/**
+ * TaskGroupRunPane — shared run-detail pane for item-based task groups
+ * (For Each runs, Map Reduce runs, future group types).
+ *
+ * All load/refresh/action state, the header with run metadata and actions,
+ * the original-request / shared-instructions sections, and the items table
+ * live here once. Feature panes stay as thin wrappers that supply a
+ * {@link TaskGroupRunPaneConfig} (labels, accent classes, API adapter,
+ * action enablement, and kind-specific extras such as the reduce step).
+ */
+
+export interface TaskGroupRunPaneItem {
+    id: string;
+    title: string;
+    prompt: string;
+    status: string;
+    error?: string;
+    dependsOn?: string[];
+    childProcessId?: string;
+}
+
+export interface TaskGroupRunPaneRun {
+    runId: string;
+    status: string;
+    originalRequest: string;
+    sharedInstructions?: string;
+    childMode: string;
+    updatedAt: string;
+    provider?: string;
+    generationProcessId?: string;
+    items: TaskGroupRunPaneItem[];
+}
+
+export type TaskGroupRunPaneClient = ReturnType<typeof useCocClient>;
+
+export interface TaskGroupRunPaneActionContext {
+    client: TaskGroupRunPaneClient;
+    workspaceId: string;
+    busyAction: string | null;
+    /** Run a named exclusive action; the resolved run replaces the pane state. */
+    runAction: (actionId: string, action: () => Promise<any>) => Promise<void>;
+    onSelectChildProcess?: (processId: string) => void;
+}
+
+export interface TaskGroupRunPaneConfig<TRun extends TaskGroupRunPaneRun> {
+    /** DOM test-id prefix (e.g. 'for-each' → 'for-each-run-pane', 'for-each-item-…'). */
+    testIdPrefix: string;
+    /** Display label used in the title, loading/empty states, and error fallbacks (e.g. 'For Each'). */
+    label: string;
+    /** Items-table column header for the item cell ('Item' | 'Map item'). */
+    itemColumnHeader: string;
+    /** Child chat link label ('Open child chat' | 'Open map chat'). */
+    childChatLabel: string;
+    /** Accent classes for the generation-chat link button. */
+    generationButtonClassName: string;
+    /** Accent classes for the Start/Continue button. */
+    primaryButtonClassName: string;
+    /** Accent classes for per-item child chat links. */
+    childLinkClassName: string;
+    /** Badge classes for the run's current status. */
+    runStatusClassName: (status: TRun['status']) => string;
+    /** Badge classes for an item's current status. */
+    itemStatusClassName: (status: string) => string;
+    canCancel: (run: TRun) => boolean;
+    canStartOrContinue: (run: TRun) => boolean;
+    api: {
+        get: (client: TaskGroupRunPaneClient, workspaceId: string, runId: string) => Promise<TRun>;
+        start: (client: TaskGroupRunPaneClient, workspaceId: string, runId: string) => Promise<TRun>;
+        continue: (client: TaskGroupRunPaneClient, workspaceId: string, runId: string) => Promise<TRun>;
+        cancel: (client: TaskGroupRunPaneClient, workspaceId: string, runId: string) => Promise<TRun>;
+        retryItem: (client: TaskGroupRunPaneClient, workspaceId: string, runId: string, itemId: string) => Promise<TRun>;
+        skipItem: (client: TaskGroupRunPaneClient, workspaceId: string, runId: string, itemId: string) => Promise<TRun>;
+    };
+    /** Extra header metadata spans rendered right after the item counts (e.g. reduce status). */
+    renderHeaderMeta?: (run: TRun) => React.ReactNode;
+    /** Extra sections rendered between shared instructions and the items table (e.g. reduce step). */
+    renderExtraSections?: (run: TRun, ctx: TaskGroupRunPaneActionContext) => React.ReactNode;
+}
+
+export interface TaskGroupRunPaneProps<TRun extends TaskGroupRunPaneRun> {
+    workspaceId: string;
+    runId: string;
+    config: TaskGroupRunPaneConfig<TRun>;
+    onClose?: () => void;
+    onSelectGenerationProcess?: (processId: string) => void;
+    onSelectChildProcess?: (processId: string) => void;
+}
+
+function singleLine(text: string, max = 120): string {
+    const flat = text.replace(/\s+/g, ' ').trim();
+    return flat.length > max ? flat.slice(0, max - 3) + '...' : flat;
+}
+
+function countItems(run: TaskGroupRunPaneRun): string {
+    const counts = new Map<string, number>();
+    for (const item of run.items) counts.set(item.status, (counts.get(item.status) ?? 0) + 1);
+    return Array.from(counts.entries()).map(([status, count]) => `${count} ${status}`).join(' - ');
+}
+
+export function TaskGroupRunPane<TRun extends TaskGroupRunPaneRun>({
+    workspaceId,
+    runId,
+    config,
+    onClose,
+    onSelectGenerationProcess,
+    onSelectChildProcess,
+}: TaskGroupRunPaneProps<TRun>) {
+    // AC-07: run data + actions target the selected clone's server.
+    const cloneClient = useCocClient(workspaceId);
+    const [run, setRun] = useState<TRun | null | undefined>(undefined);
+    const [busyAction, setBusyAction] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const prefix = config.testIdPrefix;
+
+    const refresh = useCallback(async () => {
+        try {
+            const nextRun = await config.api.get(cloneClient, workspaceId, runId);
+            setRun(nextRun);
+            setError(null);
+        } catch (err) {
+            setRun(null);
+            setError(getSpaCocClientErrorMessage(err, `Failed to load ${config.label} run`));
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [workspaceId, runId, cloneClient]);
+
+    useEffect(() => {
+        setRun(undefined);
+        void refresh();
+    }, [refresh]);
+
+    async function runAction(actionId: string, action: () => Promise<TRun>) {
+        setBusyAction(actionId);
+        setError(null);
+        try {
+            const nextRun = await action();
+            setRun(nextRun);
+        } catch (err) {
+            setError(getSpaCocClientErrorMessage(err, `${config.label} action failed`));
+        } finally {
+            setBusyAction(null);
+        }
+    }
+
+    if (run === undefined) {
+        return (
+            <div className="flex h-full items-center justify-center text-sm text-zinc-500 dark:text-zinc-400" data-testid={`${prefix}-run-pane-loading`}>
+                Loading {config.label} run...
+            </div>
+        );
+    }
+
+    if (run === null) {
+        return (
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400" data-testid={`${prefix}-run-pane-empty`}>
+                <p>{config.label} run not found.</p>
+                <p className="text-xs">Run id: <code className="font-mono">{runId}</code></p>
+                {error && <p className="text-xs text-red-600 dark:text-red-300">{error}</p>}
+            </div>
+        );
+    }
+
+    const startContinueEnabled = config.canStartOrContinue(run);
+    const cancelEnabled = config.canCancel(run);
+    const startOrContinue = () => {
+        if (run.status === 'approved') {
+            return config.api.start(cloneClient, workspaceId, run.runId);
+        }
+        return config.api.continue(cloneClient, workspaceId, run.runId);
+    };
+    const generationProcessId = run.generationProcessId;
+    const actionContext: TaskGroupRunPaneActionContext = { client: cloneClient, workspaceId, busyAction, runAction, onSelectChildProcess };
+
+    return (
+        <div className="flex h-full flex-col overflow-hidden bg-white dark:bg-zinc-950" data-testid={`${prefix}-run-pane`}>
+            <div className="flex flex-wrap items-start gap-2 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                        <h2 className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                            {config.label}: {singleLine(run.originalRequest, 90)}
+                        </h2>
+                        <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', config.runStatusClassName(run.status))} data-testid={`${prefix}-run-status`}>
+                            {run.status}
+                        </span>
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+                        <span data-testid={`${prefix}-run-counts`}>{countItems(run)}</span>
+                        {config.renderHeaderMeta?.(run)}
+                        <span>Child mode: {run.childMode === 'ask' ? 'Ask' : 'Autopilot'}</span>
+                        <span>Updated {formatRelativeTime(run.updatedAt)}</span>
+                        {run.provider && <span>Provider: {run.provider}</span>}
+                    </div>
+                </div>
+                <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
+                    {generationProcessId && onSelectGenerationProcess && (
+                        <button
+                            type="button"
+                            onClick={() => onSelectGenerationProcess(generationProcessId)}
+                            data-testid={`${prefix}-generation-link-btn`}
+                            className={cn('rounded border bg-white px-2 py-1 text-xs font-medium', config.generationButtonClassName)}
+                        >
+                            Open generation chat
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        onClick={() => runAction('continue', startOrContinue)}
+                        disabled={!startContinueEnabled || busyAction !== null}
+                        data-testid={`${prefix}-continue-btn`}
+                        className={cn('rounded border px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50', config.primaryButtonClassName)}
+                    >
+                        {run.status === 'approved' ? 'Start' : 'Continue'}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => runAction('cancel', () => config.api.cancel(cloneClient, workspaceId, run.runId))}
+                        disabled={!cancelEnabled || busyAction !== null}
+                        data-testid={`${prefix}-cancel-btn`}
+                        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    >
+                        Cancel remaining
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void refresh()}
+                        disabled={busyAction !== null}
+                        data-testid={`${prefix}-refresh-btn`}
+                        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    >
+                        Refresh
+                    </button>
+                    {onClose && (
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            data-testid={`${prefix}-close-btn`}
+                            className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        >
+                            Close
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+                {error && (
+                    <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200" data-testid={`${prefix}-run-error`}>
+                        {error}
+                    </div>
+                )}
+
+                <section className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/40" data-testid={`${prefix}-original-request`}>
+                    <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Original request</h3>
+                    <p className="whitespace-pre-wrap text-xs text-zinc-700 dark:text-zinc-200">{run.originalRequest}</p>
+                </section>
+
+                {run.sharedInstructions?.trim() && (
+                    <section className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/40" data-testid={`${prefix}-shared-instructions-preview`}>
+                        <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Shared instructions</h3>
+                        <p className="whitespace-pre-wrap text-xs text-zinc-700 dark:text-zinc-200">{run.sharedInstructions}</p>
+                    </section>
+                )}
+
+                {config.renderExtraSections?.(run, actionContext)}
+
+                <div className="overflow-hidden rounded border border-zinc-200 dark:border-zinc-800">
+                    <table className="w-full table-fixed text-left text-xs" data-testid={`${prefix}-items-table`}>
+                        <thead className="bg-zinc-50 text-[11px] uppercase tracking-wide text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
+                            <tr>
+                                <th className="w-32 px-2 py-2">Status</th>
+                                <th className="w-56 px-2 py-2">{config.itemColumnHeader}</th>
+                                <th className="px-2 py-2">Prompt preview</th>
+                                <th className="w-44 px-2 py-2">Child chat</th>
+                                <th className="w-40 px-2 py-2">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                            {run.items.map(item => (
+                                <TaskGroupRunItemRow
+                                    key={item.id}
+                                    item={item}
+                                    config={config}
+                                    busyAction={busyAction}
+                                    onSelectChildProcess={onSelectChildProcess}
+                                    onRetry={() => runAction(`retry:${item.id}`, () => config.api.retryItem(cloneClient, workspaceId, run.runId, item.id))}
+                                    onSkip={() => runAction(`skip:${item.id}`, () => config.api.skipItem(cloneClient, workspaceId, run.runId, item.id))}
+                                />
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+interface TaskGroupRunItemRowProps<TRun extends TaskGroupRunPaneRun> {
+    item: TaskGroupRunPaneItem;
+    config: TaskGroupRunPaneConfig<TRun>;
+    busyAction: string | null;
+    onSelectChildProcess?: (processId: string) => void;
+    onRetry: () => void;
+    onSkip: () => void;
+}
+
+function TaskGroupRunItemRow<TRun extends TaskGroupRunPaneRun>({ item, config, busyAction, onSelectChildProcess, onRetry, onSkip }: TaskGroupRunItemRowProps<TRun>) {
+    const prefix = config.testIdPrefix;
+    const canRetry = item.status === 'failed';
+    const canSkip = item.status === 'failed' || item.status === 'pending';
+
+    return (
+        <tr data-testid={`${prefix}-item-${item.id}`} className="align-top text-zinc-800 dark:text-zinc-100">
+            <td className="px-2 py-2">
+                <span className={cn('rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide', config.itemStatusClassName(item.status))}>
+                    {item.status}
+                </span>
+                {item.error && (
+                    <p className="mt-1 line-clamp-3 text-[11px] text-red-600 dark:text-red-300" title={item.error}>
+                        {item.error}
+                    </p>
+                )}
+            </td>
+            <td className="px-2 py-2">
+                <div className="font-medium">{item.title}</div>
+                <div className="mt-1 font-mono text-[10px] text-zinc-500 dark:text-zinc-400">{item.id}</div>
+                {item.dependsOn && item.dependsOn.length > 0 && (
+                    <div className="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
+                        Depends on {item.dependsOn.join(', ')}
+                    </div>
+                )}
+            </td>
+            <td className="px-2 py-2">
+                <p className="line-clamp-4 text-zinc-700 dark:text-zinc-200" title={item.prompt} data-testid={`${prefix}-item-prompt-${item.id}`}>
+                    {singleLine(item.prompt, 220)}
+                </p>
+            </td>
+            <td className="px-2 py-2">
+                {item.childProcessId ? (
+                    <button
+                        type="button"
+                        onClick={() => onSelectChildProcess?.(item.childProcessId!)}
+                        className={cn('rounded border px-2 py-1 text-[11px]', config.childLinkClassName)}
+                        data-testid={`${prefix}-child-link-${item.id}`}
+                    >
+                        {config.childChatLabel}
+                    </button>
+                ) : (
+                    <span className="text-[11px] text-zinc-400">Not started</span>
+                )}
+            </td>
+            <td className="px-2 py-2">
+                <div className="flex flex-wrap gap-1">
+                    <button
+                        type="button"
+                        onClick={onRetry}
+                        disabled={!canRetry || busyAction !== null}
+                        data-testid={`${prefix}-retry-${item.id}`}
+                        className="rounded border border-red-300 px-2 py-1 text-[11px] text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-950/40"
+                    >
+                        Retry
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onSkip}
+                        disabled={!canSkip || busyAction !== null}
+                        data-testid={`${prefix}-skip-${item.id}`}
+                        className="rounded border border-amber-300 px-2 py-1 text-[11px] text-amber-700 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-950/40"
+                    >
+                        Skip
+                    </button>
+                </div>
+            </td>
+        </tr>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/TaskGroupRunRow.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/TaskGroupRunRow.tsx
@@ -21,6 +21,8 @@ export interface TaskGroupRunRowDisplay {
     badge: string;
     /** Noun used in tooltips/ARIA copy (e.g. 'For Each run'). */
     groupNoun: string;
+    /** Badge tooltip. Defaults to `groupNoun`. */
+    badgeTitle?: string;
     /** Accent classes for the badge chip. */
     badgeClassName: string;
     /** Ring classes applied when the row is selected. */
@@ -29,16 +31,31 @@ export interface TaskGroupRunRowDisplay {
     statusDotClassName: string;
     /** Human-readable status (for the dot's ARIA label). */
     statusLabel: string;
-    /** Raw status value (exposed as data-run-status). */
+    /** Full status-dot ARIA label. Defaults to `status: ${statusLabel}`. */
+    statusAriaLabel?: string;
+    /** Raw status value (exposed via `statusAttributeName`). */
     status: string;
-    /** Compact per-item status summary text. */
-    summary: string;
+    /** Body attribute carrying the raw status. Defaults to 'data-run-status'. */
+    statusAttributeName?: string;
+    /** Root attribute carrying the group id. Defaults to 'data-run-id'. */
+    groupIdAttributeName?: string;
+    /** Compact per-item status summary text. Omit to skip the summary span. */
+    summary?: string;
     /** Accent + sizing classes for the summary text. */
-    summaryClassName: string;
+    summaryClassName?: string;
     /** Title preview shown after the label. */
     title: string;
-    /** Copy shown when the group has no child chats. */
-    emptyChildrenText: string;
+    /** Optional test id for the title span. */
+    titleTestId?: string;
+    /** Optional tooltip for the title span. */
+    titleTooltip?: string;
+    /** Optional ARIA label for the title span. */
+    titleAriaLabel?: string;
+    /** Chevron ARIA labels. Default to `Collapse/Expand ${groupNoun}`. */
+    collapseAriaLabel?: string;
+    expandAriaLabel?: string;
+    /** Copy shown when the group has no child chats. Omit to render nothing. */
+    emptyChildrenText?: string;
 }
 
 export interface TaskGroupRunRowGroup {
@@ -65,6 +82,13 @@ export interface TaskGroupRunRowProps {
     isPinned?: boolean;
     onTogglePin?: () => void;
     onMoreActions?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+    /** Optional drag support for the row body (e.g. Ralph session-context drags). */
+    draggable?: boolean;
+    onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
+    /** Extra data attributes applied to the row body. */
+    bodyDataAttributes?: Record<string, string | undefined>;
+    /** Tooltip for the row body. */
+    bodyTitle?: string;
     renderTaskCard: (task: any) => React.ReactNode;
 }
 
@@ -84,6 +108,10 @@ export function TaskGroupRunRow({
     isPinned,
     onTogglePin,
     onMoreActions,
+    draggable,
+    onDragStart,
+    bodyDataAttributes,
+    bodyTitle,
     renderTaskCard,
 }: TaskGroupRunRowProps) {
     const [expanded, setExpanded] = useState(false);
@@ -102,10 +130,13 @@ export function TaskGroupRunRow({
         setExpanded(value => !value);
     };
 
+    const groupIdAttribute = { [display.groupIdAttributeName ?? 'data-run-id']: group.runId };
+    const statusAttribute = { [display.statusAttributeName ?? 'data-run-status']: display.status };
+
     return (
         <div
             data-testid={`${display.testIdPrefix}-row`}
-            data-run-id={group.runId}
+            {...groupIdAttribute}
             data-selected={isSelected ? 'true' : 'false'}
             className={cn(
                 isExpanded && 'bg-[#f7f7f8] dark:bg-[#1f1f20]/80',
@@ -131,15 +162,19 @@ export function TaskGroupRunRow({
                 onTouchStart={onTouchStart}
                 onTouchEnd={onTouchEnd}
                 onTouchMove={onTouchMove}
+                draggable={draggable}
+                onDragStart={onDragStart}
                 data-testid={`${display.testIdPrefix}-body`}
-                data-run-status={display.status}
+                {...statusAttribute}
+                {...bodyDataAttributes}
                 data-expanded={isExpanded ? 'true' : 'false'}
                 data-pinned={isPinned ? 'true' : undefined}
+                title={bodyTitle}
                 aria-expanded={isExpanded}
             >
                 <span
                     className={cn('w-2 h-2 rounded-full justify-self-center transition-shadow', display.statusDotClassName)}
-                    aria-label={`status: ${display.statusLabel}`}
+                    aria-label={display.statusAriaLabel ?? `status: ${display.statusLabel}`}
                 />
                 <span
                     className={cn(
@@ -147,7 +182,7 @@ export function TaskGroupRunRow({
                         'text-[9.5px] leading-none tracking-[0.06em] py-[4px] w-full',
                         display.badgeClassName,
                     )}
-                    title={display.groupNoun}
+                    title={display.badgeTitle ?? display.groupNoun}
                 >
                     {display.badge}
                 </span>
@@ -162,7 +197,9 @@ export function TaskGroupRunRow({
                         )}
                         onClick={e => { e.stopPropagation(); toggle(); }}
                         data-testid={`${display.testIdPrefix}-chevron`}
-                        aria-label={isExpanded ? `Collapse ${display.groupNoun}` : `Expand ${display.groupNoun}`}
+                        aria-label={isExpanded
+                            ? display.collapseAriaLabel ?? `Collapse ${display.groupNoun}`
+                            : display.expandAriaLabel ?? `Expand ${display.groupNoun}`}
                         aria-expanded={isExpanded}
                     >
                         <span className="text-[12px] leading-none" aria-hidden="true">›</span>
@@ -174,19 +211,26 @@ export function TaskGroupRunRow({
                             aria-label="Unseen activity"
                         />
                     )}
-                    <span className={cn('chat-title truncate text-[#1e1e1e] dark:text-[#cccccc]', group.hasUnseen && 'font-semibold')}>
+                    <span
+                        className={cn('chat-title truncate text-[#1e1e1e] dark:text-[#cccccc]', group.hasUnseen && 'font-semibold')}
+                        title={display.titleTooltip}
+                        aria-label={display.titleAriaLabel}
+                        data-testid={display.titleTestId}
+                    >
                         {display.label}
                         <span className="ml-1.5 font-normal text-[#848484] dark:text-[#9d9d9d]">
                             {display.title}
                         </span>
                     </span>
-                    <span
-                        className={display.summaryClassName}
-                        title={display.summary}
-                        data-testid={`${display.testIdPrefix}-status-summary`}
-                    >
-                        {display.summary}
-                    </span>
+                    {display.summary !== undefined && (
+                        <span
+                            className={display.summaryClassName}
+                            title={display.summary}
+                            data-testid={`${display.testIdPrefix}-status-summary`}
+                        >
+                            {display.summary}
+                        </span>
+                    )}
                     {childCount > 0 && (
                         <span
                             className="shrink-0 text-[10px] font-mono tabular-nums text-[#848484] dark:text-[#9d9d9d]"
@@ -243,11 +287,13 @@ export function TaskGroupRunRow({
                     data-testid={`${display.testIdPrefix}-children`}
                 >
                     {group.children.length === 0 ? (
-                        <div className="px-3 py-1.5 text-[11px] text-[#848484] dark:text-[#a0a0a0]" data-testid={`${display.testIdPrefix}-no-children`}>
-                            {display.emptyChildrenText}
-                        </div>
-                    ) : group.children.map((task: any) => (
-                        <div key={task.id}>
+                        display.emptyChildrenText !== undefined && (
+                            <div className="px-3 py-1.5 text-[11px] text-[#848484] dark:text-[#a0a0a0]" data-testid={`${display.testIdPrefix}-no-children`}>
+                                {display.emptyChildrenText}
+                            </div>
+                        )
+                    ) : group.children.map((task: any, index: number) => (
+                        <div key={task.id ?? index}>
                             {renderTaskCard(task)}
                         </div>
                     ))}

--- a/packages/coc/src/server/spa/client/react/features/chat/task-group-copy-info.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/task-group-copy-info.ts
@@ -1,0 +1,42 @@
+/**
+ * task-group-copy-info — pure builders for the "Copy run/session info"
+ * context-menu actions on task-group rows in the chat list.
+ */
+
+import type { ForEachRunGroup } from './for-each-run-grouping';
+import type { MapReduceRunGroup } from './map-reduce-run-grouping';
+import type { RalphSession } from './ralph-session-grouping';
+
+export function buildForEachRunCopyInfo(group: ForEachRunGroup, processIds: string[]): string {
+    return [
+        `For Each run ${group.runId}`,
+        `Status: ${group.run.status}`,
+        `Items: ${group.run.itemCount}`,
+        `Updated: ${group.run.updatedAt ?? group.run.completedAt ?? group.run.createdAt}`,
+        'Processes:',
+        ...processIds.map(id => `  - ${id}`),
+    ].join('\n');
+}
+
+export function buildMapReduceRunCopyInfo(group: MapReduceRunGroup, processIds: string[]): string {
+    return [
+        `Map Reduce run ${group.runId}`,
+        `Status: ${group.run.status}`,
+        `Map items: ${group.run.itemCount}`,
+        `Reduce: ${group.run.reduceStatus}`,
+        `Updated: ${group.run.updatedAt ?? group.run.completedAt ?? group.run.createdAt}`,
+        'Processes:',
+        ...processIds.map(id => `  - ${id}`),
+    ].join('\n');
+}
+
+export function buildRalphSessionCopyInfo(session: RalphSession, processIds: string[]): string {
+    return [
+        `Ralph session ${session.sessionId}`,
+        `Phase: ${session.phase}`,
+        `Iterations: ${session.iterations.length}`,
+        `Updated: ${session.latestTimestamp ? new Date(session.latestTimestamp).toISOString() : 'unknown'}`,
+        'Processes:',
+        ...processIds.map(id => `  - ${id}`),
+    ].join('\n');
+}

--- a/packages/coc/src/server/spa/client/react/features/chat/task-group-expansion.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/task-group-expansion.ts
@@ -1,0 +1,90 @@
+/**
+ * task-group-expansion — workspace-scoped expand/collapse state for
+ * hierarchical task-group rows in the chat list (Ralph sessions, For Each
+ * runs, Map Reduce runs, future group types).
+ *
+ * One state object keyed by group kind replaces per-feature useState
+ * triplets. The pure helpers are unit-testable; `useTaskGroupExpansion`
+ * wraps them for ChatListPane. Expansion is cleared when the workspace
+ * changes, and per-kind set identity is preserved when another kind is
+ * toggled so memoized consumers do not recompute.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface TaskGroupExpansionState {
+    workspaceId?: string;
+    byKind: Record<string, ReadonlySet<string>>;
+}
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+export function createTaskGroupExpansionState(workspaceId?: string): TaskGroupExpansionState {
+    return { workspaceId, byKind: {} };
+}
+
+/** Expanded group ids for a kind; empty when the state belongs to another workspace. */
+export function getExpandedTaskGroupIds(
+    state: TaskGroupExpansionState,
+    workspaceId: string | undefined,
+    kind: string,
+): ReadonlySet<string> {
+    if (state.workspaceId !== workspaceId) return EMPTY_SET;
+    return state.byKind[kind] ?? EMPTY_SET;
+}
+
+/** Toggle one group id; discards state carried over from another workspace. */
+export function toggleExpandedTaskGroupId(
+    state: TaskGroupExpansionState,
+    workspaceId: string | undefined,
+    kind: string,
+    groupId: string,
+): TaskGroupExpansionState {
+    const sameWorkspace = state.workspaceId === workspaceId;
+    const current = sameWorkspace ? state.byKind[kind] ?? EMPTY_SET : EMPTY_SET;
+    const next = new Set(current);
+    if (next.has(groupId)) {
+        next.delete(groupId);
+    } else {
+        next.add(groupId);
+    }
+    return {
+        workspaceId,
+        byKind: sameWorkspace ? { ...state.byKind, [kind]: next } : { [kind]: next },
+    };
+}
+
+/** Clear expansion when the workspace changes; keeps identity when already clean. */
+export function resetTaskGroupExpansionForWorkspace(
+    state: TaskGroupExpansionState,
+    workspaceId: string | undefined,
+): TaskGroupExpansionState {
+    const isClean = state.workspaceId === workspaceId
+        && Object.values(state.byKind).every(ids => ids.size === 0);
+    if (isClean) return state;
+    return createTaskGroupExpansionState(workspaceId);
+}
+
+export interface TaskGroupExpansion {
+    expandedIds: (kind: string) => ReadonlySet<string>;
+    toggle: (kind: string, groupId: string) => void;
+}
+
+export function useTaskGroupExpansion(workspaceId: string | undefined): TaskGroupExpansion {
+    const [state, setState] = useState<TaskGroupExpansionState>(() => createTaskGroupExpansionState(workspaceId));
+
+    useEffect(() => {
+        setState(prev => resetTaskGroupExpansionForWorkspace(prev, workspaceId));
+    }, [workspaceId]);
+
+    const expandedIds = useCallback(
+        (kind: string) => getExpandedTaskGroupIds(state, workspaceId, kind),
+        [state, workspaceId],
+    );
+    const toggle = useCallback(
+        (kind: string, groupId: string) => setState(prev => toggleExpandedTaskGroupId(prev, workspaceId, kind, groupId)),
+        [workspaceId],
+    );
+
+    return { expandedIds, toggle };
+}

--- a/packages/coc/test/server/spa/client/repos/MapReducePlanReviewCard.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/MapReducePlanReviewCard.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MapReduceRun } from '@plusplusoneplusplus/coc-client';
+import type { ClientConversationTurn } from '../../../../../src/server/spa/client/react/types/dashboard';
+
+const mocks = vi.hoisted(() => ({
+    create: vi.fn(),
+    updatePlan: vi.fn(),
+    approve: vi.fn(),
+    start: vi.fn(),
+    continueRun: vi.fn(),
+    processUpdate: vi.fn(),
+    getErrorMessage: vi.fn((err: unknown, fallback: string) => err instanceof Error ? err.message : fallback),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        mapReduce: {
+            create: mocks.create,
+            updatePlan: mocks.updatePlan,
+            approve: mocks.approve,
+            start: mocks.start,
+            continue: mocks.continueRun,
+        },
+        processes: {
+            patchMetadata: mocks.processUpdate,
+        },
+    }),
+    getSpaCocClientErrorMessage: mocks.getErrorMessage,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/ui/cn', () => ({
+    cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}));
+
+import { MapReducePlanReviewCard, scanMapReducePlans, type MapReduceGenerationMetadata } from '../../../../../src/server/spa/client/react/features/chat/MapReducePlanReviewCard';
+
+const generation: MapReduceGenerationMetadata = {
+    kind: 'generation',
+    workspaceId: 'ws-1',
+    generationId: 'map-reduce-gen-1',
+    childMode: 'ask',
+    originalRequest: 'Fan out this work',
+    status: 'draft',
+};
+
+function makeRun(overrides: Partial<MapReduceRun> = {}): MapReduceRun {
+    return {
+        runId: 'map-reduce-run-1',
+        workspaceId: 'ws-1',
+        status: 'draft',
+        originalRequest: 'Fan out this work',
+        reduceInstructions: 'Merge everything',
+        maxParallel: 2,
+        childMode: 'ask',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        reduceStep: { status: 'pending' },
+        items: [
+            { id: 'item-1', title: 'First item', prompt: 'Do first', status: 'pending' },
+            { id: 'item-2', title: 'Second item', prompt: 'Do second', dependsOn: ['item-1'], status: 'pending' },
+        ],
+        ...overrides,
+    } as MapReduceRun;
+}
+
+function planJson(items = makeRun().items) {
+    return { items, reduceInstructions: 'Merge everything', maxParallel: 2 };
+}
+
+function assistantPlan(items = makeRun().items, turnIndex = 1): ClientConversationTurn {
+    return {
+        role: 'assistant',
+        turnIndex,
+        timeline: [],
+        content: `Here is the proposed plan.\n\n\`\`\`json\n${JSON.stringify(planJson(items), null, 2)}\n\`\`\``,
+    };
+}
+
+function renderCard(turns: ClientConversationTurn[] = [assistantPlan()], overrides: Partial<MapReduceGenerationMetadata> = {}) {
+    return render(
+        <MapReducePlanReviewCard
+            workspaceId="ws-1"
+            processId="queue_gen-1"
+            metadataProcess={{
+                metadata: {
+                    provider: 'copilot',
+                    model: 'gpt-5.4',
+                    mapReduce: { ...generation, ...overrides },
+                },
+            }}
+            mapReduce={{ ...generation, ...overrides }}
+            turns={turns}
+            provider="copilot"
+            model="gpt-5.4"
+            reasoningEffort="medium"
+            onApprovedRun={mocks.processUpdate}
+        />,
+    );
+}
+
+describe('MapReducePlanReviewCard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.create.mockResolvedValue(makeRun());
+        mocks.updatePlan.mockResolvedValue(makeRun());
+        mocks.approve.mockResolvedValue(makeRun({ status: 'approved', approvedAt: '2026-01-01T00:01:00.000Z' }));
+        mocks.processUpdate.mockResolvedValue({ process: {} });
+    });
+
+    it('renders the latest valid generated plan with reduce fields as an editable card', async () => {
+        renderCard();
+
+        await waitFor(() => expect(screen.getByTestId('map-reduce-plan-review-card')).toBeTruthy());
+        expect((screen.getByTestId('map-reduce-plan-item-title-0') as HTMLInputElement).value).toBe('First item');
+        expect((screen.getByTestId('map-reduce-reduce-instructions-editor') as HTMLTextAreaElement).value).toBe('Merge everything');
+        expect((screen.getByTestId('map-reduce-max-parallel-editor') as HTMLInputElement).value).toBe('2');
+        expect(screen.getByTestId('map-reduce-plan-max-parallel-pill').textContent).toContain('max 2 parallel');
+        expect(screen.getByTestId('map-reduce-plan-validation-ok').textContent).toContain('ready for approval');
+
+        fireEvent.change(screen.getByTestId('map-reduce-plan-item-title-0'), { target: { value: 'Edited first' } });
+        fireEvent.click(screen.getByTestId('map-reduce-plan-add-item'));
+        fireEvent.change(screen.getByTestId('map-reduce-plan-item-prompt-2'), { target: { value: 'Do the added item' } });
+
+        expect((screen.getByTestId('map-reduce-plan-item-title-0') as HTMLInputElement).value).toBe('Edited first');
+        expect(screen.getByTestId('map-reduce-plan-dirty').textContent).toContain('Edited');
+        expect(screen.getByTestId('map-reduce-plan-validation-ok').textContent).toContain('ready for approval');
+    });
+
+    it('keeps the previous valid plan when a later assistant turn has invalid JSON', () => {
+        const invalidTurn: ClientConversationTurn = {
+            role: 'assistant',
+            turnIndex: 3,
+            timeline: [],
+            content: 'Refinement failed.\n\n```json\n{"items":[{"id":"item-3","title":"Missing prompt","status":"pending"}]}\n```',
+        };
+
+        renderCard([assistantPlan(makeRun().items, 1), invalidTurn]);
+
+        expect(screen.getByTestId('map-reduce-plan-scan-error').textContent).toContain('Latest assistant output did not contain a valid Map Reduce plan');
+        expect((screen.getByTestId('map-reduce-plan-item-title-0') as HTMLInputElement).value).toBe('First item');
+    });
+
+    it('renders a persisted latest plan from metadata when the transcript has no parseable JSON', () => {
+        renderCard([
+            { role: 'assistant', turnIndex: 1, timeline: [], content: 'Readable summary without JSON.' },
+        ], {
+            latestItemCount: 2,
+            latestPlanTurnIndex: 1,
+            latestPlan: {
+                turnIndex: 1,
+                childMode: 'ask',
+                items: makeRun().items,
+                reduceInstructions: 'Merge everything',
+                maxParallel: 2,
+                rawJson: JSON.stringify(planJson()),
+            },
+        });
+
+        expect(screen.getByTestId('map-reduce-plan-review-card')).toBeTruthy();
+        expect((screen.getByTestId('map-reduce-plan-item-title-0') as HTMLInputElement).value).toBe('First item');
+        expect(screen.queryByTestId('map-reduce-plan-scan-error')).toBeNull();
+    });
+
+    it('blocks approval when reduce instructions are cleared', async () => {
+        renderCard();
+        await waitFor(() => expect(screen.getByTestId('map-reduce-plan-approve-btn')).toBeEnabled());
+
+        fireEvent.change(screen.getByTestId('map-reduce-reduce-instructions-editor'), { target: { value: '   ' } });
+
+        expect(screen.getByTestId('map-reduce-plan-validation-error')).toBeTruthy();
+        expect(screen.getByTestId('map-reduce-plan-approve-btn')).toBeDisabled();
+        expect(mocks.create).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getByTestId('map-reduce-reduce-instructions-editor'), { target: { value: 'Merge again' } });
+        expect(screen.getByTestId('map-reduce-plan-validation-ok').textContent).toContain('ready for approval');
+    });
+
+    it('shows Advanced JSON errors inline and blocks approval', async () => {
+        renderCard();
+        await waitFor(() => expect(screen.getByTestId('map-reduce-plan-json-toggle')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('map-reduce-plan-json-toggle'));
+        fireEvent.change(screen.getByTestId('map-reduce-plan-json'), { target: { value: '{not-json' } });
+
+        expect(screen.getByTestId('map-reduce-plan-json-error').textContent).toContain('valid JSON');
+        expect(screen.getByTestId('map-reduce-plan-approve-btn')).toBeDisabled();
+        expect(mocks.create).not.toHaveBeenCalled();
+        expect(mocks.approve).not.toHaveBeenCalled();
+    });
+
+    it('applies valid Advanced JSON edits back to the structured editor', async () => {
+        renderCard();
+        await waitFor(() => expect(screen.getByTestId('map-reduce-plan-json-toggle')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('map-reduce-plan-json-toggle'));
+        fireEvent.change(screen.getByTestId('map-reduce-plan-json'), {
+            target: {
+                value: JSON.stringify({
+                    childMode: 'autopilot',
+                    sharedInstructions: 'Run these in order.',
+                    maxParallel: 4,
+                    reduceInstructions: 'Combine outputs',
+                    items: [
+                        { id: 'json-item', title: 'JSON item', prompt: 'Do JSON work', status: 'pending' },
+                    ],
+                }, null, 2),
+            },
+        });
+
+        expect(screen.queryByTestId('map-reduce-plan-json-error')).toBeNull();
+        expect((screen.getByTestId('map-reduce-plan-item-title-0') as HTMLInputElement).value).toBe('JSON item');
+        expect((screen.getByTestId('map-reduce-shared-instructions-editor') as HTMLTextAreaElement).value).toBe('Run these in order.');
+        expect((screen.getByTestId('map-reduce-max-parallel-editor') as HTMLInputElement).value).toBe('4');
+        expect((screen.getByTestId('map-reduce-reduce-instructions-editor') as HTMLTextAreaElement).value).toBe('Combine outputs');
+        expect(screen.getByTestId('map-reduce-plan-validation-ok').textContent).toContain('ready for approval');
+    });
+
+    it('approves the reviewed plan with reduce fields and links generation metadata', async () => {
+        const onApprovedRun = vi.fn();
+        render(
+            <MapReducePlanReviewCard
+                workspaceId="ws-1"
+                processId="queue_gen-1"
+                metadataProcess={{
+                    metadata: {
+                        provider: 'copilot',
+                        model: 'gpt-5.4',
+                        mapReduce: generation,
+                    },
+                }}
+                mapReduce={generation}
+                turns={[assistantPlan()]}
+                provider="copilot"
+                model="gpt-5.4"
+                reasoningEffort="medium"
+                onApprovedRun={onApprovedRun}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId('map-reduce-plan-approve-btn')).toBeEnabled());
+        fireEvent.change(screen.getByTestId('map-reduce-max-parallel-editor'), { target: { value: '5' } });
+        fireEvent.click(screen.getByTestId('map-reduce-plan-child-mode-autopilot'));
+        fireEvent.click(screen.getByTestId('map-reduce-plan-approve-btn'));
+
+        await waitFor(() => expect(mocks.create).toHaveBeenCalledOnce());
+        expect(mocks.create).toHaveBeenCalledWith('ws-1', expect.objectContaining({
+            originalRequest: 'Fan out this work',
+            childMode: 'autopilot',
+            reduceInstructions: 'Merge everything',
+            maxParallel: 5,
+            provider: 'copilot',
+            config: { model: 'gpt-5.4', reasoningEffort: 'medium' },
+            generationProcessId: 'queue_gen-1',
+            generationId: 'map-reduce-gen-1',
+        }));
+        expect(mocks.approve).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1');
+        expect(mocks.start).not.toHaveBeenCalled();
+        expect(mocks.continueRun).not.toHaveBeenCalled();
+        expect(mocks.processUpdate).toHaveBeenCalledWith('queue_gen-1', {
+            set: expect.objectContaining({
+                mapReduce: expect.objectContaining({
+                    status: 'approved',
+                    runId: 'map-reduce-run-1',
+                    latestItemCount: 2,
+                    latestPlanTurnIndex: 1,
+                }),
+            }),
+        }, { workspace: 'ws-1' });
+        expect(onApprovedRun).toHaveBeenCalledWith('map-reduce-run-1');
+    });
+
+    it('updates the existing run plan when the generation already has a run id', async () => {
+        renderCard([assistantPlan()], { runId: 'map-reduce-run-1' });
+
+        await waitFor(() => expect(screen.getByTestId('map-reduce-plan-approve-btn')).toBeEnabled());
+        fireEvent.click(screen.getByTestId('map-reduce-plan-approve-btn'));
+
+        await waitFor(() => expect(mocks.updatePlan).toHaveBeenCalledOnce());
+        expect(mocks.updatePlan).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1', expect.objectContaining({
+            reduceInstructions: 'Merge everything',
+            maxParallel: 2,
+        }));
+        expect(mocks.create).not.toHaveBeenCalled();
+        expect(mocks.approve).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1');
+    });
+
+    it('scans the newest valid plan after a successful refinement', () => {
+        const refined = [
+            { id: 'item-1', title: 'Refined item', prompt: 'Do refined work', status: 'pending' as const },
+        ];
+        const result = scanMapReducePlans([assistantPlan(makeRun().items, 1), assistantPlan(refined, 3)]);
+
+        expect(result.error).toBeNull();
+        expect(result.plan?.turnIndex).toBe(3);
+        expect(result.plan?.items).toHaveLength(1);
+        expect(result.plan?.items[0].title).toBe('Refined item');
+    });
+});

--- a/packages/coc/test/server/spa/client/repos/MapReduceRunPane.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/MapReduceRunPane.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MapReduceRun } from '@plusplusoneplusplus/coc-client';
+
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    start: vi.fn(),
+    continueRun: vi.fn(),
+    retryItem: vi.fn(),
+    skipItem: vi.fn(),
+    retryReduce: vi.fn(),
+    cancel: vi.fn(),
+    getErrorMessage: vi.fn((err: unknown, fallback: string) => err instanceof Error ? err.message : fallback),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        mapReduce: {
+            get: mocks.get,
+            start: mocks.start,
+            continue: mocks.continueRun,
+            retryItem: mocks.retryItem,
+            skipItem: mocks.skipItem,
+            retryReduce: mocks.retryReduce,
+            cancel: mocks.cancel,
+        },
+    }),
+    getSpaCocClientErrorMessage: mocks.getErrorMessage,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/ui/cn', () => ({
+    cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/utils/format', () => ({
+    formatRelativeTime: (value: string) => `relative:${value}`,
+}));
+
+import { MapReduceRunPane } from '../../../../../src/server/spa/client/react/features/chat/MapReduceRunPane';
+
+function makeRun(overrides: Partial<MapReduceRun> = {}): MapReduceRun {
+    return {
+        runId: 'map-reduce-run-1',
+        workspaceId: 'ws-1',
+        status: 'approved',
+        originalRequest: 'Fan out the work',
+        sharedInstructions: 'Keep each map item isolated',
+        reduceInstructions: 'Merge all map results',
+        maxParallel: 3,
+        childMode: 'autopilot',
+        provider: 'copilot',
+        generationProcessId: 'queue_generation-chat',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:01:00.000Z',
+        approvedAt: '2026-01-01T00:00:30.000Z',
+        reduceStep: { status: 'pending' },
+        items: [
+            {
+                id: 'pending-item',
+                title: 'Pending item',
+                prompt: 'Do pending work',
+                status: 'pending',
+            },
+            {
+                id: 'failed-item',
+                title: 'Failed item',
+                prompt: 'Retry this work',
+                status: 'failed',
+                error: 'Child task failed',
+                childProcessId: 'queue_child-failed',
+            },
+            {
+                id: 'done-item',
+                title: 'Done item',
+                prompt: 'Already done',
+                status: 'completed',
+                childProcessId: 'queue_child-done',
+            },
+        ],
+        ...overrides,
+    } as MapReduceRun;
+}
+
+describe('MapReduceRunPane', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.get.mockResolvedValue(makeRun());
+        mocks.start.mockResolvedValue(makeRun({ status: 'running' }));
+        mocks.continueRun.mockResolvedValue(makeRun({ status: 'running' }));
+        mocks.retryItem.mockResolvedValue(makeRun({ status: 'running' }));
+        mocks.skipItem.mockResolvedValue(makeRun({ status: 'running' }));
+        mocks.retryReduce.mockResolvedValue(makeRun({ status: 'reducing', reduceStep: { status: 'running' } }));
+        mocks.cancel.mockResolvedValue(makeRun({ status: 'cancelled' }));
+    });
+
+    it('renders run metadata, reduce step, item chips, and child links', async () => {
+        const onSelectChildProcess = vi.fn();
+        const onSelectGenerationProcess = vi.fn();
+        render(<MapReduceRunPane workspaceId="ws-1" runId="map-reduce-run-1" onSelectChildProcess={onSelectChildProcess} onSelectGenerationProcess={onSelectGenerationProcess} />);
+
+        await waitFor(() => expect(screen.getByTestId('map-reduce-run-pane')).toBeTruthy());
+        expect(screen.getByTestId('map-reduce-run-status').textContent).toContain('approved');
+        expect(screen.getByTestId('map-reduce-run-counts').textContent).toContain('1 pending');
+        expect(screen.getByTestId('map-reduce-original-request').textContent).toContain('Fan out the work');
+        expect(screen.getByTestId('map-reduce-shared-instructions-preview').textContent).toContain('Keep each map item isolated');
+        expect(screen.getByTestId('map-reduce-reduce-step').textContent).toContain('Merge all map results');
+        expect(screen.getByTestId('map-reduce-reduce-status').textContent).toContain('pending');
+        expect(screen.getByTestId('map-reduce-item-prompt-pending-item').textContent).toContain('Do pending work');
+
+        fireEvent.click(screen.getByTestId('map-reduce-generation-link-btn'));
+        expect(onSelectGenerationProcess).toHaveBeenCalledWith('queue_generation-chat');
+
+        fireEvent.click(screen.getByTestId('map-reduce-child-link-done-item'));
+        expect(onSelectChildProcess).toHaveBeenCalledWith('queue_child-done');
+        expect(screen.getByTestId('map-reduce-child-link-done-item').textContent).toContain('Open map chat');
+    });
+
+    it('starts an approved run with the start endpoint', async () => {
+        mocks.get.mockResolvedValueOnce(makeRun({ status: 'approved', items: [makeRun().items[0]] }));
+
+        render(<MapReduceRunPane workspaceId="ws-1" runId="map-reduce-run-1" />);
+        await waitFor(() => expect(screen.getByTestId('map-reduce-continue-btn')).toBeEnabled());
+
+        fireEvent.click(screen.getByTestId('map-reduce-continue-btn'));
+
+        await waitFor(() => expect(mocks.start).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1'));
+        expect(mocks.continueRun).not.toHaveBeenCalled();
+    });
+
+    it('continues a reducing run with a pending reduce step', async () => {
+        mocks.get.mockResolvedValueOnce(makeRun({
+            status: 'reducing',
+            reduceStep: { status: 'pending' },
+            items: [{ ...makeRun().items[2] }],
+        }));
+
+        render(<MapReduceRunPane workspaceId="ws-1" runId="map-reduce-run-1" />);
+        await waitFor(() => expect(screen.getByTestId('map-reduce-continue-btn')).toBeEnabled());
+
+        fireEvent.click(screen.getByTestId('map-reduce-continue-btn'));
+
+        await waitFor(() => expect(mocks.continueRun).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1'));
+        expect(mocks.start).not.toHaveBeenCalled();
+    });
+
+    it('disables continue while the reduce step is running', async () => {
+        mocks.get.mockResolvedValueOnce(makeRun({
+            status: 'reducing',
+            reduceStep: { status: 'running', childProcessId: 'queue_reduce-chat' },
+            items: [{ ...makeRun().items[2] }],
+        }));
+
+        render(<MapReduceRunPane workspaceId="ws-1" runId="map-reduce-run-1" />);
+        await waitFor(() => expect(screen.getByTestId('map-reduce-run-pane')).toBeTruthy());
+        expect(screen.getByTestId('map-reduce-continue-btn')).toBeDisabled();
+        expect(screen.getByTestId('map-reduce-reduce-child-link').textContent).toContain('Open reduce chat');
+    });
+
+    it('retries a failed reduce step and links the final result when completed', async () => {
+        const onSelectChildProcess = vi.fn();
+        mocks.get.mockResolvedValueOnce(makeRun({
+            status: 'failed',
+            reduceStep: { status: 'failed', error: 'reduce blew up', childProcessId: 'queue_reduce-chat' },
+        }));
+        mocks.retryReduce.mockResolvedValueOnce(makeRun({
+            status: 'completed',
+            reduceStep: { status: 'completed', childProcessId: 'queue_reduce-final' },
+        }));
+
+        render(<MapReduceRunPane workspaceId="ws-1" runId="map-reduce-run-1" onSelectChildProcess={onSelectChildProcess} />);
+        await waitFor(() => expect(screen.getByTestId('map-reduce-reduce-step').textContent).toContain('reduce blew up'));
+
+        fireEvent.click(screen.getByTestId('map-reduce-retry-reduce'));
+        await waitFor(() => expect(mocks.retryReduce).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1'));
+
+        await waitFor(() => expect(screen.getByTestId('map-reduce-final-result-link')).toBeTruthy());
+        fireEvent.click(screen.getByTestId('map-reduce-final-result-link'));
+        expect(onSelectChildProcess).toHaveBeenCalledWith('queue_reduce-final');
+    });
+
+    it('retries failed items, skips pending items, and cancels remaining work', async () => {
+        render(<MapReduceRunPane workspaceId="ws-1" runId="map-reduce-run-1" />);
+        await waitFor(() => expect(screen.getByTestId('map-reduce-run-pane')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('map-reduce-retry-failed-item'));
+        await waitFor(() => expect(mocks.retryItem).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1', 'failed-item'));
+
+        fireEvent.click(screen.getByTestId('map-reduce-skip-pending-item'));
+        await waitFor(() => expect(mocks.skipItem).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1', 'pending-item'));
+
+        fireEvent.click(screen.getByTestId('map-reduce-cancel-btn'));
+        await waitFor(() => expect(mocks.cancel).toHaveBeenCalledWith('ws-1', 'map-reduce-run-1'));
+    });
+
+    it('shows an empty state when the run cannot be loaded', async () => {
+        mocks.get.mockRejectedValueOnce(new Error('missing run'));
+
+        render(<MapReduceRunPane workspaceId="ws-1" runId="missing-run" />);
+
+        await waitFor(() => expect(screen.getByTestId('map-reduce-run-pane-empty').textContent).toContain('Map Reduce run not found'));
+        expect(screen.getByTestId('map-reduce-run-pane-empty').textContent).toContain('missing run');
+    });
+});

--- a/packages/coc/test/server/spa/client/task-group-copy-info.test.ts
+++ b/packages/coc/test/server/spa/client/task-group-copy-info.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildForEachRunCopyInfo,
+    buildMapReduceRunCopyInfo,
+    buildRalphSessionCopyInfo,
+} from '../../../../src/server/spa/client/react/features/chat/task-group-copy-info';
+import type { ForEachRunGroup } from '../../../../src/server/spa/client/react/features/chat/for-each-run-grouping';
+import type { MapReduceRunGroup } from '../../../../src/server/spa/client/react/features/chat/map-reduce-run-grouping';
+import type { RalphSession } from '../../../../src/server/spa/client/react/features/chat/ralph-session-grouping';
+
+describe('task-group-copy-info', () => {
+    it('builds For Each run info with the freshest available timestamp', () => {
+        const group = {
+            kind: 'for-each-run',
+            runId: 'run-1',
+            run: {
+                runId: 'run-1',
+                status: 'running',
+                itemCount: 3,
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-02T00:00:00.000Z',
+            },
+            children: [],
+            latestTimestamp: 0,
+            hasUnseen: false,
+        } as unknown as ForEachRunGroup;
+
+        expect(buildForEachRunCopyInfo(group, ['p-1', 'p-2'])).toBe([
+            'For Each run run-1',
+            'Status: running',
+            'Items: 3',
+            'Updated: 2026-01-02T00:00:00.000Z',
+            'Processes:',
+            '  - p-1',
+            '  - p-2',
+        ].join('\n'));
+    });
+
+    it('falls back through completedAt then createdAt for For Each runs', () => {
+        const group = {
+            runId: 'run-2',
+            run: { status: 'completed', itemCount: 1, createdAt: 'created', completedAt: 'completed' },
+        } as unknown as ForEachRunGroup;
+        expect(buildForEachRunCopyInfo(group, [])).toContain('Updated: completed');
+
+        const draftGroup = {
+            runId: 'run-3',
+            run: { status: 'draft', itemCount: 1, createdAt: 'created' },
+        } as unknown as ForEachRunGroup;
+        expect(buildForEachRunCopyInfo(draftGroup, [])).toContain('Updated: created');
+    });
+
+    it('builds Map Reduce run info including the reduce status', () => {
+        const group = {
+            kind: 'map-reduce-run',
+            runId: 'run-1',
+            run: {
+                runId: 'run-1',
+                status: 'reducing',
+                reduceStatus: 'running',
+                itemCount: 2,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+            children: [],
+        } as unknown as MapReduceRunGroup;
+
+        expect(buildMapReduceRunCopyInfo(group, ['p-1'])).toBe([
+            'Map Reduce run run-1',
+            'Status: reducing',
+            'Map items: 2',
+            'Reduce: running',
+            'Updated: 2026-01-01T00:00:00.000Z',
+            'Processes:',
+            '  - p-1',
+        ].join('\n'));
+    });
+
+    it('builds Ralph session info with an ISO timestamp or unknown', () => {
+        const session = {
+            kind: 'ralph-session',
+            sessionId: 's-1',
+            phase: 'executing',
+            iterations: [{}, {}],
+            latestTimestamp: Date.UTC(2026, 0, 3),
+        } as unknown as RalphSession;
+
+        expect(buildRalphSessionCopyInfo(session, ['p-1'])).toBe([
+            'Ralph session s-1',
+            'Phase: executing',
+            'Iterations: 2',
+            'Updated: 2026-01-03T00:00:00.000Z',
+            'Processes:',
+            '  - p-1',
+        ].join('\n'));
+
+        const stale = { ...session, latestTimestamp: 0 } as unknown as RalphSession;
+        expect(buildRalphSessionCopyInfo(stale, [])).toContain('Updated: unknown');
+    });
+});

--- a/packages/coc/test/server/spa/client/task-group-expansion.test.ts
+++ b/packages/coc/test/server/spa/client/task-group-expansion.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+    createTaskGroupExpansionState,
+    getExpandedTaskGroupIds,
+    resetTaskGroupExpansionForWorkspace,
+    toggleExpandedTaskGroupId,
+} from '../../../../src/server/spa/client/react/features/chat/task-group-expansion';
+
+describe('task-group-expansion', () => {
+    it('starts with nothing expanded for any kind', () => {
+        const state = createTaskGroupExpansionState('ws-1');
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'ralph').size).toBe(0);
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'for-each').size).toBe(0);
+    });
+
+    it('toggles a group id on and off per kind', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'ralph').has('session-1')).toBe(true);
+
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'ralph').has('session-1')).toBe(false);
+    });
+
+    it('keeps kinds independent', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'group-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'for-each', 'group-1');
+
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'group-1');
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'ralph').has('group-1')).toBe(false);
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'for-each').has('group-1')).toBe(true);
+    });
+
+    it('preserves set identity for kinds that were not toggled', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        const ralphBefore = getExpandedTaskGroupIds(state, 'ws-1', 'ralph');
+
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'for-each', 'run-1');
+        expect(getExpandedTaskGroupIds(state, 'ws-1', 'ralph')).toBe(ralphBefore);
+    });
+
+    it('reports nothing expanded when reading a different workspace', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        expect(getExpandedTaskGroupIds(state, 'ws-2', 'ralph').size).toBe(0);
+    });
+
+    it('discards stale state when toggling under a new workspace', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-2', 'ralph', 'session-2');
+
+        expect(state.workspaceId).toBe('ws-2');
+        expect(getExpandedTaskGroupIds(state, 'ws-2', 'ralph').has('session-2')).toBe(true);
+        expect(getExpandedTaskGroupIds(state, 'ws-2', 'ralph').has('session-1')).toBe(false);
+    });
+
+    it('resets on workspace change and keeps identity when already clean', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        const clean = resetTaskGroupExpansionForWorkspace(state, 'ws-1');
+        expect(clean).toBe(state);
+
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'map-reduce', 'run-1');
+        const reset = resetTaskGroupExpansionForWorkspace(state, 'ws-2');
+        expect(reset.workspaceId).toBe('ws-2');
+        expect(getExpandedTaskGroupIds(reset, 'ws-2', 'map-reduce').size).toBe(0);
+    });
+
+    it('keeps identity when resetting a clean state with expanded-then-collapsed groups', () => {
+        let state = createTaskGroupExpansionState('ws-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        state = toggleExpandedTaskGroupId(state, 'ws-1', 'ralph', 'session-1');
+        const reset = resetTaskGroupExpansionForWorkspace(state, 'ws-1');
+        expect(reset).toBe(state);
+    });
+});


### PR DESCRIPTION
## Summary
- Extract shared TaskGroupRunPane and TaskGroupPlanReviewCard components for For Each and Map Reduce chat UI
- Reuse shared task-group row chrome in Ralph session rows
- Consolidate task-group expansion and copy-info helpers, with tests and docs for the shared UI family

## Tests
- Not run; submitting existing local commits as a PR
