### PR TITLE
fix(spa): dock status cluster in Admin & My Work sidebars, not a bott…

### DIFF
--- a/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
+++ b/packages/coc/src/server/spa/client/react/admin/AdminPanel.tsx
@@ -27,6 +27,7 @@ import { PromptsPanel } from './PromptsPanel';
 import { ProviderTokensSection } from './ProviderTokensSection';
 import { SettingsCard } from './SettingsCard';
 import { AdminInputSuffix, AdminRow, AdminSeg, AdminToggle, SourceBadge } from './adminControls';
+import { DockedStatusFooter } from '../layout/DockedStatusFooter';
 
 import { applyRuntimeConfigPatch, isContainerMode, isServersEnabled } from '../utils/config';
 import { AIProviderPage, normalizeAutoProviderRoutingConfig, type NormalizedAutoProviderRoutingConfig } from './AIProviderPage';
@@ -1316,6 +1317,12 @@ export function AdminPanel() {
                             {restarting ? <><Spinner size="sm" /> Restarting…</> : '↻ Restart Server'}
                         </button>
                     </div>
+
+                    {/* Remote-first shell: dock the status/action cluster in the
+                        admin sidebar's own footer so it lives in the left column
+                        (like the chat view) instead of the app-wide bottom band.
+                        No-ops in classic / mobile, where the topbar keeps it. */}
+                    <DockedStatusFooter />
                 </aside>
 
                 {/* ── Main pane ── */}

--- a/packages/coc/src/server/spa/client/react/hooks/ui/useStatusInDock.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/ui/useStatusInDock.ts
@@ -1,0 +1,22 @@
+import { useRemoteShellEnabled } from '../feature-flags/useRemoteShellEnabled';
+import { useBreakpoint } from './useBreakpoint';
+
+/**
+ * True when the shared status/action cluster (connection / notifications /
+ * quota / admin / theme) should be docked into the shell chrome rather than the
+ * top-right topbar corner — i.e. the remote-first shell on desktop.
+ *
+ * Centralises the gate so every host of the docked cluster agrees:
+ *   - `TopBar` hides its top-right cluster (`statusInDock`),
+ *   - `GlobalStatusDock` renders the app-wide bottom band,
+ *   - the Admin sidebar and the My Work view dock the cluster in their own
+ *     left-column footer (`DockedStatusFooter`).
+ *
+ * Off (classic mode) or on mobile the topbar keeps the cluster, so this is
+ * false and none of the docked hosts render.
+ */
+export function useStatusInDock(): boolean {
+    const remoteShell = useRemoteShellEnabled();
+    const { isMobile } = useBreakpoint();
+    return remoteShell && !isMobile;
+}

--- a/packages/coc/src/server/spa/client/react/layout/DockedStatusFooter.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/DockedStatusFooter.tsx
@@ -1,0 +1,33 @@
+/**
+ * DockedStatusFooter — hosts the shared status/action cluster
+ * (`StatusActions` `variant="sidebar"`) at the bottom of a page's own left
+ * column, matching the workspace chat view (`SplitWorkspacePanel` footer).
+ *
+ * Pages that own their own left sidebar (the Admin shell) or a full-width
+ * tabbed body (My Work) render this at the bottom of that chrome so the status
+ * cluster lives inside the sidebar and the content pane extends full height —
+ * instead of the app-wide `GlobalStatusDock` painting a partial-width bottom
+ * band with an empty strip beside it.
+ *
+ * Renders nothing unless the remote-first shell is on (desktop), so classic /
+ * mobile keep the topbar cluster. It also no-ops when rendered outside a
+ * `ThemeProvider` (e.g. isolated component tests) since the cluster is app-shell
+ * chrome that only makes sense inside the full provider tree.
+ */
+
+import { StatusActions } from './StatusActions';
+import { useStatusInDock } from '../hooks/ui/useStatusInDock';
+import { useThemeOptional } from './ThemeProvider';
+
+export interface DockedStatusFooterProps {
+    /** Admin-open handler forwarded to the docked admin button. Defaults to
+     *  navigating to `#admin` (handled by `StatusActions`). */
+    onAdminOpen?: () => void;
+}
+
+export function DockedStatusFooter({ onAdminOpen }: DockedStatusFooterProps) {
+    const inDock = useStatusInDock();
+    const theme = useThemeOptional();
+    if (!inDock || !theme) return null;
+    return <StatusActions variant="sidebar" onAdminOpen={onAdminOpen} />;
+}

--- a/packages/coc/src/server/spa/client/react/layout/GlobalStatusDock.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/GlobalStatusDock.tsx
@@ -7,21 +7,19 @@
  * the controls sit at the left and the connection pill is pushed to the right
  * edge of that column while the detail pane / composer to its right stays clear.
  *
- * The workspace chat/activity sub-tab already docks the cluster inside its own
- * left-column footer (`SplitWorkspacePanel` `footer`), which keeps the chat
- * detail pane full height. This global dock covers every OTHER tab/sub-tab, so
- * it renders null on that view to avoid double-docking. Together they hide the
- * topbar cluster on every desktop remote-shell tab (`TopBar`'s `statusInDock`).
+ * Pages that own their own left sidebar dock the cluster in that sidebar's own
+ * footer instead, so the content pane keeps full height and no partial-width
+ * band is painted beneath it:
+ *   - the workspace chat/activity sub-tab (`SplitWorkspacePanel` `footer`),
+ *   - the Admin shell (its `.ar-sidebar` hosts `DockedStatusFooter`),
+ *   - the My Work view (its body hosts `DockedStatusFooter`).
+ * This global dock covers every OTHER tab/sub-tab, so it renders null on those
+ * views to avoid double-docking. Together they hide the topbar cluster on every
+ * desktop remote-shell tab (`TopBar`'s `statusInDock`).
  *
  * Its width tracks the live left-column width published by `SplitWorkspacePanel`
  * via the `--workspace-left-col-width` CSS variable, falling back to the panel's
  * default width where no split sidebar is mounted (e.g. the terminal tab).
- *
- * The admin shell (the `admin` tab plus the embedded tool tabs) is the exception:
- * it renders its OWN fixed-width sidebar (`--ar-sidebar-w`, 248px) rather than the
- * resizable workspace left column, and never publishes `--workspace-left-col-width`.
- * On those tabs the dock tracks the admin sidebar width so it stays flush beneath
- * that sidebar instead of overhanging into the content pane.
  *
  * Rendered once at the App shell level as a flex sibling below `<main>`, so it
  * reserves its own height and never overlaps tab content. Gated to
@@ -35,21 +33,16 @@ import { useApp } from '../contexts/AppContext';
 import { useRemoteShellEnabled } from '../hooks/feature-flags/useRemoteShellEnabled';
 import { useSplitWorkspacePanelEnabled } from '../hooks/feature-flags/useSplitWorkspacePanelEnabled';
 import { useBreakpoint } from '../hooks/ui/useBreakpoint';
+import { MY_WORK_WORKSPACE_ID } from '../repos/MyWorkView';
 
 /** Fallback width when no split sidebar is mounted (matches the panel default). */
 const DEFAULT_LEFT_COL_WIDTH = 360;
 
 /**
- * Width of the admin shell's own sidebar. Mirrors `--ar-sidebar-w` in
- * admin-redesign.css; the dock sits outside `.admin-redesign` so it cannot read
- * that scoped variable and pins the constant here instead.
- */
-const ADMIN_SIDEBAR_WIDTH = 248;
-
-/**
  * Dashboard tabs whose Router branch mounts `AdminPanel` (the fixed-width admin
- * sidebar shell). On these the dock matches the admin sidebar, not the workspace
- * left column. Keep in sync with the admin cases in Router's `renderActiveView`.
+ * sidebar shell). On these the admin sidebar hosts the cluster in its own footer
+ * (`DockedStatusFooter`), so the global dock stands down. Keep in sync with the
+ * admin cases in Router's `renderActiveView`.
  */
 const ADMIN_SHELL_TABS = new Set(['admin', 'memory', 'skills', 'logs', 'stats', 'servers', 'dreams-admin']);
 
@@ -66,6 +59,14 @@ export function GlobalStatusDock({ onAdminOpen }: GlobalStatusDockProps) {
 
     if (!remoteShell || isMobile) return null;
 
+    // The admin shell hosts the cluster in its own left sidebar footer
+    // (`DockedStatusFooter`), so stand down on every tab that mounts it.
+    if (ADMIN_SHELL_TABS.has(state.activeTab)) return null;
+
+    // My Work hosts the cluster in its own body footer (`DockedStatusFooter`),
+    // so stand down there too — on every My Work sub-tab, not just chat.
+    if (state.selectedRepoId === MY_WORK_WORKSPACE_ID) return null;
+
     // The workspace chat/activity sub-tab hosts the dock in its own left-column
     // footer so the chat detail pane keeps full height. Don't render a second
     // dock over that view.
@@ -76,12 +77,9 @@ export function GlobalStatusDock({ onAdminOpen }: GlobalStatusDockProps) {
         (state.activeRepoSubTab === 'chats' || state.activeRepoSubTab === 'activity');
     if (inPanelFooter) return null;
 
-    // In the admin shell the dock follows the admin sidebar's fixed width so it
-    // stays flush beneath it; elsewhere it tracks the resizable workspace left
-    // column (or the panel default when no split sidebar is mounted).
-    const width = ADMIN_SHELL_TABS.has(state.activeTab)
-        ? `${ADMIN_SIDEBAR_WIDTH}px`
-        : `var(--workspace-left-col-width, ${DEFAULT_LEFT_COL_WIDTH}px)`;
+    // Tracks the resizable workspace left column (or the panel default when no
+    // split sidebar is mounted) so the band stays flush under that column.
+    const width = `var(--workspace-left-col-width, ${DEFAULT_LEFT_COL_WIDTH}px)`;
 
     return (
         <div

--- a/packages/coc/src/server/spa/client/react/layout/ThemeProvider.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/ThemeProvider.tsx
@@ -95,3 +95,13 @@ export function useTheme() {
     if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
     return ctx;
 }
+
+/**
+ * Like {@link useTheme} but returns `null` instead of throwing when no
+ * `ThemeProvider` is mounted. Used by app-shell chrome (e.g. the docked status
+ * footer) that must degrade to a no-op when rendered outside the full provider
+ * tree, such as in isolated component tests.
+ */
+export function useThemeOptional(): ThemeContextValue | null {
+    return useContext(ThemeContext);
+}

--- a/packages/coc/src/server/spa/client/react/repos/MyWorkView.tsx
+++ b/packages/coc/src/server/spa/client/react/repos/MyWorkView.tsx
@@ -18,6 +18,7 @@ import { cn } from '../ui';
 import type { RepoSubTab } from '../types/dashboard';
 import type { RepoData } from './repoGrouping';
 import { generateMyWorkSummary, syncMyWork } from './repositoryService';
+import { DockedStatusFooter } from '../layout/DockedStatusFooter';
 
 export const MY_WORK_WORKSPACE_ID = 'my_work';
 
@@ -174,6 +175,12 @@ export function MyWorkView() {
                 )}
                 {activeTab === 'settings' && <RepoSettingsTab workspaceId={MY_WORK_WORKSPACE_ID} repo={VIRTUAL_REPO} />}
             </div>
+
+            {/* Remote-first shell: dock the status/action cluster at the bottom
+                of the My Work body so it lives in this view's own chrome instead
+                of the app-wide bottom band. No-ops in classic / mobile, where the
+                topbar keeps the cluster. */}
+            <DockedStatusFooter />
         </div>
     );
 }

--- a/packages/coc/test/server/spa/client/admin/AdminPanel-mcp-oauth-auto-refresh.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/AdminPanel-mcp-oauth-auto-refresh.test.tsx
@@ -7,10 +7,12 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 vi.mock('@plusplusoneplusplus/forge', () => ({}));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    DASHBOARD_CONFIG_UPDATED_EVENT: 'coc-dashboard-config-updated',
     isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => false,
     isServersEnabled: () => false,
+    isRemoteShellEnabled: () => false,
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({

--- a/packages/coc/test/server/spa/client/admin/AdminPanel-pr-suggestions.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/AdminPanel-pr-suggestions.test.tsx
@@ -11,10 +11,12 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 vi.mock('@plusplusoneplusplus/forge', () => ({}));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    DASHBOARD_CONFIG_UPDATED_EVENT: 'coc-dashboard-config-updated',
     isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => false,
     isServersEnabled: () => false,
+    isRemoteShellEnabled: () => false,
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({

--- a/packages/coc/test/server/spa/client/admin/AdminPanel-scratchpad.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/AdminPanel-scratchpad.test.tsx
@@ -11,10 +11,12 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 vi.mock('@plusplusoneplusplus/forge', () => ({}));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    DASHBOARD_CONFIG_UPDATED_EVENT: 'coc-dashboard-config-updated',
     isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => false,
     isServersEnabled: () => false,
+    isRemoteShellEnabled: () => false,
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({

--- a/packages/coc/test/server/spa/client/admin/AdminPanel-work-items-ai-authoring.test.tsx
+++ b/packages/coc/test/server/spa/client/admin/AdminPanel-work-items-ai-authoring.test.tsx
@@ -11,10 +11,12 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 vi.mock('@plusplusoneplusplus/forge', () => ({}));
 
 vi.mock('../../../../../src/server/spa/client/react/utils/config', () => ({
+    DASHBOARD_CONFIG_UPDATED_EVENT: 'coc-dashboard-config-updated',
     isContainerMode: () => false,
     getApiBase: () => '',
     isRalphEnabled: () => false,
     isServersEnabled: () => false,
+    isRemoteShellEnabled: () => false,
 }));
 
 vi.mock('../../../../../src/server/spa/client/react/hooks/preferences/useDisplaySettings', () => ({

--- a/packages/coc/test/server/spa/client/repos/MyWorkView.test.tsx
+++ b/packages/coc/test/server/spa/client/repos/MyWorkView.test.tsx
@@ -78,6 +78,11 @@ vi.mock('../../../../../src/server/spa/client/react/features/repo-settings/RepoS
 // Stub repoGrouping — provide the RepoData type import
 vi.mock('../../../../../src/server/spa/client/react/repos/repoGrouping', () => ({}));
 
+// Stub the docked status footer — assert placement, not its internals.
+vi.mock('../../../../../src/server/spa/client/react/layout/DockedStatusFooter', () => ({
+    DockedStatusFooter: () => <div data-testid="docked-status-footer" />,
+}));
+
 // Feature flag: schedules-in-scheduled-slide (default off)
 vi.mock('../../../../../src/server/spa/client/react/hooks/feature-flags/useSchedulesInScheduledSlideEnabled', () => ({
     useSchedulesInScheduledSlideEnabled: () => mockSchedulesInScheduledSlideEnabled,
@@ -220,6 +225,16 @@ describe('MyWorkView', () => {
 
     it('exports MY_WORK_WORKSPACE_ID constant', () => {
         expect(MY_WORK_WORKSPACE_ID).toBe('my_work');
+    });
+
+    it('docks the status cluster footer as the last child of the view body', () => {
+        renderView();
+        const view = screen.getByTestId('my-work-view');
+        const footer = screen.getByTestId('docked-status-footer');
+        // Lives inside the My Work chrome, pinned to the bottom (last child), so
+        // the app-wide GlobalStatusDock stands down and no empty strip is drawn.
+        expect(view.contains(footer)).toBe(true);
+        expect(view.lastElementChild).toBe(footer);
     });
 
     describe('chat toggle button (removed from header)', () => {

--- a/packages/coc/test/spa/react/admin/AdminPanel-status-footer.test.tsx
+++ b/packages/coc/test/spa/react/admin/AdminPanel-status-footer.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * AdminPanel — docks the shared status cluster inside its own left sidebar
+ * footer (remote-first shell), so the app-wide GlobalStatusDock stands down and
+ * no partial-width empty strip is painted beneath the admin content pane.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { AppProvider } from '../../../../src/server/spa/client/react/contexts/AppContext';
+
+// Stub the docked footer — assert placement, not its internals.
+vi.mock('../../../../src/server/spa/client/react/layout/DockedStatusFooter', () => ({
+    DockedStatusFooter: () => <div data-testid="docked-status-footer" />,
+}));
+
+// LogsView (embedded) opens an SSE stream; jsdom has no EventSource.
+class FakeEventSource {
+    onerror: unknown = null;
+    onopen: unknown = null;
+    constructor(public url: string) {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+}
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+        headers: new Headers(),
+    });
+    global.fetch = mockFetch;
+    (globalThis as any).EventSource = FakeEventSource;
+    if (typeof window !== 'undefined') {
+        window.location.hash = '';
+    }
+});
+
+import { AdminPanel } from '../../../../src/server/spa/client/react/admin/AdminPanel';
+
+describe('AdminPanel — docked status footer', () => {
+    it('renders the docked status footer inside the admin sidebar', async () => {
+        await act(async () => {
+            render(
+                <AppProvider>
+                    <AdminPanel />
+                </AppProvider>,
+            );
+        });
+
+        const footer = screen.getByTestId('docked-status-footer');
+        const sidebar = document.querySelector('.ar-sidebar');
+        expect(sidebar).not.toBeNull();
+        expect(sidebar!.contains(footer)).toBe(true);
+        // Pinned to the very bottom of the sidebar, after the Restart footer.
+        expect(sidebar!.lastElementChild).toBe(footer);
+    });
+});

--- a/packages/coc/test/spa/react/hooks/useStatusInDock.test.tsx
+++ b/packages/coc/test/spa/react/hooks/useStatusInDock.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * useStatusInDock — true only in the remote-first shell on desktop, the single
+ * gate every host of the docked status cluster shares.
+ *
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+let mockRemoteShell = true;
+let mockIsMobile = false;
+
+vi.mock('../../../../src/server/spa/client/react/hooks/feature-flags/useRemoteShellEnabled', () => ({
+    useRemoteShellEnabled: () => mockRemoteShell,
+}));
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useBreakpoint', () => ({
+    useBreakpoint: () => ({
+        breakpoint: mockIsMobile ? 'mobile' : 'desktop',
+        isMobile: mockIsMobile,
+        isTablet: false,
+        isDesktop: !mockIsMobile,
+    }),
+}));
+
+import { useStatusInDock } from '../../../../src/server/spa/client/react/hooks/ui/useStatusInDock';
+
+beforeEach(() => {
+    mockRemoteShell = true;
+    mockIsMobile = false;
+});
+
+describe('useStatusInDock', () => {
+    it('is true in the remote-first shell on desktop', () => {
+        const { result } = renderHook(() => useStatusInDock());
+        expect(result.current).toBe(true);
+    });
+
+    it('is false when the remote shell is off (classic mode keeps the topbar cluster)', () => {
+        mockRemoteShell = false;
+        const { result } = renderHook(() => useStatusInDock());
+        expect(result.current).toBe(false);
+    });
+
+    it('is false on mobile (no room for a docked cluster)', () => {
+        mockIsMobile = true;
+        const { result } = renderHook(() => useStatusInDock());
+        expect(result.current).toBe(false);
+    });
+
+    it('is false when both are off', () => {
+        mockRemoteShell = false;
+        mockIsMobile = true;
+        const { result } = renderHook(() => useStatusInDock());
+        expect(result.current).toBe(false);
+    });
+});

--- a/packages/coc/test/spa/react/layout/DockedStatusFooter.test.tsx
+++ b/packages/coc/test/spa/react/layout/DockedStatusFooter.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * DockedStatusFooter — docks the shared status cluster in a page's own left
+ * column footer, gated to the remote-first shell on desktop, and only inside a
+ * ThemeProvider (app-shell chrome).
+ *
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../../../src/server/spa/client/react/layout/ThemeProvider';
+
+let mockInDock = true;
+
+vi.mock('../../../../src/server/spa/client/react/hooks/ui/useStatusInDock', () => ({
+    useStatusInDock: () => mockInDock,
+}));
+vi.mock('../../../../src/server/spa/client/react/layout/StatusActions', () => ({
+    StatusActions: (props: Record<string, unknown>) => (
+        <div data-testid="status-actions" data-variant={String(props.variant)} data-has-admin={String(typeof props.onAdminOpen === 'function')} />
+    ),
+}));
+
+// ThemeProvider persists to the server on mount; stub the client so it no-ops.
+vi.mock('../../../../src/server/spa/client/react/api/cocClient', () => ({
+    getSpaCocClient: () => ({
+        preferences: {
+            getGlobal: () => Promise.resolve({}),
+            patchGlobal: () => Promise.resolve({}),
+        },
+    }),
+}));
+
+import { DockedStatusFooter } from '../../../../src/server/spa/client/react/layout/DockedStatusFooter';
+
+beforeEach(() => {
+    mockInDock = true;
+    localStorage.clear();
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    });
+});
+
+describe('DockedStatusFooter', () => {
+    it('renders the sidebar StatusActions variant inside a ThemeProvider when docked', () => {
+        render(
+            <ThemeProvider>
+                <DockedStatusFooter />
+            </ThemeProvider>,
+        );
+        const cluster = screen.getByTestId('status-actions');
+        expect(cluster.getAttribute('data-variant')).toBe('sidebar');
+    });
+
+    it('forwards onAdminOpen to StatusActions', () => {
+        render(
+            <ThemeProvider>
+                <DockedStatusFooter onAdminOpen={() => {}} />
+            </ThemeProvider>,
+        );
+        expect(screen.getByTestId('status-actions').getAttribute('data-has-admin')).toBe('true');
+    });
+
+    it('renders nothing when not docked (classic / mobile)', () => {
+        mockInDock = false;
+        const { container } = render(
+            <ThemeProvider>
+                <DockedStatusFooter />
+            </ThemeProvider>,
+        );
+        expect(screen.queryByTestId('status-actions')).toBeNull();
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing outside a ThemeProvider (app-shell chrome only)', () => {
+        // No ThemeProvider — must no-op rather than throw, so isolated page
+        // component tests (Admin, My Work) that render the footer stay green.
+        const { container } = render(<DockedStatusFooter />);
+        expect(screen.queryByTestId('status-actions')).toBeNull();
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/packages/coc/test/spa/react/layout/GlobalStatusDock.test.tsx
+++ b/packages/coc/test/spa/react/layout/GlobalStatusDock.test.tsx
@@ -4,8 +4,9 @@
  * It renders the shared `StatusActions` sidebar variant across tabs, but only in
  * the remote-first shell on desktop, and only as wide as the left sidebar
  * column. Off (classic mode) or on mobile it renders nothing (topbar keeps the
- * cluster). On the workspace chat/activity sub-tab it also renders nothing —
- * that view docks the cluster in its own left-column footer instead.
+ * cluster). It also renders nothing on views that dock the cluster in their own
+ * left-column footer: the workspace chat/activity sub-tab, the admin shell, and
+ * the My Work workspace.
  *
  * @vitest-environment jsdom
  */
@@ -36,6 +37,11 @@ vi.mock('../../../../src/server/spa/client/react/layout/StatusActions', () => ({
         return <div data-testid="status-actions" data-variant={String(props.variant)} />;
     },
 }));
+// Keep this suite lightweight — pull only the workspace-id constant, not the
+// heavy MyWorkView module (Notes editor, tiptap, monaco, …).
+vi.mock('../../../../src/server/spa/client/react/repos/MyWorkView', () => ({
+    MY_WORK_WORKSPACE_ID: 'my_work',
+}));
 
 import { GlobalStatusDock } from '../../../../src/server/spa/client/react/layout/GlobalStatusDock';
 
@@ -65,24 +71,38 @@ describe('GlobalStatusDock', () => {
         expect(wrapper.className).toContain('flex-shrink-0');
     });
 
-    it('pins its width to the admin sidebar (248px) on the admin tab so it stays flush, not overhanging', () => {
-        mockAppState = { activeTab: 'admin', selectedRepoId: null, activeRepoSubTab: undefined };
+    it('pins to the workspace left-column width on a non-admin, non-chat tab', () => {
+        mockAppState = { activeTab: 'wiki', selectedRepoId: null, activeRepoSubTab: undefined };
         render(<GlobalStatusDock />);
         const wrapper = screen.getByTestId('global-status-dock');
-        // The admin shell renders its own fixed 248px sidebar and never publishes
-        // --workspace-left-col-width; using the (wider) workspace column here made
-        // the dock overhang past the sidebar into the content pane.
-        expect(wrapper.style.width).toBe('248px');
-        expect(wrapper.style.width).not.toContain('--workspace-left-col-width');
+        expect(wrapper.style.width).toContain('--workspace-left-col-width');
+        expect(wrapper.style.width).toContain('360px');
     });
 
-    it('pins to the admin sidebar width on every tab that mounts the admin shell', () => {
+    it('renders nothing on the admin tab (the admin sidebar hosts the cluster in its own footer)', () => {
+        mockAppState = { activeTab: 'admin', selectedRepoId: null, activeRepoSubTab: undefined };
+        const { container } = render(<GlobalStatusDock />);
+        // The admin shell renders its own sidebar and docks the status cluster in
+        // its footer (`DockedStatusFooter`), so the global bottom band stands down
+        // to avoid the empty partial-width strip beside it.
+        expect(screen.queryByTestId('status-actions')).toBeNull();
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing on every tab that mounts the admin shell', () => {
         for (const tab of ['admin', 'memory', 'skills', 'logs', 'stats', 'servers', 'dreams-admin']) {
             mockAppState = { activeTab: tab, selectedRepoId: null, activeRepoSubTab: undefined };
-            const { unmount } = render(<GlobalStatusDock />);
-            expect(screen.getByTestId('global-status-dock').style.width).toBe('248px');
+            const { container, unmount } = render(<GlobalStatusDock />);
+            expect(container.firstChild).toBeNull();
             unmount();
         }
+    });
+
+    it('renders nothing on the My Work workspace (its body footer hosts the cluster)', () => {
+        mockAppState = { activeTab: 'repos', selectedRepoId: 'my_work', activeRepoSubTab: 'notes' };
+        const { container } = render(<GlobalStatusDock />);
+        expect(screen.queryByTestId('status-actions')).toBeNull();
+        expect(container.firstChild).toBeNull();
     });
 
     it('forwards onAdminOpen to StatusActions', () => {


### PR DESCRIPTION
…om band

The remote-shell GlobalStatusDock rendered the status/action cluster as a full-width row below <main>, with the cluster constrained to the left-sidebar width. On the Admin and My Work pages that left an empty background strip beside the cluster at the bottom of the page. Only the chat view avoided it by docking the cluster inside its own left-column footer.

Dock the cluster in each page's own chrome instead: the Admin sidebar footer and the My Work body footer both render a new DockedStatusFooter, and GlobalStatusDock now stands down on admin-shell tabs and the My Work workspace. A shared useStatusInDock() hook centralises the remote-shell-desktop gate, and useThemeOptional() lets the footer no-op outside a ThemeProvider.