### PR TITLE
feat(coc-desktop): add Ctrl+F find-in-page support

### DIFF
--- a/packages/coc-desktop/src/find-in-page.ts
+++ b/packages/coc-desktop/src/find-in-page.ts
@@ -1,0 +1,165 @@
+/**
+ * CoC Desktop — find-in-page (Ctrl+F / Cmd+F) support.
+ *
+ * Electron has no built-in find bar, and the served SPA relies on the browser's
+ * native find-in-page for content pages (chat conversations, notes, wiki, diffs)
+ * that have no in-app search box of their own. This module supplies that missing
+ * capability: a small find-bar overlay injected into the renderer, wired through
+ * IPC to `webContents.findInPage` / `stopFindInPage` in the main process.
+ *
+ * The overlay listens on `window` in the bubble phase and bails out whenever the
+ * keydown was already `defaultPrevented` — so on the pages where the SPA already
+ * owns Ctrl+F (Chat list, Tasks, Work Items), the SPA's own search wins and this
+ * bar stays closed. It only opens where nothing else handled the shortcut.
+ *
+ * Like `splash.ts` and `app-menu.ts`, this module imports NOTHING from `electron`,
+ * so the channel constants, the count formatter, and the injected-script builder
+ * are all unit-testable under plain Node/vitest.
+ */
+
+/** IPC channel: renderer → main, "search the page for this text". */
+export const FIND_IN_PAGE_CHANNEL = 'coc-desktop:find-in-page';
+/** IPC channel: renderer → main, "clear the current find selection". */
+export const STOP_FIND_IN_PAGE_CHANNEL = 'coc-desktop:stop-find-in-page';
+/** IPC channel: main → renderer, carrying an Electron `found-in-page` result. */
+export const FIND_RESULT_CHANNEL = 'coc-desktop:find-result';
+
+/**
+ * Render the match-count label shown in the find bar. Mirrors the shape of an
+ * Electron `found-in-page` result: `activeMatchOrdinal` is the 1-based index of
+ * the highlighted match and `matches` is the total. Zero matches reads as
+ * "No results"; otherwise "3/12".
+ *
+ * Kept as a standalone, dependency-free function so it can be both unit-tested
+ * here AND embedded verbatim into the injected renderer script (via
+ * `.toString()`), keeping a single source of truth for the formatting.
+ */
+export function formatFindCount(activeMatchOrdinal: number, matches: number): string {
+    if (!matches || matches <= 0) {
+        return 'No results';
+    }
+    return activeMatchOrdinal + '/' + matches;
+}
+
+/**
+ * Build the self-contained JavaScript injected into the renderer (via
+ * `webContents.executeJavaScript`) that creates and drives the find bar.
+ *
+ * The script is idempotent — a `__cocFindBarInstalled` guard makes re-injection
+ * (e.g. on reload) a no-op. All styling is applied via the CSSOM (`el.style`),
+ * never an injected `<style>` element, so a strict page CSP cannot block it.
+ */
+export function buildFindBarScript(): string {
+    // NOTE: this string runs in the page's context, NOT here. Keep it free of
+    // TypeScript syntax and of backticks / ${...} so it nests cleanly in this
+    // template literal.
+    return `(function () {
+  if (window.__cocFindBarInstalled) { return; }
+  var api = window.cocDesktop && window.cocDesktop.find;
+  if (!api) { return; }
+  window.__cocFindBarInstalled = true;
+
+  var formatFindCount = ${formatFindCount.toString()};
+
+  var bar = document.createElement('div');
+  bar.setAttribute('role', 'search');
+  bar.style.cssText = 'position:fixed;top:12px;right:16px;z-index:2147483647;display:none;' +
+    'align-items:center;gap:6px;padding:6px 8px;border-radius:8px;' +
+    'background:#161b22;border:1px solid #30363d;box-shadow:0 6px 20px rgba(0,0,0,0.4);' +
+    'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;font-size:13px;color:#e6edf3;';
+
+  var input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'Find';
+  input.setAttribute('aria-label', 'Find in page');
+  input.style.cssText = 'width:200px;padding:4px 6px;border-radius:4px;border:1px solid #30363d;' +
+    'background:#0d1117;color:#e6edf3;outline:none;';
+
+  var count = document.createElement('span');
+  count.style.cssText = 'min-width:56px;text-align:center;color:#8b949e;';
+
+  function makeButton(label, title) {
+    var b = document.createElement('button');
+    b.type = 'button';
+    b.textContent = label;
+    b.title = title;
+    b.style.cssText = 'min-width:26px;height:26px;padding:0 6px;border-radius:4px;' +
+      'border:1px solid #30363d;background:#21262d;color:#e6edf3;cursor:pointer;';
+    return b;
+  }
+  var prevBtn = makeButton('\\u2191', 'Previous match (Shift+Enter)');
+  var nextBtn = makeButton('\\u2193', 'Next match (Enter)');
+  var closeBtn = makeButton('\\u2715', 'Close (Esc)');
+
+  bar.appendChild(input);
+  bar.appendChild(count);
+  bar.appendChild(prevBtn);
+  bar.appendChild(nextBtn);
+  bar.appendChild(closeBtn);
+
+  function mount() {
+    if (!bar.parentNode && document.body) { document.body.appendChild(bar); }
+  }
+
+  var isOpen = false;
+  var debounceTimer = null;
+
+  function runFind(findNext, forward) {
+    var text = input.value;
+    if (!text) { api.stop(); count.textContent = ''; return; }
+    api.query(text, { findNext: findNext, forward: forward });
+  }
+
+  function open() {
+    mount();
+    isOpen = true;
+    bar.style.display = 'flex';
+    input.focus();
+    input.select();
+    if (input.value) { runFind(true, true); }
+  }
+
+  function close() {
+    isOpen = false;
+    bar.style.display = 'none';
+    count.textContent = '';
+    api.stop();
+  }
+
+  input.addEventListener('input', function () {
+    if (debounceTimer) { clearTimeout(debounceTimer); }
+    debounceTimer = setTimeout(function () { runFind(false, true); }, 120);
+  });
+
+  input.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      runFind(true, !e.shiftKey);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+
+  prevBtn.addEventListener('click', function () { input.focus(); runFind(true, false); });
+  nextBtn.addEventListener('click', function () { input.focus(); runFind(true, true); });
+  closeBtn.addEventListener('click', function () { close(); });
+
+  // Bubble-phase listener on window: document-level SPA handlers fire first, so
+  // if the active page already handled Ctrl+F (calling preventDefault) we leave
+  // it alone and never open this bar.
+  window.addEventListener('keydown', function (e) {
+    if ((e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
+      if (e.defaultPrevented) { return; }
+      e.preventDefault();
+      open();
+    }
+  });
+
+  api.onResult(function (result) {
+    if (!isOpen) { return; }
+    if (!input.value) { count.textContent = ''; return; }
+    count.textContent = formatFindCount(result.activeMatchOrdinal, result.matches);
+  });
+})();`;
+}

