### PR TITLE
feat(coc): add repository picker dropdown to My Work / My Life identity chips

### DIFF
--- a/packages/coc/src/server/spa/client/react/features/remote-shell/VirtualWorkspaceShellHeader.tsx
+++ b/packages/coc/src/server/spa/client/react/features/remote-shell/VirtualWorkspaceShellHeader.tsx
@@ -3,21 +3,161 @@
  * virtual workspace (My Work / My Life). Mirrors `RemoteShellHeader`'s visual
  * shell (identity chip · divider · tabs) but, since a virtual workspace has no
  * repo/git context, renders its own identity + sub-tab set and action buttons
- * (Sync / Generate Summary) instead of the repo-picker + clone-switcher clusters.
+ * (Sync / Generate Summary) instead of the repo-picker / clone-switcher clusters.
+ *
+ * The identity chip doubles as a repository picker: clicking it opens a compact
+ * dropdown of all available real repositories so the user can switch without
+ * visiting the hamburger manager. Both My Work and My Life share the same picker
+ * logic; the blue shortcut buttons in TopBar retain their direct-navigation role.
  *
  * Rendered by `TopBar` in the remote-first desktop shell; the matching in-body
  * header (`VirtualWorkspaceInlineHeader`) covers classic shell / mobile.
  */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualWorkspaceHeader } from './useVirtualWorkspaceHeader';
 import type { VirtualWorkspaceHeaderConfig } from './virtualWorkspaceHeader';
+import type { RepoData } from '../../repos/repoGrouping';
+import { isRemoteRepo } from '../../repos/repoGrouping';
+import { getRepoSelectionId } from '../../repos/cloneIdentity';
 
 export interface VirtualWorkspaceShellHeaderProps {
     config: VirtualWorkspaceHeaderConfig;
+    repos: RepoData[];
+    onSelectRepo: (id: string) => void;
 }
 
