### PR TITLE
Fix extension canvas 404 on remote workspaces; route via clone-aware client

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -314,7 +314,11 @@ content to `canvases/<slug>.md` in the workspace Notes tree via
 posts `canvas-state` on ready and on every live update, services
 `invoke-capability` through `canvases.invokeCapability` and `set-state` through
 the revision-checked `canvases.save`, so human UI actions and AI capability
-calls share one gate. Edit mode shows the raw JSON shared state.
+calls share one gate. The extension load, `invoke-capability`, and `set-state`
+calls all route through the workspace-scoped `useCocClient(workspaceId)` client
+(like `CanvasPanel`), so a remote workspace's extension is read from and written
+to its owning server rather than the local page origin. Edit mode shows the raw
+JSON shared state.
 
 `features/chat/source-canvas/` renders the docked, read-only source-file canvas
 for local file references clicked inside assistant chat responses. The global

--- a/packages/coc/src/server/spa/client/react/features/canvas/ExtensionCanvasView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/canvas/ExtensionCanvasView.tsx
@@ -18,7 +18,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Canvas, CanvasExtension } from '@plusplusoneplusplus/coc-client';
-import { getSpaCocClient } from '../../api/cocClient';
+import { useCocClient } from '../../repos/cloneRouting';
 
 export interface ExtensionCanvasViewProps {
     workspaceId: string;
@@ -83,12 +83,20 @@ export function ExtensionCanvasView({ workspaceId, canvas, onCanvasSaved }: Exte
     const canvasCurrentRef = useRef(canvas);
     canvasCurrentRef.current = canvas;
 
+    // Route every canvas REST call to the workspace's OWNING server: the remote
+    // clone's origin for a remote workspace, else the default page origin. The
+    // bare page-origin client (getSpaCocClient) 404s for remote workspaces —
+    // their canvas (incl. the extension docs) lives only on the remote server —
+    // even though the parent CanvasPanel already loads the content via this same
+    // clone-aware client, so the frame renders while the extension GET fails.
+    const client = useCocClient(workspaceId);
+
     // (Re)load extension documents when the canvas or its revision changes —
     // the AI may have replaced the UI/capabilities via
     // create_or_update_extension_canvas, which bumps the revision.
     useEffect(() => {
         let cancelled = false;
-        getSpaCocClient().canvases.getExtension(workspaceId, canvas.id)
+        client.canvases.getExtension(workspaceId, canvas.id)
             .then(loaded => {
                 if (cancelled) return;
                 setExtension(prev =>
@@ -103,7 +111,7 @@ export function ExtensionCanvasView({ workspaceId, canvas, onCanvasSaved }: Exte
                 if (!cancelled) setLoadError('Failed to load canvas extension');
             });
         return () => { cancelled = true; };
-    }, [workspaceId, canvas.id, canvas.revision]);
+    }, [client, workspaceId, canvas.id, canvas.revision]);
 
     const postState = useCallback((target: Canvas) => {
         iframeRef.current?.contentWindow?.postMessage({
@@ -133,7 +141,7 @@ export function ExtensionCanvasView({ workspaceId, canvas, onCanvasSaved }: Exte
             }
 
             if (data.type === 'invoke-capability' && typeof data.name === 'string') {
-                getSpaCocClient().canvases.invokeCapability(workspaceId, canvasIdRef.current, data.name, data.params)
+                client.canvases.invokeCapability(workspaceId, canvasIdRef.current, data.name, data.params)
                     .then(saved => {
                         setActionError(null);
                         onCanvasSaved(saved);
@@ -146,7 +154,7 @@ export function ExtensionCanvasView({ workspaceId, canvas, onCanvasSaved }: Exte
 
             if (data.type === 'set-state') {
                 const content = JSON.stringify(data.state ?? {}, null, 2);
-                getSpaCocClient().canvases.save(workspaceId, canvasIdRef.current, {
+                client.canvases.save(workspaceId, canvasIdRef.current, {
                     content,
                     expectedRevision: canvasCurrentRef.current.revision,
                 })
@@ -162,7 +170,7 @@ export function ExtensionCanvasView({ workspaceId, canvas, onCanvasSaved }: Exte
 
         window.addEventListener('message', handleMessage);
         return () => window.removeEventListener('message', handleMessage);
-    }, [workspaceId, onCanvasSaved, postState]);
+    }, [client, workspaceId, onCanvasSaved, postState]);
 
     if (loadError) {
         return <div className="text-xs text-red-500 py-6 text-center" data-testid="extension-canvas-error">{loadError}</div>;

--- a/packages/coc/test/server/spa/client/canvas/ExtensionCanvasView.test.tsx
+++ b/packages/coc/test/server/spa/client/canvas/ExtensionCanvasView.test.tsx
@@ -5,19 +5,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 
 const mocks = vi.hoisted(() => ({
+    useCocClient: vi.fn(),
     getExtension: vi.fn(),
     invokeCapability: vi.fn(),
     save: vi.fn(),
 }));
 
-vi.mock('../../../../../src/server/spa/client/react/api/cocClient', () => ({
-    getSpaCocClient: () => ({
-        canvases: {
-            getExtension: mocks.getExtension,
-            invokeCapability: mocks.invokeCapability,
-            save: mocks.save,
-        },
-    }),
+// The view must route every workspace-scoped canvas call through the clone-aware
+// client so remote workspaces reach their OWNING server. The remote-routing
+// regression tests below override this to assert a remote workspace never
+// resolves to the shared local client.
+vi.mock('../../../../../src/server/spa/client/react/repos/cloneRouting', () => ({
+    useCocClient: mocks.useCocClient,
 }));
 
 import { ExtensionCanvasView, buildExtensionSrcDoc } from '../../../../../src/server/spa/client/react/features/canvas/ExtensionCanvasView';
@@ -68,6 +67,14 @@ describe('ExtensionCanvasView', () => {
         mocks.getExtension.mockReset().mockResolvedValue(EXTENSION);
         mocks.invokeCapability.mockReset();
         mocks.save.mockReset();
+        // Default: a single shared client backed by the method mocks above.
+        mocks.useCocClient.mockReset().mockReturnValue({
+            canvases: {
+                getExtension: mocks.getExtension,
+                invokeCapability: mocks.invokeCapability,
+                save: mocks.save,
+            },
+        });
     });
 
     it('loads the extension and renders a sandboxed iframe', async () => {
@@ -147,5 +154,76 @@ describe('ExtensionCanvasView', () => {
         });
 
         expect(mocks.invokeCapability).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * Regression: canvas data (incl. the extension docs) lives ONLY on the coc
+ * server that owns the workspace and is never synced to other servers. The view
+ * previously fetched via the bare page-origin client (getSpaCocClient), so for a
+ * REMOTE workspace the extension GET/invoke/save hit the local server — which
+ * has no clone at that id — and returned 404 ("Canvas extension not found")
+ * even though the frame rendered (the parent CanvasPanel loads content through
+ * the clone-aware client). All three calls must route via useCocClient(wsId).
+ */
+describe('ExtensionCanvasView — remote-aware routing', () => {
+    function makeClient() {
+        return {
+            canvases: {
+                getExtension: vi.fn().mockResolvedValue(EXTENSION),
+                invokeCapability: vi.fn().mockResolvedValue(makeCanvas({ revision: 3 })),
+                save: vi.fn().mockResolvedValue(makeCanvas({ revision: 3 })),
+            },
+        };
+    }
+
+    beforeEach(() => {
+        mocks.useCocClient.mockReset();
+    });
+
+    it('regression: loads the extension from the workspace-owning (remote) server, never the local client', async () => {
+        const REMOTE_WS = 'ws-remote-xyz';
+        const remoteClient = makeClient();
+        const localClient = makeClient();
+        mocks.useCocClient.mockImplementation((wsId: string) => (wsId === REMOTE_WS ? remoteClient : localClient));
+
+        render(<ExtensionCanvasView workspaceId={REMOTE_WS} canvas={makeCanvas({ workspaceId: REMOTE_WS })} onCanvasSaved={vi.fn()} />);
+        await screen.findByTestId('extension-canvas-iframe');
+
+        // Client is resolved by workspace id, and the fetch hit the remote server.
+        expect(mocks.useCocClient).toHaveBeenCalledWith(REMOTE_WS);
+        expect(remoteClient.canvases.getExtension).toHaveBeenCalledWith(REMOTE_WS, 'board-abc123');
+        // The default/local client is never used for a remote workspace — the bug.
+        expect(localClient.canvases.getExtension).not.toHaveBeenCalled();
+    });
+
+    it('regression: capability + set-state actions also route to the remote server', async () => {
+        const REMOTE_WS = 'ws-remote-xyz';
+        const remoteClient = makeClient();
+        const localClient = makeClient();
+        mocks.useCocClient.mockImplementation((wsId: string) => (wsId === REMOTE_WS ? remoteClient : localClient));
+
+        render(<ExtensionCanvasView workspaceId={REMOTE_WS} canvas={makeCanvas({ workspaceId: REMOTE_WS })} onCanvasSaved={vi.fn()} />);
+        const iframe = await screen.findByTestId('extension-canvas-iframe') as HTMLIFrameElement;
+
+        postFromIframe(iframe, { __canvasHost: true, type: 'invoke-capability', name: 'add_card', params: { id: 'c1' } });
+        postFromIframe(iframe, { __canvasHost: true, type: 'set-state', state: { cards: [] } });
+
+        await waitFor(() => expect(remoteClient.canvases.invokeCapability).toHaveBeenCalledWith(REMOTE_WS, 'board-abc123', 'add_card', { id: 'c1' }));
+        await waitFor(() => expect(remoteClient.canvases.save).toHaveBeenCalled());
+        expect(localClient.canvases.invokeCapability).not.toHaveBeenCalled();
+        expect(localClient.canvases.save).not.toHaveBeenCalled();
+    });
+
+    it('a local workspace resolves to the default client', async () => {
+        const LOCAL_WS = 'ws-local';
+        const localClient = makeClient();
+        mocks.useCocClient.mockReturnValue(localClient);
+
+        render(<ExtensionCanvasView workspaceId={LOCAL_WS} canvas={makeCanvas({ workspaceId: LOCAL_WS })} onCanvasSaved={vi.fn()} />);
+        await screen.findByTestId('extension-canvas-iframe');
+
+        expect(mocks.useCocClient).toHaveBeenCalledWith(LOCAL_WS);
+        expect(localClient.canvases.getExtension).toHaveBeenCalledWith(LOCAL_WS, 'board-abc123');
     });
 });


### PR DESCRIPTION
ExtensionCanvasView fetched the extension docs (and ran invoke-capability /
set-state) through the bare page-origin client `getSpaCocClient()`. For a
remote workspace the canvas — including the extension/ subdir — lives only on
its owning server's ~/.coc data dir and is never synced to the local server, so
the extension GET hit the local page origin and returned 404 ("Canvas extension
not found") even though the frame rendered (the parent CanvasPanel already loads
content via the clone-aware client).

Route all three ExtensionCanvasView REST calls through the workspace-scoped
`useCocClient(workspaceId)`, mirroring CanvasPanel, so a remote workspace's
extension is read from and written to its owning server. Add the resolved client
to both effect dependency arrays so a baseUrl change re-binds correctly.

Tests: mock `useCocClient` instead of `getSpaCocClient`; add remote-routing
regression tests asserting getExtension/invoke-capability/set-state reach the
remote workspace's owning client and never the local one, plus a local-workspace
case. Update the dashboard-spa knowledge reference with the routing note.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
