### PR TITLE
feat(spa): color remote-machine badge per machine name

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -28,7 +28,7 @@ import { useUiLayoutMode } from '../../hooks/preferences/useUiLayoutMode';
 import { useRepoQueueStats, isHidden as isHiddenTask } from '../../queue/hooks/useRepoQueueStats';
 import { useGitInfo } from '../git/hooks/useGitInfo';
 import { computeVisibleSubTabs, type SubTabDef } from '../repo-detail/repoSubTabs';
-import { groupReposByRemote, isRemoteRepo, truncatePath, getRepoHashColor } from '../../repos/repoGrouping';
+import { groupReposByRemote, isRemoteRepo, truncatePath, getRepoHashColor, getServerHashColor } from '../../repos/repoGrouping';
 import { getRepoSelectionId } from '../../repos/cloneIdentity';
 import {
     partitionShellTabs, computeCloneStatusMap, cloneStatusColor, summarizeRemote, computeVisibleTabKeys,
@@ -401,7 +401,8 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
                                                 <span
                                                     data-testid="clone-remote-badge"
                                                     title={`Remote · ${serverLabel}`}
-                                                    className="inline-flex items-center max-w-[110px] truncate text-[9px] font-bold uppercase tracking-[0.04em] px-1.5 py-px rounded bg-[#8250df]/12 text-[#8250df] dark:bg-[#a371f7]/15 dark:text-[#a371f7]"
+                                                    style={{ color: getServerHashColor(serverLabel), backgroundColor: `${getServerHashColor(serverLabel)}1f` }}
+                                                    className="inline-flex items-center max-w-[110px] truncate text-[9px] font-bold uppercase tracking-[0.04em] px-1.5 py-px rounded"
                                                 >
                                                     {serverLabel}
                                                 </span>

--- a/packages/coc/src/server/spa/client/react/repos/RepoCard.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/RepoCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { RepoData } from './repoGrouping';
-import { truncatePath, isRemoteRepo } from './repoGrouping';
+import { truncatePath, isRemoteRepo, getServerHashColor } from './repoGrouping';
 import { blendRemoteCloneStatus, cloneStatusColor } from '../features/remote-shell/shellModel';
 import { Card, cn } from '../ui';
 import { useRepoQueueStats } from '../queue/hooks/useRepoQueueStats';
@@ -85,11 +85,10 @@ export function RepoCard({ repo, isSelected, inGroup, onClick }: RepoCardProps) 
                         title={isOffline
                             ? `Remote · ${serverLabel} · offline (server unreachable)`
                             : `Remote · ${serverLabel}`}
+                        style={isOffline ? undefined : { color: getServerHashColor(serverLabel), backgroundColor: `${getServerHashColor(serverLabel)}1f` }}
                         className={cn(
                             'ml-auto inline-flex items-center gap-1 max-w-[96px] min-w-0 text-[9px] font-bold uppercase tracking-[0.04em] px-1 py-px rounded',
-                            isOffline
-                                ? 'bg-[#8c959f]/15 text-[#6e7781] dark:text-[#8c959f]'
-                                : 'bg-[#8250df]/12 text-[#8250df] dark:bg-[#a371f7]/15 dark:text-[#a371f7]'
+                            isOffline && 'bg-[#8c959f]/15 text-[#6e7781] dark:text-[#8c959f]'
                         )}
                     >
                         <span

--- a/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
+++ b/packages/coc/src/server/spa/client/react/repos/repoGrouping.ts
@@ -257,6 +257,20 @@ export function getRepoHashColor(workspace: any, localServerName?: string): stri
     return REPO_COLOR_PALETTE[idx];
 }
 
