### PR TITLE
Enable schedulesInScheduledSlide feature by default

### DIFF
--- a/packages/coc/src/config.ts
+++ b/packages/coc/src/config.ts
@@ -274,7 +274,7 @@ export interface CLIConfig {
         remoteShell?: boolean;
         /** Split "Workspace" left panel (chat top / git bottom) feeding one shared detail pane. Enabled by default. */
         splitWorkspacePanel?: boolean;
-        /** Schedule management inside the chat-list "Scheduled" slide (definitions list + right-pane create/edit), retiring the Schedules tab. Disabled by default. */
+        /** Schedule management inside the chat-list "Scheduled" slide (definitions list + right-pane create/edit), retiring the Schedules tab. Enabled by default. */
         schedulesInScheduledSlide?: boolean;
     };
     /** Memory promotion configuration */
@@ -592,7 +592,7 @@ export interface ResolvedCLIConfig {
         remoteShell: boolean;
         /** Split "Workspace" left panel (chat top / git bottom) feeding one shared detail pane. Enabled by default. */
         splitWorkspacePanel: boolean;
-        /** Schedule management inside the chat-list "Scheduled" slide (definitions list + right-pane create/edit), retiring the Schedules tab. Disabled by default. */
+        /** Schedule management inside the chat-list "Scheduled" slide (definitions list + right-pane create/edit), retiring the Schedules tab. Enabled by default. */
         schedulesInScheduledSlide: boolean;
     };
     /** Memory promotion configuration */
@@ -845,7 +845,7 @@ export const DEFAULT_CONFIG: ResolvedCLIConfig = {
         nativeCliSessions: false,
         remoteShell: true,
         splitWorkspacePanel: true,
-        schedulesInScheduledSlide: false,
+        schedulesInScheduledSlide: true,
     },
     memoryPromotion: {
         batchSize: 50,

--- a/packages/coc/src/config/admin-setting-definitions.ts
+++ b/packages/coc/src/config/admin-setting-definitions.ts
@@ -769,10 +769,10 @@ export const ADMIN_SETTING_DEFINITIONS: readonly AdminSettingDefinition[] = [
         },
     }),
     bool({
-        key: 'features.schedulesInScheduledSlide', default: false, runtime: 'live', runtimeFlag: 'schedulesInScheduledSlideEnabled',
+        key: 'features.schedulesInScheduledSlide', default: true, runtime: 'live', runtimeFlag: 'schedulesInScheduledSlideEnabled',
         ui: {
             group: 'dashboard', order: 68, label: 'Schedules in Scheduled slide', badge: 'experimental',
-            hint: 'Moves schedule management (create/edit/run/pause/delete + run history) into the chat-list "Scheduled" slide, opening create and detail in the main pane and hiding the old Schedules tab. Disabled by default.',
+            hint: 'Moves schedule management (create/edit/run/pause/delete + run history) into the chat-list "Scheduled" slide, opening create and detail in the main pane and hiding the old Schedules tab. Enabled by default.',
             testId: 'toggle-schedules-in-scheduled-slide-enabled',
         },
     }),

--- a/packages/coc/src/server/spa/client/react/hooks/feature-flags/useSchedulesInScheduledSlideEnabled.ts
+++ b/packages/coc/src/server/spa/client/react/hooks/feature-flags/useSchedulesInScheduledSlideEnabled.ts
@@ -9,7 +9,7 @@ import { DASHBOARD_CONFIG_UPDATED_EVENT, isSchedulesInScheduledSlideEnabled } fr
  * schedule definitions with create/edit/run/pause/delete + run history opening in
  * the main pane — and the standalone Schedules tab is hidden and redirected.
  * Global admin setting; applies to the whole deployment and takes effect on
- * reload. Disabled by default.
+ * reload. Enabled by default.
  */
 export function useSchedulesInScheduledSlideEnabled(): boolean {
     const [enabled, setEnabled] = useState(isSchedulesInScheduledSlideEnabled());

--- a/packages/coc/test/config.test.ts
+++ b/packages/coc/test/config.test.ts
@@ -1268,7 +1268,7 @@ timeout: 300
                     "nativeCliSessions": false,
                     "ralphMultiAgentGrill": false,
                     "remoteShell": true,
-                    "schedulesInScheduledSlide": false,
+                    "schedulesInScheduledSlide": true,
                     "sessionContextAttachments": false,
                     "splitWorkspacePanel": true,
                   },