--- a/packages/coc-desktop/src/main.ts
+++ b/packages/coc-desktop/src/main.ts
@@ -13,7 +13,7 @@
  */
 
 import * as path from 'path';
-import { app, BrowserWindow, Menu, Tray, dialog, nativeImage, shell, clipboard } from 'electron';
+import { app, BrowserWindow, Menu, Tray, dialog, nativeImage, shell, clipboard, ipcMain } from 'electron';
 import { attachOrStart, defaultDataDir, ServerHandle } from './server-controller';
 import { splashDataUrl } from './splash';
 import { detectAgentClis, missingAgentClis, runFirstRunPreflight } from './agent-preflight';
@@ -31,6 +31,12 @@ import {
     UpdatePrompt,
 } from './update-check';
 import { buildAppMenuTemplate, buildTrayMenuTemplate } from './app-menu';
+import {
+    FIND_IN_PAGE_CHANNEL,
+    STOP_FIND_IN_PAGE_CHANNEL,
+    FIND_RESULT_CHANNEL,
+    buildFindBarScript,
+} from './find-in-page';
 
 // Brand the app identity before anything builds the menu / dock / About panel.
 // In dev (electron launched against this package) this fixes the menu-bar name,
@@ -135,6 +141,50 @@ function wireExternalLinkRouting(win: BrowserWindow, servedUrl: string): void {
     });
 }
 