-export function VirtualWorkspaceShellHeader({ config }: VirtualWorkspaceShellHeaderProps) {
+function Chevron() {
+    return (
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M6 9l6 6 6-6" />
+        </svg>
+    );
+}
+
+function SearchIcon() {
+    return (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" />
+            <path d="M16 16l4 4" />
+        </svg>
+    );
+}
+
+function getServerName(repo: RepoData): string {
+    const remote = (repo.workspace as any).remote as { serverLabel?: string; serverId?: string } | null;
+    return String(remote?.serverLabel ?? remote?.serverId ?? (repo.workspace as any).baseUrl ?? 'remote');
+}
+
+function isRepoOffline(repo: RepoData): boolean {
+    const remote = (repo.workspace as any).remote as { connection?: string } | null;
+    if (!remote) return false;
+    const connection = remote.connection ?? 'offline';
+    return connection === 'offline' || connection === 'failed';
+}
+
+function shortPath(fullPath: string): string {
+    if (!fullPath) return '';
+    const parts = fullPath.replace(/\\/g, '/').split('/').filter(Boolean);
+    return parts.slice(-2).join('/');
+}
+
+export function VirtualWorkspaceShellHeader({ config, repos, onSelectRepo }: VirtualWorkspaceShellHeaderProps) {
     const { visibleTabs, activeTab, switchTab, statusMsg, isActionRunning, runAction } = useVirtualWorkspaceHeader(config);
     const prefix = config.testIdPrefix;
+
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState('');
+    const rootRef = useRef<HTMLDivElement>(null);
+    const searchRef = useRef<HTMLInputElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        const onDown = (e: MouseEvent) => {
+            if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                setOpen(false);
+                triggerRef.current?.focus();
+            }
+        };
+        document.addEventListener('mousedown', onDown);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('mousedown', onDown);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [open]);
+
+    // Focus the search field after the dropdown renders
+    useEffect(() => {
+        if (open) {
+            const id = setTimeout(() => searchRef.current?.focus(), 0);
+            return () => clearTimeout(id);
+        }
+    }, [open]);
+
+    const filteredRepos = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return repos;
+        return repos.filter(r => {
+            const name = String(r.workspace.name ?? '').toLowerCase();
+            const path = String(r.workspace.rootPath ?? r.workspace.path ?? '').toLowerCase();
+            const server = isRemoteRepo(r) ? getServerName(r).toLowerCase() : '';
+            return name.includes(q) || path.includes(q) || server.includes(q);
+        });
+    }, [repos, query]);
+
+    const localRepos = useMemo(() => filteredRepos.filter(r => !isRemoteRepo(r)), [filteredRepos]);
+    const remoteRepos = useMemo(() => filteredRepos.filter(isRemoteRepo), [filteredRepos]);
+
+    const handleSelect = useCallback((repo: RepoData) => {
+        if (isRepoOffline(repo)) return;
+        onSelectRepo(getRepoSelectionId(repo));
+        setOpen(false);
+        setQuery('');
+    }, [onSelectRepo]);
+
+    const renderRepoRow = (repo: RepoData, testId: string) => {
+        const name = String(repo.workspace.name ?? repo.workspace.id ?? 'Unknown');
+        const offline = isRepoOffline(repo);
+        const remote = isRemoteRepo(repo);
+        const sublabel = remote
+            ? getServerName(repo)
+            : shortPath(String(repo.workspace.rootPath ?? repo.workspace.path ?? ''));
+
+        return (
+            <button
+                key={getRepoSelectionId(repo)}
+                data-testid={testId}
+                role="menuitem"
+                disabled={offline}
+                aria-disabled={offline}
+                onClick={() => handleSelect(repo)}
+                className={
+                    'w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left text-[12px] transition-colors ' +
+                    (offline
+                        ? 'opacity-50 cursor-not-allowed text-[#848484] dark:text-[#666]'
+                        : 'text-[#1f2328] dark:text-[#cccccc] hover:bg-black/[0.04] dark:hover:bg-white/[0.06]')
+                }
+            >
+                <span className="flex-1 min-w-0">
+                    <span className="block font-semibold truncate">{name}</span>
+                    {sublabel && (
+                        <span className="block text-[10.5px] text-[#848484] dark:text-[#777] truncate">{sublabel}</span>
+                    )}
+                </span>
+                {offline && (
+                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-[#848484]/10 text-[#848484] dark:text-[#666] flex-shrink-0">
+                        offline
+                    </span>
+                )}
+            </button>
+        );
+    };
+
+    const isEmpty = filteredRepos.length === 0;
 
     return (
         <div
@@ -25,15 +165,71 @@ export function VirtualWorkspaceShellHeader({ config }: VirtualWorkspaceShellHea
             data-testid="virtual-workspace-shell-header"
             data-workspace={config.workspaceId}
         >
-            {/* Identity chip — mirrors the clone-switch pill, but static (no repo/git). */}
-            <span
-                data-testid={`${prefix}-shell-identity`}
-                title={config.label}
-                className="inline-flex items-center gap-1.5 h-[26px] px-2.5 rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#2a2a2a] text-[13px] font-semibold text-[#1f2328] dark:text-[#cccccc] flex-shrink-0"
-            >
-                <span aria-hidden>{config.icon}</span>
-                <span className="max-w-[160px] truncate">{config.label}</span>
-            </span>
+            {/* Identity chip — repo picker trigger. */}
+            <div className="relative flex-shrink-0" ref={rootRef}>
+                <button
+                    ref={triggerRef}
+                    data-testid={`${prefix}-shell-identity`}
+                    aria-haspopup="menu"
+                    aria-expanded={open}
+                    aria-label={`${config.label} — switch repository`}
+                    title="Switch repository"
+                    onClick={() => setOpen(o => !o)}
+                    className="inline-flex items-center gap-1.5 h-[26px] px-2.5 rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#2a2a2a] text-[13px] font-semibold text-[#1f2328] dark:text-[#cccccc] hover:bg-[#eaeef2] dark:hover:bg-[#333] transition-colors"
+                >
+                    <span aria-hidden>{config.icon}</span>
+                    <span className="max-w-[140px] truncate">{config.label}</span>
+                    <Chevron />
+                </button>
+
+                {open && (
+                    <div
+                        data-testid={`${prefix}-repo-dropdown`}
+                        role="menu"
+                        className="absolute left-0 top-full mt-1 z-50 w-[280px] rounded-md border border-[#e0e0e0] dark:border-[#3c3c3c] bg-white dark:bg-[#1e1e1e] shadow-lg p-1.5"
+                    >
+                        <div className="flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-[#d0d7de] dark:border-[#3c3c3c] bg-[#f6f8fa] dark:bg-[#252526]">
+                            <SearchIcon />
+                            <input
+                                ref={searchRef}
+                                data-testid={`${prefix}-repo-search`}
+                                value={query}
+                                onChange={e => setQuery(e.target.value)}
+                                placeholder="Filter repositories"
+                                className="min-w-0 flex-1 bg-transparent outline-none text-[12px] text-[#1f2328] dark:text-[#cccccc] placeholder:text-[#848484]"
+                                aria-label="Filter repositories"
+                            />
+                        </div>
+
+                        <div className="max-h-[260px] overflow-y-auto mt-1">
+                            {isEmpty ? (
+                                <div className="px-2 py-3 text-[12px] text-[#848484] dark:text-[#777] text-center">
+                                    {query.trim() ? 'No repositories match' : 'No repositories — use ☰ to add one'}
+                                </div>
+                            ) : (
+                                <>
+                                    {localRepos.length > 0 && (
+                                        <>
+                                            <div className="px-2 pt-2 pb-0.5 text-[10px] font-bold uppercase tracking-[0.07em] text-[#848484] dark:text-[#777]">
+                                                Local
+                                            </div>
+                                            {localRepos.map(r => renderRepoRow(r, `${prefix}-repo-local-row`))}
+                                        </>
+                                    )}
+                                    {remoteRepos.length > 0 && (
+                                        <>
+                                            <div className={`px-2 ${localRepos.length > 0 ? 'pt-2' : 'pt-1'} pb-0.5 text-[10px] font-bold uppercase tracking-[0.07em] text-[#848484] dark:text-[#777]`}>
+                                                Remote
+                                            </div>
+                                            {remoteRepos.map(r => renderRepoRow(r, `${prefix}-repo-remote-row`))}
+                                        </>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
 
             <span className="w-px h-[18px] bg-[#d8dee4] dark:bg-[#3c3c3c] flex-shrink-0" aria-hidden />
 

--- a/packages/coc/src/server/spa/client/react/layout/TopBar.tsx
+++ b/packages/coc/src/server/spa/client/react/layout/TopBar.tsx
@@ -219,7 +219,7 @@ export function TopBar({ onAdminOpen }: TopBarProps = {}) {
                     </button>
                 )}
                 {!isMobile && (showVirtualHeader && virtualHeaderConfig ? (
-                    <VirtualWorkspaceShellHeader config={virtualHeaderConfig} />
+                    <VirtualWorkspaceShellHeader config={virtualHeaderConfig} repos={repos} onSelectRepo={navigateToWorkspace} />
                 ) : showRemoteHeader ? (
                     // Remote-first shell: always rendered; repo may be undefined
                     // (unselected state shows a "Select repository" picker).

--- a/packages/coc/test/spa/react/remote-shell/VirtualWorkspaceHeader.test.tsx
+++ b/packages/coc/test/spa/react/remote-shell/VirtualWorkspaceHeader.test.tsx
@@ -31,6 +31,7 @@ import type {
     VirtualWorkspaceHeaderAction,
     VirtualWorkspaceHeaderConfig,
 } from '../../../../src/server/spa/client/react/features/remote-shell/virtualWorkspaceHeader';
+import type { RepoData } from '../../../../src/server/spa/client/react/repos/repoGrouping';
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -75,9 +76,27 @@ function makeConfig(overrides: Partial<VirtualWorkspaceHeaderConfig> = {}): Virt
     };
 }
 
+function makeLocalRepo(id: string, name: string, rootPath = `/home/user/${name}`): RepoData {
+    return { workspace: { id, name, rootPath } };
+}
+
+function makeRemoteRepo(id: string, name: string, serverId = 'server-1', serverLabel = 'My Server', connection = 'online'): RepoData {
+    return {
+        workspace: {
+            id,
+            name,
+            baseUrl: 'https://server-1.example.com',
+            remote: { serverId, serverLabel, connection },
+        },
+    };
+}
+
+const mockOnSelectRepo = vi.fn();
+
 beforeEach(() => {
     cleanup();
     mockDispatch.mockReset();
+    mockOnSelectRepo.mockReset();
     syncRun.mockReset().mockResolvedValue('Synced 3 items');
     generateRun.mockReset().mockResolvedValue('Summary saved to Weekly/w.md');
     mockActiveRepoSubTab = 'notes';
@@ -89,7 +108,7 @@ beforeEach(() => {
 
 describe('VirtualWorkspaceShellHeader', () => {
     it('renders identity, all sub-tabs and the action buttons', () => {
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
 
         const header = screen.getByTestId('virtual-workspace-shell-header');
         expect(header.getAttribute('data-workspace')).toBe('demo_ws');
@@ -103,7 +122,7 @@ describe('VirtualWorkspaceShellHeader', () => {
 
     it('marks the active sub-tab', () => {
         mockActiveRepoSubTab = 'git';
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
 
         expect(screen.getByTestId('demo-shell-tab-git').getAttribute('data-active')).toBe('true');
         expect(screen.getByTestId('demo-shell-tab-notes').getAttribute('data-active')).toBe('false');
@@ -111,12 +130,12 @@ describe('VirtualWorkspaceShellHeader', () => {
 
     it('falls back to Notes when the active sub-tab is not in the tab set', () => {
         mockActiveRepoSubTab = 'templates';
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
         expect(screen.getByTestId('demo-shell-tab-notes').getAttribute('data-active')).toBe('true');
     });
 
     it('switches sub-tab via dispatch + hash on click', () => {
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
 
         fireEvent.click(screen.getByTestId('demo-shell-tab-activity'));
 
@@ -126,13 +145,13 @@ describe('VirtualWorkspaceShellHeader', () => {
 
     it('hides the Schedules tab when schedules-in-scheduled-slide is enabled', () => {
         mockSchedulesInScheduledSlideEnabled = true;
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
         expect(screen.queryByTestId('demo-shell-tab-schedules')).toBeNull();
     });
 
     it('runs an action and shows its status message', async () => {
         syncRun.mockResolvedValueOnce('Synced 3 items');
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
 
         fireEvent.click(screen.getByTestId('demo-sync-btn'));
 
@@ -144,7 +163,7 @@ describe('VirtualWorkspaceShellHeader', () => {
     it('shows a busy label and disables the button while an action runs', async () => {
         let resolveRun!: (v: string | null) => void;
         syncRun.mockReturnValueOnce(new Promise<string | null>(r => { resolveRun = r; }));
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
 
         fireEvent.click(screen.getByTestId('demo-sync-btn'));
 
@@ -159,11 +178,144 @@ describe('VirtualWorkspaceShellHeader', () => {
 
     it('surfaces the error label when an action throws', async () => {
         syncRun.mockRejectedValueOnce(new Error('boom'));
-        render(<VirtualWorkspaceShellHeader config={makeConfig()} />);
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
 
         fireEvent.click(screen.getByTestId('demo-sync-btn'));
 
         await waitFor(() => expect(screen.getByTestId('demo-shell-status').textContent).toBe('Sync failed: boom'));
+    });
+
+    // ── Repo picker dropdown ────────────────────────────────────────────────
+
+    it('identity chip is a button with aria-haspopup and aria-expanded', () => {
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
+        const btn = screen.getByTestId('demo-shell-identity');
+        expect(btn.tagName).toBe('BUTTON');
+        expect(btn.getAttribute('aria-haspopup')).toBe('menu');
+        expect(btn.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('clicking the identity chip opens the dropdown', () => {
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
+        expect(screen.queryByTestId('demo-repo-dropdown')).toBeNull();
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        expect(screen.getByTestId('demo-repo-dropdown')).toBeTruthy();
+        expect(screen.getByTestId('demo-shell-identity').getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('clicking the identity chip again closes the dropdown', () => {
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        expect(screen.queryByTestId('demo-repo-dropdown')).toBeNull();
+    });
+
+    it('shows empty state with hamburger hint when no repos and dropdown is open', () => {
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const dropdown = screen.getByTestId('demo-repo-dropdown');
+        expect(dropdown.textContent).toContain('No repositories');
+        expect(dropdown.textContent).toContain('☰');
+    });
+
+    it('shows local repos in the dropdown with a Local section header', () => {
+        const repos = [makeLocalRepo('ws-1', 'shortcuts'), makeLocalRepo('ws-2', 'dotfiles')];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const dropdown = screen.getByTestId('demo-repo-dropdown');
+        expect(dropdown.textContent).toContain('Local');
+        const rows = screen.getAllByTestId('demo-repo-local-row');
+        expect(rows).toHaveLength(2);
+        expect(rows[0].textContent).toContain('shortcuts');
+        expect(rows[1].textContent).toContain('dotfiles');
+    });
+
+    it('shows remote repos in the dropdown with a Remote section header', () => {
+        const repos = [makeRemoteRepo('ws-r1', 'shortcuts', 'srv-1', 'Dev Server')];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const dropdown = screen.getByTestId('demo-repo-dropdown');
+        expect(dropdown.textContent).toContain('Remote');
+        const rows = screen.getAllByTestId('demo-repo-remote-row');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].textContent).toContain('shortcuts');
+        expect(rows[0].textContent).toContain('Dev Server');
+    });
+
+    it('clicking a local repo row calls onSelectRepo and closes the dropdown', () => {
+        const repos = [makeLocalRepo('ws-local', 'myrepo')];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        fireEvent.click(screen.getByTestId('demo-repo-local-row'));
+        expect(mockOnSelectRepo).toHaveBeenCalledWith('ws-local');
+        expect(screen.queryByTestId('demo-repo-dropdown')).toBeNull();
+    });
+
+    it('clicking a remote repo row calls onSelectRepo with the remote clone key', () => {
+        const repo = makeRemoteRepo('ws-r1', 'myrepo', 'srv-1', 'Dev Server', 'online');
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[repo]} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        fireEvent.click(screen.getByTestId('demo-repo-remote-row'));
+        // Remote clone key is "remote:<encodedServerId>:<encodedWorkspaceId>"
+        expect(mockOnSelectRepo).toHaveBeenCalledWith(expect.stringContaining('srv-1'));
+    });
+
+    it('offline remote repo is disabled and does not call onSelectRepo', () => {
+        const repo = makeRemoteRepo('ws-offline', 'offline-repo', 'srv-1', 'Dev Server', 'offline');
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[repo]} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const row = screen.getByTestId('demo-repo-remote-row') as HTMLButtonElement;
+        expect(row.disabled).toBe(true);
+        expect(row.textContent).toContain('offline');
+        fireEvent.click(row);
+        expect(mockOnSelectRepo).not.toHaveBeenCalled();
+    });
+
+    it('filter hides repos that do not match the query', () => {
+        const repos = [makeLocalRepo('ws-1', 'shortcuts'), makeLocalRepo('ws-2', 'dotfiles')];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const search = screen.getByTestId('demo-repo-search');
+        fireEvent.change(search, { target: { value: 'short' } });
+        const rows = screen.getAllByTestId('demo-repo-local-row');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].textContent).toContain('shortcuts');
+    });
+
+    it('filter shows "No repositories match" when nothing passes the filter', () => {
+        const repos = [makeLocalRepo('ws-1', 'shortcuts')];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        fireEvent.change(screen.getByTestId('demo-repo-search'), { target: { value: 'zzz-no-match' } });
+        expect(screen.getByTestId('demo-repo-dropdown').textContent).toContain('No repositories match');
+    });
+
+    it('Escape closes the dropdown', () => {
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={[]} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        expect(screen.getByTestId('demo-repo-dropdown')).toBeTruthy();
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByTestId('demo-repo-dropdown')).toBeNull();
+    });
+
+    it('shows both Local and Remote sections when both types are present', () => {
+        const repos = [
+            makeLocalRepo('ws-1', 'local-repo'),
+            makeRemoteRepo('ws-r1', 'remote-repo', 'srv-1', 'Dev Server', 'online'),
+        ];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const dropdown = screen.getByTestId('demo-repo-dropdown');
+        expect(dropdown.textContent).toContain('Local');
+        expect(dropdown.textContent).toContain('Remote');
+    });
+
+    it('short path of rootPath is shown as sublabel for local repos', () => {
+        const repos = [makeLocalRepo('ws-1', 'myrepo', '/home/user/projects/myrepo')];
+        render(<VirtualWorkspaceShellHeader config={makeConfig()} repos={repos} onSelectRepo={mockOnSelectRepo} />);
+        fireEvent.click(screen.getByTestId('demo-shell-identity'));
+        const row = screen.getByTestId('demo-repo-local-row');
+        expect(row.textContent).toContain('projects/myrepo');
     });
 });
 


### PR DESCRIPTION
Clicking the 📋 My Work or 🏠 My Life outlined chip in the remote-first
desktop shell now opens a compact repository picker instead of acting as a
static label. The dropdown lists all local and remote repositories in separate
sections with a filter field, shows an offline badge on unreachable remote
repos (which are disabled), and falls back to an empty state pointing to the
hamburger manager when no repositories are added yet. Selecting a repository
navigates using the existing workspace-navigation path so per-repository route
memory and remote-server routing continue to work. The blue My Work/My Life
shortcut buttons, mobile/classic header behavior, and the hamburger repository
manager are unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
