### PR TITLE
Fix CoC LLM tools silently dropped under Codex in desktop builds

### DIFF
--- a/.github/skills/coc-knowledge/references/sdk-wrapper.md
+++ b/.github/skills/coc-knowledge/references/sdk-wrapper.md
@@ -296,6 +296,15 @@ Pipeline (all in `coc-agent-sdk/src/llm-tools/`):
 4. `buildCocLlmToolsMcpConfig()` emits the `{ command, args, env }` stdio spec; bridge
    path resolves to the dist-adjacent `bridge.js`, overridable via
    `setCocLlmToolsBridgePath()` / `COC_LLM_TOOLS_BRIDGE_PATH` for bundled hosts.
+   `command` defaults to `process.execPath`. When the host runs on an Electron
+   binary (`process.versions.electron` set — the CoC desktop server is forked as
+   Electron's Node via `ELECTRON_RUN_AS_NODE=1`, so `process.execPath` is the
+   Electron executable) and the launcher is that binary, the emitted `env` also
+   carries `ELECTRON_RUN_AS_NODE=1`. Without it the bridge child boots Electron's
+   GUI runtime, never answers the MCP stdio handshake, and the provider silently
+   drops all CoC tools. This must be an explicit `env` entry because Codex
+   sanitizes inherited env for MCP server children (Claude inherits it, but that
+   is incidental); plain-Node hosts are unaffected.
 
 Provider wiring (per request, only when `options.tools` is non-empty; disposed in
 `finally`):

--- a/packages/coc-agent-sdk/src/llm-tools/mcp-config.ts
+++ b/packages/coc-agent-sdk/src/llm-tools/mcp-config.ts
@@ -18,6 +18,8 @@ export const COC_LLM_TOOLS_ENDPOINT_ENV = 'COC_LLM_TOOLS_ENDPOINT';
 export const COC_LLM_TOOLS_TOKEN_ENV = 'COC_LLM_TOOLS_TOKEN';
 /** Optional env var overriding the resolved bridge script path. */
 export const COC_LLM_TOOLS_BRIDGE_PATH_ENV = 'COC_LLM_TOOLS_BRIDGE_PATH';