+/** Guard so the global find-in-page IPC handlers are registered only once. */
+let findInPageIpcRegistered = false;
+
+/**
+ * Register the app-wide find-in-page IPC handlers exactly once. They drive
+ * `findInPage` / `stopFindInPage` on whichever window's renderer sent the
+ * request (`event.sender`), so this stays correct even with multiple windows.
+ */
+function registerFindInPageIpc(): void {
+    if (findInPageIpcRegistered) {
+        return;
+    }
+    findInPageIpcRegistered = true;
+    ipcMain.on(FIND_IN_PAGE_CHANNEL, (event, text: string, options?: Electron.FindInPageOptions) => {
+        // Electron throws on an empty query; the renderer guards too, but be safe.
+        if (typeof text !== 'string' || text.length === 0) {
+            return;
+        }
+        event.sender.findInPage(text, options ?? {});
+    });
+    ipcMain.on(STOP_FIND_IN_PAGE_CHANNEL, (event) => {
+        event.sender.stopFindInPage('clearSelection');
+    });
+}
+
+/**
+ * Wire find-in-page for a window: relay each `found-in-page` result back to the
+ * renderer (so the find bar can show the match count) and inject the find-bar
+ * script once the SPA has loaded. Injection is idempotent, so a reload is safe.
+ */
+function wireFindInPage(win: BrowserWindow): void {
+    const wc = win.webContents;
+    wc.on('found-in-page', (_event, result) => {
+        if (!wc.isDestroyed()) {
+            wc.send(FIND_RESULT_CHANNEL, result);
+        }
+    });
+    wc.on('did-finish-load', () => {
+        wc.executeJavaScript(buildFindBarScript()).catch(() => {
+            /* injection is a nicety — never break the app if it fails */
+        });
+    });
+}
+
 /**
  * Point the main window at the live CoC SPA and reveal it once painted.
  * Always `loadURL` against `http://127.0.0.1:<port>` — never a bundled
@@ -143,6 +193,7 @@ function wireExternalLinkRouting(win: BrowserWindow, servedUrl: string): void {
 async function showServedSpa(url: string): Promise<void> {
     mainWindow = createWindow();
     wireExternalLinkRouting(mainWindow, url);
+    wireFindInPage(mainWindow);
 
     // Reveal the window only once the renderer can paint, then drop the splash,
     // so the user never sees an empty white frame.
@@ -394,6 +445,10 @@ async function bootstrap(): Promise<void> {
     // AC-01: install the native application menu (with "Check for Updates…")
     // before any window paints, so the menu bar is correct from first show.
     setupApplicationMenu();
+
+    // Register the find-in-page IPC handlers before any window loads, so the
+    // injected find bar can talk to the main process as soon as it appears.
+    registerFindInPageIpc();
 
     // macOS: set the dock icon early (BrowserWindow `icon` is ignored by macOS).
     // Only override when the real icon file resolves — otherwise leave the dock

--- a/packages/coc-desktop/src/preload.ts
+++ b/packages/coc-desktop/src/preload.ts
@@ -2,12 +2,24 @@
  * CoC Desktop — preload script.
  *
  * Runs in the renderer's isolated context before the SPA loads. The SPA is the
- * unmodified CoC web client served from localhost, so for v1 the preload only
- * exposes a tiny, read-only bridge for diagnostics. Privileged IPC channels are
+ * unmodified CoC web client served from localhost, so the preload exposes only a
+ * tiny bridge: read-only diagnostics plus the find-in-page channel used by the
+ * injected find bar (see `find-in-page.ts`). Further privileged IPC channels are
  * added by later acceptance criteria as the main process grows them.
  */
 
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
+import {
+    FIND_IN_PAGE_CHANNEL,
+    STOP_FIND_IN_PAGE_CHANNEL,
+    FIND_RESULT_CHANNEL,
+} from './find-in-page';
+
+/** Shape of an Electron `found-in-page` result, as relayed to the renderer. */
+interface FindResult {
+    activeMatchOrdinal: number;
+    matches: number;
+}
 
 const api = {
     /** Identifies the host so the SPA can tell it is running inside the desktop shell. */
@@ -16,6 +28,21 @@ const api = {
         electron: process.versions.electron,
         chrome: process.versions.chrome,
         node: process.versions.node,
+    },
+    /**
+     * Find-in-page bridge for the injected find bar. `query` searches the page,
+     * `stop` clears the current selection, and `onResult` subscribes to match
+     * counts (returning an unsubscribe function).
+     */
+    find: {
+        query: (text: string, options: { forward?: boolean; findNext?: boolean }) =>
+            ipcRenderer.send(FIND_IN_PAGE_CHANNEL, text, options),
+        stop: () => ipcRenderer.send(STOP_FIND_IN_PAGE_CHANNEL),
+        onResult: (callback: (result: FindResult) => void) => {
+            const listener = (_event: unknown, result: FindResult) => callback(result);
+            ipcRenderer.on(FIND_RESULT_CHANNEL, listener);
+            return () => ipcRenderer.removeListener(FIND_RESULT_CHANNEL, listener);
+        },
     },
 } as const;
 

