### PR TITLE
fix(skills): include OneDrive skill directories in loadSkillsForWorks…

### DIFF
--- a/packages/coc/src/server/skills/skill-handler.ts
+++ b/packages/coc/src/server/skills/skill-handler.ts
@@ -458,7 +458,25 @@ export async function loadSkillsForWorkspace(
         }
     }
 
-    let skills = dedupByName([...localSkills, ...globalSkills, ...globalExtraSkills, ...extraSkills]);
+    // OneDrive-based skill directories (Windows)
+    const oneDriveSkills: SkillInfo[] = [];
+    const seenNames = new Set([...localNames, ...globalNames, ...globalExtraSkills.map(s => s.name), ...extraSkills.map(s => s.name)]);
+    const homedir = os.homedir();
+    for (const variant of ['OneDrive', 'OneDrive - Microsoft']) {
+        const oneDriveSkillsDir = path.join(homedir, variant, '.github', 'skills');
+        if (fs.existsSync(oneDriveSkillsDir)) {
+            const odSkills = listInstalledSkills(oneDriveSkillsDir);
+            for (const skill of odSkills) {
+                if (seenNames.has(skill.name)) continue;
+                seenNames.add(skill.name);
+                skill.source = 'extra-folder';
+                skill.folderPath = oneDriveSkillsDir;
+                oneDriveSkills.push(skill);
+            }
+        }
+    }
+
+    let skills = dedupByName([...localSkills, ...globalSkills, ...globalExtraSkills, ...extraSkills, ...oneDriveSkills]);
     if (dataDir) {
         try {
             const repoPrefsPath = getRepoDataPath(dataDir, id, 'preferences.json');

--- a/packages/coc/test/server/skill-handler-onedrive.test.ts
+++ b/packages/coc/test/server/skill-handler-onedrive.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for OneDrive skill directory support in loadSkillsForWorkspace.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+// Capture real homedir before any mock takes effect.
+// eslint-disable-next-line no-var
+var _realHomedir: string;
+
+vi.mock('os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('os')>();
+    _realHomedir = actual.homedir();
+    return {
+        ...actual,
+        homedir: vi.fn(() => _realHomedir),
+    };
+});
+
+import { loadSkillsForWorkspace, skillCache } from '../../src/server/skills/skill-handler';
+import { createMockProcessStore } from './helpers/mock-process-store';
+import type { WorkspaceInfo } from '@plusplusoneplusplus/forge';
+
+describe('loadSkillsForWorkspace — OneDrive skill directories', () => {
+    let tmpDir: string;
+    let workspaceDir: string;
+    let store: ReturnType<typeof createMockProcessStore>;
+    const workspaceId = 'ws-onedrive-test';
+
+    beforeEach(() => {
+        skillCache.clear();
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-od-'));
+        workspaceDir = path.join(tmpDir, 'repo');
+        fs.mkdirSync(workspaceDir, { recursive: true });
+        store = createMockProcessStore({
+            initialWorkspaces: [{
+                id: workspaceId,
+                name: 'Test Workspace',
+                rootPath: workspaceDir,
+            } as WorkspaceInfo],
+        });
+        store.getWorkspaces = vi.fn(async () => [{
+            id: workspaceId,
+            name: 'Test Workspace',
+            rootPath: workspaceDir,
+        } as WorkspaceInfo]);
+        vi.mocked(os.homedir).mockImplementation(() => _realHomedir);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('includes skills from OneDrive/.github/skills', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        const oneDriveSkillsDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        fs.mkdirSync(path.join(oneDriveSkillsDir, 'od-skill'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveSkillsDir, 'od-skill', 'SKILL.md'), '---\ndescription: OneDrive skill\n---\n# od-skill');
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, undefined, store);
+
+        const odSkill = skills.find(s => s.name === 'od-skill');
+        expect(odSkill).toBeDefined();
+        expect(odSkill!.source).toBe('extra-folder');
+        expect(odSkill!.folderPath).toBe(oneDriveSkillsDir);
+        expect(odSkill!.description).toBe('OneDrive skill');
+    });
+
+    it('includes skills from OneDrive - Microsoft/.github/skills', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        const oneDriveMsSkillsDir = path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills');
+        fs.mkdirSync(path.join(oneDriveMsSkillsDir, 'ms-skill'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveMsSkillsDir, 'ms-skill', 'SKILL.md'), '---\ndescription: MS OneDrive skill\n---\n# ms-skill');
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, undefined, store);
+
+        const msSkill = skills.find(s => s.name === 'ms-skill');
+        expect(msSkill).toBeDefined();
+        expect(msSkill!.source).toBe('extra-folder');
+        expect(msSkill!.folderPath).toBe(oneDriveMsSkillsDir);
+    });
+
+    it('includes skills from both OneDrive variants when both exist', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        const oneDriveDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        const oneDriveMsDir = path.join(fakeHome, 'OneDrive - Microsoft', '.github', 'skills');
+        fs.mkdirSync(path.join(oneDriveDir, 'skill-a'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveDir, 'skill-a', 'SKILL.md'), '# skill-a');
+        fs.mkdirSync(path.join(oneDriveMsDir, 'skill-b'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveMsDir, 'skill-b', 'SKILL.md'), '# skill-b');
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, undefined, store);
+
+        const names = skills.map(s => s.name);
+        expect(names).toContain('skill-a');
+        expect(names).toContain('skill-b');
+    });
+
+    it('skips OneDrive directories that do not exist', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        fs.mkdirSync(fakeHome, { recursive: true });
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, undefined, store);
+
+        // Should not error and return empty (or only local/global)
+        expect(skills).toEqual([]);
+    });
+
+    it('local repo skills take precedence over OneDrive skills with same name', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        const oneDriveDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        fs.mkdirSync(path.join(oneDriveDir, 'shared-skill'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveDir, 'shared-skill', 'SKILL.md'), '---\ndescription: onedrive version\n---');
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        // Create local skill with same name
+        const localSkillsDir = path.join(workspaceDir, '.github', 'skills');
+        fs.mkdirSync(path.join(localSkillsDir, 'shared-skill'), { recursive: true });
+        fs.writeFileSync(path.join(localSkillsDir, 'shared-skill', 'SKILL.md'), '---\ndescription: local version\n---');
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, undefined, store);
+
+        const shared = skills.find(s => s.name === 'shared-skill');
+        expect(shared).toBeDefined();
+        expect(shared!.source).toBe('repo');
+        expect(shared!.description).toBe('local version');
+    });
+
+    it('global skills take precedence over OneDrive skills with same name', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        const oneDriveDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        fs.mkdirSync(path.join(oneDriveDir, 'shared-skill'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveDir, 'shared-skill', 'SKILL.md'), '---\ndescription: onedrive version\n---');
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        // Create global skill with same name
+        const dataDir = path.join(tmpDir, 'data');
+        const globalSkillsDir = path.join(dataDir, 'skills');
+        fs.mkdirSync(path.join(globalSkillsDir, 'shared-skill'), { recursive: true });
+        fs.writeFileSync(path.join(globalSkillsDir, 'shared-skill', 'SKILL.md'), '---\ndescription: global version\n---');
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, dataDir, store);
+
+        const shared = skills.find(s => s.name === 'shared-skill');
+        expect(shared).toBeDefined();
+        expect(shared!.source).toBe('global');
+        expect(shared!.description).toBe('global version');
+    });
+
+    it('extra-folder skills take precedence over OneDrive skills with same name', async () => {
+        const fakeHome = path.join(tmpDir, 'home');
+        const oneDriveDir = path.join(fakeHome, 'OneDrive', '.github', 'skills');
+        fs.mkdirSync(path.join(oneDriveDir, 'shared-skill'), { recursive: true });
+        fs.writeFileSync(path.join(oneDriveDir, 'shared-skill', 'SKILL.md'), '---\ndescription: onedrive version\n---');
+        vi.mocked(os.homedir).mockReturnValue(fakeHome);
+
+        // Create extra-folder skill with same name
+        const extraDir = path.join(tmpDir, 'extra');
+        fs.mkdirSync(path.join(extraDir, 'shared-skill'), { recursive: true });
+        fs.writeFileSync(path.join(extraDir, 'shared-skill', 'SKILL.md'), '---\ndescription: extra version\n---');
+
+        store.getWorkspaces = vi.fn(async () => [{
+            id: workspaceId,
+            name: 'Test',
+            rootPath: workspaceDir,
+            extraSkillFolders: [extraDir],
+        } as WorkspaceInfo]);
+
+        const ws: WorkspaceInfo = { id: workspaceId, name: 'Test', rootPath: workspaceDir, extraSkillFolders: [extraDir] } as WorkspaceInfo;
+        const skills = await loadSkillsForWorkspace(ws, undefined, store);
+
+        const shared = skills.find(s => s.name === 'shared-skill');
+        expect(shared).toBeDefined();
+        expect(shared!.source).toBe('extra-folder');
+        expect(shared!.description).toBe('extra version');
+    });
+});

