### PR TITLE
Replace GITHUB/ADO header keyword with provider logo

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteProviderBadge.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteProviderBadge.tsx
@@ -1,0 +1,65 @@
+/**
+ * RemoteProviderBadge — renders the hosting provider as a small logo (GitHub /
+ * Azure DevOps) instead of an uppercase text keyword. Unknown remotes fall back
+ * to the plain "Remote" text label. The provider name is still exposed via
+ * title/aria-label so the badge stays accessible and testable, and a
+ * `data-provider` attribute carries the resolved kind for tests and styling.
+ *
+ * Distinct from `features/chat/ProviderBadge`, which badges the AI/model
+ * provider (Copilot / Codex / Claude) for a chat.
+ */
+import { remoteProviderKind, remoteProviderLabel } from './shellModel';
+
+function GitHubMark({ size }: { size: number }) {
+    return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+        </svg>
+    );
+}
+
+function AzureDevOpsMark({ size }: { size: number }) {
+    return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M0 8.877L2.247 5.91l8.405-3.416V.022l7.37 5.393L2.966 8.338v8.225L0 15.707zm24-4.45v14.651l-5.753 4.9-9.303-3.057v3.056l-5.978-7.416 15.057 1.798V5.415z" />
+        </svg>
+    );
+}
+
+export interface RemoteProviderBadgeProps {
+    /** Normalized remote URL (`host/user/repo`) whose provider drives the icon. */
+    normalizedUrl: string | null | undefined;
+    /** Wrapper classes (position/spacing/color); inherited by the icon via `currentColor`. */
+    className?: string;
+    /** Icon edge length in px. */
+    iconSize?: number;
+    /** Optional test id forwarded to the wrapper. */
+    testId?: string;
+}
+
+export function RemoteProviderBadge({ normalizedUrl, className, iconSize = 12, testId }: RemoteProviderBadgeProps) {
+    const kind = remoteProviderKind(normalizedUrl);
+    const label = remoteProviderLabel(normalizedUrl);
+
+    // Unknown/other remotes keep the readable text label — there's no logo to show.
+    if (kind === 'remote') {
+        return (
+            <span className={className} data-testid={testId} data-provider={kind}>
+                {label}
+            </span>
+        );
+    }
+
+    return (
+        <span
+            className={className}
+            data-testid={testId}
+            data-provider={kind}
+            role="img"
+            aria-label={label}
+            title={label}
+        >
+            {kind === 'github' ? <GitHubMark size={iconSize} /> : <AzureDevOpsMark size={iconSize} />}
+        </span>
+    );
+}

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteScopeCluster.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteScopeCluster.tsx
@@ -20,7 +20,8 @@ import { getRepoSelectionId, isRepoSelected } from '../../repos/cloneIdentity';
 import { groupKey, groupReposByRemote, type RepoData, type RepoGroup } from '../../repos/repoGrouping';
 import { resolveRepoWorkItemOriginScope } from '../work-items/workItemOriginScope';
 import type { RepoSubTab } from '../../types/dashboard';
-import { computeCloneStatusMap, partitionShellTabs, remoteProviderLabel, summarizeRemote } from './shellModel';
+import { computeCloneStatusMap, partitionShellTabs, summarizeRemote } from './shellModel';
+import { RemoteProviderBadge } from './RemoteProviderBadge';
 import { useRecentRemotes } from './useRecentRemotes';
 import { useShellNavigation } from './useShellNavigation';
 
@@ -116,7 +117,6 @@ export function RemoteScopeCluster({ repo, repos }: RemoteScopeClusterProps) {
     }, [groups, repos, cloneId]);
     const activeGroupKey = activeGroup ? groupKey(activeGroup) : null;
     const activeSummary = activeGroup ? summarizeRemote(activeGroup, cloneStatus, unseenCounts) : null;