--- a/packages/coc-desktop/test/find-in-page.test.ts
+++ b/packages/coc-desktop/test/find-in-page.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for find-in-page (Ctrl+F / Cmd+F) support.
+ *
+ * The module is electron-free, so we can assert the pure count formatter and the
+ * IPC channel names directly, and drive the injected find-bar script against a
+ * minimal DOM/window stub to verify the behaviour that actually matters:
+ *   - Ctrl+F / Cmd+F opens the bar,
+ *   - but ONLY when the keydown wasn't already handled (defaultPrevented) by the
+ *     SPA's own search — the anti-conflict guard,
+ *   - Escape closes it and clears the selection,
+ *   - and match counts render from `found-in-page` results.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+    formatFindCount,
+    buildFindBarScript,
+    FIND_IN_PAGE_CHANNEL,
+    STOP_FIND_IN_PAGE_CHANNEL,
+    FIND_RESULT_CHANNEL,
+} from '../src/find-in-page';
+
+describe('formatFindCount', () => {
+    it('renders active/total for a normal match', () => {
+        expect(formatFindCount(3, 12)).toBe('3/12');
+        expect(formatFindCount(1, 1)).toBe('1/1');
+    });
+
+    it('reads "No results" when there are zero matches', () => {
+        expect(formatFindCount(0, 0)).toBe('No results');
+    });
+
+    it('treats missing/negative totals as no results', () => {
+        expect(formatFindCount(0, undefined as unknown as number)).toBe('No results');
+        expect(formatFindCount(0, -1)).toBe('No results');
+    });
+});
+
+describe('IPC channel names', () => {
+    it('are distinct and namespaced', () => {
+        const channels = [FIND_IN_PAGE_CHANNEL, STOP_FIND_IN_PAGE_CHANNEL, FIND_RESULT_CHANNEL];
+        expect(new Set(channels).size).toBe(3);
+        for (const c of channels) {
+            expect(c.startsWith('coc-desktop:')).toBe(true);
+        }
+    });
+});
+
+// --- Minimal DOM/window harness for the injected script ------------------------
+
+interface FakeEl {
+    tag: string;
+    style: Record<string, string>;
+    parentNode: FakeEl | null;
+    textContent: string;
+    value: string;
+    type: string;
+    children: FakeEl[];
+    setAttribute: (k: string, v: string) => void;
+    appendChild: (c: FakeEl) => void;
+    addEventListener: (type: string, cb: (e: unknown) => void) => void;
+    dispatch: (type: string, e: unknown) => void;
+    focus: () => void;
+    select: () => void;
+}
+
+function makeEl(tag: string): FakeEl {
+    const listeners: Record<string, Array<(e: unknown) => void>> = {};
+    return {
+        tag,
+        style: {},
+        parentNode: null,
+        textContent: '',
+        value: '',
+        type: '',
+        children: [],
+        setAttribute: () => {},
+        appendChild(c: FakeEl) {
+            this.children.push(c);
+            c.parentNode = this;
+        },
+        addEventListener(type, cb) {
+            (listeners[type] ||= []).push(cb);
+        },
+        dispatch(type, e) {
+            (listeners[type] || []).forEach((f) => f(e));
+        },
+        focus: () => {},
+        select: () => {},
+    };
+}
+
+interface Harness {
+    created: FakeEl[];
+    body: FakeEl;
+    winKeydown: (e: unknown) => void;
+    onResultCb: (r: { activeMatchOrdinal: number; matches: number }) => void;
+    query: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    el: (tag: string) => FakeEl;
+}
+
+function runFindBar(): Harness {
+    const created: FakeEl[] = [];
+    const body = makeEl('body');
+    const doc = {
+        body,
+        createElement: (tag: string) => {
+            const el = makeEl(tag);
+            created.push(el);
+            return el;
+        },
+    };
+    const winListeners: Record<string, Array<(e: unknown) => void>> = {};
+    const query = vi.fn();
+    const stop = vi.fn();
+    let onResultCb: (r: { activeMatchOrdinal: number; matches: number }) => void = () => {};
+    const win: Record<string, unknown> = {
+        cocDesktop: {
+            find: {
+                query,
+                stop,
+                onResult: (cb: typeof onResultCb) => {
+                    onResultCb = cb;
+                    return () => {};
+                },
+            },
+        },
+        addEventListener(type: string, cb: (e: unknown) => void) {
+            (winListeners[type] ||= []).push(cb);
+        },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    const run = new Function('window', 'document', 'setTimeout', 'clearTimeout', buildFindBarScript());
+    run(win, doc, setTimeout, clearTimeout);
+
+    return {
+        created,
+        body,
+        winKeydown: (e) => (winListeners['keydown'] || []).forEach((f) => f(e)),
+        get onResultCb() {
+            return onResultCb;
+        },
+        query,
+        stop,
+        el: (tag: string) => created.find((c) => c.tag === tag)!,
+    } as Harness;
+}
+
+describe('buildFindBarScript (functional)', () => {
+    it('is idempotent — a second injection is a no-op', () => {
+        const win: Record<string, unknown> = { __cocFindBarInstalled: true };
+        const createElement = vi.fn();
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+        const run = new Function('window', 'document', 'setTimeout', 'clearTimeout', buildFindBarScript());
+        run(win, { body: null, createElement }, setTimeout, clearTimeout);
+        expect(createElement).not.toHaveBeenCalled();
+    });
+
+    it('bails out cleanly when the preload find bridge is absent', () => {
+        const win: Record<string, unknown> = {};
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+        const run = new Function('window', 'document', 'setTimeout', 'clearTimeout', buildFindBarScript());
+        expect(() =>
+            run(win, { body: null, createElement: () => makeEl('x') }, setTimeout, clearTimeout),
+        ).not.toThrow();
+        expect(win.__cocFindBarInstalled).toBeUndefined();
+    });
+
+    it('opens the bar on Ctrl+F', () => {
+        const h = runFindBar();
+        const bar = h.el('div');
+        // Closed initially — the script hides it via cssText, not style.display.
+        expect(bar.style.display).not.toBe('flex');
+        expect(bar.parentNode).toBeNull();
+        const e = { ctrlKey: true, metaKey: false, key: 'f', defaultPrevented: false, preventDefault: vi.fn() };
+        h.winKeydown(e);
+        expect(e.preventDefault).toHaveBeenCalled();
+        expect(bar.style.display).toBe('flex');
+        expect(bar.parentNode).toBe(h.body);
+    });
+
+    it('opens the bar on Cmd+F (macOS metaKey)', () => {
+        const h = runFindBar();
+        const bar = h.el('div');
+        const e = { ctrlKey: false, metaKey: true, key: 'f', defaultPrevented: false, preventDefault: vi.fn() };
+        h.winKeydown(e);
+        expect(e.preventDefault).toHaveBeenCalled();
+        expect(bar.style.display).toBe('flex');
+    });
+
+    it('defers to the SPA when the keydown was already handled', () => {
+        const h = runFindBar();
+        const bar = h.el('div');
+        const e = { ctrlKey: true, metaKey: false, key: 'f', defaultPrevented: true, preventDefault: vi.fn() };
+        h.winKeydown(e);
+        expect(e.preventDefault).not.toHaveBeenCalled();
+        expect(bar.style.display).not.toBe('flex');
+        expect(bar.parentNode).toBeNull();
+    });
+
+    it('renders the match count from found-in-page results while open', () => {
+        const h = runFindBar();
+        const input = h.el('input');
+        const count = h.el('span');
+        h.winKeydown({ ctrlKey: true, metaKey: false, key: 'f', defaultPrevented: false, preventDefault: vi.fn() });
+        input.value = 'needle';
+        h.onResultCb({ activeMatchOrdinal: 2, matches: 5 });
+        expect(count.textContent).toBe('2/5');
+        h.onResultCb({ activeMatchOrdinal: 0, matches: 0 });
+        expect(count.textContent).toBe('No results');
+    });
+
+    it('Escape closes the bar and clears the selection', () => {
+        const h = runFindBar();
+        const bar = h.el('div');
+        const input = h.el('input');
+        h.winKeydown({ ctrlKey: true, metaKey: false, key: 'f', defaultPrevented: false, preventDefault: vi.fn() });
+        expect(bar.style.display).toBe('flex');
+        input.dispatch('keydown', { key: 'Escape', preventDefault: vi.fn() });
+        expect(bar.style.display).toBe('none');
+        expect(h.stop).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Electron has no native find bar, and the served SPA relies on the
browser's built-in find-in-page for content pages (chat conversations,
notes, wiki, diffs) that lack an in-app search box. The desktop shell
never wired one up, so Ctrl+F / Cmd+F did nothing there.

Add a find bar injected into the renderer that drives
webContents.findInPage / stopFindInPage over IPC. The bar listens on
window in the bubble phase and bails when the keydown was already
defaultPrevented, so the SPA's own Ctrl+F search boxes (Chat list,
Tasks, Work Items) still win on their pages — the bar only fills the
gap where nothing else handled the shortcut.

- find-in-page.ts: electron-free channel constants, formatFindCount,
  and the idempotent, CSP-safe injected find-bar script builder.
- preload.ts: expose a find bridge (query/stop/onResult) over IPC.
- main.ts: register the find IPC handlers, relay found-in-page results,
  and inject the bar on load.

Tests: formatFindCount unit cases plus a functional harness that runs
the injected script against a DOM stub, covering open on Ctrl+F/Cmd+F,
the defer-to-SPA guard, Escape-to-close, and match-count rendering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