--- a/packages/coc/test/server/skill-handler.test.ts
+++ b/packages/coc/test/server/skill-handler.test.ts
@@ -7,6 +7,20 @@ import * as http from 'http';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+
+// Mock os.homedir to prevent real OneDrive skill directories from polluting tests.
+// eslint-disable-next-line no-var
+var _realHomedir: string;
+
+vi.mock('os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('os')>();
+    _realHomedir = actual.homedir();
+    return {
+        ...actual,
+        homedir: vi.fn(() => _realHomedir),
+    };
+});
+
 import { registerSkillRoutes, sortSkillsByUsage, skillCache, SKILL_CACHE_TTL_MS, loadSkillsForWorkspace, readConfiguredGlobalExtraFolders } from '../../src/server/skills/skill-handler';
 import { createMockProcessStore } from './helpers/mock-process-store';
 import type { Route } from '../../src/server/types';
@@ -102,6 +116,8 @@ describe('registerSkillRoutes', () => {
         skillCache.clear();
         routes = [];
         workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-api-'));
+        // Point homedir to a temp dir so OneDrive skill scanning doesn't pick up real user skills.
+        vi.mocked(os.homedir).mockReturnValue(workspaceDir);
         store = createMockProcessStore({
             initialWorkspaces: [{
                 id: workspaceId,

--- a/packages/coc/test/server/skill-handler.test.ts
+++ b/packages/coc/test/server/skill-handler.test.ts
@@ -1109,19 +1109,16 @@ describe('loadSkillsForWorkspace — configured global extra folders (AC #2)', (
     it('expands ~ in a configured global extra folder path', async () => {
         const home = mkTmp('ge-home-');
         mkSkill(path.join(home, 'my-skills'), 'tilde-skill', 'description: via tilde');
-        const prevHome = process.env.HOME;
-        const prevUserProfile = process.env.USERPROFILE;
-        // os.homedir() reads $HOME on POSIX and %USERPROFILE% on Windows.
-        process.env.HOME = home;
-        process.env.USERPROFILE = home;
+        // os.homedir is mocked at the module level, so point it at the temp home
+        // to drive `~` expansion instead of mutating process.env.
+        vi.mocked(os.homedir).mockReturnValue(home);
         try {
             const skills = await loadSkillsForWorkspace(ws(), undefined, store, { globalExtraFolders: ['~/my-skills'] });
             const s = skills.find(x => x.name === 'tilde-skill');
             expect(s).toBeDefined();
             expect(s!.source).toBe('global-extra-folder');
         } finally {
-            if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
-            if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+            vi.mocked(os.homedir).mockReturnValue(_realHomedir);
         }
     });
 });


### PR DESCRIPTION
…pace

The skill-config-resolver (execution path) already scanned OneDrive-based skill directories (~/<OneDrive>/.github/skills/), but loadSkillsForWorkspace (used by the UI listing API) did not. This caused skills placed in OneDrive folders to be available at execution time but invisible in the dashboard skill picker.

Add the same OneDrive directory scanning logic to loadSkillsForWorkspace, using source='extra-folder' for consistency. Skills from higher-priority sources (repo, global, extra-folder) still take precedence over OneDrive skills with the same name.

Also mock os.homedir in skill-handler.test.ts to prevent real user OneDrive skills from polluting test assertions.