--- a/packages/coc/test/e2e/repos.spec.ts
+++ b/packages/coc/test/e2e/repos.spec.ts
@@ -1003,14 +1003,15 @@ test.describe('Hash Navigation — Remaining Sub-tabs', () => {
         await expect(page.locator('button[data-subtab="tasks"]')).toHaveClass(/active/);
     });
 
-    test('hash navigation to #repos/<id>/schedules selects Schedules sub-tab', async ({ page, serverUrl }) => {
+    test('hash navigation to #repos/<id>/schedules opens Activity when the Schedules sub-tab is hidden', async ({ page, serverUrl }) => {
         await seedWorkspace(serverUrl, 'ws-hash-sched', 'hash-schedules-repo', '/tmp/hash-sched-repo');
 
         await page.goto(`${serverUrl}/#repos/ws-hash-sched/schedules`);
 
         await expect(page.locator('[data-tab="repos"]')).toHaveClass(/active/);
         await expect(page.locator('#repo-detail-content')).toBeVisible({ timeout: 10000 });
-        await expect(page.locator('button[data-subtab="schedules"]')).toHaveClass(/active/);
+        await expect(page.locator('button[data-subtab="activity"]')).toHaveClass(/active/);
+        await expect(page.locator('button[data-subtab="schedules"]')).toHaveCount(0);
     });
 });
 

--- a/packages/coc/test/e2e/schedule-management.spec.ts
+++ b/packages/coc/test/e2e/schedule-management.spec.ts
@@ -21,8 +21,19 @@ import { seedSchedule } from './fixtures/schedule-seed';
 // Helpers
 // ────────────────────────────────────────────────────────────────────────────
 
+async function disableSchedulesInScheduledSlide(serverUrl: string): Promise<void> {
+    const res = await request(`${serverUrl}/api/admin/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ 'features.schedulesInScheduledSlide': false }),
+    });
+    if (res.status !== 200) {
+        throw new Error(`Failed to disable schedules-in-slide feature: ${res.status} ${res.body}`);
+    }
+}
+
 /** Navigate to the Schedules sub-tab of the sole workspace in the sidebar. */
 async function navigateToSchedules(page: Page, serverUrl: string): Promise<void> {
+    await disableSchedulesInScheduledSlide(serverUrl);
     // Pre-dismiss the welcome modal AND concept tour so neither blocks pointer events.
     await request(`${serverUrl}/api/preferences`, {
         method: 'PATCH',

--- a/packages/coc/test/e2e/schedule-script.spec.ts
+++ b/packages/coc/test/e2e/schedule-script.spec.ts
@@ -20,6 +20,16 @@ import { seedSchedule } from './fixtures/schedule-seed';
 // Helpers
 // ────────────────────────────────────────────────────────────────────────────
 
+async function disableSchedulesInScheduledSlide(serverUrl: string): Promise<void> {
+    const res = await request(`${serverUrl}/api/admin/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ 'features.schedulesInScheduledSlide': false }),
+    });
+    if (res.status !== 200) {
+        throw new Error(`Failed to disable schedules-in-slide feature: ${res.status} ${res.body}`);
+    }
+}
+
 /** Poll GET /api/queue/:id until status matches or timeout. */
 async function waitForTaskStatus(
     serverUrl: string,
@@ -47,6 +57,7 @@ async function waitForTaskStatus(
 
 /** Navigate to the Schedules sub-tab of the first workspace in the sidebar. */
 async function navigateToSchedules(page: Page, serverUrl: string): Promise<void> {
+    await disableSchedulesInScheduledSlide(serverUrl);
     // Pre-dismiss the welcome modal AND concept tour so neither blocks pointer events.
     await request(`${serverUrl}/api/preferences`, {
         method: 'PATCH',


### PR DESCRIPTION
Flip the features.schedulesInScheduledSlide default to true so schedule
management lives in the chat-list Scheduled slide out of the box, and
update related hints/comments and the config default test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>