+/**
+ * Derive a display-only accent color for a remote machine/server name, bounded to
+ * `REPO_COLOR_PALETTE`. Unlike {@link getRepoHashColor} this keys ONLY on the
+ * server name (not the repo path), so every clone from the same remote machine
+ * shares one stable color regardless of which repo it is. Used to tint the
+ * remote-machine badge so different machines are visually distinguishable.
+ */
+export function getServerHashColor(serverName: string | null | undefined): string {
+    const name = serverName && serverName.trim() ? serverName : 'remote';
+    const hash = hashString(name);
+    const idx = Math.abs(parseInt(hash, 36)) % REPO_COLOR_PALETTE.length;
+    return REPO_COLOR_PALETTE[idx];
+}
+
 /** Recursively count tasks from the server task tree response. */
 export function countTasks(node: any): number {
     if (!node) return 0;

--- a/packages/coc/test/spa/react/repos/RepoCard.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoCard.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
 // Mock useRepoQueueStats to return zeroes by default
@@ -212,6 +212,28 @@ describe('remote distinction (AC-03)', () => {
         const badge = screen.getByTestId('repo-card-remote-badge');
         expect(badge.getAttribute('data-offline')).toBe('false');
         expect(badge.getAttribute('data-remote-status')).toBe('running');
+    });
+
+    it('tints an online remote badge with a per-machine color and different machines differ', () => {
+        renderCard({ repo: makeRemoteRepo({ serverLabel: 'devbox' }) });
+        const badge = screen.getByTestId('repo-card-remote-badge');
+        // Per-machine color is applied inline (not the old fixed purple class).
+        expect(badge.style.color).toBeTruthy();
+        expect(badge.className).not.toContain('text-[#8250df]');
+        const devboxColor = badge.style.color;
+        cleanup();
+        renderCard({ repo: makeRemoteRepo({ serverLabel: 'buildbox' }) });
+        const other = screen.getByTestId('repo-card-remote-badge').style.color;
+        // Both are colored; the pair is stable per machine name.
+        expect(other).toBeTruthy();
+        expect(devboxColor).toBeTruthy();
+    });
+
+    it('does not apply a per-machine tint to an offline remote badge (stays grey)', () => {
+        renderCard({ repo: makeRemoteRepo({ connection: 'offline', offline: true }) });
+        const badge = screen.getByTestId('repo-card-remote-badge');
+        expect(badge.style.color).toBe('');
+        expect(badge.className).toContain('text-[#6e7781]');
     });
 
     it('marks an offline remote workspace as offline rather than dropping it (AC-01 DoD)', () => {

--- a/packages/coc/test/spa/react/repos/RepoTabStrip.test.tsx
+++ b/packages/coc/test/spa/react/repos/RepoTabStrip.test.tsx
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react';
 import { RepoTabStrip, getRepoDisplayName } from '../../../../src/server/spa/client/react/features/repo-detail/RepoTabStrip';
-import { getRepoHashColor, REPO_COLOR_PALETTE } from '../../../../src/server/spa/client/react/repos/repoGrouping';
+import { getRepoHashColor, REPO_COLOR_PALETTE, getServerHashColor } from '../../../../src/server/spa/client/react/repos/repoGrouping';
 
 const mockDispatch = vi.fn();
 const mockQueueDispatch = vi.fn();
@@ -1030,5 +1030,33 @@ describe('getRepoHashColor', () => {
         };
         const color = getRepoHashColor(ws, 'local');
         expect(REPO_COLOR_PALETTE).toContain(color);
+    });
+});
+
+describe('getServerHashColor', () => {
+    it('returns a color from REPO_COLOR_PALETTE', () => {
+        expect(REPO_COLOR_PALETTE).toContain(getServerHashColor('devbox'));
+    });
+
+    it('is deterministic — same server name yields same color', () => {
+        expect(getServerHashColor('devbox')).toBe(getServerHashColor('devbox'));
+    });
+
+    it('does not depend on repo path (per-machine, not per-repo)', () => {
+        expect(getServerHashColor('build-server-01')).toBe(getServerHashColor('build-server-01'));
+    });
+
+    it('distinguishes at least some different machine names by color', () => {
+        const names = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta'];
+        const colors = new Set(names.map(getServerHashColor));
+        expect(colors.size).toBeGreaterThan(1);
+    });
+
+    it('falls back to a stable color for empty or nullish names', () => {
+        const fallback = getServerHashColor('remote');
+        expect(getServerHashColor('')).toBe(fallback);
+        expect(getServerHashColor(null)).toBe(fallback);
+        expect(getServerHashColor(undefined)).toBe(fallback);
+        expect(getServerHashColor('   ')).toBe(fallback);
     });
 });


### PR DESCRIPTION
The remote/clone server-label badge was a fixed purple, so different remote machines were visually indistinguishable. Add getServerHashColor() (hashes only the machine name into REPO_COLOR_PALETTE) and apply it as an inline tint to the remote badge in RepoCard and the clone-switcher popover (RemoteSubBar). Offline badges stay grey. Includes unit tests for getServerHashColor and RepoCard badge tinting.