### PR TITLE
fix: bump @github/copilot-sdk to ^1.0.6 to fix credential-key drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^1.0.0"
+    "@github/copilot-sdk": "^1.0.6"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/coc-agent-sdk/package.json
+++ b/packages/coc-agent-sdk/package.json
@@ -27,7 +27,7 @@
     "test:run": "vitest run"
   },
   "peerDependencies": {
-    "@github/copilot-sdk": "^1.0.0",
+    "@github/copilot-sdk": "^1.0.6",
     "@openai/codex-sdk": ">=0.1.0",
     "@anthropic-ai/claude-agent-sdk": ">=0.3.0",
     "@opencode-ai/sdk": ">=0.1.0"

--- a/packages/coc/package.json
+++ b/packages/coc/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.185",
     "@excalidraw/excalidraw": "^0.18.1",
-    "@github/copilot-sdk": "^1.0.0",
+    "@github/copilot-sdk": "^1.0.6",
     "@monaco-editor/react": "^4.7.0",
     "@octokit/rest": "^22.0.1",
     "@openai/codex-sdk": "^0.133.0",

--- a/packages/deep-wiki/package.json
+++ b/packages/deep-wiki/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^1.0.0",
+    "@github/copilot-sdk": "^1.0.6",
     "@octokit/rest": "^22.0.1",
     "@plusplusoneplusplus/coc-agent-sdk": "*",
     "@plusplusoneplusplus/coc-workflow": "^0.1.0",

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@plusplusoneplusplus/coc-workflow": "*",
     "@plusplusoneplusplus/coc-agent-sdk": "*",
-    "@github/copilot-sdk": "^1.0.0",
+    "@github/copilot-sdk": "^1.0.6",
     "@octokit/rest": "^22.0.1",
     "azure-devops-node-api": "^14.1.0",
     "better-sqlite3": "^11.9.1",


### PR DESCRIPTION
## Issue
`@github/copilot-sdk` was pinned at `^1.0.0`, which bundles `@github/copilot@1.0.61`. That runtime reads the **legacy** Windows Credential Manager key (`copilot-cli/https://github.com:<user>`). The standalone Copilot CLI (>=1.0.69) uses the **new** key (`https://github.com:<user>.copilot-cli`), so re-login only refreshes the new key and coc's spawned runtime keeps reading a stale token → `401 Bad credentials`.

## Fix
Bump `@github/copilot-sdk` to `^1.0.6` (pulls `@github/copilot@1.0.69`), aligning coc's runtime with the standalone CLI on a single credential key. Bumped in all 5 `package.json` files (root + coc, coc-agent-sdk, deep-wiki, forge).

Verified: `forge` builds clean with the bumped SDK.

_Lockfile intentionally omitted; regenerate via `npm install` on merge._