### PR TITLE
feat(ask-mode): allow full Bash tool in ask/read-only mode

### DIFF
--- a/packages/coc-agent-sdk/src/claude-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/claude-sdk-service.ts
@@ -284,11 +284,11 @@ type ClaudePermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'p
 /**
  * Tools auto-approved in ask/read-only mode. Under `acceptEdits` the SDK only
  * auto-accepts file edits, so Bash and WebFetch would otherwise be denied (no
- * canUseTool callback, headless — no human to answer the prompt). Allow-listing
- * scoped, read-only specifiers lets ask-mode sessions run investigative commands
- * like `gh pr view` and fetch URLs without opening up arbitrary shell writes.
+ * canUseTool callback, headless — no human to answer the prompt). Full Bash is
+ * allowed because the <coc-read-only-mode> system prompt already prevents
+ * editing git-tracked files; shell execution (tests, grep, etc.) is safe.
  */
-const ASK_MODE_AUTO_APPROVED_TOOLS = ['Bash(gh:*)', 'WebFetch'] as const;
+const ASK_MODE_AUTO_APPROVED_TOOLS = ['Bash', 'WebFetch'] as const;
 
 /**
  * MCP server config accepted by Claude Code's `query({ options: { mcpServers } })`.

--- a/packages/coc-agent-sdk/test/ai/claude-sdk-service.test.ts
+++ b/packages/coc-agent-sdk/test/ai/claude-sdk-service.test.ts
@@ -1928,7 +1928,7 @@ describe('ClaudeSDKService.sendMessage', () => {
         expect(queryFn.mock.calls[0][0].options.allowDangerouslySkipPermissions).toBeUndefined();
     });
 
-    it('auto-allows scoped gh Bash and WebFetch in interactive (ask) mode', async () => {
+    it('auto-allows full Bash and WebFetch in interactive (ask) mode', async () => {
         queryFn.mockReturnValueOnce(makeMessages([
             { type: 'result', subtype: 'success' },
         ]));
@@ -1936,9 +1936,9 @@ describe('ClaudeSDKService.sendMessage', () => {
         await svc.sendMessage({ prompt: 'investigate', mode: 'interactive' });
 
         const allowedTools = queryFn.mock.calls[0][0].options.allowedTools;
-        expect(allowedTools).toContain('Bash(gh:*)');
+        expect(allowedTools).toContain('Bash');
         expect(allowedTools).toContain('WebFetch');
-        expect(allowedTools).not.toContain('Bash');
+        expect(allowedTools).not.toContain('Bash(gh:*)');
     });
 
     it('uses acceptEdits permission mode when mode is undefined', async () => {
@@ -1952,7 +1952,7 @@ describe('ClaudeSDKService.sendMessage', () => {
         expect(queryFn.mock.calls[0][0].options.allowDangerouslySkipPermissions).toBeUndefined();
     });
 
-    it('auto-allows scoped gh Bash and WebFetch when mode is undefined', async () => {
+    it('auto-allows full Bash and WebFetch when mode is undefined', async () => {
         queryFn.mockReturnValueOnce(makeMessages([
             { type: 'result', subtype: 'success' },
         ]));
@@ -1960,9 +1960,9 @@ describe('ClaudeSDKService.sendMessage', () => {
         await svc.sendMessage({ prompt: 'investigate' });
 
         const allowedTools = queryFn.mock.calls[0][0].options.allowedTools;
-        expect(allowedTools).toContain('Bash(gh:*)');
+        expect(allowedTools).toContain('Bash');
         expect(allowedTools).toContain('WebFetch');
-        expect(allowedTools).not.toContain('Bash');
+        expect(allowedTools).not.toContain('Bash(gh:*)');
     });
 
     it('passes Claude model IDs through but drops Copilot model IDs', async () => {


### PR DESCRIPTION
Previously only `Bash(gh:*)` was auto-approved in ask mode, blocking all other shell execution (tests, grep, ls, etc.). The git-tracked-file restriction is already enforced by the <coc-read-only-mode> system prompt, so there is no need to scope-limit the Bash tool at the permission layer.

Updates two test assertions to expect `Bash` (unrestricted) instead of `Bash(gh:*)`, and verifies the scoped form is no longer injected.