### PR TITLE
Detect gh pr create inside bash -lc shell wrappers

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -178,7 +178,10 @@ card. The
 (`pullRequestDetection.ts`, no new regex) with persisted bindings looked up by
 `task_id`. Detection requires PR-creation evidence from the GitHub connector's
 create-pull-request tool, or per shell tool call: a `gh pr create` /
-`az repos pr create` command, a result carrying the
+`az repos pr create` command — including when the harness serializes it inside a
+shell-interpreter wrapper (`bash -lc '…'`, `/bin/bash -c "…"`, `sh -c '…'`), whose
+quoted payload is unwrapped and scanned so the wrapped command still matches — a
+result carrying the
 `submit_commits_as_pr.py` wrapper's structured success line (a line-start
 `JSON: {... "pr_url": "...", "status": "done"}` — recognized even when surfaced
 by a later `grep`/`tail` of the wrapper's persisted stdout, since the original

--- a/packages/coc/src/server/spa/client/react/features/chat/conversation/pullRequestDetection.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/conversation/pullRequestDetection.ts
@@ -89,6 +89,48 @@ function getCommandString(args: unknown): string {
     return '';
 }
 
+// A shell interpreter invoked with a `-c`/`-lc` flag, e.g. `bash -lc '<cmd>'`,
+// `/bin/bash -c "<cmd>"`, `sh -c '<cmd>'`. Some agent harnesses serialize every
+// shell tool call this way, so the real command lives entirely inside the quoted
+// payload. Without unwrapping, `stripQuotedShellText` erases that payload and a
+// genuine `gh pr create` is never seen.
+const SHELL_WRAPPER_RE = /^\s*(?:\S*\/)?(?:ba|z|k|da)?sh\s+-[a-z]*c\b\s*/i;
+
+/**
+ * If `command` is a shell-interpreter wrapper (`bash -lc '…'`, `sh -c "…"`, …),
+ * returns the inner command payload — the first quoted argument after the
+ * `-c`/`-lc` flag. Returns null for anything that is not such a wrapper, so a
+ * quoted argument to an ordinary command (e.g. `rg "gh pr create" .`) is never
+ * treated as a command to scan.
+ */
+function extractShellWrapperPayload(command: string): string | null {
+    const match = SHELL_WRAPPER_RE.exec(command);
+    if (!match) return null;
+    const rest = command.slice(match[0].length);
+    const quote = rest[0];
+    if (quote !== '"' && quote !== "'") return null;
+
+    let payload = '';
+    let escaped = false;
+    for (let i = 1; i < rest.length; i++) {
+        const ch = rest[i];
+        if (escaped) {
+            payload += ch;
+            escaped = false;
+            continue;
+        }
+        if (ch === '\\' && quote === '"') {
+            escaped = true;
+            payload += ch;
+            continue;
+        }
+        if (ch === quote) return payload;
+        payload += ch;
+    }
+    // Unterminated quote: treat the remainder as the payload.
+    return payload;
+}
+
 function stripQuotedShellText(command: string): string {
     let quote: '"' | "'" | null = null;
     let escaped = false;
@@ -117,9 +159,17 @@ function stripQuotedShellText(command: string): string {
     return stripped;
 }
 
-function isPullRequestCreatingCommand(command: string): boolean {
+function matchesPrCreatePattern(command: string): boolean {
     const commandOutsideQuotes = stripQuotedShellText(command);
     return PR_CREATING_PATTERNS.some(re => re.test(commandOutsideQuotes));
+}
+
+function isPullRequestCreatingCommand(command: string): boolean {
+    if (matchesPrCreatePattern(command)) return true;
+    // Also scan inside a shell-interpreter wrapper (`bash -lc 'gh pr create …'`),
+    // where the real command is quoted and would otherwise be stripped away.
+    const payload = extractShellWrapperPayload(command);
+    return payload !== null && matchesPrCreatePattern(payload);
 }
 
 function isPullRequestCreatingWrapperCommand(command: string): boolean {

--- a/packages/coc/test/spa/react/pullRequestDetection.test.ts
+++ b/packages/coc/test/spa/react/pullRequestDetection.test.ts
@@ -44,6 +44,82 @@ describe('detectPullRequestsInToolGroup', () => {
         expect(pullRequests[0].url).toBe('https://github.com/org/repo/pull/99');
     });
 
+    it('detects a GitHub PR when gh pr create is wrapped in bash -lc', () => {
+        // Regression (PR #484): some agent harnesses serialize every shell tool
+        // call as `/bin/bash -lc '<real command>'`. The real `gh pr create` then
+        // lives entirely inside the single-quoted payload, which the quote-strip
+        // used to erase — so the PR URL in the result was never detected.
+        const pullRequests = detectPullRequestsInToolGroup([
+            {
+                id: 'tool-1',
+                toolName: 'shell',
+                args: {
+                    command:
+                        "/bin/bash -lc 'gh pr create --base main --head pr/7f5d8f2-make-schedule-persistence-async --fill'",
+                },
+                result: 'https://github.com/plusplusoneplusplus/shortcuts/pull/484',
+            },
+        ]);
+
+        expect(pullRequests).toEqual<DetectedPullRequest[]>([
+            {
+                number: 484,
+                url: 'https://github.com/plusplusoneplusplus/shortcuts/pull/484',
+                provider: 'github',
+                owner: 'plusplusoneplusplus',
+                repo: 'shortcuts',
+                toolCallId: 'tool-1',
+            },
+        ]);
+    });
+
+    it('detects an ADO PR when az repos pr create is wrapped in sh -c', () => {
+        const pullRequests = detectPullRequestsInToolGroup([
+            {
+                id: 'tool-1',
+                toolName: 'shell',
+                args: { command: 'sh -c "az repos pr create --title \\"feat\\""' },
+                result: 'https://dev.azure.com/myorg/MyProject/_git/MyRepo/pullrequest/12345',
+            },
+        ]);
+
+        expect(pullRequests).toHaveLength(1);
+        expect(pullRequests[0]).toMatchObject({
+            number: 12345,
+            provider: 'azure-devops',
+            organization: 'myorg',
+            project: 'MyProject',
+        });
+    });
+
+    it('ignores a wrapped command that only mentions gh pr create inside a search', () => {
+        // The wrapper unwrap must not re-introduce false positives: here the inner
+        // payload runs `rg`, and `gh pr create` is just its quoted search pattern.
+        const pullRequests = detectPullRequestsInToolGroup([
+            {
+                id: 'tool-1',
+                toolName: 'shell',
+                args: { command: '/bin/bash -lc \'rg -n "gh pr create" packages/coc/test\'' },
+                result: 'https://github.com/org/repo/pull/99',
+            },
+        ]);
+
+        expect(pullRequests).toEqual([]);
+    });
+
+    it('ignores a read-only gh pr view wrapped in bash -lc', () => {
+        const pullRequests = detectPullRequestsInToolGroup([
+            {
+                id: 'tool-1',
+                toolName: 'shell',
+                args: { command: "/bin/bash -lc 'gh pr view 99'" },
+                result: 'https://github.com/org/repo/pull/99',
+            },
+        ]);
+
+        expect(pullRequests).toEqual([]);
+    });
+
     it('ignores gh pr view output', () => {
         const pullRequests = detectPullRequestsInToolGroup([
             {


### PR DESCRIPTION
PR-creation detection stripped all quoted text before matching
`gh pr create` / `az repos pr create`, to avoid false positives from a
command that merely mentions those strings inside a quoted argument
(e.g. `rg "gh pr create"`). But some agent harnesses serialize every
shell tool call as `/bin/bash -lc '<real command>'`, putting the actual
`gh pr create` entirely inside the stripped quote region. The command
match failed, the evidence gate skipped the tool call, and the PR URL in
the result was never extracted — so a PR created in-chat (e.g. #484) was
never surfaced.

Unwrap a shell-interpreter payload (`bash -lc '…'`, `/bin/bash -c "…"`,
`sh -c '…'`) and match PR patterns against the inner command, while still
running the inner command through the quote-strip so a wrapped
`rg "gh pr create"` stays a false negative. Non-wrapper commands are
unaffected.

Add regression tests for the wrapped GitHub and ADO create commands, plus
guards that a wrapped search and a wrapped read-only `gh pr view` stay
ignored.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
