### PR TITLE
pr/4dadf46b2 fixspa keep splitworkspacepanel footer p

### DIFF
--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -1284,7 +1284,11 @@ Workspace while Git remains available inside `SplitWorkspacePanel`.
   `hidden` so scroll/selection survive. Collapsed state persists per workspace
   under `split-workspace:{workspaceId}:chat-collapsed` and
   `split-workspace:{workspaceId}:git-collapsed`, written only on an explicit
-  user toggle (never on mount or workspace switch).
+  user toggle (never on mount or workspace switch). The optional docked `footer`
+  (the remote-first shell's status cluster) is pinned to the bottom-left of the
+  column; when both halves are collapsed neither carries `flex-1`, so a `flex-1`
+  spacer is rendered above the footer to keep it at the bottom instead of riding
+  up under the headers.
 - The git half uses a dense skin to save vertical space. `SplitWorkspacePanel`
   exposes a `gitHeaderExtra` slot on the git section header (rendered right of
   the chevron+label toggle; its clicks don't toggle; stays visible while

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -651,6 +651,17 @@ the current repo or in an already-registered, **online** remote clone:
   `context.files`, and enqueues on the **target** repo's routed CoC client (a
   `{ id, baseUrl, remote: {} }` `CloneRef` through `useCocClient`). A failed
   source read surfaces an inline error and never enqueues.
+- **Remote-sourced plan** → when the *source* workspace itself is a remote clone
+  (`sourceIsRemote`/`sourceBaseUrl` props, derived by `ChatDetail` from the
+  aggregated repo entry → `lookupCloneBaseUrl` → membership in this server's own
+  workspace list), the plan content is always inlined regardless of what the
+  target list claims, and both the source read and the fallback enqueue route to
+  the source server's baseUrl explicitly. This prevents a remote machine's plan
+  path from being enqueued as a path-reference task on the local server (which
+  the executor would rewrite to `Follow the instruction <path>.` via
+  `context.files`). `buildImplementTargets` carries the caller-supplied
+  `isRemote`/`baseUrl`/`serverLabel` when it synthesizes the missing current
+  repo instead of hardcoding a local target.
 
 Each run records an `ImplementationRecord` (process id, plan path, enqueue time,
 plus target identity: `targetWorkspaceId`, `targetLabel`, `targetServerLabel`,

--- a/.github/skills/coc-knowledge/references/dashboard-spa.md
+++ b/.github/skills/coc-knowledge/references/dashboard-spa.md
@@ -1297,7 +1297,11 @@ Workspace while Git remains available inside `SplitWorkspacePanel`.
   (`splitGitHeaderNode`, mirroring the `splitDetailNode` pattern) and passes it
   to `RepoGitTab` as `headerToolbarContainer`; `RepoGitTab` portals a
   `compact` `GitPanelHeader` (slim pills/buttons, timestamp without " ago")
-  into it instead of rendering the 38px toolbar strip. In split layout the
+  into it instead of rendering the 38px toolbar strip. The hoisted portal is a
+  sibling OUTSIDE the git list's `onClickCapture` wrapper — portaled React
+  events bubble through the React tree, so nesting it would make toolbar clicks
+  (Pull/refresh) mark git last-clicked and steal the shared detail pane from
+  the chat. In split layout the
   search bar also slims (placeholder `Search commits…`, full hint kept in
   `aria-label`), the `git-repo-sections` grid tightens, and `BranchChanges` /
   `WorkingTree` render their `compact` variant: flat left-accent rows instead

--- a/.github/skills/coc-knowledge/references/rest-api.md
+++ b/.github/skills/coc-knowledge/references/rest-api.md
@@ -88,7 +88,7 @@ Chat canvas side panel (gated by `canvas.enabled`, default off). Markdown or cod
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/processes` | List processes (with search/filter) |
-| GET | `/api/processes/:id` | Process detail |
+| GET | `/api/processes/:id` | Process detail. For a `queue_<taskId>` id whose task is still queued (no process record yet), returns a synthetic process; its `metadata` mirrors the real record's `{ type, queueTaskId, mode, workspaceId }` so the SPA can resolve the chat mode before the executor starts |
 | PATCH | `/api/processes/:id` | Partial process update. Full `metadata` still replaces the stored metadata object; callers that only need to add/remove metadata fields should send `metadataPatch: { set?: object, unset?: string[] }`, which the server merges into current stored metadata. `metadata` and `metadataPatch` are mutually exclusive. |
 | DELETE | `/api/processes/:id` | Delete process |
 | POST | `/api/processes/:id/message` | Follow-up message. Body accepts `content`, optional `mode` (`ask` or `autopilot`; legacy `plan` is accepted as Ask), `deliveryMode`, `images`, `skillNames`, `model`, and `reasoningEffort` (`'low'\|'medium'\|'high'\|'xhigh'`) for a per-turn override. A stopped chat in `cancelled` status is accepted only when it has a saved `sdkSessionId`; the queued continuation is bound to that session for strict resume and otherwise returns `409 SESSION_NOT_RESUMABLE` instead of starting a fresh session. A process with `metadata.stoppedChatResume.resumable === false` also returns `409 SESSION_NOT_RESUMABLE`, so a failed strict resume cannot be retried or converted into a fresh-session follow-up. |

--- a/packages/coc/AGENTS.md
+++ b/packages/coc/AGENTS.md
@@ -232,7 +232,16 @@ all have their own `references/*.md`.
   detects a `write_canvas` call with `purpose: 'plan'`, and `ChatDetail` passes
   the canvas id as `planCanvasId`. A canvas-backed plan has no on-disk path, so
   the card always reads the canvas content (`sourceClient.canvases.get`) and
-  inlines it in the prompt for both local and remote targets.
+  inlines it in the prompt for both local and remote targets. When the **source**
+  workspace is itself a remote clone (`sourceIsRemote`/`sourceBaseUrl` props,
+  derived in `ChatDetail` from the aggregated repo entry → `lookupCloneBaseUrl` →
+  local workspace-list membership), the plan is always content-embedded and the
+  source read / fallback enqueue route to the source server's baseUrl explicitly —
+  never enqueue a remote machine's plan path as a path-reference (`context.files`)
+  task, which the executor rewrites to `Follow the instruction <path>.` on the
+  wrong server. `buildImplementTargets` carries the caller's
+  `isRemote`/`baseUrl`/`serverLabel` when synthesizing the missing current repo
+  instead of hardcoding a local target.
 - **Copilot long-context tier** is automatic at the provider boundary: chat
   and follow-up executors derive `contextTier` only via
   `getCopilotContextTierForModel` (tiered billing metadata —

--- a/packages/coc/src/server/routes/api-process-routes.ts
+++ b/packages/coc/src/server/routes/api-process-routes.ts
@@ -122,6 +122,7 @@ function queuedTaskToProcess(task: QueuedTask): AIProcess {
     // QueueStatus is a subset of AIProcessStatus (no 'cancelling'), so a direct
     // assignment satisfies the synthesised AIProcess shape.
     const status: AIProcessStatus = task.status;
+    const payload = task.payload as any;
     return {
         id: toQueueProcessId(task.id),
         type: task.type || 'chat',
@@ -130,7 +131,17 @@ function queuedTaskToProcess(task: QueuedTask): AIProcess {
         fullPrompt: prompt,
         startTime: new Date(task.createdAt),
         title: task.displayName,
-        workingDirectory: task.folderPath ?? (task.payload as any)?.workingDirectory,
+        workingDirectory: task.folderPath ?? payload?.workingDirectory,
+        // Mirror the metadata the real process record will carry (see
+        // process-lifecycle-runner) so the SPA can resolve the chat mode
+        // before the executor starts — without it, a freshly enqueued
+        // autopilot chat renders its composer in the default ask mode.
+        metadata: {
+            type: task.type || 'chat',
+            queueTaskId: task.id,
+            mode: normalizeChatMode(payload?.mode),
+            workspaceId: payload?.workspaceId,
+        },
     };
 }
 

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -240,6 +240,15 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
     const followUpInputRef = useRef<string>('');
     const richTextRef = useRef<RichTextInputHandle>(null);
     const selectedModeRef = useRef<ChatMode>('ask');
+    // True once the mode selector has been synced from the loaded task (or the
+    // user has picked a mode). Lets the sync effect re-run across task
+    // snapshots — the first snapshot of a freshly enqueued chat can be a
+    // synthetic process without a mode — while never clobbering a user pick.
+    const modeSyncDoneRef = useRef(false);
+    const setSelectedModeFromUser = useCallback((mode: ChatMode) => {
+        modeSyncDoneRef.current = true;
+        setSelectedMode(mode);
+    }, []);
 
     const loadCounterRef = useRef(0);
     const conversationContainerRef = useRef<HTMLDivElement>(null);
@@ -1125,7 +1134,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         // recomputes (the chat now has a ralph context) and the Ralph pill
         // disappears; reset the selector to a value that still exists so we
         // don't show a "selected pill that no longer exists" UI glitch.
-        onPromotedToRalph: () => setSelectedMode('ask'),
+        onPromotedToRalph: () => setSelectedModeFromUser('ask'),
         // `/compact` surfaces its result (or error) as a transient toast; the
         // displayed transcript is never rewritten.
         notifyCompact: addToast,
@@ -1744,20 +1753,27 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         };
     }, [client, taskId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    // Sync mode selector with the loaded task's mode
+    // Sync mode selector with the loaded task's mode. Depends on the task
+    // object (not just its id): a freshly enqueued chat's first snapshot may
+    // be a synthetic process with no mode yet, so the sync must retry when a
+    // later snapshot (real process / queue refresh) delivers the mode.
+    // `modeSyncDoneRef` makes the sync one-shot so it never overrides a mode
+    // the user picked in the composer.
     useEffect(() => {
-        if (!task) {
+        if (!task || modeSyncDoneRef.current) {
             return;
         }
         const draft = getDraft(taskId);
         if (normalizeChatMode(draft?.mode)) {
+            modeSyncDoneRef.current = true;
             return;
         }
         const taskMode = resolveLoadedTaskMode(task);
         if (taskMode) {
+            modeSyncDoneRef.current = true;
             setSelectedMode(taskMode);
         }
-    }, [task?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [task]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Re-fetch conversation when user re-clicks the already-selected task
     // (REFRESH_SELECTED_QUEUE_TASK bumps refreshVersion).
@@ -2452,7 +2468,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                             followUpInput={followUpInput}
                             setFollowUpInput={setFollowUpInput}
                             selectedMode={selectedMode}
-                            setSelectedMode={setSelectedMode}
+                            setSelectedMode={setSelectedModeFromUser}
                             onSend={sendFollowUpWithPrefix}
                             onRetry={retryLastMessage}
                             onStop={handleStop}
@@ -2595,7 +2611,7 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                     followUpInput={followUpInput}
                     setFollowUpInput={setFollowUpInput}
                     selectedMode={selectedMode}
-                    setSelectedMode={setSelectedMode}
+                    setSelectedMode={setSelectedModeFromUser}
                     onSend={sendFollowUpWithPrefix}
                     onRetry={retryLastMessage}
                     onStop={handleStop}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatDetail.tsx
@@ -11,7 +11,8 @@ import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import { getSpaCocClientErrorMessage } from '../../api/cocClient';
 import type { CanvasSummary } from '@plusplusoneplusplus/coc-client';
 import { useCocClient } from '../../repos/cloneRouting';
-import { getCocClientForWorkspace } from '../../repos/cloneRegistry';
+import { getCocClientForWorkspace, lookupCloneBaseUrl } from '../../repos/cloneRegistry';
+import { isRemoteWorkspace } from '../../repos/remoteWorkspaceAggregation';
 import { getConversationTurns } from './conversation/chatConversationUtils';
 import { getSessionIdFromProcess } from './conversation/ConversationMetadataPopover';
 import { useQueue } from '../../contexts/QueueContext';
@@ -366,6 +367,24 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
         const workspace = appState.workspaces.find((ws: any) => ws.id === workspaceId);
         return typeof workspace?.name === 'string' ? workspace.name : undefined;
     }, [appState.workspaces, workspaceId]);
+    // Remote identity of the SOURCE workspace (where the plan file lives). The
+    // implement card must never treat a remote-sourced plan as local: its plan
+    // path only exists on the source machine. Resolution order: aggregated repo
+    // entry (authoritative remote marker + baseUrl) → clone registry (remote
+    // tabs register id→baseUrl without a ReposProvider) → membership in this
+    // server's own workspace list (an id this server does not own is not local).
+    const sourceRemoteInfo = useMemo(() => {
+        const none = { isRemote: false, baseUrl: undefined as string | undefined, serverLabel: undefined as string | undefined };
+        if (!workspaceId) return none;
+        const repoWs = reposCtx?.repos?.find((r: any) => r?.workspace?.id === workspaceId)?.workspace;
+        if (repoWs && isRemoteWorkspace(repoWs)) {
+            return { isRemote: true, baseUrl: repoWs.baseUrl, serverLabel: repoWs.remote.serverLabel };
+        }
+        const baseUrl = lookupCloneBaseUrl(workspaceId);
+        if (baseUrl) return { isRemote: true, baseUrl, serverLabel: undefined };
+        const knownLocal = appState.workspaces.some((ws: any) => ws?.id === workspaceId);
+        return { ...none, isRemote: appState.workspaces.length > 0 && !knownLocal };
+    }, [reposCtx?.repos, appState.workspaces, workspaceId]);
     const implementTargets = useMemo(() => {
         if (!isRemoteShellEnabled() || !reposCtx) return undefined;
         return buildImplementTargets(reposCtx.repos, {
@@ -373,8 +392,11 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
             label: workspaceName,
             workingDirectory: workspaceRootPath || undefined,
             remoteUrl: workspaceRemoteUrl,
+            isRemote: sourceRemoteInfo.isRemote,
+            baseUrl: sourceRemoteInfo.baseUrl,
+            serverLabel: sourceRemoteInfo.serverLabel,
         });
-    }, [reposCtx, reposCtx?.repos, workspaceId, workspaceName, workspaceRootPath, workspaceRemoteUrl]);
+    }, [reposCtx, reposCtx?.repos, workspaceId, workspaceName, workspaceRootPath, workspaceRemoteUrl, sourceRemoteInfo]);
 
     const sessionContextAttachmentsEnabled = isSessionContextAttachmentsEnabled();
     const canRetrieveConversations = useConversationRetrievalCapability(workspaceId, sessionContextAttachmentsEnabled);
@@ -2417,6 +2439,8 @@ export function ChatDetail({ taskId, onBack, workspaceId, isPopOut = false, vari
                             planCanvasId={effectivePlanCanvasId}
                             workspaceId={workspaceId}
                             workingDirectory={workingDirectory}
+                            sourceIsRemote={sourceRemoteInfo.isRemote}
+                            sourceBaseUrl={sourceRemoteInfo.baseUrl}
                             existingRuns={resolvedRuns}
                             availableTargets={implementTargets}
                             sourceProcessId={processId ?? undefined}

--- a/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ChatListPane.tsx
@@ -3449,7 +3449,20 @@ export function ChatListPane({
                                 ),
                                 hidden: false,
                             },
-                            { id: 'all' as const, label: 'All', count: scopeCounts.all, icon: null, hidden: false },
+                            {
+                                id: 'all' as const,
+                                label: 'All',
+                                count: scopeCounts.all,
+                                icon: (
+                                    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" aria-hidden="true">
+                                        <rect x="1.5" y="1.5" width="4" height="4" rx="0.5" />
+                                        <rect x="8.5" y="1.5" width="4" height="4" rx="0.5" />
+                                        <rect x="1.5" y="8.5" width="4" height="4" rx="0.5" />
+                                        <rect x="8.5" y="8.5" width="4" height="4" rx="0.5" />
+                                    </svg>
+                                ),
+                                hidden: false,
+                            },
                         ]).filter(s => !s.hidden).map(scope => {
                             const on = activeScope === scope.id;
                             return (
@@ -3458,9 +3471,11 @@ export function ChatListPane({
                                     type="button"
                                     role="tab"
                                     aria-selected={on}
+                                    aria-label={`${scope.label} (${scope.count})`}
+                                    title={scope.label}
                                     onClick={() => setActiveScope(scope.id)}
                                     className={cn(
-                                        'h-[26px] min-w-0 px-1.5 inline-flex items-center justify-center gap-1 text-[11.5px] leading-none font-medium rounded transition-[background-color,color,box-shadow] duration-100',
+                                        'h-[26px] min-w-0 px-1 inline-flex items-center justify-center gap-1 text-[11.5px] leading-none font-medium rounded transition-[background-color,color,box-shadow] duration-100',
                                         on
                                             ? 'bg-white dark:bg-[#1e1e1e] text-[#1e1e1e] dark:text-[#cccccc] shadow-[0_1px_0_rgba(0,0,0,0.04),0_0_0_1px_rgba(224,224,224,0.7)] dark:shadow-[0_1px_0_rgba(0,0,0,0.20),0_0_0_1px_rgba(71,71,73,0.7)]'
                                             : 'text-[#606060] dark:text-[#9d9d9d] hover:text-[#1e1e1e] dark:hover:text-[#cccccc]',
@@ -3468,8 +3483,7 @@ export function ChatListPane({
                                     data-testid={`activity-scope-tab-${scope.id}`}
                                     data-active={on || undefined}
                                 >
-                                    {scope.icon && <span className="opacity-80 flex-shrink-0">{scope.icon}</span>}
-                                    <span className="min-w-0 truncate whitespace-nowrap">{scope.label}</span>
+                                    <span className="opacity-80 flex-shrink-0">{scope.icon}</span>
                                     <span
                                         className={cn(
                                             'text-[10.5px] font-mono tabular-nums whitespace-nowrap flex-shrink-0',

--- a/packages/coc/src/server/spa/client/react/features/chat/ImplementPlanCard.tsx
+++ b/packages/coc/src/server/spa/client/react/features/chat/ImplementPlanCard.tsx
@@ -13,6 +13,12 @@
  *  • Remote target → reads the plan content on the initiating server, embeds it
  *    in the prompt, and enqueues on the target repo's routed CoC client, because
  *    the remote machine cannot read the initiating machine's local plan path.
+ *
+ * The path-based prompt is only safe when the plan verifiably lives on the
+ * server that runs the task. When the SOURCE workspace is itself a remote clone
+ * (`sourceIsRemote`), the plan content is always read from the source server and
+ * embedded inline — regardless of what the target list claims — so a remote
+ * machine's plan path can never leak into a task on the wrong server.
  * The selector is gated entirely by the targets the caller supplies (which come
  * from existing remote repo/server availability), so installs without remote
  * support keep the unchanged local-only UI.
@@ -93,6 +99,15 @@ export interface ImplementPlanCardProps {
     planCanvasId?: string;
     workspaceId?: string;
     workingDirectory?: string;
+    /**
+     * True when the source workspace (where the plan file lives) is NOT a local
+     * workspace of this dashboard's server — a remote clone, or a workspace id
+     * this server does not own. Forces the inline-content prompt so a
+     * machine-local plan path never leaks into a task on another server.
+     */
+    sourceIsRemote?: boolean;
+    /** Remote routing base URL of the source workspace, when known. */
+    sourceBaseUrl?: string;
     onImplemented: (newProcessId: string) => void;
     /** Existing implementation runs with resolved live status. */
     existingRuns?: ExistingRun[];
@@ -170,10 +185,24 @@ function planFileBasename(filePath: string): string {
     return idx >= 0 ? normalized.slice(idx + 1) : normalized;
 }
 
-/** Resolve a target to a CocClient routing ref: remote → object marker, local → id. */
-function toCloneRef(target: ImplementTarget | undefined, fallbackId: string | undefined): CloneRef | undefined {
+/**
+ * Resolve the enqueue routing ref. An explicit remote target routes via its own
+ * baseUrl. When the run falls back to the source workspace and that workspace is
+ * a remote clone with a known baseUrl, route to the source server explicitly — a
+ * bare remote workspace id silently resolves to the LOCAL client when the clone
+ * registry does not know it. Everything else routes by id.
+ */
+function toCloneRef(
+    target: ImplementTarget | undefined,
+    fallbackId: string | undefined,
+    source?: { isRemote?: boolean; baseUrl?: string },
+): CloneRef | undefined {
     if (target?.isRemote && target.baseUrl) {
         return { id: target.workspaceId, baseUrl: target.baseUrl, remote: {} };
+    }
+    const targetIsSource = !target || target.workspaceId === fallbackId;
+    if (targetIsSource && source?.isRemote && source.baseUrl) {
+        return { id: fallbackId ?? '', baseUrl: source.baseUrl, remote: {} };
     }
     return target?.workspaceId ?? fallbackId;
 }
@@ -186,6 +215,8 @@ export function ImplementPlanCard({
     planCanvasId,
     workspaceId,
     workingDirectory,
+    sourceIsRemote,
+    sourceBaseUrl,
     onImplemented,
     existingRuns = [],
     onViewRun,
@@ -209,8 +240,16 @@ export function ImplementPlanCard({
 
     // AC-07/AC-03: the source client (initiating server) persists the record and
     // reads the plan; the target client routes the enqueue to the chosen repo.
-    const sourceClient = useCocClient(workspaceId);
-    const targetClient = useCocClient(toCloneRef(selectedTarget, workspaceId));
+    // When the source workspace is a remote clone with a known baseUrl, route
+    // both explicitly — bare-id resolution falls back to the local client when
+    // the clone registry does not know the workspace.
+    const sourceRef: CloneRef | undefined = sourceIsRemote && sourceBaseUrl
+        ? { id: workspaceId ?? '', baseUrl: sourceBaseUrl, remote: {} }
+        : workspaceId;
+    const sourceClient = useCocClient(sourceRef);
+    const targetClient = useCocClient(
+        toCloneRef(selectedTarget, workspaceId, { isRemote: sourceIsRemote, baseUrl: sourceBaseUrl }),
+    );
 
     const [submitting, setSubmitting] = useState(false);
     const [submitted, setSubmitted] = useState(false);
@@ -271,6 +310,11 @@ export function ImplementPlanCard({
         setError(null);
         try {
             const isRemote = !!selectedTarget?.isRemote;
+            const targetIsSource = !selectedTarget || selectedTarget.workspaceId === workspaceId;
+            // A run that stays on the source workspace inherits the source's
+            // remote-ness: the target list may omit or mislabel the current
+            // workspace (repos still loading, offline clone, no ReposProvider).
+            const runsRemotely = isRemote || (targetIsSource && !!sourceIsRemote);
             const targetWorkspaceId = selectedTarget?.workspaceId ?? workspaceId;
             const targetWorkingDirectory = selectedTarget?.workingDirectory ?? workingDirectory;
 
@@ -278,14 +322,15 @@ export function ImplementPlanCard({
             // content from the source server and embed it inline (local or remote).
             // File-based plans keep the existing convention: local runs reference
             // the path, remote runs embed the file content read from the source
-            // server (AC-04).
+            // server (AC-04). A remote-sourced plan is always embedded — its path
+            // only exists on the source machine.
             let prompt: string;
             let context: { files: string[] } | undefined;
             if (planCanvasId) {
                 const planContent = await readSourceCanvasContent(planCanvasId);
                 prompt = buildCanvasPrompt(activePlanFilePath, planContent);
                 context = undefined;
-            } else if (isRemote) {
+            } else if (isRemote || sourceIsRemote) {
                 const planContent = await readSourcePlanContent();
                 prompt = buildRemotePrompt(activePlanFilePath, planContent);
                 context = undefined;
@@ -320,7 +365,7 @@ export function ImplementPlanCard({
                     targetWorkspaceId,
                     targetLabel: selectedTarget?.label,
                     targetServerLabel: isRemote ? selectedTarget?.serverLabel : undefined,
-                    isRemoteTarget: isRemote,
+                    isRemoteTarget: runsRemotely,
                 };
                 const prevImpls = Array.isArray(sourceMetadata?.implementations)
                     ? (sourceMetadata!.implementations as ImplementationRecord[])

--- a/packages/coc/src/server/spa/client/react/features/chat/implementTargets.ts
+++ b/packages/coc/src/server/spa/client/react/features/chat/implementTargets.ts
@@ -31,6 +31,12 @@ export interface CurrentRepoRef {
     workingDirectory?: string;
     /** Git remote URL of the current repo; drives the same-origin scoping. */
     remoteUrl?: string | null;
+    /** True when the current workspace is a remote clone (not owned by this server). */
+    isRemote?: boolean;
+    /** Remote routing base URL of the current workspace, when known. */
+    baseUrl?: string;
+    /** Remote server label of the current workspace, when known. */
+    serverLabel?: string;
 }
 
 /** True when an aggregated remote clone is currently online and reachable (AC-02). */
@@ -110,11 +116,16 @@ export function buildImplementTargets(
     if (current.workspaceId) {
         const idx = targets.findIndex(t => t.workspaceId === current.workspaceId);
         if (idx === -1) {
+            // Carry the caller-supplied remote identity: hardcoding isRemote:false
+            // here made a remote-sourced plan look local, leaking its machine-local
+            // path into a task enqueued on the wrong server.
             targets.unshift({
                 workspaceId: current.workspaceId,
                 label: current.label || current.workspaceId,
+                serverLabel: current.isRemote ? current.serverLabel : undefined,
                 workingDirectory: current.workingDirectory,
-                isRemote: false,
+                baseUrl: current.isRemote ? current.baseUrl : undefined,
+                isRemote: !!current.isRemote,
             });
         } else if (idx > 0) {
             const [cur] = targets.splice(idx, 1);

--- a/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
+++ b/packages/coc/src/server/spa/client/react/features/git/RepoGitTab.tsx
@@ -1783,6 +1783,35 @@ export function RepoGitTab({ workspaceId, layout, detailContainer, detailActive,
         </div>
     );
 
+    // Toolbar (branch pill + fetch/pull/push + refresh). Rendered inline at the
+    // top of the list pane normally; when the split panel provides a section
+    // header slot it's portaled there instead — as a sibling OUTSIDE the list's
+    // onClickCapture wrapper, so toolbar clicks (Pull/refresh/…) don't mark git
+    // last-clicked and steal the shared detail pane from the chat.
+    const panelHeader = (
+        <GitPanelHeader
+            branch={branchName || 'HEAD'}
+            ahead={ahead}
+            behind={behind}
+            refreshing={refreshing}
+            onRefresh={refreshAll}
+            onBranchClick={() => setBranchPickerOpen(true)}
+            onFetch={handleFetch}
+            onPull={handlePull}
+            onPush={handlePush}
+            onRebaseAutosquash={handleRebaseAutosquash}
+            fetching={fetching}
+            pulling={pulling}
+            pushing={pushing}
+            rebasing={rebasing}
+            lastRefreshedAt={lastRefreshedAt}
+            compact={headerHoisted}
+        />
+    );
+    const hoistedHeaderPortal = headerHoisted && headerToolbarContainer
+        ? createPortal(panelHeader, headerToolbarContainer)
+        : null;
+
     // Left panel — commit list + working tree + branch changes, including the
     // GitPanelHeader fetch/pull/push actions and inline stage/commit. Reused
     // verbatim by both the standalone layout and the split-workspace list slot;
@@ -1799,31 +1828,7 @@ export function RepoGitTab({ workspaceId, layout, detailContainer, detailActive,
                 {!isSplitWorkspace && (
                     <style>{`@media (min-width: 1024px) { [data-testid="git-commit-list-panel"] { width: ${sidebarWidth}px !important; } }`}</style>
                 )}
-                {(() => {
-                    const panelHeader = (
-                        <GitPanelHeader
-                            branch={branchName || 'HEAD'}
-                            ahead={ahead}
-                            behind={behind}
-                            refreshing={refreshing}
-                            onRefresh={refreshAll}
-                            onBranchClick={() => setBranchPickerOpen(true)}
-                            onFetch={handleFetch}
-                            onPull={handlePull}
-                            onPush={handlePush}
-                            onRebaseAutosquash={handleRebaseAutosquash}
-                            fetching={fetching}
-                            pulling={pulling}
-                            pushing={pushing}
-                            rebasing={rebasing}
-                            lastRefreshedAt={lastRefreshedAt}
-                            compact={headerHoisted}
-                        />
-                    );
-                    return headerHoisted && headerToolbarContainer
-                        ? createPortal(panelHeader, headerToolbarContainer)
-                        : panelHeader;
-                })()}
+                {!headerHoisted && panelHeader}
                 {/* Search input (filter-bar style: subtle background card containing a bordered search box) */}
                 <div
                     className={`${isSplitWorkspace ? 'px-2 py-1' : 'px-2.5 py-1.5'} border-b border-[#e0e0e0] dark:border-[#3c3c3c] bg-[#f5f5f5] dark:bg-[#252526]`}
@@ -2173,6 +2178,10 @@ export function RepoGitTab({ workspaceId, layout, detailContainer, detailActive,
                 >
                     {listPane}
                 </div>
+                {/* Hoisted toolbar portal lives OUTSIDE the capture wrapper: portaled
+                    React events still bubble through the React tree, so keeping it
+                    inside made every Pull/refresh click steal the shared detail pane. */}
+                {hoistedHeaderPortal}
                 {detailActive && detailContainer
                     ? createPortal(
                         <div

--- a/packages/coc/src/server/spa/client/react/features/notes/NotesView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/notes/NotesView.tsx
@@ -14,6 +14,7 @@ import type { TextAnchor } from './editor/textAnchor';
 import { AddCommentDialog } from './editor/NotesDialogs';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
+import { usePublishWorkspaceLeftColWidth } from '../../hooks/ui/useWorkspaceLeftColWidth';
 import { useApp } from '../../contexts/AppContext';
 import { buildNoteHash } from '../../layout/Router';
 import { useNoteReferences } from './editor/useNoteReferences';
@@ -27,6 +28,12 @@ export interface NotesViewProps {
     initialNotePath?: string | null;
     /** Default chat scope for the NoteChatPanel. Defaults to 'per-workspace'. */
     defaultScope?: ChatScope;
+    /**
+     * Whether this Notes tab is the active/visible sub-tab. Views are kept
+     * mounted-but-hidden across tab switches, so only the active one publishes
+     * its sidebar width to the global status dock. Defaults to `true` for
+     * standalone use. */
+    active?: boolean;
 }
 
 const MAX_NAV_HISTORY = 50;
@@ -35,7 +42,7 @@ function getNotesChatLegacyOpenStorageKey(workspaceId: string): string {
     return `coc-notes-chat-panel-open-${workspaceId}`;
 }
 
-export function NotesView({ workspaceId, initialNotePath, defaultScope }: NotesViewProps) {
+export function NotesView({ workspaceId, initialNotePath, defaultScope, active = true }: NotesViewProps) {
     const { dispatch } = useApp();
     const [selectedPath, setSelectedPath] = useState<string | null>(initialNotePath ?? null);
     const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -113,6 +120,12 @@ export function NotesView({ workspaceId, initialNotePath, defaultScope }: NotesV
         storageKey: 'coc.notesView.sidebarWidth',
         direction: 'left',
     });
+
+    // Keep the app-shell status dock flush under the notes tree sidebar (not the
+    // wider workspace default) by publishing this sidebar's live width — but only
+    // while this Notes tab is the active one, since the view stays mounted-hidden
+    // on other tabs. On mobile the sidebar is a drawer, so clear it.
+    usePublishWorkspaceLeftColWidth(sidebarResize.width, isMobile || !active);
 
     const commentsPanelResize = useResizablePanel({
         initialWidth: 288,

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/RepoDetail.tsx
@@ -850,6 +850,7 @@ export function RepoDetail({ repo, repos, onRefresh, chromeless = false }: RepoD
                                     workspaceId={ws.id}
                                     initialNotePath={state.selectedNotePath}
                                     defaultScope="per-note"
+                                    active={activeSubTab === 'notes'}
                                 />}
                             </div>
                         )}

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/SplitWorkspacePanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/SplitWorkspacePanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { cn } from '../../ui';
 import { useBreakpoint } from '../../hooks/ui/useBreakpoint';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
+import { usePublishWorkspaceLeftColWidth } from '../../hooks/ui/useWorkspaceLeftColWidth';
 
 /**
  * Layout shell for the split "Workspace" view (behind the `splitWorkspacePanel`
@@ -228,19 +229,10 @@ export function SplitWorkspacePanel({
     const [gitCollapsed, toggleGit] = useCollapsedState(splitWorkspaceGitCollapsedStorageKey(workspaceId));
 
     // Publish the live left-column width so the App shell's global status dock
-    // (`GlobalStatusDock`) can match this sidebar's width. Cleared on unmount /
-    // mobile so the dock falls back to its default width where no split sidebar
+    // (`GlobalStatusDock`) can match this sidebar's width. Cleared on mobile /
+    // unmount so the dock falls back to its default width where no split sidebar
     // is on screen.
-    useEffect(() => {
-        if (isMobile) {
-            document.documentElement.style.removeProperty('--workspace-left-col-width');
-            return;
-        }
-        document.documentElement.style.setProperty('--workspace-left-col-width', `${leftColumn.width}px`);
-        return () => {
-            document.documentElement.style.removeProperty('--workspace-left-col-width');
-        };
-    }, [isMobile, leftColumn.width]);
+    usePublishWorkspaceLeftColWidth(leftColumn.width, isMobile);
 
     // Narrow / mobile fallback: single scrolling column, no split, no dividers.
     // Each reused tab keeps its own single-column behavior; we just stack the

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/SplitWorkspacePanel.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/SplitWorkspacePanel.tsx
@@ -266,6 +266,10 @@ export function SplitWorkspacePanel({
     // Chat keeps its persisted fixed height when both are open; when git is
     // collapsed the chat half fills the remaining space instead.
     const chatFills = !chatCollapsed && gitCollapsed;
+    // When both halves are collapsed neither one carries `flex-1`, so nothing
+    // fills the column and the docked footer would ride up under the git header
+    // instead of staying pinned to the bottom-left. A spacer absorbs the slack.
+    const bothCollapsed = chatCollapsed && gitCollapsed;
 
     return (
         <div
@@ -350,6 +354,17 @@ export function SplitWorkspacePanel({
                         {gitList}
                     </div>
                 </div>
+
+                {/* Both halves collapsed: no half carries flex-1, so this
+                    spacer grows to fill the column and keeps the footer pinned
+                    to the bottom-left instead of riding up under the headers. */}
+                {bothCollapsed && (
+                    <div
+                        className="flex-1 min-h-0"
+                        aria-hidden="true"
+                        data-testid="split-workspace-spacer"
+                    />
+                )}
 
                 {/* Docked footer pinned to the bottom of the left column (below
                     the git half). Hosts the remote-first shell's status cluster. */}

--- a/packages/coc/src/server/spa/client/react/features/repo-detail/WorkspaceRightDock.tsx
+++ b/packages/coc/src/server/spa/client/react/features/repo-detail/WorkspaceRightDock.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { cn, SegmentedControl } from '../../ui';
+import { cn } from '../../ui';
 import { useResizablePanel } from '../../hooks/ui/useResizablePanel';
 import { TerminalView } from '../terminal/TerminalView';
 import { ExplorerPanel } from './explorer/ExplorerPanel';
@@ -33,7 +33,9 @@ export type { WorkspaceDockView } from './WorkspaceDockToggle';
 /**
  * WorkspaceRightDock — a VS Code-style right-side dock at the workspace level
  * (behind the `splitWorkspacePanel` flag) that hosts the existing Terminal and
- * File Explorer, switchable via a segmented Terminal|Explorer control. It lives
+ * File Explorer, switchable via compact Terminal|Explorer tabs in a single-row
+ * header. The active terminal's toolbar (picker + new-terminal action) portals
+ * into that same header row so the whole bar reads as one control. It lives
  * to the right of everything and stays mounted across every sub-tab (chat, git,
  * notes, work-items, …) so the running PTY session and explorer state survive a
  * sub-tab change, a dock close, or a view switch.
@@ -131,10 +133,75 @@ export function useWorkspaceDock(workspaceId: string): WorkspaceDockController {
     return { isOpen, toggleOpen, view, setView, width, isDragging, handleMouseDown, handleTouchStart };
 }
 
-const DOCK_VIEW_OPTIONS: readonly { value: WorkspaceDockView; label: string; testId: string }[] = [
-    { value: 'terminal', label: 'Terminal', testId: 'workspace-dock-view-terminal' },
-    { value: 'explorer', label: 'Explorer', testId: 'workspace-dock-view-explorer' },
+const DOCK_VIEW_TABS: readonly {
+    value: WorkspaceDockView;
+    label: string;
+    testId: string;
+    icon: JSX.Element;
+}[] = [
+    {
+        value: 'terminal',
+        label: 'Terminal',
+        testId: 'workspace-dock-view-terminal',
+        icon: (
+            <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polyline points="3,4 6,8 3,12" />
+                <line x1="8" y1="12" x2="13" y2="12" />
+            </svg>
+        ),
+    },
+    {
+        value: 'explorer',
+        label: 'Explorer',
+        testId: 'workspace-dock-view-explorer',
+        icon: (
+            <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" aria-hidden="true">
+                <path d="M2 4.2h4l1.2 1.6H14v6.9H2z" />
+            </svg>
+        ),
+    },
 ];
+
+/**
+ * Compact Terminal | Explorer tabs for the dock's single-row header. Underline
+ * marks the active view; the terminal picker + new-terminal action portal into
+ * the same row to the right (see WorkspaceRightDock), so the header reads as one
+ * bar rather than a stack of a pill switcher over a separate terminal toolbar.
+ */
+function DockViewTabs({
+    view,
+    onChange,
+}: {
+    view: WorkspaceDockView;
+    onChange: (value: WorkspaceDockView) => void;
+}) {
+    return (
+        <div className="flex h-full flex-shrink-0 items-stretch" role="tablist" data-testid="workspace-dock-view-switcher">
+            {DOCK_VIEW_TABS.map(tab => {
+                const active = view === tab.value;
+                return (
+                    <button
+                        key={tab.value}
+                        type="button"
+                        role="tab"
+                        aria-selected={active}
+                        onClick={() => onChange(tab.value)}
+                        data-testid={tab.testId}
+                        className={cn(
+                            'flex items-center gap-1.5 px-2.5 text-xs border-b-2 -mb-px transition-colors',
+                            active
+                                ? 'border-[#0078d4] text-[#1f1f1f] dark:text-white'
+                                : 'border-transparent text-[#616161] hover:text-[#1f1f1f] dark:text-[#9d9d9d] dark:hover:text-white',
+                        )}
+                    >
+                        <span className="opacity-80">{tab.icon}</span>
+                        {tab.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
 
 export interface WorkspaceRightDockProps {
     workspaceId: string;
@@ -159,6 +226,12 @@ export function WorkspaceRightDock({ workspaceId, dock }: WorkspaceRightDockProp
     useEffect(() => {
         if (isOpen) setEverOpened(true);
     }, [isOpen]);
+
+    // The terminal toolbar portals into this header slot so the Terminal/Explorer
+    // tabs and the terminal picker share one row. Only target it while the
+    // terminal view is active; on Explorer the toolbar falls back to rendering
+    // inline (hidden inside its display:none container).
+    const [pickerSlot, setPickerSlot] = useState<HTMLDivElement | null>(null);
 
     return (
         <div
@@ -188,22 +261,20 @@ export function WorkspaceRightDock({ workspaceId, dock }: WorkspaceRightDockProp
                 <span className="h-full w-px bg-[#c8c8c8] dark:bg-[#5a5a5a] group-hover:w-[2px] group-hover:bg-[#007acc] transition-all" />
             </div>
 
-            {/* Dock body: segmented switcher header + the two (keep-alive) views. */}
+            {/* Dock body: single-row header (view tabs + portaled terminal toolbar)
+                + the two (keep-alive) views. */}
             <div
                 className="flex min-h-0 flex-col overflow-hidden"
                 style={{ width }}
                 data-testid="workspace-dock-body"
             >
                 <div
-                    className="flex h-[30px] flex-shrink-0 items-center border-b border-[#e5e5e5] px-2 dark:border-[#333]"
+                    className="flex h-[35px] flex-shrink-0 items-center gap-1 border-b border-[#e5e5e5] pr-1 dark:border-[#333]"
                     data-testid="workspace-dock-header"
                 >
-                    <SegmentedControl
-                        options={DOCK_VIEW_OPTIONS}
-                        value={view}
-                        onChange={setView}
-                        data-testid="workspace-dock-view-switcher"
-                    />
+                    <DockViewTabs view={view} onChange={setView} />
+                    {/* Portal target for the active terminal's toolbar (picker + new). */}
+                    <div ref={setPickerSlot} className="flex min-w-0 flex-1 items-center" />
                 </div>
 
                 {everOpened && (
@@ -213,7 +284,11 @@ export function WorkspaceRightDock({ workspaceId, dock }: WorkspaceRightDockProp
                             style={{ display: view === 'terminal' ? undefined : 'none' }}
                             data-testid="workspace-dock-terminal"
                         >
-                            <TerminalView key={workspaceId} workspaceId={workspaceId} />
+                            <TerminalView
+                                key={workspaceId}
+                                workspaceId={workspaceId}
+                                toolbarPortalTarget={view === 'terminal' ? pickerSlot : null}
+                            />
                         </div>
                         <div
                             className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"

--- a/packages/coc/src/server/spa/client/react/features/terminal/TerminalView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/terminal/TerminalView.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '../../ui/cn';
 import { TerminalPanel } from './TerminalPanel';
 import { useCocClient } from '../../repos/cloneRouting';
@@ -14,6 +15,14 @@ import type { TerminalSessionInfo } from './hooks/useTerminalWebSocket';
 
 export interface TerminalViewProps {
     workspaceId: string;
+    /**
+     * When set, the toolbar (terminal picker + new-terminal action) renders into
+     * this element via a portal instead of inline. The workspace dock uses it to
+     * merge the toolbar into its single-row header next to the Terminal/Explorer
+     * tabs; standalone usage (the classic Terminal sub-tab) leaves it undefined
+     * and keeps the inline bordered toolbar.
+     */
+    toolbarPortalTarget?: HTMLElement | null;
 }
 
 interface TerminalTab {
@@ -26,7 +35,7 @@ interface TerminalTab {
 }
 
 
-export function TerminalView({ workspaceId }: TerminalViewProps) {
+export function TerminalView({ workspaceId, toolbarPortalTarget }: TerminalViewProps) {
     // Route terminal REST (list/pin) to the workspace's clone (AC-07). The PTY
     // socket itself is routed inside useTerminalWebSocket via the same registry.
     const client = useCocClient(workspaceId);
@@ -238,13 +247,20 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
 
     const activeTab = terminals.find(t => t.id === activeId) ?? null;
 
-    return (
-        <div className="flex flex-col h-full" data-testid="terminal-view">
-            {/* Toolbar: compact terminal picker + new-terminal action */}
-            <div
-                ref={toolbarRef}
-                className="flex items-center gap-1 px-2 py-1 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 shrink-0"
-            >
+    // Toolbar: compact terminal picker + new-terminal action. Rendered inline by
+    // default; the workspace dock portals it into its single-row header so the
+    // Terminal/Explorer tabs and the picker share one bar (no bordered wrapper /
+    // background then — the header supplies those).
+    const toolbar = (
+        <div
+            ref={toolbarRef}
+            className={cn(
+                "flex items-center gap-1",
+                toolbarPortalTarget
+                    ? "h-full w-full px-1"
+                    : "px-2 py-1 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 shrink-0",
+            )}
+        >
                 {terminals.length > 0 ? (
                     <div className="relative min-w-0">
                         {editingId && activeTab ? (
@@ -381,7 +397,12 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
                         {pinError}
                     </span>
                 ) : null}
-            </div>
+        </div>
+    );
+
+    return (
+        <div className="flex flex-col h-full" data-testid="terminal-view">
+            {toolbarPortalTarget ? createPortal(toolbar, toolbarPortalTarget) : toolbar}
 
             {/* Terminal panels — all rendered, visibility toggled */}
             <div className="flex-1 min-h-0 relative">

--- a/packages/coc/src/server/spa/client/react/features/terminal/TerminalView.tsx
+++ b/packages/coc/src/server/spa/client/react/features/terminal/TerminalView.tsx
@@ -36,7 +36,11 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
     const [editValue, setEditValue] = useState('');
     const [pinningIds, setPinningIds] = useState<Set<string>>(() => new Set());
     const [pinError, setPinError] = useState<string | null>(null);
+    // Compact picker: the terminal list collapses into a "Terminal N ▾" dropdown
+    // so a narrow dock never overflows with a horizontal tab strip.
+    const [menuOpen, setMenuOpen] = useState(false);
     const editInputRef = useRef<HTMLInputElement>(null);
+    const toolbarRef = useRef<HTMLDivElement>(null);
     const counterRef = useRef(0);
 
     const createTerminal = useCallback(() => {
@@ -183,6 +187,7 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
     }, []);
 
     const startRename = useCallback((tab: TerminalTab) => {
+        setMenuOpen(false);
         setEditingId(tab.id);
         setEditValue(tab.title);
     }, []);
@@ -210,73 +215,157 @@ export function TerminalView({ workspaceId }: TerminalViewProps) {
         }
     }, [editingId]);
 
+    // Close the picker menu on outside click (anywhere below the toolbar) or Escape.
+    // The toolbar itself — including the "+" button — counts as "inside" so those
+    // clicks don't dismiss it mid-interaction.
+    useEffect(() => {
+        if (!menuOpen) return;
+        function handlePointerDown(event: MouseEvent) {
+            if (toolbarRef.current && !toolbarRef.current.contains(event.target as Node)) {
+                setMenuOpen(false);
+            }
+        }
+        function handleKeyDown(event: KeyboardEvent) {
+            if (event.key === 'Escape') setMenuOpen(false);
+        }
+        document.addEventListener('mousedown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [menuOpen]);
+
+    const activeTab = terminals.find(t => t.id === activeId) ?? null;
+
     return (
         <div className="flex flex-col h-full" data-testid="terminal-view">
-            {/* Toolbar */}
-            <div className="flex items-center gap-1 px-2 py-1 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 shrink-0">
-                {/* Tab strip */}
-                <div className="flex items-center gap-0.5 overflow-x-auto flex-1 min-w-0">
-                    {terminals.map(tab => (
-                        <button
-                            key={tab.id}
-                            className={cn(
-                                "flex items-center gap-1.5 px-3 py-1 text-xs rounded-t whitespace-nowrap group",
-                                "hover:bg-gray-200 dark:hover:bg-gray-700",
-                                tab.id === activeId
-                                    ? "bg-white dark:bg-gray-800 border border-b-0 border-gray-200 dark:border-gray-700 font-medium"
-                                    : "text-gray-500 dark:text-gray-400"
-                            )}
-                            onClick={() => setActiveId(tab.id)}
-                            data-testid={`terminal-tab-${tab.id}`}
-                        >
-                            <span className="text-xs">⬛</span>
-                            {editingId === tab.id ? (
-                                <input
-                                    ref={editInputRef}
-                                    className="text-xs bg-transparent border border-blue-400 dark:border-blue-500 rounded px-1 py-0 outline-none w-24"
-                                    value={editValue}
-                                    onChange={(e) => setEditValue(e.target.value)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter') { e.preventDefault(); commitRename(); }
-                                        if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
-                                    }}
-                                    onBlur={commitRename}
-                                    onClick={(e) => e.stopPropagation()}
-                                    data-testid={`terminal-tab-rename-input-${tab.id}`}
-                                />
-                            ) : (
+            {/* Toolbar: compact terminal picker + new-terminal action */}
+            <div
+                ref={toolbarRef}
+                className="flex items-center gap-1 px-2 py-1 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 shrink-0"
+            >
+                {terminals.length > 0 ? (
+                    <div className="relative min-w-0">
+                        {editingId && activeTab ? (
+                            <input
+                                ref={editInputRef}
+                                className="text-xs bg-transparent border border-blue-400 dark:border-blue-500 rounded px-1.5 py-1 outline-none w-32"
+                                value={editValue}
+                                onChange={(e) => setEditValue(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') { e.preventDefault(); commitRename(); }
+                                    if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
+                                }}
+                                onBlur={commitRename}
+                                data-testid={`terminal-tab-rename-input-${activeTab.id}`}
+                            />
+                        ) : (
+                            <button
+                                type="button"
+                                className="flex items-center gap-1.5 px-2 py-1 max-w-[220px] text-xs rounded text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700"
+                                onClick={() => setMenuOpen(open => !open)}
+                                title="Switch terminal"
+                                aria-haspopup="menu"
+                                aria-expanded={menuOpen}
+                                data-menu-open={menuOpen ? 'true' : 'false'}
+                                data-testid="terminal-picker-btn"
+                            >
+                                <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" aria-hidden="true" />
                                 <span
-                                    onDoubleClick={(e) => { e.stopPropagation(); startRename(tab); }}
-                                    data-testid={`terminal-tab-title-${tab.id}`}
+                                    className="truncate"
+                                    onDoubleClick={(e) => { e.stopPropagation(); if (activeTab) startRename(activeTab); }}
+                                    data-testid={`terminal-tab-title-${activeTab?.id ?? ''}`}
                                 >
-                                    {tab.title}
+                                    {activeTab?.title ?? 'Terminal'}
                                 </span>
-                            )}
-                            <span
-                                className={cn(
-                                    "ml-0.5 cursor-pointer",
-                                    (!tab.serverSessionId || pinningIds.has(tab.id)) && "cursor-not-allowed opacity-40",
-                                    tab.pinned
-                                        ? "opacity-80 hover:opacity-100 text-blue-500 dark:text-blue-400"
-                                        : "opacity-0 group-hover:opacity-50 hover:!opacity-100"
-                                )}
-                                onClick={(e) => { e.stopPropagation(); void togglePin(tab.id); }}
-                                title={!tab.serverSessionId ? 'Waiting for terminal session' : tab.pinned ? 'Unpin terminal' : 'Pin terminal'}
-                                aria-disabled={!tab.serverSessionId || pinningIds.has(tab.id)}
-                                data-testid={`terminal-tab-pin-${tab.id}`}
+                                {terminals.length > 1 ? (
+                                    <span className="text-[10px] leading-none px-1 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 shrink-0" data-testid="terminal-count-badge">
+                                        {terminals.length}
+                                    </span>
+                                ) : null}
+                                <svg className="w-3 h-3 shrink-0 opacity-60" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                    <polyline points="4,6 8,10 12,6" />
+                                </svg>
+                            </button>
+                        )}
+
+                        {menuOpen ? (
+                            <div
+                                className="absolute left-0 top-full z-20 mt-1 min-w-[200px] max-w-[280px] rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-1 shadow-lg"
+                                role="menu"
+                                data-testid="terminal-picker-menu"
                             >
-                                📌
-                            </span>
-                            <span
-                                className="ml-0.5 opacity-50 hover:opacity-100"
-                                onClick={(e) => { e.stopPropagation(); closeTerminal(tab.id); }}
-                                data-testid={`terminal-tab-close-${tab.id}`}
-                            >
-                                ✕
-                            </span>
-                        </button>
-                    ))}
-                </div>
+                                {terminals.map(tab => (
+                                    <div
+                                        key={tab.id}
+                                        role="menuitemradio"
+                                        aria-checked={tab.id === activeId}
+                                        className={cn(
+                                            "group mx-1 flex items-center gap-1.5 rounded px-2 py-1.5 text-xs cursor-pointer",
+                                            "hover:bg-gray-100 dark:hover:bg-gray-700",
+                                            tab.id === activeId
+                                                ? "bg-gray-100 dark:bg-gray-700/60 font-medium text-gray-800 dark:text-gray-100"
+                                                : "text-gray-600 dark:text-gray-300"
+                                        )}
+                                        onClick={() => { setActiveId(tab.id); setMenuOpen(false); }}
+                                        data-testid={`terminal-menu-item-${tab.id}`}
+                                    >
+                                        <span
+                                            className={cn(
+                                                "h-1.5 w-1.5 rounded-full shrink-0",
+                                                tab.id === activeId ? "bg-green-500" : "bg-gray-400 dark:bg-gray-500"
+                                            )}
+                                            aria-hidden="true"
+                                        />
+                                        <span className="flex-1 truncate" data-testid={`terminal-menu-title-${tab.id}`}>
+                                            {tab.title}
+                                        </span>
+                                        <span
+                                            className={cn(
+                                                "cursor-pointer",
+                                                (!tab.serverSessionId || pinningIds.has(tab.id)) && "cursor-not-allowed opacity-40",
+                                                tab.pinned
+                                                    ? "opacity-80 hover:opacity-100 text-blue-500 dark:text-blue-400"
+                                                    : "opacity-0 group-hover:opacity-50 hover:!opacity-100"
+                                            )}
+                                            onClick={(e) => { e.stopPropagation(); void togglePin(tab.id); }}
+                                            title={!tab.serverSessionId ? 'Waiting for terminal session' : tab.pinned ? 'Unpin terminal' : 'Pin terminal'}
+                                            aria-disabled={!tab.serverSessionId || pinningIds.has(tab.id)}
+                                            data-testid={`terminal-tab-pin-${tab.id}`}
+                                        >
+                                            📌
+                                        </span>
+                                        <span
+                                            className="opacity-50 hover:opacity-100"
+                                            onClick={(e) => { e.stopPropagation(); closeTerminal(tab.id); }}
+                                            title="Close terminal"
+                                            data-testid={`terminal-tab-close-${tab.id}`}
+                                        >
+                                            ✕
+                                        </span>
+                                    </div>
+                                ))}
+                                <div className="my-1 border-t border-gray-200 dark:border-gray-700" />
+                                <button
+                                    type="button"
+                                    className="mx-1 flex w-[calc(100%-0.5rem)] items-center gap-1.5 rounded px-2 py-1.5 text-xs text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                                    onClick={() => { createTerminal(); setMenuOpen(false); }}
+                                    data-testid="terminal-menu-new"
+                                >
+                                    <span className="text-sm leading-none">+</span>
+                                    New terminal
+                                </button>
+                            </div>
+                        ) : null}
+                    </div>
+                ) : (
+                    <span className="px-1 text-xs text-gray-400 dark:text-gray-500 select-none">
+                        No terminals
+                    </span>
+                )}
+
+                <div className="min-w-0 flex-1" />
 
                 {/* New Terminal button */}
                 <button

--- a/packages/coc/src/server/spa/client/react/hooks/ui/useWorkspaceLeftColWidth.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/ui/useWorkspaceLeftColWidth.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+/**
+ * CSS custom property (published on `<html>`) that the App-shell
+ * `GlobalStatusDock` reads to size its bottom status bar to the current view's
+ * left panel, so the bar stays flush under that panel instead of overhanging
+ * into the content area.
+ */
+export const WORKSPACE_LEFT_COL_WIDTH_VAR = '--workspace-left-col-width';
+
+/**
+ * Publish a left-column pixel width to `--workspace-left-col-width` so the
+ * app-shell `GlobalStatusDock` can match whatever left panel is currently on
+ * screen (the split workspace panel, the notes sidebar, …).
+ *
+ * Dashboard views are routinely kept mounted-but-hidden across tab switches, so
+ * a hidden view must NOT keep owning this shared variable. Pass `disabled` when
+ * the panel is not the anchor for the dock — on mobile (no docked bar), or when
+ * this view is not the active tab — to clear the variable and let the active
+ * view (or the dock's own default fallback) take over.
+ */
+export function usePublishWorkspaceLeftColWidth(width: number, disabled: boolean): void {
+    useEffect(() => {
+        const root = document.documentElement;
+        if (disabled) {
+            root.style.removeProperty(WORKSPACE_LEFT_COL_WIDTH_VAR);
+            return;
+        }
+        root.style.setProperty(WORKSPACE_LEFT_COL_WIDTH_VAR, `${width}px`);
+        return () => {
+            root.style.removeProperty(WORKSPACE_LEFT_COL_WIDTH_VAR);
+        };
+    }, [width, disabled]);
+}

--- a/packages/coc/src/server/spa/client/react/layout/GlobalStatusDock.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/GlobalStatusDock.tsx
@@ -17,6 +17,12 @@
  * via the `--workspace-left-col-width` CSS variable, falling back to the panel's
  * default width where no split sidebar is mounted (e.g. the terminal tab).
  *
+ * The admin shell (the `admin` tab plus the embedded tool tabs) is the exception:
+ * it renders its OWN fixed-width sidebar (`--ar-sidebar-w`, 248px) rather than the
+ * resizable workspace left column, and never publishes `--workspace-left-col-width`.
+ * On those tabs the dock tracks the admin sidebar width so it stays flush beneath
+ * that sidebar instead of overhanging into the content pane.
+ *
  * Rendered once at the App shell level as a flex sibling below `<main>`, so it
  * reserves its own height and never overlaps tab content. Gated to
  * `remoteShell && desktop`:
@@ -32,6 +38,20 @@ import { useBreakpoint } from '../hooks/ui/useBreakpoint';
 
 /** Fallback width when no split sidebar is mounted (matches the panel default). */
 const DEFAULT_LEFT_COL_WIDTH = 360;
+
+/**
+ * Width of the admin shell's own sidebar. Mirrors `--ar-sidebar-w` in
+ * admin-redesign.css; the dock sits outside `.admin-redesign` so it cannot read
+ * that scoped variable and pins the constant here instead.
+ */
+const ADMIN_SIDEBAR_WIDTH = 248;
+
+/**
+ * Dashboard tabs whose Router branch mounts `AdminPanel` (the fixed-width admin
+ * sidebar shell). On these the dock matches the admin sidebar, not the workspace
+ * left column. Keep in sync with the admin cases in Router's `renderActiveView`.
+ */
+const ADMIN_SHELL_TABS = new Set(['admin', 'memory', 'skills', 'logs', 'stats', 'servers', 'dreams-admin']);
 
 export interface GlobalStatusDockProps {
     /** Admin-open handler, forwarded to the docked admin button. */
@@ -56,10 +76,17 @@ export function GlobalStatusDock({ onAdminOpen }: GlobalStatusDockProps) {
         (state.activeRepoSubTab === 'chats' || state.activeRepoSubTab === 'activity');
     if (inPanelFooter) return null;
 
+    // In the admin shell the dock follows the admin sidebar's fixed width so it
+    // stays flush beneath it; elsewhere it tracks the resizable workspace left
+    // column (or the panel default when no split sidebar is mounted).
+    const width = ADMIN_SHELL_TABS.has(state.activeTab)
+        ? `${ADMIN_SIDEBAR_WIDTH}px`
+        : `var(--workspace-left-col-width, ${DEFAULT_LEFT_COL_WIDTH}px)`;
+
     return (
         <div
             className="flex-shrink-0"
-            style={{ width: `var(--workspace-left-col-width, ${DEFAULT_LEFT_COL_WIDTH}px)` }}
+            style={{ width }}
             data-testid="global-status-dock"
         >
             <StatusActions variant="sidebar" onAdminOpen={onAdminOpen} />

--- a/packages/coc/src/server/spa/client/react/layout/StatusActions.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/StatusActions.tsx
@@ -10,9 +10,10 @@
  *     left sidebar (remote-first shell). It full-bleeds a top border and lays
  *     the icon buttons and connection label out as a single row, ordered
  *     left→right as [Admin] [NotificationBell] [Quota] [Theme] with the
- *     connection pill pushed to the right edge (`justify-between`). It uses a
- *     soft blue-tinted background (distinct from the sidebar's neutral gray) so
- *     the dock reads as a separate strip rather than blending into the panel.
+ *     connection pill pushed to the right edge (`justify-between`). It uses the
+ *     shell's neutral chrome background (matching the topbar/bottom-nav) with a
+ *     top border, so the dock reads as part of the shell chrome and is set off
+ *     from the sidebar body by the border rather than a colored tint.
  *     The bell/quota popovers open upward (`placement="up"`) since the dock
  *     sits at the bottom edge of the viewport.
  *
@@ -71,10 +72,10 @@ export function StatusActions({ variant = 'topbar', onAdminOpen }: StatusActions
     if (variant === 'sidebar') {
         return (
             <div
-                className="flex flex-shrink-0 items-center justify-between gap-1 px-2 py-1.5 border-t border-[#b9d2f2] dark:border-[#34496b] bg-[#dbe8fa] dark:bg-[#23324a]"
+                className="flex flex-shrink-0 items-center justify-between gap-1 px-2.5 py-1.5 border-t border-[#e0e0e0] dark:border-[#3c3c3c] bg-[#f3f3f3] dark:bg-[#252526]"
                 data-testid="sidebar-status-actions"
             >
-                <span className="flex items-center gap-0.5 flex-shrink-0">
+                <span className="flex items-center gap-1 flex-shrink-0">
                     <button
                         data-tab="admin"
                         className={

--- a/packages/coc/src/server/spa/client/react/repos/MyLifeView.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/MyLifeView.tsx
@@ -160,6 +160,7 @@ export function MyLifeView() {
                     <NotesView
                         workspaceId={MY_LIFE_WORKSPACE_ID}
                         initialNotePath={state.selectedNotePath}
+                        active={activeTab === 'notes'}
                     />
                 </div>
                 <div style={{ display: activeTab === 'git' ? undefined : 'none' }} className="h-full min-w-0 overflow-hidden">

--- a/packages/coc/src/server/spa/client/react/repos/MyWorkView.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/MyWorkView.tsx
@@ -161,6 +161,7 @@ export function MyWorkView() {
                         workspaceId={MY_WORK_WORKSPACE_ID}
                         initialNotePath={state.selectedNotePath}
                         defaultScope="per-workspace"
+                        active={activeTab === 'notes'}
                     />
                 </div>
                 <div style={{ display: activeTab === 'git' ? undefined : 'none' }} className="h-full min-w-0 overflow-hidden">

--- a/packages/coc/test/server/queued-process-not-found.test.ts
+++ b/packages/coc/test/server/queued-process-not-found.test.ts
@@ -140,6 +140,50 @@ describe('Queued process synthetic response', () => {
             const body = JSON.parse(res.body);
             expect(body.process.workingDirectory).toBe('/custom/path');
         });
+
+        it('should carry the chat mode in synthetic metadata so a fresh autopilot chat does not fall back to ask', async () => {
+            const mockBridge = createMockBridge({
+                getTask: vi.fn().mockReturnValue({
+                    id: 'task-autopilot',
+                    type: 'chat',
+                    status: 'queued',
+                    priority: 'normal',
+                    createdAt: 1700000000000,
+                    payload: { kind: 'chat', mode: 'autopilot', prompt: 'do it', workspaceId: 'ws-1' },
+                    config: {},
+                }),
+            });
+            await startWithBridge(mockBridge);
+
+            const res = await getJSON(`${baseUrl}/api/processes/queue_task-autopilot`);
+            expect(res.status).toBe(200);
+
+            const body = JSON.parse(res.body);
+            expect(body.process.metadata.mode).toBe('autopilot');
+            expect(body.process.metadata.workspaceId).toBe('ws-1');
+            expect(body.process.metadata.queueTaskId).toBe('task-autopilot');
+        });
+
+        it('should omit an invalid payload mode from synthetic metadata', async () => {
+            const mockBridge = createMockBridge({
+                getTask: vi.fn().mockReturnValue({
+                    id: 'task-badmode',
+                    type: 'chat',
+                    status: 'queued',
+                    priority: 'normal',
+                    createdAt: 1700000000000,
+                    payload: { kind: 'chat', mode: 'bogus', prompt: 'hi' },
+                    config: {},
+                }),
+            });
+            await startWithBridge(mockBridge);
+
+            const res = await getJSON(`${baseUrl}/api/processes/queue_task-badmode`);
+            expect(res.status).toBe(200);
+
+            const body = JSON.parse(res.body);
+            expect(body.process.metadata.mode).toBeUndefined();
+        });
     });
 
     describe('GET /api/processes/:id/output', () => {

--- a/packages/coc/test/server/spa/client/repos/ChatDetail-implement-plan.test.ts
+++ b/packages/coc/test/server/spa/client/repos/ChatDetail-implement-plan.test.ts
@@ -114,6 +114,32 @@ describe('ChatDetail implement-plan handoff', () => {
         expect(between.split('\n').length).toBeLessThanOrEqual(3);
     });
 
+    // Regression: a remote report's plan path used to be enqueued on the LOCAL
+    // server as "Follow the instruction /home/.../x.plan.md." because the card
+    // never learned the source workspace was remote.
+    it('passes the source workspace remote identity to the card', () => {
+        const cardBlock = source.match(/<ImplementPlanCard[\s\S]*?\/>/);
+        expect(cardBlock).not.toBeNull();
+        const block = cardBlock![0];
+        expect(block).toContain('sourceIsRemote={sourceRemoteInfo.isRemote}');
+        expect(block).toContain('sourceBaseUrl={sourceRemoteInfo.baseUrl}');
+    });
+
+    it('derives source remote identity from repos, clone registry, and local workspace membership', () => {
+        expect(source).toContain('const sourceRemoteInfo = useMemo(');
+        expect(source).toContain('isRemoteWorkspace(repoWs)');
+        expect(source).toContain('lookupCloneBaseUrl(workspaceId)');
+        expect(source).toMatch(/appState\.workspaces\.some\(\(ws: any\) => ws\?\.id === workspaceId\)/);
+    });
+
+    it('feeds the current workspace remote identity into buildImplementTargets', () => {
+        const call = source.match(/buildImplementTargets\(reposCtx\.repos,\s*\{[\s\S]*?\}\)/);
+        expect(call).not.toBeNull();
+        expect(call![0]).toContain('isRemote: sourceRemoteInfo.isRemote');
+        expect(call![0]).toContain('baseUrl: sourceRemoteInfo.baseUrl');
+        expect(call![0]).toContain('serverLabel: sourceRemoteInfo.serverLabel');
+    });
+
     it('resolves implementation runs from task metadata', () => {
         expect(source).toContain('rawImplementations');
         expect(source).toContain('task?.metadata?.implementations');

--- a/packages/coc/test/server/spa/client/repos/ImplementPlanCard.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/ImplementPlanCard.test.tsx
@@ -569,6 +569,145 @@ describe('ImplementPlanCard', () => {
         await waitFor(() => expect(onImplemented).toHaveBeenCalledWith('queue_task-remote'));
     });
 
+    // ── Remote-sourced plans (regression: remote plan path leaked into a ──
+    // ── local task as "Follow the instruction /home/.../x.plan.md.") ─────
+
+    it('inlines a remote-sourced plan and routes to the source server when no targets are supplied', async () => {
+        mockRemoteReadTrustedBlob.mockResolvedValue({
+            content: '# Plan\nRemote-sourced work.',
+            encoding: 'utf-8',
+            mimeType: 'text/markdown',
+        });
+        mockRemoteEnqueue.mockResolvedValue({ task: { id: 'task-src-remote' } });
+
+        render(
+            <ImplementPlanCard
+                planFilePath="/home/remote-user/.coc/repos/ws-remote/notes/x.plan.md"
+                workspaceId="ws-remote"
+                workingDirectory="/home/remote-user/repo"
+                sourceIsRemote
+                sourceBaseUrl="http://127.0.0.1:4000"
+                onImplemented={onImplemented}
+            />,
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('implement-plan-card-btn'));
+        });
+
+        // Plan read and enqueue both route to the source's remote server.
+        await waitFor(() => expect(mockRemoteReadTrustedBlob).toHaveBeenCalledWith('/home/remote-user/.coc/repos/ws-remote/notes/x.plan.md'));
+        await waitFor(() => expect(mockRemoteEnqueue).toHaveBeenCalledTimes(1));
+        // The local client is never touched — no phantom local task.
+        expect(mockEnqueue).not.toHaveBeenCalled();
+        expect(mockReadTrustedBlob).not.toHaveBeenCalled();
+
+        const payload = mockRemoteEnqueue.mock.calls[0][0];
+        expect(payload.payload.workspaceId).toBe('ws-remote');
+        expect(payload.payload.workingDirectory).toBe('/home/remote-user/repo');
+        // Content is inlined; no machine-local file reference in the payload.
+        expect(payload.payload.context).toBeUndefined();
+        expect(payload.payload.prompt).toContain('Remote-sourced work.');
+        expect(payload.payload.prompt).toContain('BEGIN PLAN');
+    });
+
+    it('inlines a remote-sourced plan even when the target list mislabels the source as local', async () => {
+        // Shape produced by the old buildImplementTargets fallback: the current
+        // (remote) workspace re-added with isRemote:false and no baseUrl.
+        const mislabeledSource: ImplementTarget = {
+            workspaceId: 'ws-remote',
+            label: 'my-app',
+            isRemote: false,
+            workingDirectory: '/home/remote-user/repo',
+        };
+        mockRemoteReadTrustedBlob.mockResolvedValue({ content: 'plan body', encoding: 'utf-8', mimeType: 'text/markdown' });
+        mockRemoteEnqueue.mockResolvedValue({ task: { id: 'task-mislabeled' } });
+        mockProcessUpdate.mockResolvedValue({ process: {} });
+
+        render(
+            <ImplementPlanCard
+                planFilePath="/home/remote-user/notes/x.plan.md"
+                workspaceId="ws-remote"
+                workingDirectory="/home/remote-user/repo"
+                sourceIsRemote
+                sourceBaseUrl="http://127.0.0.1:4000"
+                onImplemented={onImplemented}
+                sourceProcessId="queue_source-1"
+                sourceMetadata={{ type: 'chat' }}
+                onRecordPersisted={onRecordPersisted}
+                availableTargets={[mislabeledSource]}
+            />,
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('implement-plan-card-btn'));
+        });
+
+        await waitFor(() => expect(mockRemoteEnqueue).toHaveBeenCalledTimes(1));
+        expect(mockEnqueue).not.toHaveBeenCalled();
+
+        const payload = mockRemoteEnqueue.mock.calls[0][0];
+        expect(payload.payload.context).toBeUndefined();
+        expect(payload.payload.prompt).toContain('BEGIN PLAN');
+
+        // The run stays on the source's remote server, so the record marks it remote.
+        await waitFor(() => expect(mockRemoteUpdate).toHaveBeenCalledTimes(1));
+        const rec = mockRemoteUpdate.mock.calls[0][1].set.implementations[0];
+        expect(rec.isRemoteTarget).toBe(true);
+    });
+
+    it('fails loudly instead of enqueuing when a remote-sourced plan cannot be read', async () => {
+        // Source is remote but no baseUrl is known (unreachable/unregistered), so
+        // the source read falls back to the local client and fails — previously
+        // this silently enqueued a broken path-reference task on the local server.
+        mockReadTrustedBlob.mockRejectedValue(new Error('File does not exist'));
+
+        render(
+            <ImplementPlanCard
+                planFilePath="/home/remote-user/notes/x.plan.md"
+                workspaceId="ws-remote"
+                workingDirectory="/home/remote-user/repo"
+                sourceIsRemote
+                onImplemented={onImplemented}
+            />,
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('implement-plan-card-btn'));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('implement-plan-card-error').textContent)
+                .toContain('Could not read the plan file');
+        });
+        expect(mockEnqueue).not.toHaveBeenCalled();
+        expect(mockRemoteEnqueue).not.toHaveBeenCalled();
+        expect(onImplemented).not.toHaveBeenCalled();
+    });
+
+    it('keeps the path-based local enqueue when sourceIsRemote is false', async () => {
+        mockEnqueue.mockResolvedValue({ task: { id: 'task-local' } });
+
+        render(
+            <ImplementPlanCard
+                planFilePath="/repo/plan.md"
+                workspaceId="ws-local"
+                workingDirectory="/repo"
+                sourceIsRemote={false}
+                onImplemented={onImplemented}
+            />,
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('implement-plan-card-btn'));
+        });
+
+        await waitFor(() => expect(mockEnqueue).toHaveBeenCalledTimes(1));
+        const payload = mockEnqueue.mock.calls[0][0];
+        expect(payload.payload.context.files).toEqual(['/repo/plan.md']);
+        expect(payload.payload.prompt).toBe('Read and implement the plan file at /repo/plan.md');
+    });
+
     // ── Canvas-backed plans (purpose: 'plan') ───────────────────────────
 
     it('reads the canvas content and embeds it inline for a local run', async () => {

--- a/packages/coc/test/server/spa/client/repos/implementTargets.test.ts
+++ b/packages/coc/test/server/spa/client/repos/implementTargets.test.ts
@@ -147,6 +147,41 @@ describe('buildImplementTargets', () => {
         expect(targets.filter(t => t.workspaceId === 'ws-current')).toHaveLength(1);
     });
 
+    // Regression: the synthesized fallback used to hardcode isRemote:false, so a
+    // remote-sourced plan (current workspace = remote clone missing from the repo
+    // list) was treated as local and its machine-local path leaked into a task
+    // enqueued on the wrong server.
+    it('synthesizes a REMOTE current target when the caller marks the current workspace remote', () => {
+        const targets = buildImplementTargets([], {
+            workspaceId: 'ws-remote-current',
+            label: 'remote-app',
+            workingDirectory: '/home/user/repo',
+            isRemote: true,
+            baseUrl: 'http://127.0.0.1:4000',
+            serverLabel: 'dev-vm',
+        });
+        expect(targets[0]).toMatchObject({
+            workspaceId: 'ws-remote-current',
+            label: 'remote-app',
+            workingDirectory: '/home/user/repo',
+            isRemote: true,
+            baseUrl: 'http://127.0.0.1:4000',
+            serverLabel: 'dev-vm',
+        });
+    });
+
+    it('ignores remote routing metadata in the fallback when the current workspace is local', () => {
+        const targets = buildImplementTargets([], {
+            workspaceId: 'ws-current',
+            label: 'current-app',
+            baseUrl: 'http://127.0.0.1:4000',
+            serverLabel: 'dev-vm',
+        });
+        expect(targets[0]).toMatchObject({ workspaceId: 'ws-current', isRemote: false });
+        expect(targets[0].baseUrl).toBeUndefined();
+        expect(targets[0].serverLabel).toBeUndefined();
+    });
+
     describe('same-origin scoping', () => {
         const ORIGIN = 'https://github.com/acme/shortcuts.git';
 

--- a/packages/coc/test/server/spa/client/terminal-view-picker.test.tsx
+++ b/packages/coc/test/server/spa/client/terminal-view-picker.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Behavioural tests for the compact terminal picker: the terminal list
+ * collapses into a "Terminal N ▾" dropdown so a narrow dock never overflows
+ * with a horizontal tab strip. Covers open/switch/close/new/rename/badge and
+ * the menu-dismiss paths (Escape + outside click).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+// xterm.js does not run in jsdom — render a lightweight stand-in.
+vi.mock('../../../../src/server/spa/client/react/features/terminal/TerminalPanel', () => ({
+    TerminalPanel: ({ sessionId }: { sessionId: string }) => (
+        <div data-testid={`mock-terminal-panel-${sessionId}`}>mock terminal</div>
+    ),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
+    getApiBase: () => '/api',
+    isRalphEnabled: () => false,
+}));
+
+let uuidCounter = 0;
+vi.stubGlobal('crypto', {
+    randomUUID: () => `test-uuid-${++uuidCounter}`,
+});
+
+// Pinned-terminal hydration fetch resolves with no sessions.
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue({ sessions: [] }),
+}));
+
+import { TerminalView } from '../../../../src/server/spa/client/react/features/terminal/TerminalView';
+
+describe('TerminalView compact picker', () => {
+    beforeEach(() => {
+        uuidCounter = 0;
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    /** Render and create `n` terminals via the toolbar + button. */
+    function renderAndCreate(n: number) {
+        render(<TerminalView workspaceId="ws1" />);
+        for (let i = 0; i < n; i++) {
+            fireEvent.click(screen.getByTestId('terminal-new-btn'));
+        }
+    }
+
+    it('shows "No terminals" and no picker before any terminal exists', () => {
+        render(<TerminalView workspaceId="ws1" />);
+        expect(screen.getByTestId('terminal-empty-state')).toBeTruthy();
+        expect(screen.getByText('No terminals')).toBeTruthy();
+        expect(screen.queryByTestId('terminal-picker-btn')).toBeNull();
+    });
+
+    it('shows the active terminal in the picker button once created', () => {
+        renderAndCreate(1);
+        const btn = screen.getByTestId('terminal-picker-btn');
+        expect(btn).toBeTruthy();
+        expect(btn.getAttribute('data-menu-open')).toBe('false');
+        expect(screen.getByTestId('terminal-tab-title-test-uuid-1').textContent).toBe('Terminal 1');
+    });
+
+    it('hides the count badge for one terminal and shows it for multiple', () => {
+        renderAndCreate(1);
+        expect(screen.queryByTestId('terminal-count-badge')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('terminal-new-btn'));
+        expect(screen.getByTestId('terminal-count-badge').textContent).toBe('2');
+    });
+
+    it('opens the menu and lists every terminal', () => {
+        renderAndCreate(2);
+        expect(screen.queryByTestId('terminal-picker-menu')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('terminal-picker-btn'));
+
+        expect(screen.getByTestId('terminal-picker-menu')).toBeTruthy();
+        expect(screen.getByTestId('terminal-menu-item-test-uuid-1')).toBeTruthy();
+        expect(screen.getByTestId('terminal-menu-item-test-uuid-2')).toBeTruthy();
+        // Newest terminal is active.
+        expect(screen.getByTestId('terminal-menu-item-test-uuid-2').getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('switches the active terminal from the menu and closes it', () => {
+        renderAndCreate(2);
+        fireEvent.click(screen.getByTestId('terminal-picker-btn'));
+
+        fireEvent.click(screen.getByTestId('terminal-menu-item-test-uuid-1'));
+
+        expect(screen.queryByTestId('terminal-picker-menu')).toBeNull();
+        // Picker button now reflects uuid-1 as active.
+        expect(screen.getByTestId('terminal-tab-title-test-uuid-1')).toBeTruthy();
+    });
+
+    it('creates a new terminal from the menu footer and closes the menu', () => {
+        renderAndCreate(1);
+        fireEvent.click(screen.getByTestId('terminal-picker-btn'));
+
+        fireEvent.click(screen.getByTestId('terminal-menu-new'));
+
+        expect(screen.queryByTestId('terminal-picker-menu')).toBeNull();
+        expect(screen.getByTestId('terminal-count-badge').textContent).toBe('2');
+        // The freshly created terminal (uuid-2) is active.
+        expect(screen.getByTestId('terminal-tab-title-test-uuid-2')).toBeTruthy();
+    });
+
+    it('closes a terminal from the menu without dismissing the menu', () => {
+        renderAndCreate(2);
+        fireEvent.click(screen.getByTestId('terminal-picker-btn'));
+
+        fireEvent.click(screen.getByTestId('terminal-tab-close-test-uuid-1'));
+
+        expect(screen.getByTestId('terminal-picker-menu')).toBeTruthy();
+        expect(screen.queryByTestId('terminal-menu-item-test-uuid-1')).toBeNull();
+        expect(screen.getByTestId('terminal-menu-item-test-uuid-2')).toBeTruthy();
+    });
+
+    it('renames the active terminal via double-click without opening the menu', () => {
+        renderAndCreate(1);
+
+        fireEvent.doubleClick(screen.getByTestId('terminal-tab-title-test-uuid-1'));
+
+        expect(screen.queryByTestId('terminal-picker-menu')).toBeNull();
+        const input = screen.getByTestId('terminal-tab-rename-input-test-uuid-1');
+        fireEvent.change(input, { target: { value: 'api' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        expect(screen.getByTestId('terminal-tab-title-test-uuid-1').textContent).toBe('api');
+    });
+
+    it('dismisses the menu on Escape', () => {
+        renderAndCreate(1);
+        fireEvent.click(screen.getByTestId('terminal-picker-btn'));
+        expect(screen.getByTestId('terminal-picker-menu')).toBeTruthy();
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        expect(screen.queryByTestId('terminal-picker-menu')).toBeNull();
+    });
+
+    it('dismisses the menu when clicking outside the toolbar', () => {
+        renderAndCreate(1);
+        fireEvent.click(screen.getByTestId('terminal-picker-btn'));
+        expect(screen.getByTestId('terminal-picker-menu')).toBeTruthy();
+
+        fireEvent.mouseDown(document.body);
+
+        expect(screen.queryByTestId('terminal-picker-menu')).toBeNull();
+    });
+});

--- a/packages/coc/test/server/spa/client/terminal-view-pin.test.tsx
+++ b/packages/coc/test/server/spa/client/terminal-view-pin.test.tsx
@@ -146,7 +146,16 @@ describe('TerminalView pin/unpin', () => {
         return { result, fetchMock };
     }
 
+    /** Terminal pin/close controls live in the compact picker dropdown; open it (idempotent). */
+    function openMenu() {
+        const btn = screen.getByTestId('terminal-picker-btn');
+        if (btn.getAttribute('data-menu-open') !== 'true') {
+            fireEvent.click(btn);
+        }
+    }
+
     async function waitForServerSession(tabId: string) {
+        openMenu();
         await waitFor(() => {
             expect(screen.getByTestId(`terminal-tab-pin-${tabId}`).title).toBe('Pin terminal');
         });
@@ -154,6 +163,7 @@ describe('TerminalView pin/unpin', () => {
 
     it('renders pin button on terminal tab', () => {
         renderAndCreate();
+        openMenu();
         const pinBtn = screen.getByTestId('terminal-tab-pin-test-uuid-1');
         expect(pinBtn).toBeTruthy();
         expect(pinBtn.textContent).toBe('📌');
@@ -207,6 +217,7 @@ describe('TerminalView pin/unpin', () => {
     it('ignores pin clicks until the tab has a server session id', () => {
         terminalPanelMockState.autoCreateSessions = false;
         const { fetchMock } = renderAndCreate();
+        openMenu();
 
         const pinBtn = screen.getByTestId('terminal-tab-pin-test-uuid-1');
         expect(pinBtn.title).toBe('Waiting for terminal session');
@@ -220,14 +231,15 @@ describe('TerminalView pin/unpin', () => {
         fireEvent.click(screen.getByTestId('terminal-new-btn'));
         await waitForServerSession('test-uuid-1');
 
-        expect(screen.getByTestId('terminal-tab-test-uuid-2').className).toContain('font-medium');
+        // The newest terminal (uuid-2) is the active one in the picker.
+        expect(screen.getByTestId('terminal-menu-item-test-uuid-2').getAttribute('aria-checked')).toBe('true');
 
         fireEvent.click(screen.getByTestId('terminal-tab-pin-test-uuid-1'));
 
         await waitFor(() => {
             expect(screen.getByTestId('terminal-tab-pin-test-uuid-1').className).toContain('opacity-80');
         });
-        expect(screen.getByTestId('terminal-tab-test-uuid-2').className).toContain('font-medium');
+        expect(screen.getByTestId('terminal-menu-item-test-uuid-2').getAttribute('aria-checked')).toBe('true');
     });
 
     it('multiple tabs can be pinned independently through their own server sessions', async () => {
@@ -254,7 +266,9 @@ describe('TerminalView pin/unpin', () => {
         mockTerminalFetch({ sessions: [makeSession('sess-pinned', true)] });
         render(<TerminalView workspaceId="ws1" />);
 
-        const hydratedPin = await screen.findByTestId('terminal-tab-pin-server-sess-pinned');
+        await screen.findByTestId('terminal-picker-btn');
+        openMenu();
+        const hydratedPin = screen.getByTestId('terminal-tab-pin-server-sess-pinned');
         expect(hydratedPin.className).toContain('opacity-80');
 
         fireEvent.click(hydratedPin);

--- a/packages/coc/test/spa/react/RepoGitTab.test.ts
+++ b/packages/coc/test/spa/react/RepoGitTab.test.ts
@@ -607,6 +607,26 @@ describe('RepoGitTab', () => {
             expect(source).toContain('compact={headerHoisted}');
         });
 
+        // Regression: portaled React events still bubble through the REACT tree,
+        // so if the hoisted toolbar portal is a child of the onClickCapture list
+        // wrapper, clicking Pull/refresh in the section header marks git as
+        // last-clicked and steals the shared detail pane from the chat.
+        it('keeps the hoisted toolbar portal OUTSIDE the onClickCapture list wrapper', () => {
+            // Portal is built once, gated on the hoist condition.
+            expect(source).toContain('const hoistedHeaderPortal = headerHoisted && headerToolbarContainer');
+            // The list pane only renders the toolbar inline when NOT hoisted.
+            expect(source).toContain('{!headerHoisted && panelHeader}');
+            // The capture wrapper (git-split-workspace-list) must not contain the
+            // portal; it renders as a sibling after the wrapper closes.
+            const captureWrapper = source.match(/data-testid="git-split-workspace-list"[\s\S]*?\{listPane\}\s*<\/div>/);
+            expect(captureWrapper).toBeTruthy();
+            expect(captureWrapper![0]).not.toContain('hoistedHeaderPortal');
+            const splitBlock = source.match(/if \(isSplitWorkspace\) \{[\s\S]*?\n {4}\}/);
+            expect(splitBlock).toBeTruthy();
+            const wrapperEnd = splitBlock![0].indexOf('{listPane}');
+            expect(splitBlock![0].indexOf('{hoistedHeaderPortal}')).toBeGreaterThan(wrapperEnd);
+        });
+
         it('slims the search bar in split mode (shorter placeholder, tighter padding), full hint kept in aria-label', () => {
             expect(source).toContain("isSplitWorkspace ? 'Search commits…' : 'Search subject, hash, author, path…'");
             expect(source).toContain("isSplitWorkspace ? 'px-2 py-1' : 'px-2.5 py-1.5'");

--- a/packages/coc/test/spa/react/hooks/useWorkspaceLeftColWidth.test.tsx
+++ b/packages/coc/test/spa/react/hooks/useWorkspaceLeftColWidth.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * usePublishWorkspaceLeftColWidth — publishes a left-column width to the
+ * `--workspace-left-col-width` CSS variable so the app-shell GlobalStatusDock
+ * can size its bottom bar flush under the current view's left panel.
+ *
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+    usePublishWorkspaceLeftColWidth,
+    WORKSPACE_LEFT_COL_WIDTH_VAR,
+} from '../../../../src/server/spa/client/react/hooks/ui/useWorkspaceLeftColWidth';
+
+const readVar = () => document.documentElement.style.getPropertyValue(WORKSPACE_LEFT_COL_WIDTH_VAR);
+
+function Harness({ width, disabled }: { width: number; disabled: boolean }) {
+    usePublishWorkspaceLeftColWidth(width, disabled);
+    return null;
+}
+
+beforeEach(() => {
+    document.documentElement.style.removeProperty(WORKSPACE_LEFT_COL_WIDTH_VAR);
+});
+
+describe('usePublishWorkspaceLeftColWidth', () => {
+    it('publishes the width in px while enabled', () => {
+        render(<Harness width={280} disabled={false} />);
+        expect(readVar()).toBe('280px');
+    });
+
+    it('does not publish (and clears) while disabled', () => {
+        document.documentElement.style.setProperty(WORKSPACE_LEFT_COL_WIDTH_VAR, '999px');
+        render(<Harness width={280} disabled={true} />);
+        expect(readVar()).toBe('');
+    });
+
+    it('tracks width changes', () => {
+        const { rerender } = render(<Harness width={280} disabled={false} />);
+        expect(readVar()).toBe('280px');
+        rerender(<Harness width={321} disabled={false} />);
+        expect(readVar()).toBe('321px');
+    });
+
+    it('clears when it flips from enabled to disabled (e.g. tab becomes inactive)', () => {
+        const { rerender } = render(<Harness width={280} disabled={false} />);
+        expect(readVar()).toBe('280px');
+        rerender(<Harness width={280} disabled={true} />);
+        expect(readVar()).toBe('');
+    });
+
+    it('clears the variable on unmount so the dock falls back', () => {
+        const { unmount } = render(<Harness width={280} disabled={false} />);
+        expect(readVar()).toBe('280px');
+        unmount();
+        expect(readVar()).toBe('');
+    });
+});

--- a/packages/coc/test/spa/react/layout/GlobalStatusDock.test.tsx
+++ b/packages/coc/test/spa/react/layout/GlobalStatusDock.test.tsx
@@ -65,6 +65,26 @@ describe('GlobalStatusDock', () => {
         expect(wrapper.className).toContain('flex-shrink-0');
     });
 
+    it('pins its width to the admin sidebar (248px) on the admin tab so it stays flush, not overhanging', () => {
+        mockAppState = { activeTab: 'admin', selectedRepoId: null, activeRepoSubTab: undefined };
+        render(<GlobalStatusDock />);
+        const wrapper = screen.getByTestId('global-status-dock');
+        // The admin shell renders its own fixed 248px sidebar and never publishes
+        // --workspace-left-col-width; using the (wider) workspace column here made
+        // the dock overhang past the sidebar into the content pane.
+        expect(wrapper.style.width).toBe('248px');
+        expect(wrapper.style.width).not.toContain('--workspace-left-col-width');
+    });
+
+    it('pins to the admin sidebar width on every tab that mounts the admin shell', () => {
+        for (const tab of ['admin', 'memory', 'skills', 'logs', 'stats', 'servers', 'dreams-admin']) {
+            mockAppState = { activeTab: tab, selectedRepoId: null, activeRepoSubTab: undefined };
+            const { unmount } = render(<GlobalStatusDock />);
+            expect(screen.getByTestId('global-status-dock').style.width).toBe('248px');
+            unmount();
+        }
+    });
+
     it('forwards onAdminOpen to StatusActions', () => {
         const onAdminOpen = vi.fn();
         render(<GlobalStatusDock onAdminOpen={onAdminOpen} />);

--- a/packages/coc/test/spa/react/layout/StatusActions.test.tsx
+++ b/packages/coc/test/spa/react/layout/StatusActions.test.tsx
@@ -120,16 +120,19 @@ describe('StatusActions — sidebar variant', () => {
         expect(screen.getByTestId('sidebar-admin-toggle').className).toContain('bg-[#0078d4]');
     });
 
-    it('uses a distinct blue-tinted dock background (not the sidebar gray)', () => {
+    it('uses the shell chrome background set off by a top border (no colored tint)', () => {
         render(<StatusActions variant="sidebar" />);
         const dock = screen.getByTestId('sidebar-status-actions');
-        // The dock must stand apart from the sidebar body, so it must NOT reuse
-        // the neutral panel gray and must carry its own tinted background/border.
-        expect(dock.className).not.toContain('bg-[#f3f3f3]');
-        expect(dock.className).not.toContain('dark:bg-[#252526]');
-        expect(dock.className).toContain('bg-[#dbe8fa]');
-        expect(dock.className).toContain('dark:bg-[#23324a]');
-        expect(dock.className).toContain('border-[#b9d2f2]');
-        expect(dock.className).toContain('dark:border-[#34496b]');
+        // The dock reads as part of the shell chrome: it reuses the neutral
+        // topbar/bottom-nav background and is separated from the sidebar body by
+        // a top border, not a blue tint that clashes with the dark theme.
+        expect(dock.className).toContain('bg-[#f3f3f3]');
+        expect(dock.className).toContain('dark:bg-[#252526]');
+        expect(dock.className).toContain('border-t');
+        expect(dock.className).toContain('border-[#e0e0e0]');
+        expect(dock.className).toContain('dark:border-[#3c3c3c]');
+        // The old blue-tinted fill/border must be gone.
+        expect(dock.className).not.toContain('bg-[#dbe8fa]');
+        expect(dock.className).not.toContain('dark:bg-[#23324a]');
     });
 });

--- a/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatDetail.test.tsx
@@ -925,6 +925,106 @@ describe('ChatDetail', () => {
             expect(screen.getByTestId('mode-pill-ask').getAttribute('aria-checked')).toBe('true');
             expect(screen.getByTestId('mode-pill-autopilot').getAttribute('aria-checked')).toBe('false');
         });
+
+        // Regression: a freshly enqueued autopilot chat's first /processes/
+        // snapshot is a synthetic queued process. If that snapshot carries no
+        // mode, the composer must still sync to autopilot when a later
+        // snapshot (queue refresh / real process record) delivers the mode —
+        // previously the sync only ran once per task id and the composer
+        // stayed stuck on the default ask mode.
+        it('syncs to autopilot when the mode only arrives on a later task snapshot', async () => {
+            const taskId = 'queue_task-fresh';
+            let processCalls = 0;
+            const syntheticProcess = {
+                id: taskId,
+                type: 'chat',
+                status: 'queued',
+                metadata: { type: 'chat', queueTaskId: 'task-fresh' },
+                conversationTurns: [],
+            };
+            const realProcess = makeProcess({
+                id: taskId,
+                status: 'running',
+                metadata: { mode: 'autopilot', sessionId: 'sess-fresh' },
+            });
+            setupFetch({
+                '/skills/all': { body: { merged: [] } },
+                '/processes/': () => {
+                    processCalls += 1;
+                    const p = processCalls === 1 ? syntheticProcess : realProcess;
+                    return new Response(JSON.stringify({ process: p, children: [], total: 0 }), {
+                        status: 200,
+                        headers: { 'content-type': 'application/json' },
+                    });
+                },
+                '/models': { body: [] },
+            });
+
+            const refreshRef = createRef<() => void>();
+            function FreshChatHarness() {
+                const { dispatch } = useQueue();
+                useEffect(() => {
+                    (refreshRef as React.MutableRefObject<(() => void) | null>).current =
+                        () => dispatch({ type: 'REFRESH_SELECTED_QUEUE_TASK' });
+                }, [dispatch]);
+                return <ChatDetail taskId={taskId} />;
+            }
+            render(<Wrap><FreshChatHarness /></Wrap>);
+
+            // First snapshot (synthetic, no mode) loaded — chat is pending, no composer yet
+            await waitFor(() => {
+                expect(processCalls).toBeGreaterThanOrEqual(1);
+            });
+
+            // Second snapshot delivers the real process with metadata.mode
+            await act(async () => {
+                refreshRef.current?.();
+            });
+            await waitFor(() => {
+                expect(screen.getByTestId('mode-pill-autopilot').getAttribute('aria-checked')).toBe('true');
+            });
+        });
+
+        it('does not clobber a user-picked mode when a later task snapshot repeats the task mode', async () => {
+            const taskId = 'queue_task-user-pick';
+            const proc = makeProcess({
+                id: taskId,
+                metadata: { mode: 'autopilot', sessionId: 'sess-user-pick' },
+            });
+            setupFetch({
+                '/skills/all': { body: { merged: [] } },
+                '/processes/': { body: { process: proc, children: [], total: 0 } },
+                '/models': { body: [] },
+            });
+
+            const refreshRef = createRef<() => void>();
+            function UserPickHarness() {
+                const { dispatch } = useQueue();
+                useEffect(() => {
+                    (refreshRef as React.MutableRefObject<(() => void) | null>).current =
+                        () => dispatch({ type: 'REFRESH_SELECTED_QUEUE_TASK' });
+                }, [dispatch]);
+                return <ChatDetail taskId={taskId} />;
+            }
+            render(<Wrap><UserPickHarness /></Wrap>);
+
+            // Initial sync lands on autopilot from the loaded process
+            await waitFor(() => {
+                expect(screen.getByTestId('mode-pill-autopilot').getAttribute('aria-checked')).toBe('true');
+            });
+
+            // User flips the composer to ask
+            fireEvent.click(screen.getByTestId('mode-pill-ask'));
+            expect(screen.getByTestId('mode-pill-ask').getAttribute('aria-checked')).toBe('true');
+
+            // A refresh re-delivers the same autopilot task — must NOT reset the pick
+            await act(async () => {
+                refreshRef.current?.();
+            });
+            await waitFor(() => {
+                expect(screen.getByTestId('mode-pill-ask').getAttribute('aria-checked')).toBe('true');
+            });
+        });
     });
 
     // ── Follow-up send ─────────────────────────────────────────────────────

--- a/packages/coc/test/spa/react/repos/ChatListPane-scheduled-scope.test.tsx
+++ b/packages/coc/test/spa/react/repos/ChatListPane-scheduled-scope.test.tsx
@@ -251,8 +251,11 @@ describe('ChatListPane Scheduled scope', () => {
             render(<ChatListPane {...defaultProps} history={[makeTask()]} />);
         });
         const tab = screen.getByTestId('activity-scope-tab-loops');
-        expect(tab.textContent).toContain('Scheduled');
+        // Label is accessible via title and aria-label, not visible text content.
+        expect(tab.getAttribute('title')).toBe('Scheduled');
+        expect(tab.getAttribute('aria-label')).toContain('Scheduled');
         expect(tab.textContent).not.toContain('Loops');
+        expect(tab.textContent).not.toContain('Scheduled');
     });
 
     it('excludes scheduled runs from Chats count and includes them in Scheduled count', async () => {

--- a/packages/coc/test/spa/react/repos/notes/NotesView-statusdock-width.test.tsx
+++ b/packages/coc/test/spa/react/repos/notes/NotesView-statusdock-width.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * NotesView publishes its sidebar width to the app-shell status dock.
+ *
+ * The GlobalStatusDock sizes its bottom bar to `--workspace-left-col-width`.
+ * NotesView has its own (narrower) resizable tree sidebar, so it must publish
+ * that width while it is the ACTIVE Notes tab — otherwise the dock keeps the
+ * wider workspace default and overhangs past the notes sidebar into the editor.
+ * Because tabs stay mounted-but-hidden, an inactive Notes tab must NOT own the
+ * variable, and mobile (drawer sidebar) must clear it.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import type { NoteTreeNode, NotesRootEntry } from '../../../../../src/server/spa/client/react/features/notes/notesApi';
+import { NotesView } from '../../../../../src/server/spa/client/react/features/notes/NotesView';
+
+const VAR = '--workspace-left-col-width';
+const readVar = () => document.documentElement.style.getPropertyValue(VAR);
+
+const mocks = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    listRoots: vi.fn(),
+    getTree: vi.fn(),
+    getGitStatus: vi.fn(),
+    getComments: vi.fn(),
+    addToast: vi.fn(),
+    isMobile: false,
+}));
+
+vi.mock('../../../../../src/server/spa/client/react/contexts/AppContext', () => ({
+    useApp: () => ({ state: {}, dispatch: mocks.dispatch }),
+}));
+vi.mock('../../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
+    useBreakpoint: () => ({ isMobile: mocks.isMobile, isTablet: false, isDesktop: !mocks.isMobile, breakpoint: mocks.isMobile ? 'mobile' : 'desktop' }),
+}));
+vi.mock('../../../../../src/server/spa/client/react/contexts/ToastContext', () => ({
+    useGlobalToast: () => ({ addToast: mocks.addToast, removeToast: vi.fn(), toasts: [] }),
+}));
+vi.mock('../../../../../src/server/spa/client/react/features/notes/notesApi', () => ({
+    notesApi: {
+        listRoots: (...args: any[]) => mocks.listRoots(...args),
+        getTree: (...args: any[]) => mocks.getTree(...args),
+        getGitStatus: (...args: any[]) => mocks.getGitStatus(...args),
+        getComments: (...args: any[]) => mocks.getComments(...args),
+    },
+}));
+vi.mock('../../../../../src/server/spa/client/react/features/notes/editor/NoteEditor', async () => {
+    const React = await import('react');
+    return { NoteEditor: () => React.createElement('div', { 'data-testid': 'mock-note-editor' }) };
+});
+vi.mock('../../../../../src/server/spa/client/react/features/notes/editor/NoteChatPanel', async () => {
+    const React = await import('react');
+    return { NoteChatPanel: () => React.createElement('div', { 'data-testid': 'mock-note-chat-panel' }) };
+});
+vi.mock('../../../../../src/server/spa/client/react/features/notes/editor/CommentsSidebar', async () => {
+    const React = await import('react');
+    return { CommentsSidebar: () => React.createElement('div', { 'data-testid': 'mock-comments-sidebar' }) };
+});
+
+const ROOTS: NotesRootEntry[] = [{ rootId: 'default', label: 'Notes', isDefault: true }];
+const TREE: NoteTreeNode[] = [{ name: 'NB', path: 'NB', type: 'notebook', children: [] }];
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    window.location.hash = '';
+    document.documentElement.style.removeProperty(VAR);
+    mocks.isMobile = false;
+    mocks.listRoots.mockResolvedValue({ roots: ROOTS });
+    mocks.getGitStatus.mockResolvedValue({ initialized: false });
+    mocks.getComments.mockResolvedValue({ threads: {} });
+    mocks.getTree.mockResolvedValue({ tree: TREE, notesRoot: '/managed/notes', systemFolders: [] });
+});
+
+describe('NotesView — publishes sidebar width to the status dock', () => {
+    it('publishes the notes sidebar width (default 280px) while active on desktop', async () => {
+        render(<NotesView workspaceId="ws1" active />);
+        await waitFor(() => expect(readVar()).toBe('280px'));
+    });
+
+    it('honors a persisted sidebar width', async () => {
+        window.localStorage.setItem('coc.notesView.sidebarWidth', '360');
+        render(<NotesView workspaceId="ws1" active />);
+        await waitFor(() => expect(readVar()).toBe('360px'));
+    });
+
+    it('does not own the variable while inactive (kept mounted-hidden on another tab)', async () => {
+        document.documentElement.style.setProperty(VAR, '640px');
+        render(<NotesView workspaceId="ws1" active={false} />);
+        await waitFor(() => expect(readVar()).toBe(''));
+    });
+
+    it('clears the variable on mobile (sidebar is a drawer, no docked bar)', async () => {
+        mocks.isMobile = true;
+        document.documentElement.style.setProperty(VAR, '640px');
+        render(<NotesView workspaceId="ws1" active />);
+        await waitFor(() => expect(readVar()).toBe(''));
+    });
+});

--- a/packages/coc/test/spa/react/split-workspace-panel/SplitWorkspacePanel.test.tsx
+++ b/packages/coc/test/spa/react/split-workspace-panel/SplitWorkspacePanel.test.tsx
@@ -293,6 +293,38 @@ describe('SplitWorkspacePanel collapsible sections', () => {
         expect(screen.getByTestId('split-workspace-git-header')).toBeTruthy();
     });
 
+    it('grows a flex spacer only when both halves are collapsed, to keep the footer at the bottom', () => {
+        render(
+            <SplitWorkspacePanel
+                workspaceId="ws-spacer"
+                chatList={<div data-testid="chat-content">chat</div>}
+                gitList={<div data-testid="git-content">git</div>}
+                detail={<div data-testid="detail-content">detail</div>}
+                footer={<div data-testid="my-footer">footer</div>}
+            />,
+        );
+        // Both expanded: an open half already fills the column, so no spacer.
+        expect(screen.queryByTestId('split-workspace-spacer')).toBeNull();
+
+        // Collapse only chat: git still fills via flex-1 → still no spacer.
+        act(() => { fireEvent.click(screen.getByTestId('split-workspace-chat-header')); });
+        expect(screen.queryByTestId('split-workspace-spacer')).toBeNull();
+
+        // Collapse git too: now nothing carries flex-1, so the spacer appears
+        // to push the docked footer to the bottom-left, and sits above it.
+        act(() => { fireEvent.click(screen.getByTestId('split-workspace-git-header')); });
+        const spacer = screen.getByTestId('split-workspace-spacer');
+        expect(spacer.className).toContain('flex-1');
+        const left = screen.getByTestId('split-workspace-left');
+        const footer = screen.getByTestId('split-workspace-footer');
+        const children = Array.from(left.children);
+        expect(children.indexOf(spacer)).toBeLessThan(children.indexOf(footer));
+
+        // Re-expand git: the fill returns, so the spacer is dropped again.
+        act(() => { fireEvent.click(screen.getByTestId('split-workspace-git-header')); });
+        expect(screen.queryByTestId('split-workspace-spacer')).toBeNull();
+    });
+
     it('toggling a header expands it back and restores the divider and fixed height', () => {
         renderPanel();
         const chatHeader = () => screen.getByTestId('split-workspace-chat-header');

--- a/packages/coc/test/spa/react/workspace-right-dock/WorkspaceDockMergedHeader.test.tsx
+++ b/packages/coc/test/spa/react/workspace-right-dock/WorkspaceDockMergedHeader.test.tsx
@@ -1,0 +1,115 @@
+/** @vitest-environment jsdom */
+/**
+ * Regression guard for the single-row dock header: the terminal toolbar (picker
+ * + new-terminal action) must portal INTO the dock header next to the
+ * Terminal/Explorer tabs — not render as a second stacked row. Renders the real
+ * WorkspaceRightDock + TerminalView together (only xterm's TerminalPanel, the
+ * Monaco ExplorerPanel, and config/network are mocked).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
+
+vi.mock('../../../../src/server/spa/client/react/features/terminal/TerminalPanel', () => ({
+    TerminalPanel: ({ sessionId }: { sessionId: string }) => (
+        <div data-testid={`mock-terminal-panel-${sessionId}`}>mock terminal</div>
+    ),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/features/repo-detail/explorer/ExplorerPanel', () => ({
+    ExplorerPanel: ({ workspaceId }: { workspaceId: string }) => (
+        <div data-testid="mock-explorer">explorer:{workspaceId}</div>
+    ),
+}));
+
+vi.mock('../../../../src/server/spa/client/react/utils/config', () => ({
+    isContainerMode: () => false,
+    getApiBase: () => '/api',
+    isRalphEnabled: () => false,
+}));
+
+let uuidCounter = 0;
+vi.stubGlobal('crypto', {
+    randomUUID: () => `test-uuid-${++uuidCounter}`,
+});
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue({ sessions: [] }),
+}));
+
+import {
+    WorkspaceRightDock,
+    useWorkspaceDock,
+} from '../../../../src/server/spa/client/react/features/repo-detail/WorkspaceRightDock';
+
+function Harness({ workspaceId = 'ws1' }: { workspaceId?: string }) {
+    const dock = useWorkspaceDock(workspaceId);
+    return (
+        <div>
+            <button data-testid="ext-toggle" onClick={dock.toggleOpen}>toggle</button>
+            <WorkspaceRightDock workspaceId={workspaceId} dock={dock} />
+        </div>
+    );
+}
+
+function openDock() {
+    act(() => {
+        fireEvent.click(screen.getByTestId('ext-toggle'));
+    });
+}
+
+describe('WorkspaceRightDock single-row header', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        uuidCounter = 0;
+    });
+
+    it('renders compact Terminal/Explorer tabs in the header', () => {
+        render(<Harness />);
+        openDock();
+
+        const header = screen.getByTestId('workspace-dock-header');
+        expect(within(header).getByTestId('workspace-dock-view-terminal')).toBeTruthy();
+        expect(within(header).getByTestId('workspace-dock-view-explorer')).toBeTruthy();
+    });
+
+    it('portals the terminal toolbar into the header (single row, not stacked)', () => {
+        render(<Harness />);
+        openDock();
+
+        const header = screen.getByTestId('workspace-dock-header');
+        // The new-terminal action lives in the header from the start (empty state).
+        expect(within(header).getByTestId('terminal-new-btn')).toBeTruthy();
+
+        // Create a terminal → its picker also appears inside the header row.
+        act(() => {
+            fireEvent.click(within(header).getByTestId('terminal-new-btn'));
+        });
+        expect(within(header).getByTestId('terminal-picker-btn')).toBeTruthy();
+    });
+
+    it('drops the toolbar out of the header when Explorer is active', () => {
+        render(<Harness />);
+        openDock();
+
+        const header = screen.getByTestId('workspace-dock-header');
+        act(() => {
+            fireEvent.click(within(header).getByTestId('terminal-new-btn'));
+        });
+        expect(within(header).getByTestId('terminal-picker-btn')).toBeTruthy();
+
+        // Switch to Explorer → toolbar no longer portals into the header.
+        act(() => {
+            fireEvent.click(within(header).getByTestId('workspace-dock-view-explorer'));
+        });
+        expect(within(header).queryByTestId('terminal-picker-btn')).toBeNull();
+        expect(within(header).queryByTestId('terminal-new-btn')).toBeNull();
+
+        // Switching back restores it.
+        act(() => {
+            fireEvent.click(within(header).getByTestId('workspace-dock-view-terminal'));
+        });
+        expect(within(header).getByTestId('terminal-picker-btn')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
- **fix(spa): keep SplitWorkspacePanel footer pinned to bottom when both halves collapsed**
- **fix(spa): blend sidebar status dock into shell chrome instead of blue tint**
- **fix(spa): align bottom status dock to the admin sidebar width**
- **feat(spa): compact terminal picker in workspace dock**
- **fix(spa): align bottom status dock to the notes sidebar width**
- **feat(spa): merge terminal toolbar into the dock's single-row header**
- **fix(coc): keep a fresh autopilot chat's composer in autopilot mode**
- **fix(spa): keep hoisted git toolbar clicks from stealing the shared detail pane**
- **fix(spa): never enqueue a remote-sourced plan as a local path-reference task**
- **feat(spa): icon-only Activity scope tabs with accessible labels**
