### PR TITLE
pr/60fd968e8 featcodex derive context window usage fr

### DIFF
--- a/packages/coc-agent-sdk/src/codex-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/codex-sdk-service.ts
@@ -37,6 +37,7 @@ import { CocToolRuntime } from './llm-tools/coc-tool-runtime';
 import { cocToolBridgeServer } from './llm-tools/bridge-server';
 import { buildCocLlmToolsMcpConfig, COC_LLM_TOOLS_MCP_SERVER_NAME } from './llm-tools/mcp-config';
 import { isSupportedCodexImagePath } from './image-converter';
+import { getModelContextWindow } from './model-registry';
 import { resolveCodexExecutablePath } from './codex-exec-path';
 import { spawn } from 'child_process';
 import { createRequire } from 'module';
@@ -147,9 +148,13 @@ interface CodexTurnFailedEvent {
  * Per-turn token totals from a Codex `turn.completed` event — the ONLY usage
  * signal the `@openai/codex-sdk` exposes (index.d.ts `Usage`). Codex has no
  * native context-window signal (no max/limit, no running session total), so
- * `addCodexUsage` cannot populate `TokenUsage.tokenLimit` / `currentTokens`.
- * Deriving a context window from the model registry or the latest-turn snapshot
- * is intentionally out of scope, so the context meter stays hidden for Codex.
+ * `addCodexUsage` derives the context meter from two independent sources: the
+ * static per-model `contextWindow` in `MODEL_REGISTRY` supplies `tokenLimit`,
+ * and this event's own totals supply `currentTokens` as a latest-turn
+ * occupancy snapshot (`input_tokens + output_tokens`; `cached_input_tokens` is
+ * already a subset of `input_tokens`, and reasoning tokens are excluded because
+ * they do not persist in context across turns). When the model id is unknown to
+ * the registry, `tokenLimit` stays unset and the meter remains hidden.
  */
 interface CodexUsage {
     input_tokens?: number;
@@ -1112,7 +1117,7 @@ export class CodexSDKService implements ISDKService {
                     continue;
                 }
                 if (event.type === 'turn.completed') {
-                    tokenUsage = addCodexUsage(tokenUsage, event.usage);
+                    tokenUsage = addCodexUsage(tokenUsage, event.usage, effectiveModel);
                     continue;
                 }
                 if (event.type === 'turn.failed') {
@@ -1828,13 +1833,29 @@ function codexUsageNumber(value: number | undefined): number {
 /**
  * Accumulate a Codex per-turn `Usage` into the shared `TokenUsage` envelope.
  *
- * Only per-turn fields are populated. The context-window fields
- * (`tokenLimit`, `currentTokens`, `systemTokens`, `toolDefinitionsTokens`,
- * `conversationTokens`) are intentionally left untouched: Codex emits no native
- * context-window signal (see the `CodexUsage` note above), so the UI keeps the
- * context meter hidden for Codex by design.
+ * The per-turn totals (input/output/cache/total) accumulate across turns. The
+ * context meter is derived instead of accumulated:
+ *   - `tokenLimit` = the model's static `contextWindow` from `MODEL_REGISTRY`
+ *     (via `getModelContextWindow`). Left unset for models the registry does not
+ *     know, so the indicator stays hidden rather than guessing a default.
+ *   - `currentTokens` = a latest-turn occupancy snapshot, `input_tokens +
+ *     output_tokens` of THIS turn (not a cumulative sum). `cached_input_tokens`
+ *     is already a subset of `input_tokens`, so it is not added again; reasoning
+ *     tokens are excluded because they do not persist in context across turns.
+ *     Overwriting each turn means the newest snapshot wins, and Codex
+ *     auto-compaction is handled naturally (the post-compaction turn reports the
+ *     smaller context).
+ *
+ * `currentTokens`/`tokenLimit` are only set together, and only when the model is
+ * known — an unknown model leaves the whole context meter unset. The breakdown
+ * fields (`systemTokens`, `toolDefinitionsTokens`, `conversationTokens`) are
+ * never populated: Codex provides no breakdown and none is fabricated.
  */
-function addCodexUsage(current: TokenUsage | undefined, usage: CodexUsage | undefined): TokenUsage | undefined {
+function addCodexUsage(
+    current: TokenUsage | undefined,
+    usage: CodexUsage | undefined,
+    modelId?: string,
+): TokenUsage | undefined {
     if (!usage) return current;
 
     const result = current ? { ...current } : emptyCodexTokenUsage();
@@ -1843,6 +1864,12 @@ function addCodexUsage(current: TokenUsage | undefined, usage: CodexUsage | unde
     result.cacheReadTokens += codexUsageNumber(usage.cached_input_tokens);
     result.totalTokens = result.inputTokens + result.outputTokens;
     result.turnCount += 1;
+
+    const tokenLimit = modelId ? getModelContextWindow(modelId) : undefined;
+    if (tokenLimit != null) {
+        result.tokenLimit = tokenLimit;
+        result.currentTokens = codexUsageNumber(usage.input_tokens) + codexUsageNumber(usage.output_tokens);
+    }
     return result;
 }
 

--- a/packages/coc-agent-sdk/src/model-registry.ts
+++ b/packages/coc-agent-sdk/src/model-registry.ts
@@ -75,14 +75,18 @@ const MODEL_DEFINITIONS: readonly ModelDefinition[] = [
         label: 'GPT-5.4',
         description: '',
         tier: 'standard',
-        contextWindow: 128_000,
+        // Sourced from Codex's own model catalog (~/.codex/models_cache.json,
+        // context_window field) — the whole GPT-5.x Codex family reports 272k.
+        contextWindow: 272_000,
     },
     {
         id: 'gpt-5.3-codex',
         label: 'GPT-5.3 Codex',
         description: '',
         tier: 'premium',
-        contextWindow: 128_000,
+        // Same GPT-5.x Codex family context window as gpt-5.4 (272k). See the
+        // Codex model catalog note above.
+        contextWindow: 272_000,
     },
     {
         id: 'gemini-3-pro-preview',

--- a/packages/coc-agent-sdk/test/ai/codex-sdk-token-usage.test.ts
+++ b/packages/coc-agent-sdk/test/ai/codex-sdk-token-usage.test.ts
@@ -19,14 +19,14 @@ function makeCodexMock(events: Array<Record<string, unknown>>) {
     return { client, thread };
 }
 
-async function sendWithEvents(events: Array<Record<string, unknown>>) {
+async function sendWithEvents(events: Array<Record<string, unknown>>, model?: string) {
     const svc = new CodexSDKService();
     const { client } = makeCodexMock(events);
     (svc as unknown as { sdk: unknown }).sdk = client;
     (svc as unknown as { availabilityCache: unknown }).availabilityCache = { available: true };
 
     try {
-        return await svc.sendMessage({ prompt: 'test' });
+        return await svc.sendMessage({ prompt: 'test', ...(model ? { model } : {}) });
     } finally {
         svc.dispose();
     }
@@ -102,11 +102,10 @@ describe('CodexSDKService token usage', () => {
         expect(result.tokenUsage).toBeUndefined();
     });
 
-    it('populates per-turn fields but leaves context-window fields undefined (no native Codex signal)', async () => {
-        // Codex exposes no native context-window signal, so the per-turn mapping
-        // must never fabricate the context meter. Guards the documented Codex
-        // limitation: tokenLimit/currentTokens (and the rest of the breakdown)
-        // stay undefined even when per-turn usage is reported.
+    it('leaves the context meter unset when no model id is provided', async () => {
+        // Without a model id there is no registry entry to source a context
+        // window from, so tokenLimit/currentTokens (and the never-populated
+        // breakdown fields) stay undefined even when per-turn usage is reported.
         const result = await sendWithEvents([
             { type: 'thread.started', thread_id: 'thread-1' },
             {
@@ -128,11 +127,102 @@ describe('CodexSDKService token usage', () => {
         expect(result.tokenUsage?.cacheReadTokens).toBe(10);
         expect(result.tokenUsage?.totalTokens).toBe(110);
         expect(result.tokenUsage?.turnCount).toBe(1);
-        // Context-window fields are never populated for Codex.
+        // Context-window fields stay unset with no model id.
         expect(result.tokenUsage?.tokenLimit).toBeUndefined();
         expect(result.tokenUsage?.currentTokens).toBeUndefined();
         expect(result.tokenUsage?.systemTokens).toBeUndefined();
         expect(result.tokenUsage?.toolDefinitionsTokens).toBeUndefined();
         expect(result.tokenUsage?.conversationTokens).toBeUndefined();
+    });
+
+    it('AC-01: derives tokenLimit from the registry and currentTokens from the latest turn', async () => {
+        // gpt-5.4 has a registry contextWindow (128k). currentTokens is the
+        // latest-turn occupancy snapshot: input_tokens + output_tokens. The
+        // subset field cached_input_tokens is NOT added again, and reasoning
+        // tokens are excluded.
+        const result = await sendWithEvents([
+            { type: 'thread.started', thread_id: 'thread-1' },
+            {
+                type: 'turn.completed',
+                usage: {
+                    input_tokens: 1000,
+                    cached_input_tokens: 400,
+                    output_tokens: 250,
+                    reasoning_output_tokens: 90,
+                },
+            },
+            { type: 'item.completed', item: { id: 'item-1', type: 'agent_message', text: 'ok' } },
+        ], 'gpt-5.4');
+
+        expect(result.success).toBe(true);
+        expect(result.tokenUsage?.tokenLimit).toBe(128_000);
+        // input + output only (cached is a subset of input; reasoning excluded).
+        expect(result.tokenUsage?.currentTokens).toBe(1250);
+        // No fabricated breakdown for Codex.
+        expect(result.tokenUsage?.systemTokens).toBeUndefined();
+        expect(result.tokenUsage?.toolDefinitionsTokens).toBeUndefined();
+        expect(result.tokenUsage?.conversationTokens).toBeUndefined();
+    });
+
+    it('AC-01: latest-turn snapshot wins for currentTokens while per-turn totals accumulate', async () => {
+        const result = await sendWithEvents([
+            { type: 'thread.started', thread_id: 'thread-1' },
+            {
+                type: 'turn.completed',
+                usage: { input_tokens: 5000, output_tokens: 500 },
+            },
+            {
+                type: 'turn.completed',
+                usage: { input_tokens: 8000, cached_input_tokens: 6000, output_tokens: 300 },
+            },
+            { type: 'item.completed', item: { id: 'item-1', type: 'agent_message', text: 'done' } },
+        ], 'gpt-5.4');
+
+        expect(result.success).toBe(true);
+        // Per-turn totals still accumulate across turns.
+        expect(result.tokenUsage?.inputTokens).toBe(13_000);
+        expect(result.tokenUsage?.outputTokens).toBe(800);
+        expect(result.tokenUsage?.cacheReadTokens).toBe(6000);
+        expect(result.tokenUsage?.totalTokens).toBe(13_800);
+        expect(result.tokenUsage?.turnCount).toBe(2);
+        // currentTokens is a snapshot of the LATEST turn only, not cumulative.
+        expect(result.tokenUsage?.tokenLimit).toBe(128_000);
+        expect(result.tokenUsage?.currentTokens).toBe(8300);
+    });
+
+    it('AC-01: cached tokens do not inflate the currentTokens snapshot', async () => {
+        // Even when nearly all input is cached, currentTokens counts input once.
+        const result = await sendWithEvents([
+            { type: 'thread.started', thread_id: 'thread-1' },
+            {
+                type: 'turn.completed',
+                usage: { input_tokens: 2000, cached_input_tokens: 1900, output_tokens: 100 },
+            },
+            { type: 'item.completed', item: { id: 'item-1', type: 'agent_message', text: 'ok' } },
+        ], 'gpt-5.3-codex');
+
+        expect(result.success).toBe(true);
+        expect(result.tokenUsage?.tokenLimit).toBe(128_000);
+        // 2000 + 100, NOT 2000 + 1900 + 100.
+        expect(result.tokenUsage?.currentTokens).toBe(2100);
+    });
+
+    it('AC-02: unregistered model leaves tokenLimit unset so the indicator stays hidden', async () => {
+        const result = await sendWithEvents([
+            { type: 'thread.started', thread_id: 'thread-1' },
+            {
+                type: 'turn.completed',
+                usage: { input_tokens: 500, output_tokens: 120 },
+            },
+            { type: 'item.completed', item: { id: 'item-1', type: 'agent_message', text: 'ok' } },
+        ], 'gpt-nonexistent-9.9');
+
+        expect(result.success).toBe(true);
+        // Per-turn totals are still reported.
+        expect(result.tokenUsage?.inputTokens).toBe(500);
+        expect(result.tokenUsage?.outputTokens).toBe(120);
+        // The indicator-driving tokenLimit is absent for an unknown model.
+        expect(result.tokenUsage?.tokenLimit).toBeUndefined();
+        expect(result.tokenUsage?.currentTokens).toBeUndefined();
     });
 });

--- a/packages/coc-agent-sdk/test/ai/codex-sdk-token-usage.test.ts
+++ b/packages/coc-agent-sdk/test/ai/codex-sdk-token-usage.test.ts
@@ -136,7 +136,7 @@ describe('CodexSDKService token usage', () => {
     });
 
     it('AC-01: derives tokenLimit from the registry and currentTokens from the latest turn', async () => {
-        // gpt-5.4 has a registry contextWindow (128k). currentTokens is the
+        // gpt-5.4 has a registry contextWindow (272k). currentTokens is the
         // latest-turn occupancy snapshot: input_tokens + output_tokens. The
         // subset field cached_input_tokens is NOT added again, and reasoning
         // tokens are excluded.
@@ -155,7 +155,7 @@ describe('CodexSDKService token usage', () => {
         ], 'gpt-5.4');
 
         expect(result.success).toBe(true);
-        expect(result.tokenUsage?.tokenLimit).toBe(128_000);
+        expect(result.tokenUsage?.tokenLimit).toBe(272_000);
         // input + output only (cached is a subset of input; reasoning excluded).
         expect(result.tokenUsage?.currentTokens).toBe(1250);
         // No fabricated breakdown for Codex.
@@ -186,7 +186,7 @@ describe('CodexSDKService token usage', () => {
         expect(result.tokenUsage?.totalTokens).toBe(13_800);
         expect(result.tokenUsage?.turnCount).toBe(2);
         // currentTokens is a snapshot of the LATEST turn only, not cumulative.
-        expect(result.tokenUsage?.tokenLimit).toBe(128_000);
+        expect(result.tokenUsage?.tokenLimit).toBe(272_000);
         expect(result.tokenUsage?.currentTokens).toBe(8300);
     });
 
@@ -202,7 +202,7 @@ describe('CodexSDKService token usage', () => {
         ], 'gpt-5.3-codex');
 
         expect(result.success).toBe(true);
-        expect(result.tokenUsage?.tokenLimit).toBe(128_000);
+        expect(result.tokenUsage?.tokenLimit).toBe(272_000);
         // 2000 + 100, NOT 2000 + 1900 + 100.
         expect(result.tokenUsage?.currentTokens).toBe(2100);
     });

--- a/packages/forge/test/ai/model-registry.test.ts
+++ b/packages/forge/test/ai/model-registry.test.ts
@@ -392,7 +392,9 @@ describe('Model Registry', () => {
         });
 
         it('returns known context window for gpt-5.4', () => {
-            expect(getModelContextWindow('gpt-5.4')).toBe(128_000);
+            // GPT-5.x Codex family reports 272k (Codex models_cache.json
+            // context_window field); see model-registry gpt-5.4 entry.
+            expect(getModelContextWindow('gpt-5.4')).toBe(272_000);
         });
 
         it('returns undefined for unknown model ID', () => {


### PR DESCRIPTION
- **feat(codex): derive context-window usage from model registry + latest turn**
- **fix(codex): correct gpt-5.x context window to sourced 272k**