-    const activeProvider = remoteProviderLabel(activeGroup?.normalizedUrl);
     const { recentGroups, remainingGroups, recordUse } = useRecentRemotes(groups);
 
     useEffect(() => {
@@ -263,7 +263,11 @@ export function RemoteScopeCluster({ repo, repos }: RemoteScopeClusterProps) {
                 className="relative inline-flex items-center gap-1.5 h-[26px] px-2 rounded-md text-[12.5px] font-semibold text-[#1f2328] dark:text-[#cccccc] hover:bg-black/[0.04] dark:hover:bg-white/[0.06] max-w-[190px]"
             >
                 <span className="inline-block w-2 h-2 rounded-full flex-shrink-0" style={{ background: activeSummary?.color ?? '#848484' }} aria-hidden />
-                <span className="hidden xl:inline text-[9.5px] font-bold uppercase tracking-[0.08em] text-[#848484] dark:text-[#777]">{activeProvider}</span>
+                <RemoteProviderBadge
+                    normalizedUrl={activeGroup?.normalizedUrl}
+                    testId="remote-provider-badge"
+                    className="hidden xl:inline-flex items-center text-[9.5px] font-bold uppercase tracking-[0.08em] text-[#848484] dark:text-[#777]"
+                />
                 <span className="truncate">{activeSummary?.name ?? repo.workspace.name}</span>
                 {activeSummary && activeSummary.cloneCount > 1 && (
                     <span className="hidden lg:inline-flex items-center gap-0.5 h-[16px] px-1.5 rounded-full text-[10px] font-semibold leading-none bg-black/[0.06] dark:bg-white/[0.10] text-[#555] dark:text-[#bbb]">

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/RemoteSubBar.tsx
@@ -33,8 +33,8 @@ import { groupReposByRemote, isRemoteRepo, truncatePath, getRepoHashColor, getSe
 import { getRepoSelectionId } from '../../repos/cloneIdentity';
 import {
     partitionShellTabs, computeCloneStatusMap, cloneStatusColor, summarizeRemote, computeVisibleTabKeys,
-    remoteProviderLabel,
 } from './shellModel';
+import { RemoteProviderBadge } from './RemoteProviderBadge';
 import { useShellNavigation } from './useShellNavigation';
 import type { RepoData } from '../../repos/repoGrouping';
 import type { RepoSubTab } from '../../types/dashboard';
@@ -106,7 +106,6 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
     );
     const remoteColor = getRepoHashColor(clones[0]?.workspace, getHostname() ?? 'local');
     const remoteLabel = group ? summarizeRemote(group, cloneStatus, {}).name : ws.name;
-    const providerLabel = remoteProviderLabel(group?.normalizedUrl);
     const branch = repo.gitInfo?.branch || null;
 
     const { fetchRepos, unseenCounts } = useRepos();
@@ -303,7 +302,7 @@ export function RemoteSubBar({ repo, repos }: RemoteSubBarProps) {
             </div>
 
             {/* ── Remote scope ── */}
-            {remoteTabs.length > 0 && <span className={scopeLabelClass} data-testid="scope-label-remote">{providerLabel}</span>}
+            {remoteTabs.length > 0 && <RemoteProviderBadge normalizedUrl={group?.normalizedUrl} className={scopeLabelClass} testId="scope-label-remote" />}
             {remoteTabs.map(t => renderTab(t, 'remote-scope-tab'))}
 
             {/* divider */}

--- a/packages/coc/src/server/spa/client/react/features/remote-shell/shellModel.ts
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/shellModel.ts
@@ -204,18 +204,36 @@ export function summarizeRemote(
     return { status, unseen, cloneCount: group.repos.length, color, name };
 }
 
+/** Hosting provider a remote resolves to. `remote` is the unknown/other fallback. */
+export type RemoteProviderKind = 'github' | 'ado' | 'remote';
+
+/**
+ * Derive the hosting provider from a normalized remote URL (`host/user/repo`).
+ * Returns `remote` for unknown or empty hosts.
+ */
+export function remoteProviderKind(normalizedUrl: string | null | undefined): RemoteProviderKind {
+    if (!normalizedUrl) return 'remote';
+    const host = normalizedUrl.split('/')[0]?.toLowerCase() ?? '';
+    if (host === 'dev.azure.com' || host.endsWith('.visualstudio.com') || host.includes('azure.com')) {
+        return 'ado';
+    }
+    if (host === 'github.com' || host.endsWith('.github.com') || host.includes('github')) {
+        return 'github';
+    }
+    return 'remote';
+}
+
 /**
  * Derive the hosting-provider label ("ADO" or "GitHub") from a normalized
  * remote URL (`host/user/repo`). Falls back to "Remote" for unknown hosts.
  */
 export function remoteProviderLabel(normalizedUrl: string | null | undefined): string {
-    if (!normalizedUrl) return 'Remote';
-    const host = normalizedUrl.split('/')[0]?.toLowerCase() ?? '';
-    if (host === 'dev.azure.com' || host.endsWith('.visualstudio.com') || host.includes('azure.com')) {
-        return 'ADO';
+    switch (remoteProviderKind(normalizedUrl)) {
+        case 'ado':
+            return 'ADO';
+        case 'github':
+            return 'GitHub';
+        default:
+            return 'Remote';
     }
-    if (host === 'github.com' || host.endsWith('.github.com') || host.includes('github')) {
-        return 'GitHub';
-    }
-    return 'Remote';
 }

--- a/packages/coc/test/spa/react/remote-shell/RemoteProviderBadge.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteProviderBadge.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * RemoteProviderBadge — unit tests for the hosting-provider logo/label rendering.
+ *
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { RemoteProviderBadge } from '../../../../src/server/spa/client/react/features/remote-shell/RemoteProviderBadge';
+
+afterEach(cleanup);
+
+describe('RemoteProviderBadge', () => {
+    it('renders the GitHub logo with an accessible label for GitHub remotes', () => {
+        render(<RemoteProviderBadge normalizedUrl="github.com/acme/shortcuts" testId="badge" />);
+        const badge = screen.getByTestId('badge');
+        expect(badge.getAttribute('data-provider')).toBe('github');
+        expect(badge.getAttribute('aria-label')).toBe('GitHub');
+        expect(badge.getAttribute('title')).toBe('GitHub');
+        expect(badge.getAttribute('role')).toBe('img');
+        // Icon replaces the text keyword.
+        expect(badge.textContent).toBe('');
+        expect(badge.querySelector('svg')).not.toBeNull();
+    });
+
+    it('renders the Azure DevOps logo for ADO remotes', () => {
+        render(<RemoteProviderBadge normalizedUrl="dev.azure.com/org/project/repo" testId="badge" />);
+        const badge = screen.getByTestId('badge');
+        expect(badge.getAttribute('data-provider')).toBe('ado');
+        expect(badge.getAttribute('aria-label')).toBe('ADO');
+        expect(badge.textContent).toBe('');
+        expect(badge.querySelector('svg')).not.toBeNull();
+    });
+
+    it('falls back to the plain "Remote" text for unknown or missing remotes', () => {
+        render(<RemoteProviderBadge normalizedUrl="gitlab.com/acme/repo" testId="badge" />);
+        const badge = screen.getByTestId('badge');
+        expect(badge.getAttribute('data-provider')).toBe('remote');
+        expect(badge.textContent).toBe('Remote');
+        // No logo for unknown providers.
+        expect(badge.querySelector('svg')).toBeNull();
+    });
+
+    it('renders "Remote" text when the URL is null', () => {
+        render(<RemoteProviderBadge normalizedUrl={null} testId="badge" />);
+        const badge = screen.getByTestId('badge');
+        expect(badge.getAttribute('data-provider')).toBe('remote');
+        expect(badge.textContent).toBe('Remote');
+    });
+
+    it('honors a custom icon size', () => {
+        render(<RemoteProviderBadge normalizedUrl="github.com/acme/shortcuts" iconSize={20} testId="badge" />);
+        const svg = screen.getByTestId('badge').querySelector('svg');
+        expect(svg?.getAttribute('width')).toBe('20');
+        expect(svg?.getAttribute('height')).toBe('20');
+    });
+
+    it('applies the provided wrapper className', () => {
+        render(<RemoteProviderBadge normalizedUrl="github.com/acme/shortcuts" className="my-wrapper" testId="badge" />);
+        expect(screen.getByTestId('badge').className).toBe('my-wrapper');
+    });
+});

--- a/packages/coc/test/spa/react/remote-shell/RemoteScopeCluster.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteScopeCluster.test.tsx
@@ -92,6 +92,27 @@ describe('RemoteScopeCluster', () => {
             .toEqual(['work-items', 'pull-requests']);
     });
 
+    it('shows the GitHub logo (not a keyword) in the remote chip for GitHub remotes', () => {
+        render(<RemoteScopeCluster repo={mockRepos[0]} repos={mockRepos} />);
+
+        const badge = screen.getByTestId('remote-provider-badge');
+        expect(badge.getAttribute('data-provider')).toBe('github');
+        expect(badge.getAttribute('aria-label')).toBe('GitHub');
+        expect(badge.textContent).toBe('');
+        expect(badge.querySelector('svg')).not.toBeNull();
+    });
+
+    it('shows the Azure DevOps logo in the remote chip for ADO remotes', () => {
+        const ADO = 'https://dev.azure.com/org/project/_git/repo';
+        mockRepos = [repo('a', 'repo', ADO), repo('b', 'repo-2', ADO)];
+        render(<RemoteScopeCluster repo={mockRepos[0]} repos={mockRepos} />);
+
+        const badge = screen.getByTestId('remote-provider-badge');
+        expect(badge.getAttribute('data-provider')).toBe('ado');
+        expect(badge.getAttribute('aria-label')).toBe('ADO');
+        expect(badge.querySelector('svg')).not.toBeNull();
+    });
+
     it('opens the remote dropdown with recent rows, Show all, search, and add actions', () => {
         mockRepos = [
             repo('a', 'shortcuts', SHORTCUTS),

--- a/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/RemoteSubBar.test.tsx
@@ -97,14 +97,18 @@ describe('RemoteSubBar', () => {
         expect(remoteTabs).toEqual(['work-items', 'pull-requests']);
     });
 
-    it('labels the remote scope by provider (GitHub) and drops the Clone scope label', () => {
+    it('marks the remote scope with the GitHub logo (not a keyword) and drops the Clone scope label', () => {
         renderBar();
         const label = screen.getByTestId('scope-label-remote');
-        expect(label.textContent).toBe('GitHub');
+        expect(label.getAttribute('data-provider')).toBe('github');
+        expect(label.getAttribute('aria-label')).toBe('GitHub');
+        // The keyword text is replaced by an icon.
+        expect(label.textContent).toBe('');
+        expect(label.querySelector('svg')).not.toBeNull();
         expect(screen.queryByTestId('scope-label-clone')).toBeNull();
     });
 
-    it('labels the remote scope ADO for Azure DevOps remotes', () => {
+    it('marks the remote scope with the Azure DevOps logo for ADO remotes', () => {
         const ado = 'https://dev.azure.com/org/project/_git/repo';
         const adoRepo = (id: string, name: string) => ({
             workspace: { id, name, color: '#0078d4', remoteUrl: ado, rootPath: `/r/${id}` },
@@ -112,7 +116,10 @@ describe('RemoteSubBar', () => {
         });
         const repos = [adoRepo('a', 'repo'), adoRepo('b', 'repo-2')];
         render(<RemoteSubBar repo={repos[0] as any} repos={repos as any} />);
-        expect(screen.getByTestId('scope-label-remote').textContent).toBe('ADO');
+        const label = screen.getByTestId('scope-label-remote');
+        expect(label.getAttribute('data-provider')).toBe('ado');
+        expect(label.getAttribute('aria-label')).toBe('ADO');
+        expect(label.querySelector('svg')).not.toBeNull();
     });
 
     it('shows every non-remote tab in the clone scope, inline, when width is unconstrained', () => {

--- a/packages/coc/test/spa/react/remote-shell/shellModel.test.ts
+++ b/packages/coc/test/spa/react/remote-shell/shellModel.test.ts
@@ -10,6 +10,7 @@ import {
     blendRemoteCloneStatus,
     summarizeRemote,
     remoteProviderLabel,
+    remoteProviderKind,
     REMOTE_SCOPE_KEYS,
 } from '../../../../src/server/spa/client/react/features/remote-shell/shellModel';
 import type { SubTabDef } from '../../../../src/server/spa/client/react/features/repo-detail/repoSubTabs';
@@ -218,5 +219,24 @@ describe('remoteProviderLabel', () => {
         expect(remoteProviderLabel(null)).toBe('Remote');
         expect(remoteProviderLabel(undefined)).toBe('Remote');
         expect(remoteProviderLabel('')).toBe('Remote');
+    });
+});
+
+describe('remoteProviderKind', () => {
+    it('returns "ado" for Azure DevOps remotes', () => {
+        expect(remoteProviderKind('dev.azure.com/org/project/repo')).toBe('ado');
+        expect(remoteProviderKind('acme.visualstudio.com/project/repo')).toBe('ado');
+    });
+
+    it('returns "github" for GitHub remotes', () => {
+        expect(remoteProviderKind('github.com/acme/shortcuts')).toBe('github');
+        expect(remoteProviderKind('ghe.github.com/acme/repo')).toBe('github');
+    });
+
+    it('returns "remote" for unknown or empty hosts', () => {
+        expect(remoteProviderKind('gitlab.com/acme/repo')).toBe('remote');
+        expect(remoteProviderKind(null)).toBe('remote');
+        expect(remoteProviderKind(undefined)).toBe('remote');
+        expect(remoteProviderKind('')).toBe('remote');
     });
 });


### PR DESCRIPTION
The remote-shell header (single-row RemoteScopeCluster and two-row
RemoteSubBar) showed the hosting provider as an uppercase text keyword
(GITHUB / ADO). Replace it with a small GitHub or Azure DevOps logo
via a new RemoteProviderBadge component. Unknown remotes keep the plain
"Remote" text since there's no logo to show. The provider name stays
accessible through title/aria-label, and a data-provider attribute
carries the resolved kind.

Add shellModel.remoteProviderKind() as the source of truth for the
provider ('github' | 'ado' | 'remote'); remoteProviderLabel() now
derives from it. RemoteProviderBadge is named to disambiguate from the
existing features/chat/ProviderBadge (AI/model provider).

Tests: unit tests for RemoteProviderBadge (logo vs. text, size,
className), remoteProviderKind cases in shellModel, and updated
RemoteScopeCluster/RemoteSubBar assertions to check the rendered logo +
aria-label instead of keyword text.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
