### PR TITLE
pr/48bca0096 featcomposer container width signal icon

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/chat/ComposerMetaStrip.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ComposerMetaStrip.tsx
@@ -41,12 +41,28 @@ export interface ComposerMetaStripProps {
     sessionToolTokens?: number;
     /** Conversation-history token count when the provider reports a breakdown. */
     sessionConversationTokens?: number;
+    /**
+     * When true, the composer pane is container-narrow: the cwd chip renders
+     * only the last path segment (basename) with no `cwd` label, keeping the
+     * full path in its `title` tooltip. Wide/normal state is unchanged.
+     */
+    compact?: boolean;
 }
 
 function shortenPath(path: string, maxLen = 32): string {
     if (path.length <= maxLen) return path;
     const head = '…';
     return head + path.slice(path.length - (maxLen - head.length));
+}
+
+/**
+ * Last path segment of `path` (basename), tolerant of POSIX (`/`) and Windows
+ * (`\`) separators and trailing slashes. Falls back to the trimmed path when no
+ * segment can be extracted (e.g. a bare `/`).
+ */
+function basename(path: string): string {
+    const segments = path.split(/[/\\]+/).filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1] : path;
 }
 
 function formatTokenCount(n: number): string {
@@ -65,6 +81,7 @@ export function ComposerMetaStrip({
     sessionSystemTokens,
     sessionToolTokens,
     sessionConversationTokens,
+    compact = false,
 }: ComposerMetaStripProps) {
     const [ctxPopoverOpen, setCtxPopoverOpen] = useState(false);
 
@@ -134,9 +151,11 @@ export function ComposerMetaStrip({
                     <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-shrink-0 opacity-70">
                         <path d="M2 4a1 1 0 0 1 1-1h3.5l1.5 1.5H13a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4z" />
                     </svg>
-                    <span aria-hidden="true" className="hidden sm:inline font-mono text-[9px] uppercase tracking-wider opacity-60">cwd</span>
-                    <code className="font-mono text-[10.5px] text-[#1e1e1e] dark:text-[#cccccc] truncate">
-                        {shortenPath(trimmedCwd!)}
+                    {!compact && (
+                        <span aria-hidden="true" className="hidden sm:inline font-mono text-[9px] uppercase tracking-wider opacity-60">cwd</span>
+                    )}
+                    <code data-testid="composer-cwd-path" className="font-mono text-[10.5px] text-[#1e1e1e] dark:text-[#cccccc] truncate">
+                        {compact ? basename(trimmedCwd!) : shortenPath(trimmedCwd!)}
                     </code>
                 </span>
             )}

--- a/packages/coc/src/server/spa/client/react/features/chat/EffortTierSelector.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/EffortTierSelector.tsx
@@ -46,6 +46,12 @@ export interface EffortTierSelectorProps {
     'data-testid'?: string;
     className?: string;
     mobileTapTarget?: boolean;
+    /**
+     * Container-narrow signal (AC-03): when true, drop the "Effort:" prefix and
+     * show only the selected tier value, regardless of viewport. Fires in
+     * addition to the viewport `sm:` compaction driven by `mobileTapTarget`.
+     */
+    compact?: boolean;
     autoProviderMode?: boolean;
 }
 
@@ -56,6 +62,7 @@ export function EffortTierSelector({
     disabled = false,
     className,
     mobileTapTarget = false,
+    compact = false,
     autoProviderMode = false,
     ...rest
 }: EffortTierSelectorProps) {
@@ -106,11 +113,14 @@ export function EffortTierSelector({
                 <span aria-hidden="true" className={cn('font-mono text-[10px] font-semibold text-[#848484] dark:text-[#999]', mobileTapTarget ? 'inline sm:hidden' : 'hidden')}>
                     E
                 </span>
-                <span className={cn(
-                    'font-mono text-[10.5px] font-medium text-[#848484] dark:text-[#999] truncate',
-                    mobileTapTarget && 'hidden sm:inline',
-                )}>
-                    Effort: {selectedLabel}
+                <span
+                    className={cn(
+                        'font-mono text-[10.5px] font-medium text-[#848484] dark:text-[#999] truncate',
+                        mobileTapTarget && 'hidden sm:inline',
+                    )}
+                    data-testid="effort-tier-label"
+                >
+                    {compact ? selectedLabel : `Effort: ${selectedLabel}`}
                 </span>
                 <svg
                     width="7" height="7"

--- a/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
@@ -1028,6 +1028,7 @@ export function FollowUpInputArea({
                                     onChange={onEffortTierChange}
                                     data-testid="follow-up-effort-tier-selector"
                                     mobileTapTarget={true}
+                                    compact={isToolbarNarrow}
                                 />
                             )}
                             {/* Model selector chip — shows the active model

--- a/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
@@ -16,6 +16,7 @@ import type { EffortLevel, EffortPillOption } from './EffortPillSelector';
 import { EffortTierSelector } from './EffortTierSelector';
 import type { EffortTierKey, LocalEffortTiersMap } from '../../hooks/useProviderEffortTiers';
 import { ComposerMetaStrip } from './ComposerMetaStrip';
+import { useContainerWidth } from './hooks/useContainerWidth';
 import { useModifierKey } from '../../hooks/ui/useModifierKey';
 import { usePromptAutocomplete } from '../../hooks/usePromptAutocomplete';
 import { usePromptAutocompleteEnabled } from '../../hooks/usePromptAutocompleteEnabled';
@@ -281,6 +282,14 @@ export function FollowUpInputArea({
 }: FollowUpInputAreaProps) {
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    // Container-width signal for the compact composer footer: the toolbar
+    // measures its OWN width (not the viewport) so it compacts when the
+    // composer pane is narrow — e.g. when the reference/note panel is open
+    // beside it on a wide screen. Width 0 means "not yet measured" (or SSR /
+    // no ResizeObserver), in which case we keep the full/wide layout.
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const toolbarWidth = useContainerWidth(toolbarRef);
+    const isToolbarNarrow = toolbarWidth.width > 0 && toolbarWidth.isNarrow;
     const modHeld = useModifierKey(inputWrapperRef as RefObject<HTMLElement>);
     // Global (unscoped) detection so chips show the "send" state even when input isn't focused.
     const chipsCtrlHeld = useModifierKey();
@@ -960,6 +969,7 @@ export function FollowUpInputArea({
                             data-testid="activity-chat-input"
                         />
                         <div
+                            ref={toolbarRef}
                             className="flex flex-nowrap lg:flex-wrap items-center gap-x-px gap-y-0.5 pl-2 pr-1.5 py-1 border-t border-[#e0e0e0] dark:border-[#3c3c3c]"
                             data-testid="chat-input-toolbar"
                         >
@@ -1040,6 +1050,10 @@ export function FollowUpInputArea({
                                         data-testid="model-picker-chip"
                                         aria-haspopup="listbox"
                                         aria-expanded={modelCommand.modelMenuVisible}
+                                        // Keep the full model name as the accessible name in both
+                                        // states — when narrow the text label is hidden and only the
+                                        // hexagon icon remains, so aria-label carries the name.
+                                        aria-label={`Model: ${modelCommand.modelOverride || sessionModel || 'model'}`}
                                     >
                                         <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="shrink-0">
                                             <polygon
@@ -1049,9 +1063,14 @@ export function FollowUpInputArea({
                                                 strokeLinejoin="round"
                                             />
                                         </svg>
-                                        <span className="truncate font-mono text-[10.5px] font-medium text-[#848484] dark:text-[#999]">
-                                            {modelCommand.modelOverride || sessionModel || 'model'}
-                                        </span>
+                                        {!isToolbarNarrow && (
+                                            <span
+                                                data-testid="model-picker-chip-label"
+                                                className="truncate font-mono text-[10.5px] font-medium text-[#848484] dark:text-[#999]"
+                                            >
+                                                {modelCommand.modelOverride || sessionModel || 'model'}
+                                            </span>
+                                        )}
                                         {/* Mirrors AgentSelectorChip: chevron
                                              only, no inline ✕ clear. The
                                              override is cleared via the "Use

--- a/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/FollowUpInputArea.tsx
@@ -1237,6 +1237,7 @@ export function FollowUpInputArea({
                             <div className="hidden lg:flex items-center">
                                 <ComposerMetaStrip
                                     className="mx-1"
+                                    compact={isToolbarNarrow}
                                     workingDirectory={workingDirectory}
                                     sessionTokenLimit={sessionTokenLimit}
                                     sessionCurrentTokens={sessionCurrentTokens}

--- a/packages/coc/test/server/spa/client/repos/FollowUpInputArea-container-compact.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/FollowUpInputArea-container-compact.test.tsx
@@ -13,6 +13,9 @@
  *  - AC-01: the container-width signal drives compaction; full layout when wide.
  *  - AC-04: the "Claude" model chip collapses to icon-only when narrow while
  *    keeping the model name as its accessible name.
+ *  - AC-02: the cwd chip collapses to the last folder name (basename) with the
+ *    full path in its title, driven by the same container-narrow signal threaded
+ *    down into ComposerMetaStrip.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -219,6 +222,29 @@ describe('FollowUpInputArea – container-driven compact footer', () => {
             })} />);
             expect(screen.getByTestId('model-picker-chip').getAttribute('aria-label'))
                 .toBe('Model: claude-sonnet-4-6');
+        });
+    });
+
+    describe('AC-02 – cwd chip → basename when narrow (prop threaded)', () => {
+        const CWD = '/Users/yihengtao/Documents/Projects/nanochat';
+
+        it('shows only the last folder name and drops the cwd label when narrow', () => {
+            setContainerWidth('narrow', 420);
+            render(<FollowUpInputArea {...defaultProps({ workingDirectory: CWD })} />);
+            const chip = screen.getByTestId('composer-cwd-chip');
+            expect(screen.getByTestId('composer-cwd-path').textContent).toBe('nanochat');
+            expect(chip.textContent).not.toMatch(/\bcwd\b/);
+            // Full path preserved in the title tooltip.
+            expect(chip.getAttribute('title')).toBe(`Working directory: ${CWD}`);
+        });
+
+        it('shows the head-truncated path and cwd label when wide', () => {
+            setContainerWidth('wide', 900);
+            render(<FollowUpInputArea {...defaultProps({ workingDirectory: CWD })} />);
+            const chip = screen.getByTestId('composer-cwd-chip');
+            // Wide keeps the ellipsis-prefixed head-truncated form + the `cwd` label.
+            expect(screen.getByTestId('composer-cwd-path').textContent?.startsWith('…')).toBe(true);
+            expect(chip.querySelector('span[class*="uppercase"]')?.textContent).toBe('cwd');
         });
     });
 });

--- a/packages/coc/test/server/spa/client/repos/FollowUpInputArea-container-compact.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/FollowUpInputArea-container-compact.test.tsx
@@ -247,4 +247,32 @@ describe('FollowUpInputArea – container-driven compact footer', () => {
             expect(chip.querySelector('span[class*="uppercase"]')?.textContent).toBe('cwd');
         });
     });
+
+    describe('AC-03 – Effort tier selector drops the "Effort:" prefix when narrow', () => {
+        const tierProps = {
+            useEffortTierMode: true,
+            selectedEffortTier: 'medium' as const,
+            onEffortTierChange: vi.fn(),
+            effortTierMap: {
+                'very-low': { model: 'gpt-5.4-mini', reasoningEffort: 'low', source: 'default' as const },
+                low: { model: 'gpt-5-mini', reasoningEffort: 'low', source: 'config' as const },
+                medium: { model: 'gpt-5', reasoningEffort: '', source: 'default' as const },
+                high: { model: 'gpt-5-pro', reasoningEffort: 'high', source: 'config' as const },
+            },
+        };
+
+        it('shows only the tier value (no "Effort:" word) when narrow', () => {
+            setContainerWidth('narrow', 420);
+            render(<FollowUpInputArea {...defaultProps(tierProps)} />);
+            const label = screen.getByTestId('effort-tier-label');
+            expect(label.textContent).toBe('Medium');
+            expect(label.textContent).not.toMatch(/Effort:/);
+        });
+
+        it('shows "Effort: <tier>" when wide', () => {
+            setContainerWidth('wide', 900);
+            render(<FollowUpInputArea {...defaultProps(tierProps)} />);
+            expect(screen.getByTestId('effort-tier-label').textContent).toBe('Effort: Medium');
+        });
+    });
 });

--- a/packages/coc/test/server/spa/client/repos/FollowUpInputArea-container-compact.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/FollowUpInputArea-container-compact.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the CONTAINER-width driven compact composer footer.
+ *
+ * Unlike the viewport-driven (`lg:` / `sm:`) compaction covered by
+ * FollowUpInputArea-compact-toolbar.test.tsx, these behaviours fire when the
+ * toolbar measures its OWN width below the `narrow` threshold (<500px) via the
+ * `useContainerWidth` hook — so the footer compacts when the composer pane is
+ * narrow even on a wide browser window (reference/note panel open beside it).
+ *
+ * Covers:
+ *  - AC-01: the container-width signal drives compaction; full layout when wide.
+ *  - AC-04: the "Claude" model chip collapses to icon-only when narrow while
+ *    keeping the model name as its accessible name.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Container-width mock — controlled per-test via setContainerWidthTier().
+// ---------------------------------------------------------------------------
+
+let currentTier: 'wide' | 'medium' | 'narrow' = 'wide';
+let currentWidth = 900;
+
+function setContainerWidth(tier: 'wide' | 'medium' | 'narrow', width: number) {
+    currentTier = tier;
+    currentWidth = width;
+}
+
+vi.mock('../../../../../src/server/spa/client/react/features/chat/hooks/useContainerWidth', () => ({
+    useContainerWidth: () => ({
+        width: currentWidth,
+        tier: currentTier,
+        isWide: currentTier === 'wide',
+        isMedium: currentTier === 'medium',
+        isNarrow: currentTier === 'narrow',
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Standard FollowUpInputArea harness mocks (mirror the compact-toolbar test).
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../../src/server/spa/client/react/hooks/ui/useModifierKey', () => ({
+    useModifierKey: () => false,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/ui', () => ({
+    Button: ({ children, ...rest }: any) => <button {...rest}>{children}</button>,
+    SuggestionChips: () => null,
+    SendButton: () => <button data-testid="activity-chat-send-btn">Send</button>,
+    QueueFollowUpButton: ({ onSend }: any) => (
+        <button data-testid="activity-chat-send-btn" onClick={() => onSend('enqueue')}>Send</button>
+    ),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/ui/AttachmentPreviews', () => ({
+    AttachmentPreviews: () => null,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/ui/cn', () => ({
+    cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/shared/RichTextInput', () => ({
+    RichTextInput: vi.fn().mockImplementation(() => null),
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/features/chat/SlashCommandMenu', () => ({
+    SlashCommandMenu: () => null,
+    META_SKILL_ITEMS: [],
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/features/chat/ModelCommandMenu', () => ({
+    ModelCommandMenu: () => null,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/features/chat/ModePillSelector', () => ({
+    ModePillSelector: () => <div data-testid="mode-pill-selector-inner" />,
+    DEFAULT_MODE_PILL_OPTIONS: [],
+    RALPH_MODE_PILL_OPTION: { value: 'ralph', label: 'Ralph' },
+    getVisibleModePillOptions: () => [
+        { value: 'ask', label: 'Ask', dotClass: 'bg-yellow-500' },
+        { value: 'autopilot', label: 'Autopilot', dotClass: 'bg-green-500' },
+    ],
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/features/chat/EffortPillSelector', () => ({
+    EffortPillSelector: () => null,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/repos/modeConfig', () => ({
+    MODE_BORDER_COLORS: {
+        ask: { border: '', ring: '' },
+        plan: { border: '', ring: '' },
+        autopilot: { border: '', ring: '' },
+    },
+    MODE_ICONS: { ask: '?', plan: 'P', autopilot: 'A' },
+    MODE_LABELS: { ask: 'Ask', plan: 'Plan', autopilot: 'Autopilot' },
+    MODE_TOOLTIPS: { ask: 'Ask', plan: 'Plan', autopilot: 'Autopilot' },
+    cycleMode: (m: string) => (m === 'ask' ? 'plan' : 'ask'),
+}));
+
+vi.mock('@plusplusoneplusplus/forge', () => ({}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { FollowUpInputArea } from '../../../../../src/server/spa/client/react/features/chat/FollowUpInputArea';
+import { createRef } from 'react';
+
+const MODEL_COMMAND = {
+    modelMenuVisible: false,
+    modelFilter: '',
+    filteredModels: [],
+    modelHighlightIndex: 0,
+    modelOverride: null,
+    setModelOverride: vi.fn(),
+    handleModelSelect: vi.fn(),
+    showModelMenu: vi.fn(),
+    dismissModelMenu: vi.fn(),
+    handleModelKeyDown: vi.fn(),
+    setModelFilter: vi.fn(),
+};
+
+function defaultProps(overrides: Partial<Parameters<typeof FollowUpInputArea>[0]> = {}) {
+    return {
+        richTextRef: createRef<any>(),
+        inputDisabled: false,
+        sending: false,
+        isActiveGeneration: false,
+        isCancelling: false,
+        error: null,
+        resumeFeedback: null,
+        suggestions: [],
+        followUpInput: '',
+        setFollowUpInput: vi.fn(),
+        selectedMode: 'ask' as const,
+        setSelectedMode: vi.fn(),
+        onSend: vi.fn().mockResolvedValue(undefined),
+        onRetry: vi.fn(),
+        skills: [],
+        attachments: [],
+        onAttachmentPaste: vi.fn(),
+        onAttachmentRemove: vi.fn(),
+        onAttachmentFiles: vi.fn(),
+        attachmentError: null,
+        pastePreview: null,
+        task: null,
+        modelCommand: { ...MODEL_COMMAND },
+        sessionModel: 'claude-opus-4-8',
+        slashCommands: {
+            handleInputChange: vi.fn(),
+            handleKeyDown: vi.fn().mockReturnValue(false),
+            selectSkill: vi.fn(),
+            dismissMenu: vi.fn(),
+            menuVisible: false,
+            menuFilter: '',
+            filteredSkills: [],
+            highlightIndex: 0,
+        },
+        ...overrides,
+    };
+}
+
+describe('FollowUpInputArea – container-driven compact footer', () => {
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        setContainerWidth('wide', 900);
+    });
+
+    describe('AC-01 – container-width signal', () => {
+        it('renders the full model label when the toolbar is wide (≥700px)', () => {
+            setContainerWidth('wide', 900);
+            render(<FollowUpInputArea {...defaultProps()} />);
+            expect(screen.getByTestId('model-picker-chip-label')).toBeTruthy();
+            expect(screen.getByTestId('model-picker-chip-label').textContent).toBe('claude-opus-4-8');
+        });
+
+        it('collapses to compact rendering when the measured width is below the narrow threshold', () => {
+            setContainerWidth('narrow', 420);
+            render(<FollowUpInputArea {...defaultProps()} />);
+            // AC-04 compaction is visible: the model text label is dropped.
+            expect(screen.queryByTestId('model-picker-chip-label')).toBeNull();
+        });
+
+        it('keeps the full layout when width is unmeasured (0) to avoid a compact flash', () => {
+            setContainerWidth('narrow', 0);
+            render(<FollowUpInputArea {...defaultProps()} />);
+            // width 0 is "not yet measured" → full layout despite the narrow tier.
+            expect(screen.getByTestId('model-picker-chip-label')).toBeTruthy();
+        });
+    });
+
+    describe('AC-04 – model chip → icon only when narrow', () => {
+        it('hides the model text label when narrow but keeps the accessible name', () => {
+            setContainerWidth('narrow', 420);
+            render(<FollowUpInputArea {...defaultProps()} />);
+            const chip = screen.getByTestId('model-picker-chip');
+            expect(screen.queryByTestId('model-picker-chip-label')).toBeNull();
+            expect(chip.getAttribute('aria-label')).toBe('Model: claude-opus-4-8');
+        });
+
+        it('shows icon + model name when wide, with the accessible name preserved', () => {
+            setContainerWidth('wide', 900);
+            render(<FollowUpInputArea {...defaultProps()} />);
+            const chip = screen.getByTestId('model-picker-chip');
+            expect(screen.getByTestId('model-picker-chip-label').textContent).toBe('claude-opus-4-8');
+            expect(chip.getAttribute('aria-label')).toBe('Model: claude-opus-4-8');
+        });
+
+        it('uses the model override in the accessible name when one is active', () => {
+            setContainerWidth('narrow', 420);
+            render(<FollowUpInputArea {...defaultProps({
+                modelCommand: { ...MODEL_COMMAND, modelOverride: 'claude-sonnet-4-6' },
+            })} />);
+            expect(screen.getByTestId('model-picker-chip').getAttribute('aria-label'))
+                .toBe('Model: claude-sonnet-4-6');
+        });
+    });
+});

--- a/packages/coc/test/spa/react/repos/ComposerMetaStrip.test.tsx
+++ b/packages/coc/test/spa/react/repos/ComposerMetaStrip.test.tsx
@@ -32,6 +32,44 @@ describe('ComposerMetaStrip', () => {
         expect(code?.textContent?.startsWith('…')).toBe(true);
     });
 
+    // — Compact (container-narrow) cwd chip: AC-02 ——————————————————————
+
+    it('renders only the last path segment and no cwd label when compact', () => {
+        render(<ComposerMetaStrip workingDirectory="/Users/yihengtao/Documents/Projects/nanochat" compact />);
+        const chip = screen.getByTestId('composer-cwd-chip');
+        const path = screen.getByTestId('composer-cwd-path');
+        // Basename only — no head-truncation ellipsis, no parent segments
+        expect(path.textContent).toBe('nanochat');
+        expect(path.textContent).not.toContain('/');
+        expect(path.textContent).not.toContain('…');
+        // The tiny `cwd` label is dropped in compact mode
+        expect(chip.textContent).not.toMatch(/\bcwd\b/);
+        // Full path preserved in the title tooltip for accessibility
+        expect(chip.getAttribute('title')).toBe('Working directory: /Users/yihengtao/Documents/Projects/nanochat');
+    });
+
+    it('renders the cwd label and head-truncated path when not compact (wide)', () => {
+        const long = '/Users/yihengtao/Documents/Projects/nanochat/a/deep/path/that/keeps/going';
+        render(<ComposerMetaStrip workingDirectory={long} />);
+        const chip = screen.getByTestId('composer-cwd-chip');
+        const path = screen.getByTestId('composer-cwd-path');
+        // Wide keeps the existing head-truncated (ellipsis-prefixed) form
+        expect(path.textContent?.startsWith('…')).toBe(true);
+        // The `cwd` label element is present in wide mode
+        expect(chip.querySelector('span[class*="uppercase"]')?.textContent).toBe('cwd');
+        expect(chip.getAttribute('title')).toContain(long);
+    });
+
+    it('tolerates a trailing slash when extracting the basename in compact mode', () => {
+        render(<ComposerMetaStrip workingDirectory="/Users/yihengtao/Projects/nanochat/" compact />);
+        expect(screen.getByTestId('composer-cwd-path').textContent).toBe('nanochat');
+    });
+
+    it('tolerates Windows-style separators when extracting the basename in compact mode', () => {
+        render(<ComposerMetaStrip workingDirectory={'C:\\Users\\yh\\Projects\\nanochat'} compact />);
+        expect(screen.getByTestId('composer-cwd-path').textContent).toBe('nanochat');
+    });
+
     it('renders the ctx fuel gauge when token limit is provided', () => {
         render(<ComposerMetaStrip sessionTokenLimit={200_000} sessionCurrentTokens={84_300} />);
         expect(screen.getByTestId('composer-ctx-fuel')).toBeTruthy();

--- a/packages/coc/test/spa/react/repos/EffortTierSelector.test.tsx
+++ b/packages/coc/test/spa/react/repos/EffortTierSelector.test.tsx
@@ -80,4 +80,26 @@ describe('EffortTierSelector', () => {
         rerender(<EffortTierSelector tiers={tiers} selectedTier="very-low" onChange={onChange} />);
         expect(screen.getByTestId('effort-tier-selector').getAttribute('data-tier-value')).toBe('very-low');
     });
+
+    // AC-03 — container-narrow: drop the "Effort:" prefix, show value only.
+    describe('compact (container-narrow)', () => {
+        it('renders the value without the "Effort:" prefix when compact', () => {
+            render(<EffortTierSelector tiers={tiers} selectedTier="medium" onChange={() => {}} compact />);
+            const label = screen.getByTestId('effort-tier-label');
+            expect(label.textContent).toBe('Medium');
+            expect(label.textContent).not.toMatch(/Effort:/);
+        });
+
+        it('keeps the "Effort:" prefix when not compact', () => {
+            render(<EffortTierSelector tiers={tiers} selectedTier="medium" onChange={() => {}} />);
+            expect(screen.getByTestId('effort-tier-label').textContent).toBe('Effort: Medium');
+        });
+
+        it('preserves the accessible tier name in the compact form', () => {
+            render(<EffortTierSelector tiers={tiers} selectedTier="high" onChange={() => {}} compact />);
+            expect(screen.getByTestId('effort-tier-trigger-btn').getAttribute('aria-label')).toBe(
+                'Effort tier: High',
+            );
+        });
+    });
 });


### PR DESCRIPTION
- **feat(composer): container-width signal + icon-only model chip (AC-01, AC-04)**
- **feat(composer): cwd chip → basename + tooltip when narrow (AC-02)**
- **feat(composer): drop "Effort:" prefix when composer narrow (AC-03)**