+/** Env var that makes an Electron binary boot as plain Node instead of the GUI runtime. */
+export const ELECTRON_RUN_AS_NODE_ENV = 'ELECTRON_RUN_AS_NODE';
 
 /** Provider-neutral stdio MCP server spec for the bridge. */
 export interface CocLlmToolsMcpServerConfig {
@@ -52,8 +54,28 @@ export function resolveCocLlmToolsBridgePath(): string {
 }
 
 /**
+ * Whether this process is running on an Electron binary (including when it was
+ * launched as plain Node via `ELECTRON_RUN_AS_NODE=1`). In that case
+ * `process.execPath` is the Electron executable, so a child spawned with it must
+ * carry `ELECTRON_RUN_AS_NODE=1` to boot as Node rather than the GUI runtime.
+ */
+function isRunningUnderElectron(): boolean {
+    return Boolean((process.versions as { electron?: string }).electron);
+}
+
+/**
  * Build the stdio MCP server config that launches the bridge for a given
  * {@link CocToolBridgeServer} registration.
+ *
+ * When the bridge is launched with the Electron binary — which is what
+ * `process.execPath` points at inside the CoC desktop server (forked as
+ * Electron's Node via `ELECTRON_RUN_AS_NODE=1`) — the child's env must set
+ * `ELECTRON_RUN_AS_NODE=1` too, or Electron boots its GUI runtime and never
+ * answers the MCP stdio handshake, so the provider silently drops CoC tools.
+ * Codex strips inherited env from MCP server children, so this cannot be left to
+ * inheritance; it is injected here as an explicit env entry (Claude happens to
+ * inherit it, but relying on that is fragile). Real-Node hosts are unaffected —
+ * the flag is only added when running on an Electron binary and launching with it.
  */
 export function buildCocLlmToolsMcpConfig(options: {
     endpoint: string;
@@ -65,13 +87,18 @@ export function buildCocLlmToolsMcpConfig(options: {
     /** Optional Codex MCP allow-list for tools exposed by the bridge. */
     enabledTools?: string[];
 }): CocLlmToolsMcpServerConfig {
+    const command = options.command ?? process.execPath;
+    const env: Record<string, string> = {
+        [COC_LLM_TOOLS_ENDPOINT_ENV]: options.endpoint,
+        [COC_LLM_TOOLS_TOKEN_ENV]: options.token,
+    };
+    if (command === process.execPath && isRunningUnderElectron()) {
+        env[ELECTRON_RUN_AS_NODE_ENV] = '1';
+    }
     return {
-        command: options.command ?? process.execPath,
+        command,
         args: [options.bridgePath ?? resolveCocLlmToolsBridgePath()],
-        env: {
-            [COC_LLM_TOOLS_ENDPOINT_ENV]: options.endpoint,
-            [COC_LLM_TOOLS_TOKEN_ENV]: options.token,
-        },
+        env,
         ...(options.enabledTools?.length ? { enabled_tools: options.enabledTools } : {}),
     };
 }

--- a/packages/coc-agent-sdk/test/ai/coc-tool-bridge.test.ts
+++ b/packages/coc-agent-sdk/test/ai/coc-tool-bridge.test.ts
@@ -228,9 +228,22 @@ describe('bridge JSON-RPC handlers', () => {
 });
 
 describe('buildCocLlmToolsMcpConfig', () => {
+    const hadElectron = 'electron' in process.versions;
+    const originalElectron = (process.versions as { electron?: string }).electron;
+
+    const setElectron = (version: string | undefined) => {
+        if (version === undefined) {
+            delete (process.versions as { electron?: string }).electron;
+        } else {
+            (process.versions as { electron?: string }).electron = version;
+        }
+    };
+
     afterEach(() => {
         setCocLlmToolsBridgePath(undefined);
         delete process.env.COC_LLM_TOOLS_BRIDGE_PATH;
+        // Restore the real Electron marker (absent under a plain-node vitest run).
+        setElectron(hadElectron ? originalElectron : undefined);
     });
 
     it('produces a stdio server spec with endpoint+token env vars', () => {
@@ -241,6 +254,41 @@ describe('buildCocLlmToolsMcpConfig', () => {
             [COC_LLM_TOOLS_ENDPOINT_ENV]: 'http://127.0.0.1:5000',
             [COC_LLM_TOOLS_TOKEN_ENV]: 'tok123',
         });
+    });
+
+    it('does NOT set ELECTRON_RUN_AS_NODE when not running under Electron', () => {
+        setElectron(undefined);
+        const config = buildCocLlmToolsMcpConfig({ endpoint: 'http://127.0.0.1:5000', token: 'tok', bridgePath: '/x/bridge.js' });
+        expect(config.env).not.toHaveProperty('ELECTRON_RUN_AS_NODE');
+    });
+
+    it('sets ELECTRON_RUN_AS_NODE=1 when the bridge is launched with the Electron binary', () => {
+        // Regression: the CoC desktop server runs as Electron's Node
+        // (ELECTRON_RUN_AS_NODE=1), so process.execPath is the Electron binary.
+        // Codex strips inherited env from MCP server children, so the flag must be
+        // injected explicitly or the bridge boots Electron's GUI runtime, never
+        // answers the MCP handshake, and CoC tools silently disappear.
+        setElectron('35.7.5');
+        const config = buildCocLlmToolsMcpConfig({ endpoint: 'http://127.0.0.1:5000', token: 'tok', bridgePath: '/x/bridge.js' });
+        expect(config.command).toBe(process.execPath);
+        expect(config.env.ELECTRON_RUN_AS_NODE).toBe('1');
+        // Endpoint/token still present alongside the injected flag.
+        expect(config.env[COC_LLM_TOOLS_ENDPOINT_ENV]).toBe('http://127.0.0.1:5000');
+        expect(config.env[COC_LLM_TOOLS_TOKEN_ENV]).toBe('tok');
+    });
+
+    it('does NOT set ELECTRON_RUN_AS_NODE when a non-Electron command is supplied explicitly', () => {
+        // Even under Electron, an explicit real-Node launcher must not be forced
+        // into ELECTRON_RUN_AS_NODE mode.
+        setElectron('35.7.5');
+        const config = buildCocLlmToolsMcpConfig({
+            endpoint: 'http://127.0.0.1:5000',
+            token: 'tok',
+            command: '/usr/local/bin/node',
+            bridgePath: '/x/bridge.js',
+        });
+        expect(config.command).toBe('/usr/local/bin/node');
+        expect(config.env).not.toHaveProperty('ELECTRON_RUN_AS_NODE');
     });
 
     it('honors an explicit bridge-path override', () => {


### PR DESCRIPTION
The CoC desktop server is forked as Electron's Node (ELECTRON_RUN_AS_NODE=1),
so process.execPath is the Electron binary. buildCocLlmToolsMcpConfig launches
the LLM-tools stdio bridge with that binary but only passed ENDPOINT/TOKEN env.
Codex sanitizes inherited env for MCP server children, stripping
ELECTRON_RUN_AS_NODE, so the bridge child booted Electron's GUI runtime instead
of Node, never answered the MCP handshake, and Codex silently continued the turn
with zero CoC tools. Claude worked only incidentally because it forwards its full
inherited env to MCP children.

Inject ELECTRON_RUN_AS_NODE=1 into the bridge env when running on an Electron
binary and launching with it. Provider-neutral (one fix for both Codex and
Claude); no-op for plain-Node hosts.

Tests: regression coverage in coc-tool-bridge.test.ts asserting the flag is set
under a simulated Electron process, absent on plain Node, and absent when an
explicit non-Electron command is supplied. Verified end-to-end: under the real
Electron binary the bridge now answers the MCP initialize handshake (hung before).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
