### PR TITLE
feat(coc-agent-sdk): point copilot high tier at gpt-5.6-sol

### DIFF
--- a/packages/coc-agent-sdk/src/effort-tier-defaults.ts
+++ b/packages/coc-agent-sdk/src/effort-tier-defaults.ts
@@ -30,7 +30,7 @@ const COPILOT_DEFAULTS: EffortTierDefaultsMap = {
     'very-low': { model: 'gpt-5.4-mini',      reasoningEffort: 'low'   },
     low:    { model: 'claude-sonnet-5',   reasoningEffort: 'high'  },
     medium: { model: 'claude-opus-4.8',   reasoningEffort: null    },
-    high:   { model: 'gpt-5.5',           reasoningEffort: 'xhigh' },
+    high:   { model: 'gpt-5.6-sol',       reasoningEffort: 'xhigh' },
 };
 
 const CODEX_DEFAULTS: EffortTierDefaultsMap = {

--- a/packages/coc-agent-sdk/test/effort-tier-defaults.test.ts
+++ b/packages/coc-agent-sdk/test/effort-tier-defaults.test.ts
@@ -17,7 +17,7 @@ describe('getDefaultEffortTiers', () => {
             'very-low': { model: 'gpt-5.4-mini',      reasoningEffort: 'low'   },
             low:    { model: 'claude-sonnet-5',   reasoningEffort: 'high'  },
             medium: { model: 'claude-opus-4.8',   reasoningEffort: null    },
-            high:   { model: 'gpt-5.5',           reasoningEffort: 'xhigh' },
+            high:   { model: 'gpt-5.6-sol',       reasoningEffort: 'xhigh' },
         });
     });
 
@@ -76,7 +76,7 @@ describe('mergeEffortTiersWithDefaults', () => {
             'very-low': { model: 'gpt-5.4-mini',      reasoningEffort: 'low',   source: 'default' },
             low:    { model: 'claude-sonnet-5',   reasoningEffort: 'high',  source: 'default' },
             medium: { model: 'claude-opus-4.8',   reasoningEffort: null,    source: 'default' },
-            high:   { model: 'gpt-5.5',           reasoningEffort: 'xhigh', source: 'default' },
+            high:   { model: 'gpt-5.6-sol',       reasoningEffort: 'xhigh', source: 'default' },
         });
     });
 

--- a/packages/coc/test/server/agent-provider-effort-tiers-routes.test.ts
+++ b/packages/coc/test/server/agent-provider-effort-tiers-routes.test.ts
@@ -161,13 +161,13 @@ describe('GET /api/agent-providers/:provider/effort-tiers', () => {
             'very-low': { model: 'gpt-5.4-mini',     reasoningEffort: 'low',   source: 'default' },
             low:    { model: 'claude-sonnet-5',   reasoningEffort: 'high',  source: 'default' },
             medium: { model: 'claude-opus-4.8',   reasoningEffort: null,    source: 'default' },
-            high:   { model: 'gpt-5.5',           reasoningEffort: 'xhigh', source: 'default' },
+            high:   { model: 'gpt-5.6-sol',       reasoningEffort: 'xhigh', source: 'default' },
         });
         expect(data.defaults).toEqual({
             'very-low': { model: 'gpt-5.4-mini',     reasoningEffort: 'low'   },
             low:    { model: 'claude-sonnet-5',   reasoningEffort: 'high'  },
             medium: { model: 'claude-opus-4.8',   reasoningEffort: null    },
-            high:   { model: 'gpt-5.5',           reasoningEffort: 'xhigh' },
+            high:   { model: 'gpt-5.6-sol',       reasoningEffort: 'xhigh' },
         });
     });
 


### PR DESCRIPTION
Change the Copilot provider's `high` effort-tier default model from
gpt-5.5 to gpt-5.6-sol (reasoning effort stays xhigh). Update the two
effort-tier-defaults test assertions to match.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
