### PR TITLE
fix(codex): use app-server daemon/proxy handshake for quota RPC

### DIFF
--- a/packages/coc-agent-sdk/src/codex-sdk-service.ts
+++ b/packages/coc-agent-sdk/src/codex-sdk-service.ts
@@ -712,11 +712,7 @@ export class CodexSDKService implements ISDKService {
     }
 
     private async loadModelCatalog(): Promise<IModelInfo[]> {
-        const codexBinPath = this.resolveCodexBinPath();
-        const { stdout } = await execFileAsync(process.execPath, [codexBinPath, 'debug', 'models'], {
-            timeout: 30_000,
-            maxBuffer: 50 * 1024 * 1024,
-        });
+        const { stdout } = await this.runCodexCli(['debug', 'models'], { timeout: 30_000 });
         const parsed = JSON.parse(stdout) as { models?: unknown };
         if (!Array.isArray(parsed.models)) return [];
         const models = parsed.models
@@ -809,10 +805,45 @@ export class CodexSDKService implements ISDKService {
         }
     }
 
-    /** Spawn `codex app-server`, send RPC messages, and return rate limits. */
-    private fetchRateLimitsViaRpc(codexBinPath: string): Promise<CodexRateLimitsResult> {
+    /**
+     * Run the bundled Codex CLI (`codex <args>`) as a child of the current Node
+     * runtime, resolving with its captured stdio. Shared by the model-catalog
+     * and quota RPCs so every Codex CLI invocation uses the same robust spawn
+     * pattern (Node runtime + resolved `codex.js` path, rather than relying on a
+     * `codex` binary on PATH).
+     */
+    private runCodexCli(args: string[], options: { timeout: number }): Promise<{ stdout: string; stderr: string }> {
+        const codexBinPath = this.resolveCodexBinPath();
+        return execFileAsync(process.execPath, [codexBinPath, ...args], {
+            timeout: options.timeout,
+            maxBuffer: 50 * 1024 * 1024,
+        });
+    }
+
+    /**
+     * Fetch Codex rate limits over JSON-RPC.
+     *
+     * In `@openai/codex` ≥ 0.133.0, `codex app-server` is a subcommand *group*:
+     * the bare invocation prints usage help and exits immediately, so the old
+     * code raced the exit against the RPC response and always reported
+     * "app-server exited before returning rate limits". The supported flow is a
+     * two-step handshake:
+     *   1. `app-server daemon start` — idempotent; brings the daemon up (or
+     *      no-ops if it is already running).
+     *   2. `app-server proxy` — pipes stdin/stdout to the running daemon socket,
+     *      over which we speak JSON-RPC.
+     */
+    private async fetchRateLimitsViaRpc(codexBinPath: string): Promise<CodexRateLimitsResult> {
+        // Ensure the app-server daemon is running before opening the proxy. This
+        // is idempotent, so it is safe to run on every quota query.
+        await this.runCodexCli(['app-server', 'daemon', 'start'], { timeout: 15_000 });
+        return this.readRateLimitsViaProxy(codexBinPath);
+    }
+
+    /** Spawn `codex app-server proxy`, send RPC messages, and return rate limits. */
+    private readRateLimitsViaProxy(codexBinPath: string): Promise<CodexRateLimitsResult> {
         return new Promise<CodexRateLimitsResult>((resolve, reject) => {
-            const child = spawn(process.execPath, [codexBinPath, 'app-server'], {
+            const child = spawn(process.execPath, [codexBinPath, 'app-server', 'proxy'], {
                 stdio: ['pipe', 'pipe', 'ignore'],
                 windowsHide: true,
             });
@@ -829,7 +860,7 @@ export class CodexSDKService implements ISDKService {
 
             const timer = setTimeout(() => {
                 cleanup();
-                reject(new Error('Codex app-server RPC timed out'));
+                reject(new Error('Codex app-server proxy RPC timed out'));
             }, 10_000);
 
             child.on('error', (err) => {
@@ -842,7 +873,7 @@ export class CodexSDKService implements ISDKService {
                 clearTimeout(timer);
                 if (!settled) {
                     settled = true;
-                    reject(new Error('Codex app-server exited before returning rate limits'));
+                    reject(new Error('Codex app-server proxy exited before returning rate limits'));
                 }
             });
 
@@ -865,8 +896,10 @@ export class CodexSDKService implements ISDKService {
                 }
             });
 
+            // Every message carries the JSON-RPC 2.0 envelope so the daemon
+            // accepts it (bare messages without `jsonrpc` are rejected).
             const send = (msg: Record<string, unknown>) => {
-                child.stdin!.write(JSON.stringify(msg) + '\n');
+                child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', ...msg }) + '\n');
             };
 
             send({

--- a/packages/coc-agent-sdk/test/ai/codex-sdk-quota-rpc.test.ts
+++ b/packages/coc-agent-sdk/test/ai/codex-sdk-quota-rpc.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Codex SDK Service — Account quota JSON-RPC handshake tests.
+ *
+ * Regression coverage for the `@openai/codex` ≥ 0.133.0 change that turned
+ * `codex app-server` into a subcommand group. The bare invocation now prints
+ * help and exits immediately, so the quota query must instead run
+ * `app-server daemon start` (idempotent) followed by `app-server proxy`, and
+ * every JSON-RPC message must carry the `jsonrpc: "2.0"` envelope.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import { PassThrough, Writable } from 'stream';
+import { CodexSDKService } from '../../src/codex-sdk-service';
+import { execFileAsync } from '../../src/internal/exec-utils';
+
+vi.mock('child_process', () => ({
+    spawn: vi.fn(),
+}));
+
+vi.mock('../../src/internal/exec-utils', () => ({
+    execFileAsync: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(spawn);
+const mockExecFileAsync = vi.mocked(execFileAsync);
+
+/** Minimal stand-in for the spawned `codex app-server proxy` child process. */
+class MockCodexProxyChild extends EventEmitter {
+    public readonly stdout = new PassThrough();
+    public readonly stdinWrites: string[] = [];
+    public readonly stdin: Writable;
+    public readonly kill = vi.fn(() => true);
+
+    public constructor() {
+        super();
+        this.stdin = new Writable({
+            write: (chunk, _encoding, callback) => {
+                this.stdinWrites.push(Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk));
+                callback();
+            },
+        });
+    }
+
+    public writeStdoutLine(line: string): void {
+        this.stdout.write(line + '\n');
+    }
+
+    /** Parsed JSON-RPC messages this child received on stdin. */
+    public sentMessages(): Array<Record<string, unknown>> {
+        return this.stdinWrites
+            .join('')
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line) as Record<string, unknown>);
+    }
+}
+
+const RATE_LIMITS_RESULT = {
+    rateLimits: {
+        limitId: 'codex',
+        limitName: null,
+        primary: { usedPercent: 10, windowDurationMins: 300, resetsAt: 1700000000 },
+        secondary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1700500000 },
+        credits: { hasCredits: false, unlimited: false, balance: '0' },
+        planType: 'plus',
+        rateLimitReachedType: null,
+    },
+};
+
+async function flushMicrotasks(): Promise<void> {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+describe('CodexSDKService.getAccountQuota — app-server daemon/proxy handshake', () => {
+    beforeEach(() => {
+        mockSpawn.mockReset();
+        mockExecFileAsync.mockReset();
+        mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' });
+    });
+
+    it('starts the daemon then proxies JSON-RPC and returns mapped quota', async () => {
+        const child = new MockCodexProxyChild();
+        mockSpawn.mockReturnValueOnce(child as never);
+
+        const svc = new CodexSDKService();
+        const promise = svc.getAccountQuota();
+
+        // Let the daemon-start await settle and the proxy spawn/stdin writes run.
+        await flushMicrotasks();
+
+        // AC-01: the daemon is started (idempotent) before the proxy opens.
+        expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+        const daemonArgs = mockExecFileAsync.mock.calls[0][1] as string[];
+        expect(daemonArgs.slice(-3)).toEqual(['app-server', 'daemon', 'start']);
+
+        // AC-01: the RPC session runs over `app-server proxy`, not bare `app-server`.
+        expect(mockSpawn).toHaveBeenCalledTimes(1);
+        const proxyArgs = mockSpawn.mock.calls[0][1] as string[];
+        expect(proxyArgs.slice(-2)).toEqual(['app-server', 'proxy']);
+
+        // Deliver the rateLimits response (id: 2) the code waits for.
+        child.writeStdoutLine(JSON.stringify({ jsonrpc: '2.0', id: 2, result: RATE_LIMITS_RESULT }));
+
+        const result = await promise;
+        expect(Object.keys(result.quotaSnapshots).sort()).toEqual(['five_hour', 'seven_day']);
+        expect(result.quotaSnapshots['five_hour'].usedRequests).toBe(10);
+    });
+
+    it('sends every JSON-RPC message with the jsonrpc 2.0 envelope (AC-02)', async () => {
+        const child = new MockCodexProxyChild();
+        mockSpawn.mockReturnValueOnce(child as never);
+
+        const svc = new CodexSDKService();
+        const promise = svc.getAccountQuota();
+        await flushMicrotasks();
+
+        const messages = child.sentMessages();
+        expect(messages.length).toBe(3);
+        for (const msg of messages) {
+            expect(msg.jsonrpc).toBe('2.0');
+        }
+        expect(messages.map(m => m.method)).toEqual([
+            'initialize',
+            'initialized',
+            'account/rateLimits/read',
+        ]);
+
+        child.writeStdoutLine(JSON.stringify({ jsonrpc: '2.0', id: 2, result: RATE_LIMITS_RESULT }));
+        await promise;
+    });
+
+    it('rejects with a proxy-specific error when the proxy exits early', async () => {
+        const child = new MockCodexProxyChild();
+        mockSpawn.mockReturnValueOnce(child as never);
+
+        const svc = new CodexSDKService();
+        const promise = svc.getAccountQuota();
+        await flushMicrotasks();
+
+        child.emit('exit', 0);
+
+        await expect(promise).rejects.toThrow(/app-server proxy exited before returning rate limits/);
+    });
+});


### PR DESCRIPTION
codex app-server became a subcommand group in @openai/codex 0.133.0,
so the bare `app-server` spawn printed help and exited immediately,
producing "app-server exited before returning rate limits" in the
desktop quota panel.

- Start the daemon via idempotent `app-server daemon start`, then open
  the JSON-RPC session over `app-server proxy` (AC-01).
- Envelope every JSON-RPC message with jsonrpc: "2.0" (AC-02).
- Extract a shared runCodexCli helper so loadModelCatalog and the quota
  RPC use one robust invocation pattern (AC-03).

Adds regression tests covering the daemon->proxy order, the jsonrpc
envelope, and the proxy-exit error path.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
